### PR TITLE
Extra dignostics for chunk reader out of bounds error

### DIFF
--- a/common/singleChunkReader.go
+++ b/common/singleChunkReader.go
@@ -337,7 +337,7 @@ func (cr *singleChunkReader) Close() error {
 	if cr.positionInChunk < cr.length {
 		b := &bytes.Buffer{}
 		b.Write(stack())
-		cr.generalLogger.Log(pipeline.LogDebug, "Early close of chunk: "+b.String())
+		cr.generalLogger.Log(pipeline.LogInfo, "Early close of chunk in singleChunkReader: "+b.String())
 	}
 	cr.use()
 	defer cr.unuse()

--- a/common/singleChunkReader.go
+++ b/common/singleChunkReader.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Azure/azure-pipeline-go/pipeline"
 	"hash"
 	"io"
+	"math"
 	"runtime"
 )
 
@@ -166,7 +167,7 @@ func (cr *singleChunkReader) BlockingPrefetch(fileReader io.ReaderAt, isRetry bo
 	}
 
 	// get buffer from pool
-	cr.buffer = cr.slicePool.RentSlice(uint32(cr.length))
+	cr.buffer = cr.slicePool.RentSlice(uint32Checked(cr.length))
 
 	// read bytes into the buffer
 	cr.chunkLogger.LogChunkStatus(cr.chunkId, EWaitReason.Disk())
@@ -340,4 +341,12 @@ func stack() []byte {
 		}
 		buf = make([]byte, 2*len(buf))
 	}
+}
+
+// while we never expect any out of range errors, due to chunk sizes fitting easily into uint32, here we make sure
+func uint32Checked(i int64) uint32 {
+	if i > math.MaxUint32 {
+		panic("int64 out of range for cast to uint32")
+	}
+	return uint32(i)
 }

--- a/common/singleChunkReader.go
+++ b/common/singleChunkReader.go
@@ -153,7 +153,7 @@ func (cr *singleChunkReader) HasPrefetchedEntirelyZeros() bool {
 	defer cr.unuse()
 
 	if cr.buffer == nil {
-		return false // not prefetched  (and, to simply error handling in teh caller, we don't call retryBlockingPrefetchIfNecessary here)
+		return false // not prefetched (and, to simply error handling in teh caller, we don't call retryBlockingPrefetchIfNecessary here)
 	}
 
 	for _, b := range cr.buffer {

--- a/ste/xfer-localToRemote.go
+++ b/ste/xfer-localToRemote.go
@@ -152,7 +152,7 @@ func scheduleUploadChunks(jptm IJobPartTransferMgr, srcName string, srcFile comm
 		// of the file read later (when doing a retry)
 		// BTW, the reader we create here just works with a single chuck. (That's in contrast with downloads, where we have
 		// to use an object that encompasses the whole file, so that it can put the chunks back into order. We don't have that requirement here.)
-		chunkReader := common.NewSingleChunkReader(context, sourceFileFactory, id, adjustedChunkSize, jptm, slicePool, cacheLimiter)
+		chunkReader := common.NewSingleChunkReader(context, sourceFileFactory, id, adjustedChunkSize, jptm, jptm, slicePool, cacheLimiter)
 
 		// Wait until we have enough RAM, and when we do, prefetch the data for this chunk.
 		chunkDataError := chunkReader.BlockingPrefetch(srcFile, false)


### PR DESCRIPTION
Adds extra diagnostic logging to detect unexpected race conditions in the use of singleChunkReader

Background: we are not able to reproduce issue #191. We suspect the most likely root cause is something calling Close from a different goroutine than Read... while the Read is still running.  We have verified that that causes the observed symtoms, if the call happens at the right time.  As for what might be calling it, we suspect it may be something somewhere in the HTTP stack, following some kind of error.  This logging will hopefully catch the issue in the act, and thus confirm the root cause.