### PR TITLE
Improve logging of HTTP errors

### DIFF
--- a/ste/ErrorExt.go
+++ b/ste/ErrorExt.go
@@ -4,12 +4,14 @@ import (
 	"github.com/Azure/azure-storage-azcopy/azbfs"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/Azure/azure-storage-file-go/azfile"
+	"net/http"
 )
 
 type ErrorEx struct {
 	error
 }
 
+// TODO: consider rolling MSRequestID into this, so that all places that use this can pick up, and log, the request ID too
 func (errex ErrorEx) ErrorCodeAndString() (int, string) {
 	switch e := interface{}(errex.error).(type) {
 	case azblob.StorageError:
@@ -21,4 +23,20 @@ func (errex ErrorEx) ErrorCodeAndString() (int, string) {
 	default:
 		return 0, errex.Error()
 	}
+}
+
+type hasResponse interface {
+	Response() *http.Response
+}
+
+// MSRequestID gets the request ID guid associated with the failed request.
+// Returns "" if there isn't one (either no request, or there is a request but it doesn't have the header)
+func (errex ErrorEx) MSRequestID() string {
+	if respErr, ok := errex.error.(hasResponse); ok {
+		r := respErr.Response()
+		if r != nil {
+			return r.Header.Get("X-Ms-Request-Id")
+		}
+	}
+	return ""
 }

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -332,7 +332,7 @@ func (jptm *jobPartTransferMgr) failActiveTransfer(typ transferErrorCode, descri
 	if !jptm.WasCanceled() {
 		jptm.Cancel()
 		status, msg := ErrorEx{err}.ErrorCodeAndString()
-		jptm.logTransferError(typ, jptm.Info().Source, jptm.Info().Destination, msg+" when "+descriptionOfWhereErrorOccurred, status)
+		jptm.logTransferError(typ, jptm.Info().Source, jptm.Info().Destination, msg+" when "+descriptionOfWhereErrorOccurred+"\n", status) // terminate with \n to more clearly separate it from following, potentially UN-related lines in the log
 		jptm.SetStatus(failureStatus)
 		jptm.SetErrorCode(int32(status)) // TODO: what are the rules about when this needs to be set, and doesn't need to be (e.g. for earlier failures)?
 		// If the status code was 403, it means there was an authentication error and we exit.


### PR DESCRIPTION
Linebreak so they don't confusingly run into the unrelated log entry that follows them, and include the request ID to make correlation easier.