### PR TITLE
Feature/md5 save and check

### DIFF
--- a/cmd/copyDownloadBlobEnumerator.go
+++ b/cmd/copyDownloadBlobEnumerator.go
@@ -72,6 +72,7 @@ func (e *copyDownloadBlobEnumerator) enumerate(cca *cookedCopyCmdArgs) error {
 			Destination:      blobLocalPath,
 			LastModifiedTime: blobProperties.LastModified(),
 			SourceSize:       blobProperties.ContentLength(),
+			ContentMD5:       blobProperties.ContentMD5(),
 		}, cca)
 		// only one transfer for this Job, dispatch the JobPart
 		err := e.dispatchFinalPart(cca)
@@ -290,7 +291,9 @@ func (e *copyDownloadBlobEnumerator) enumerate(cca *cookedCopyCmdArgs) error {
 				Source:           util.stripSASFromBlobUrl(util.createBlobUrlFromContainer(blobUrlParts, blobInfo.Name)).String(),
 				Destination:      util.generateLocalPath(cca.destination, blobRelativePath),
 				LastModifiedTime: blobInfo.Properties.LastModified,
-				SourceSize:       *blobInfo.Properties.ContentLength}, cca)
+				SourceSize:       *blobInfo.Properties.ContentLength,
+				ContentMD5:       blobInfo.Properties.ContentMD5,
+			}, cca)
 		}
 		marker = listBlob.NextMarker
 	}

--- a/cmd/copyDownloadBlobEnumerator.go
+++ b/cmd/copyDownloadBlobEnumerator.go
@@ -151,7 +151,9 @@ func (e *copyDownloadBlobEnumerator) enumerate(cca *cookedCopyCmdArgs) error {
 					Source:           util.stripSASFromBlobUrl(util.createBlobUrlFromContainer(blobUrlParts, blobPath)).String(),
 					Destination:      util.generateLocalPath(cca.destination, blobRelativePath),
 					LastModifiedTime: blobProperties.LastModified(),
-					SourceSize:       blobProperties.ContentLength()}, cca)
+					SourceSize:       blobProperties.ContentLength(),
+					ContentMD5:       blobProperties.ContentMD5(),
+				}, cca)
 				continue
 			}
 			if !cca.recursive {
@@ -202,7 +204,9 @@ func (e *copyDownloadBlobEnumerator) enumerate(cca *cookedCopyCmdArgs) error {
 						Source:           util.stripSASFromBlobUrl(util.createBlobUrlFromContainer(blobUrlParts, blobInfo.Name)).String(),
 						Destination:      util.generateLocalPath(cca.destination, blobRelativePath),
 						LastModifiedTime: blobInfo.Properties.LastModified,
-						SourceSize:       *blobInfo.Properties.ContentLength}, cca)
+						SourceSize:       *blobInfo.Properties.ContentLength,
+						ContentMD5:       blobInfo.Properties.ContentMD5,
+					}, cca)
 				}
 				marker = listBlob.NextMarker
 			}

--- a/cmd/copyDownloadFileEnumerator.go
+++ b/cmd/copyDownloadFileEnumerator.go
@@ -155,7 +155,8 @@ func (e *copyDownloadFileEnumerator) addDownloadFileTransfer(srcURL url.URL, des
 		Source:           gCopyUtil.stripSASFromFileShareUrl(srcURL).String(),
 		Destination:      destPath,
 		LastModifiedTime: properties.LastModified(),
-		SourceSize:       properties.ContentLength()},
+		SourceSize:       properties.ContentLength(),
+		ContentMD5:       properties.ContentMD5()},
 		cca)
 }
 

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -51,9 +51,10 @@ func init() {
 			} else {
 				return fmt.Errorf("invalid source type %s pased to delete. azcopy support removing blobs and files only", srcLocationType.String())
 			}
-			// Since remove uses the copy command arguments cook, set the blobType to None
+			// Since remove uses the copy command arguments cook, set the blobType to None and validation option
 			// else parsing the arguments will fail.
 			raw.blobType = common.EBlobType.None().String()
+			raw.md5ValidationOption = common.DefaultHashValidationOption.String()
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/syncDownloadEnumerator.go
+++ b/cmd/syncDownloadEnumerator.go
@@ -215,6 +215,7 @@ func (e *syncDownloadEnumerator) listSourceAndCompare(cca *cookedSyncCmdArgs, p 
 				Destination:      blobLocalPath,
 				SourceSize:       *blobInfo.Properties.ContentLength,
 				LastModifiedTime: blobInfo.Properties.LastModified,
+				ContentMD5:       blobInfo.Properties.ContentMD5,
 			}, cca)
 
 			delete(e.SourceFiles, blobLocalPath)
@@ -295,6 +296,7 @@ func (e *syncDownloadEnumerator) listTheDestinationIfRequired(cca *cookedSyncCmd
 			Destination:      cca.source,
 			SourceSize:       bProperties.ContentLength(),
 			LastModifiedTime: bProperties.LastModified(),
+			ContentMD5:       bProperties.ContentMD5(),
 		}, cca)
 	}
 

--- a/cmd/syncDownloadEnumerator.go
+++ b/cmd/syncDownloadEnumerator.go
@@ -419,6 +419,9 @@ func (e *syncDownloadEnumerator) enumerate(cca *cookedSyncCmdArgs) error {
 	// Set the preserve-last-modified-time to true in CopyJobRequest
 	e.CopyJobRequest.BlobAttributes.PreserveLastModifiedTime = true
 
+	// set MD5 validation behaviour
+	e.CopyJobRequest.BlobAttributes.MD5ValidationOption = cca.md5ValidationOption
+
 	// Copying the JobId of sync job to individual deleteJobRequest.
 	e.DeleteJobRequest.JobID = e.JobID
 	// FromTo of DeleteJobRequest will be BlobTrash.

--- a/common/emptyChunkReader.go
+++ b/common/emptyChunkReader.go
@@ -29,8 +29,8 @@ import (
 type emptyChunkReader struct {
 }
 
-func (cr *emptyChunkReader) TryBlockingPrefetch(fileReader io.ReaderAt) bool {
-	return true
+func (cr *emptyChunkReader) BlockingPrefetch(fileReader io.ReaderAt, isRetry bool) error {
+	return nil
 }
 
 func (cr *emptyChunkReader) Seek(offset int64, whence int) (int64, error) {

--- a/common/emptyChunkReader.go
+++ b/common/emptyChunkReader.go
@@ -22,6 +22,7 @@ package common
 
 import (
 	"errors"
+	"hash"
 	"io"
 )
 
@@ -58,4 +59,8 @@ func (cr *emptyChunkReader) HasPrefetchedEntirelyZeros() bool {
 
 func (cr *emptyChunkReader) Length() int64 {
 	return 0
+}
+
+func (cr *emptyChunkReader) WriteBufferTo(h hash.Hash) {
+	return // no content to write
 }

--- a/common/fe-ste-models.go
+++ b/common/fe-ste-models.go
@@ -525,6 +525,52 @@ func (ct *CredentialType) Parse(s string) error {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+var EHashValidationOption = HashValidationOption(0)
+
+var DefaultHashValidationOption = EHashValidationOption.FailIfDifferent()
+
+type HashValidationOption uint8
+
+// LogOnly is the least strict option
+func (HashValidationOption) LogOnly() HashValidationOption { return HashValidationOption(0) }
+
+// FailIfDifferent says fail if hashes different, but NOT fail if saved hash is
+// totally missing. This is a balance of convenience (for cases where no hash is saved) vs strictness
+// (to validate strictly when one is present)
+func (HashValidationOption) FailIfDifferent() HashValidationOption { return HashValidationOption(1) }
+
+// FailIfDifferentOrMissing is the strictest option, and useful for testing or validation in cases when
+// we _know_ there should be a hash
+func (HashValidationOption) FailIfDifferentOrMissing() HashValidationOption {
+	return HashValidationOption(2)
+}
+
+func (hvo HashValidationOption) String() string {
+	return enum.StringInt(hvo, reflect.TypeOf(hvo))
+}
+
+func (hvo *HashValidationOption) Parse(s string) error {
+	val, err := enum.ParseInt(reflect.TypeOf(hvo), s, true, true)
+	if err == nil {
+		*hvo = val.(HashValidationOption)
+	}
+	return err
+}
+
+func (hvo HashValidationOption) MarshalJSON() ([]byte, error) {
+	return json.Marshal(hvo.String())
+}
+
+func (hvo *HashValidationOption) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	return hvo.Parse(s)
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 const (
 	DefaultBlockBlobBlockSize = 8 * 1024 * 1024
 	MaxBlockBlobBlockSize     = 100 * 1024 * 1024

--- a/common/rpc-models.go
+++ b/common/rpc-models.go
@@ -108,14 +108,15 @@ type ListRequest struct {
 
 // This struct represents the optional attribute for blob request header
 type BlobTransferAttributes struct {
-	BlobType                 BlobType      // The type of a blob - BlockBlob, PageBlob, AppendBlob
-	ContentType              string        //The content type specified for the blob.
-	ContentEncoding          string        //Specifies which content encodings have been applied to the blob.
-	BlockBlobTier            BlockBlobTier // Specifies the tier to set on the block blobs.
-	PageBlobTier             PageBlobTier  // Specifies the tier to set on the page blobs.
-	Metadata                 string        //User-defined Name-value pairs associated with the blob
-	NoGuessMimeType          bool          // represents user decision to interpret the content-encoding from source file
-	PreserveLastModifiedTime bool          // when downloading, tell engine to set file's timestamp to timestamp of blob
+	BlobType                 BlobType             // The type of a blob - BlockBlob, PageBlob, AppendBlob
+	ContentType              string               //The content type specified for the blob.
+	ContentEncoding          string               //Specifies which content encodings have been applied to the blob.
+	BlockBlobTier            BlockBlobTier        // Specifies the tier to set on the block blobs.
+	PageBlobTier             PageBlobTier         // Specifies the tier to set on the page blobs.
+	Metadata                 string               //User-defined Name-value pairs associated with the blob
+	NoGuessMimeType          bool                 // represents user decision to interpret the content-encoding from source file
+	PreserveLastModifiedTime bool                 // when downloading, tell engine to set file's timestamp to timestamp of blob
+	MD5ValidationOption      HashValidationOption // when downloading, how strictly should we validate MD5 hashes?
 	BlockSizeInBytes         uint32
 }
 

--- a/common/singleChunkReader.go
+++ b/common/singleChunkReader.go
@@ -42,11 +42,8 @@ type SingleChunkReader interface {
 	// Closer is needed to clean up resources
 	io.Closer
 
-	// TryBlockingPrefetch tries to read the full contents of the chunk into RAM. Returns true if succeeded for false if failed,
-	// although callers do not have to check the return value (and there is no error object returned). Why?
-	// Because its OK to keep using this object even if the prefetch fails, since in that case
-	// any subsequent Read will just retry the same read as we do here, and if it fails at that time then Read will return an error.
-	TryBlockingPrefetch(fileReader io.ReaderAt) bool
+	// BlockingPrefetch tries to read the full contents of the chunk into RAM.
+	BlockingPrefetch(fileReader io.ReaderAt, isRetry bool) error
 
 	// CaptureLeadingBytes is used to grab enough of the initial bytes to do MIME-type detection.  Expected to be called only
 	// on the first chunk in each file (since there's no point in calling it on others)
@@ -118,18 +115,6 @@ func NewSingleChunkReader(ctx context.Context, sourceFactory ChunkReaderSourceFa
 	}
 }
 
-// Prefetch, and ignore any errors (just leave in not-prefetch-yet state, if there was an error)
-// If we leave it in the not-prefetched state here, then when Read happens that will trigger another read attempt,
-// and that one WILL return any error that happens
-func (cr *singleChunkReader) TryBlockingPrefetch(fileReader io.ReaderAt) bool {
-	err := cr.blockingPrefetch(fileReader, false)
-	if err != nil {
-		cr.returnBuffer() // if there was an error, be sure to put us back into a valid "not-yet-prefetched" state
-		return false
-	}
-	return true
-}
-
 func (cr *singleChunkReader) HasPrefetchedEntirelyZeros() bool {
 	if cr.buffer == nil {
 		return false // not prefetched  (and, to simply error handling in teh caller, we don't call retryBlockingPrefetchIfNecessary here)
@@ -153,7 +138,7 @@ func (cr *singleChunkReader) HasPrefetchedEntirelyZeros() bool {
 // (Allowing the caller to provide the reader to us allows a sequential read approach, since caller can control the order sequentially (in the initial, non-retry, scenario)
 // We use io.ReaderAt, rather than io.Reader, just for maintainablity/ensuring correctness. (Since just using Reader requires the caller to
 // follow certain assumptions about positioning the file pointer at the right place before calling us, but using ReaderAt does not).
-func (cr *singleChunkReader) blockingPrefetch(fileReader io.ReaderAt, isRetry bool) error {
+func (cr *singleChunkReader) BlockingPrefetch(fileReader io.ReaderAt, isRetry bool) error {
 	if cr.buffer != nil {
 		return nil // already prefetched
 	}
@@ -198,7 +183,7 @@ func (cr *singleChunkReader) retryBlockingPrefetchIfNecessary() error {
 
 	// no need to seek first, because its a ReaderAt
 	const isRetry = true // retries are the only time we need to redo the prefetch
-	return cr.blockingPrefetch(sourceFile, isRetry)
+	return cr.BlockingPrefetch(sourceFile, isRetry)
 }
 
 // Seeks within this chunk

--- a/ste/JobPartPlan.go
+++ b/ste/JobPartPlan.go
@@ -14,7 +14,7 @@ import (
 // dataSchemaVersion defines the data schema version of JobPart order files supported by
 // current version of azcopy
 // To be Incremented every time when we release azcopy with changed dataSchema
-const DataSchemaVersion common.Version = 1
+const DataSchemaVersion common.Version = 2
 
 const (
 	ContentTypeMaxBytes     = 256  // If > 65536, then jobPartPlanBlobData's ContentTypeLength's type  field must change
@@ -212,6 +212,9 @@ type JobPartPlanDstLocal struct {
 
 	// Specifies whether the timestamp of destination file has to be set to the modified time of source file
 	PreserveLastModifiedTime bool
+
+	// says how MD5 verification failures should be actioned
+	MD5VerificationOption common.HashValidationOption
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ste/JobPartPlanFileName.go
+++ b/ste/JobPartPlanFileName.go
@@ -241,7 +241,8 @@ func (jpfn JobPartPlanFileName) Create(order common.CopyJobPartOrderRequest) {
 		common.PanicIfErr(err)
 		eof += int64(bytesWritten)
 
-		// For S2S copy, write the src properties
+		// For S2S copy (and, in the case of Content-MD5, always), write the src properties
+		// TODO: *** reviewers: is it OK to use this in a non S2S scenario, for the MD5s?? ***
 		if len(order.Transfers[t].ContentType) != 0 {
 			bytesWritten, err = file.WriteString(order.Transfers[t].ContentType)
 			common.PanicIfErr(err)
@@ -267,7 +268,7 @@ func (jpfn JobPartPlanFileName) Create(order common.CopyJobPartOrderRequest) {
 			common.PanicIfErr(err)
 			eof += int64(bytesWritten)
 		}
-		if order.Transfers[t].ContentMD5 != nil {
+		if order.Transfers[t].ContentMD5 != nil { // if non-nil but 0 len, will simply not be read by the consumer (since length is zero)
 			bytesWritten, err = file.WriteString(string(order.Transfers[t].ContentMD5))
 			common.PanicIfErr(err)
 			eof += int64(bytesWritten)

--- a/ste/JobPartPlanFileName.go
+++ b/ste/JobPartPlanFileName.go
@@ -155,6 +155,7 @@ func (jpfn JobPartPlanFileName) Create(order common.CopyJobPartOrderRequest) {
 		},
 		DstLocalData: JobPartPlanDstLocal{
 			PreserveLastModifiedTime: order.BlobAttributes.PreserveLastModifiedTime,
+			MD5VerificationOption:    order.BlobAttributes.MD5ValidationOption,
 		},
 		atomicJobStatus: common.EJobStatus.InProgress(), // We default to InProgress
 	}

--- a/ste/JobPartPlanFileName.go
+++ b/ste/JobPartPlanFileName.go
@@ -242,7 +242,6 @@ func (jpfn JobPartPlanFileName) Create(order common.CopyJobPartOrderRequest) {
 		eof += int64(bytesWritten)
 
 		// For S2S copy (and, in the case of Content-MD5, always), write the src properties
-		// TODO: *** reviewers: is it OK to use this in a non S2S scenario, for the MD5s?? ***
 		if len(order.Transfers[t].ContentType) != 0 {
 			bytesWritten, err = file.WriteString(order.Transfers[t].ContentType)
 			common.PanicIfErr(err)

--- a/ste/md5Comparer.go
+++ b/ste/md5Comparer.go
@@ -26,7 +26,7 @@ import (
 	"github.com/Azure/azure-storage-azcopy/common"
 )
 
-type md5Comparsion struct {
+type md5Comparer struct {
 	expected      []byte
 	actualAsSaved []byte
 	logger        common.ILogger
@@ -44,7 +44,7 @@ var errActualMd5NotComputed = errors.New("no MDB was computed within this applic
 // Check compares the two MD5s, and returns any error if applicable
 // Any informational logging will be done within Check, so all the caller needs to do
 // is respond to non-nil errors
-func (c *md5Comparsion) Check() error {
+func (c *md5Comparer) Check() error {
 
 	if c.actualAsSaved == nil || len(c.actualAsSaved) == 0 {
 		return errActualMd5NotComputed // Should never happen

--- a/ste/md5Comparer.go
+++ b/ste/md5Comparer.go
@@ -38,7 +38,7 @@ type md5Comparer struct {
 	logger           transferSpecificLogger
 }
 
-// TODO: let's add an aka.ms link to the message, that gives more info
+// TODO: let's add an aka.ms link to the message,  that gives more info
 var errMd5Mismatch = errors.New("the MD5 hash of the data, as we received it, did not match the expected value, as found in the Blob/File Service. " +
 	"This means that either there is a data integrity error OR another tool has failed to keep the stored hash up to date")
 

--- a/ste/md5Comparison.go
+++ b/ste/md5Comparison.go
@@ -1,0 +1,65 @@
+// Copyright © 2017 Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ste
+
+import (
+	"bytes"
+	"errors"
+	"github.com/Azure/azure-storage-azcopy/common"
+)
+
+type md5Comparsion struct {
+	expected      []byte
+	actualAsSaved []byte
+	logger        common.ILogger
+}
+
+// TODO: let's add an aka.ms link to the message, that gives more info
+var errMd5Mismatch = errors.New("the MD5 hash of the data, as we received it, did not match the expected value, as found in the Blob/File Service. " +
+	"This means that either there is a data integrity error OR another tool has failed to keep the stored hash up to date")
+
+// TODO: let's add an aka.ms link to the message, that gives more info
+var errExpectedMd5Missing = errors.New("no MD5 was stored in the Blob/File service against this file. This application is currently configured to treat missing MD5 hashes as errors")
+
+var errActualMd5NotComputed = errors.New("no MDB was computed within this application. This indicates a logic error in this application")
+
+// Check compares the two MD5s, and returns any error if applicable
+// Any informational logging will be done within Check, so all the caller needs to do
+// is respond to non-nil errors
+func (c *md5Comparsion) Check() error {
+
+	if c.actualAsSaved == nil || len(c.actualAsSaved) == 0 {
+		return errActualMd5NotComputed // Should never happen
+	}
+
+	if c.expected == nil || len(c.expected) == 0 {
+		return errExpectedMd5Missing
+	}
+
+	match := bytes.Equal(c.expected, c.actualAsSaved)
+	if !match {
+		return errMd5Mismatch
+	}
+
+	return nil
+
+	// TODO: add logging-only options. E.g. 3-levels of processing: FailIfDifferentOrMissing, FailIfDifferent, LogOnly
+}

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -426,11 +426,11 @@ func (jpm *jobPartMgr) createPipeline(ctx context.Context) {
 	}
 }
 
-func (jpm *jobPartMgr) SlicePool() common.ByteSlicePooler{
+func (jpm *jobPartMgr) SlicePool() common.ByteSlicePooler {
 	return jpm.slicePool
 }
 
-func (jpm *jobPartMgr) CacheLimiter() common.CacheLimiter{
+func (jpm *jobPartMgr) CacheLimiter() common.CacheLimiter {
 	return jpm.cacheLimiter
 }
 
@@ -473,9 +473,8 @@ func (jpm *jobPartMgr) SAS() (string, string) {
 	return jpm.sourceSAS, jpm.destinationSAS
 }
 
-func (jpm *jobPartMgr) localDstData() (preserveLastModifiedTime bool) {
-	dstData := &jpm.Plan().DstLocalData
-	return dstData.PreserveLastModifiedTime
+func (jpm *jobPartMgr) localDstData() *JobPartPlanDstLocal {
+	return &jpm.Plan().DstLocalData
 }
 
 // Call Done when a transfer has completed its epilog; this method returns the number of transfers completed so far
@@ -521,10 +520,9 @@ func (jpm *jobPartMgr) ReleaseAConnection() {
 func (jpm *jobPartMgr) ShouldLog(level pipeline.LogLevel) bool  { return jpm.jobMgr.ShouldLog(level) }
 func (jpm *jobPartMgr) Log(level pipeline.LogLevel, msg string) { jpm.jobMgr.Log(level, msg) }
 func (jpm *jobPartMgr) Panic(err error)                         { jpm.jobMgr.Panic(err) }
-func (jpm *jobPartMgr) LogChunkStatus(id common.ChunkID, reason common.WaitReason){
+func (jpm *jobPartMgr) LogChunkStatus(id common.ChunkID, reason common.WaitReason) {
 	jpm.jobMgr.LogChunkStatus(id, reason)
 }
-
 
 // TODO: Can we delete this method?
 // numberOfTransfersDone returns the numberOfTransfersDone_doNotUse of JobPartPlanInfo

--- a/ste/uploader-blockBlob.go
+++ b/ste/uploader-blockBlob.go
@@ -44,6 +44,7 @@ type blockBlobUploader struct {
 	leadingBytes     []byte      // no lock because is written before first chunk-func go routine is scheduled
 	mu               *sync.Mutex // protects the fields below
 	blockIds         []string
+	md5Channel       chan []byte
 }
 
 func newBlockBlobUploader(jptm IJobPartTransferMgr, destination string, p pipeline.Pipeline, pacer *pacer) (uploader, error) {
@@ -74,6 +75,7 @@ func newBlockBlobUploader(jptm IJobPartTransferMgr, destination string, p pipeli
 		pacer:        pacer,
 		mu:           &sync.Mutex{},
 		blockIds:     make([]string, numChunks),
+		md5Channel:   newMd5Channel(),
 	}, nil
 }
 
@@ -83,6 +85,10 @@ func (u *blockBlobUploader) ChunkSize() uint32 {
 
 func (u *blockBlobUploader) NumChunks() uint32 {
 	return u.numChunks
+}
+
+func (u *blockBlobUploader) Md5Channel() chan<- []byte {
+	return u.md5Channel
 }
 
 func (u *blockBlobUploader) SetLeadingBytes(leadingBytes []byte) {
@@ -151,8 +157,21 @@ func (u *blockBlobUploader) generatePutWholeBlob(id common.ChunkID, blockIndex i
 		jptm.LogChunkStatus(id, common.EWaitReason.Body())
 		var err error
 		if jptm.Info().SourceSize == 0 {
+			// Empty file
 			_, err = u.blockBlobUrl.Upload(jptm.Context(), bytes.NewReader(nil), blobHttpHeader, metaData, azblob.BlobAccessConditions{})
+
 		} else {
+			// File with content
+
+			// Get the MD5 that was computed as we read the file
+			md5Hash, ok := <-u.md5Channel
+			if !ok {
+				jptm.FailActiveUpload("Getting hash", errNoHash)
+				return
+			}
+			blobHttpHeader.ContentMD5 = md5Hash
+
+			// Upload the file
 			body := newLiteRequestBodyPacer(reader, u.pacer)
 			_, err = u.blockBlobUrl.Upload(jptm.Context(), body, blobHttpHeader, metaData, azblob.BlobAccessConditions{})
 		}
@@ -182,13 +201,20 @@ func (u *blockBlobUploader) Epilogue() {
 	if jptm.TransferStatus() > 0 && shouldPutBlockList == putListNeeded {
 		jptm.Log(pipeline.LogDebug, fmt.Sprintf("Conclude Transfer with BlockList %s", blockIds))
 
-		// fetching the blob http headers with content-type, content-encoding attributes
-		// fetching the metadata passed with the JobPartOrder
-		blobHttpHeader, metaData := jptm.BlobDstData(u.leadingBytes)
+		md5Hash, ok := <-u.md5Channel
+		if ok {
+			// fetching the blob http headers with content-type, content-encoding attributes
+			// fetching the metadata passed with the JobPartOrder
+			blobHttpHeader, metaData := jptm.BlobDstData(u.leadingBytes)
+			blobHttpHeader.ContentMD5 = md5Hash
 
-		_, err := u.blockBlobUrl.CommitBlockList(jptm.Context(), blockIds, blobHttpHeader, metaData, azblob.BlobAccessConditions{})
-		if err != nil {
-			jptm.FailActiveUpload("Committing block list", err)
+			_, err := u.blockBlobUrl.CommitBlockList(jptm.Context(), blockIds, blobHttpHeader, metaData, azblob.BlobAccessConditions{})
+			if err != nil {
+				jptm.FailActiveUpload("Committing block list", err)
+				// don't return, since need cleanup below
+			}
+		} else {
+			jptm.FailActiveUpload("Getting hash", errNoHash)
 			// don't return, since need cleanup below
 		}
 	}

--- a/ste/xfer-localToRemote.go
+++ b/ste/xfer-localToRemote.go
@@ -152,6 +152,12 @@ func localToRemote(jptm IJobPartTransferMgr, p pipeline.Pipeline, pacer *pacer, 
 		chunkDataError := chunkReader.BlockingPrefetch(srcFile, false)
 
 		// Add the bytes to the hash
+		// NOTE: if there is a retry on this chunk later (a 503 from Service) our current implementation of singleChunkReader
+		// (as at Jan 2019) will re-read from the disk.  If that part of the file has been updated by another process,
+		// that means it will not longer match the hash we set here. That would be bad. So we rely on logic
+		// elsewhere in our upload code to avoid/fail or retry such transfers.
+		// TODO: move the above note to the place where we implement the avoid/fail/retry and refer to that in a comment
+		//      on the retry file-re-read logic
 		if chunkDataError == nil {
 			chunkReader.WriteBufferTo(md5Hasher)
 		} else {

--- a/ste/xfer-remoteToLocal.go
+++ b/ste/xfer-remoteToLocal.go
@@ -185,7 +185,7 @@ func epilogueWithCleanupDownload(jptm IJobPartTransferMgr, activeDstFile *os.Fil
 
 		// Check MD5 (but only if file was fully flushed and saved - else no point and may not have actualAsSaved hash anyway)
 		if !jptm.TransferStatus().DidFail() {
-			comparison := md5Comparsion{
+			comparison := md5Comparer{
 				expected:      info.SrcHTTPHeaders.ContentMD5, // the MD5 that came back from Service when we enumerated the source
 				actualAsSaved: md5OfFileAsWritten,
 				logger:        jptm}

--- a/ste/xfer-remoteToLocal.go
+++ b/ste/xfer-remoteToLocal.go
@@ -186,9 +186,10 @@ func epilogueWithCleanupDownload(jptm IJobPartTransferMgr, activeDstFile *os.Fil
 		// Check MD5 (but only if file was fully flushed and saved - else no point and may not have actualAsSaved hash anyway)
 		if !jptm.TransferStatus().DidFail() {
 			comparison := md5Comparer{
-				expected:      info.SrcHTTPHeaders.ContentMD5, // the MD5 that came back from Service when we enumerated the source
-				actualAsSaved: md5OfFileAsWritten,
-				logger:        jptm}
+				expected:         info.SrcHTTPHeaders.ContentMD5, // the MD5 that came back from Service when we enumerated the source
+				actualAsSaved:    md5OfFileAsWritten,
+				validationOption: jptm.MD5ValidationOption(),
+				logger:           jptm}
 			err := comparison.Check()
 			if err != nil {
 				jptm.FailActiveDownload("Checking MD5 hash", err)

--- a/ste/xfer-remoteToLocal.go
+++ b/ste/xfer-remoteToLocal.go
@@ -81,7 +81,7 @@ func remoteToLocal(jptm IJobPartTransferMgr, p pipeline.Pipeline, pacer *pacer, 
 	if err != nil {
 		jptm.LogDownloadError(info.Source, info.Destination, "File Creation Error "+err.Error(), 0)
 		jptm.SetStatus(common.ETransferStatus.Failed())
-		epilogueWithCleanupDownload(jptm, nil, nil)
+		epilogueWithCleanupDownload(jptm, nil, nil) // use standard epilogue for consistency
 		return
 	}
 	// TODO: Question: do we need to Stat the file, to check its size, after explicitly making it with the desired size?
@@ -170,22 +170,29 @@ func remoteToLocal(jptm IJobPartTransferMgr, p pipeline.Pipeline, pacer *pacer, 
 func epilogueWithCleanupDownload(jptm IJobPartTransferMgr, activeDstFile *os.File, cw common.ChunkedFileWriter) {
 	info := jptm.Info()
 
-	if activeDstFile != nil {
-		// wait until all received chunks are flushed out
-		_, flushError := cw.Flush(jptm.Context()) // todo: use, and check the MD5 hash returned here
+	haveNonEmptyFile := activeDstFile != nil
+	if haveNonEmptyFile {
 
-		// Close file
-		fileCloseErr := activeDstFile.Close() // always try to close if, even if flush failed
-		if (flushError != nil || fileCloseErr != nil) && !jptm.TransferStatus().DidFail() {
-			// it WAS successful up to now, but the file flush/closing failed.
-			message := ""
-			if flushError != nil {
-				message = "File Flush Error " + flushError.Error()
-			} else {
-				message = "File Closure Error " + fileCloseErr.Error()
+		// wait until all received chunks are flushed out
+		md5OfFileAsWritten, flushError := cw.Flush(jptm.Context())
+		closeErr := activeDstFile.Close() // always try to close if, even if flush failed
+		if flushError != nil {
+			jptm.FailActiveDownload("Flushing file", flushError)
+		}
+		if closeErr != nil {
+			jptm.FailActiveDownload("Closing file", closeErr)
+		}
+
+		// Check MD5 (but only if file was fully flushed and saved - else no point and may not have actualAsSaved hash anyway)
+		if !jptm.TransferStatus().DidFail() {
+			comparison := md5Comparsion{
+				expected:      info.SrcHTTPHeaders.ContentMD5, // the MD5 that came back from Service when we enumerated the source
+				actualAsSaved: md5OfFileAsWritten,
+				logger:        jptm}
+			err := comparison.Check()
+			if err != nil {
+				jptm.FailActiveDownload("Checking MD5 hash", err)
 			}
-			jptm.LogDownloadError(info.Source, info.Destination, message, 0)
-			jptm.SetStatus(common.ETransferStatus.Failed())
 		}
 	}
 


### PR DESCRIPTION
John Rusk @ 1/29/2019 3:29:28 PM
    Make prefetch have an error code

    Since we need to know whether prefetch happened to compute hashes.

John Rusk @ 1/29/2019 8:59:10 PM
    PUT whole-of-file MD5s

    blobFS is not covered by this commit. But Block, Page and Append blobs are, and so are Azure Files

John Rusk @ 1/30/2019 1:49:12 PM
    Check MD5s when downloading

John Rusk @ 1/30/2019 2:36:43 PM
    Refactor schedulding of upload chunks for testability

    So that the main scheduling routine can be tested in isolation of all the precursor setup stuff

John Rusk @ 2/6/2019 6:09:42 PM
    Add command-line options to control the strictness of MD5 validation

