### PR TITLE
oauth: accept external client id

### DIFF
--- a/common/oauthTokenManager.go
+++ b/common/oauthTokenManager.go
@@ -309,6 +309,7 @@ type OAuthTokenInfo struct {
 	ActiveDirectoryEndpoint string `json:"_ad_endpoint"`
 	Identity                bool   `json:"_identity"`
 	IdentityInfo            IdentityInfo
+	ClientID                string `json:"_client_id"`
 }
 
 // IdentityInfo contains info for MSI.
@@ -413,9 +414,14 @@ func (credInfo *OAuthTokenInfo) RefreshTokenWithUserCredential(ctx context.Conte
 		return nil, err
 	}
 
+	var applicationId = credInfo.ClientID
+	if applicationId == "" {
+		applicationId = ApplicationID
+	}
+
 	spt, err := adal.NewServicePrincipalTokenFromManualToken(
 		*oauthConfig,
-		ApplicationID,
+		applicationId,
 		Resource,
 		credInfo.Token)
 	if err != nil {


### PR DESCRIPTION
Right now, azcopy uses its own application id for token refreshing which will not work if the refresh token was acquired by external apps, such as Azure CLI and POSH. This PR will fix this problem, hence enable Azure CLI to host azcopy for faster storage data operations
I checked out other routines in the same file, I believe only the `RefreshTokenWithUserCredential` requires this adjustments.

//CC @williexu, @jiacfan, @zezha-msft 

