### PR TITLE
Feature/enhanced perf diagnostics

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -839,7 +839,7 @@ func (cca *cookedCopyCmdArgs) ReportProgressOrExit(lcm common.LifecycleMgr) {
 	}
 }
 
-// Is disk speed looking like a constraint on throughput?  Ignore the first minute,
+// Is disk speed looking like a constraint on throughput?  Ignore the first little-while,
 // to give an (arbitrary) amount of time for things to reach steady-state.
 func getPerfDisplayText(perfDiagnosticStrings []string, isDiskConstrained bool, durationOfJob time.Duration) (perfString string, diskString string) {
 	perfString = ""

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -842,13 +842,22 @@ func (cca *cookedCopyCmdArgs) ReportProgressOrExit(lcm common.LifecycleMgr) {
 // Is disk speed looking like a constraint on throughput?  Ignore the first minute,
 // to give an (arbitrary) amount of time for things to reach steady-state.
 func getPerfDisplayText(perfDiagnosticStrings []string, isDiskConstrained bool, durationOfJob time.Duration) (perfString string, diskString string) {
-	perfString = "[States: " + strings.Join(perfDiagnosticStrings, ", ") + "], "
-	if isDiskConstrained && durationOfJob.Seconds() > 30 {
+	perfString = ""
+	if shouldDisplayPerfStates(glcm) {
+		perfString = "[States: " + strings.Join(perfDiagnosticStrings, ", ") + "], "
+	}
+
+	haveBeenRunningLongEnoughToStabilize := durationOfJob.Seconds() > 30 // this duration is an arbitrary guestimate
+	if isDiskConstrained && haveBeenRunningLongEnoughToStabilize {
 		diskString = " (disk may be limiting speed)"
 	} else {
 		diskString = ""
 	}
 	return
+}
+
+func shouldDisplayPerfStates(lcm common.LifecycleMgr) bool {
+	return lcm.GetEnvironmentVariable(common.EEnvironmentVariable.ShowPerfStates()) != ""
 }
 
 func isStdinPipeIn() (bool, error) {

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -829,7 +829,7 @@ func (cca *cookedCopyCmdArgs) ReportProgressOrExit(lcm common.LifecycleMgr) {
 			summary.TransfersSkipped,
 			summary.TotalTransfers,
 			scanningString,
-			getPerfString))
+			perfString))
 	} else {
 		glcm.Progress(fmt.Sprintf("%v Done, %v Failed, %v Pending, %v Skipped, %v Total%s, %s2-sec Throughput (Mb/s): %v%s",
 			summary.TransfersCompleted,

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -817,22 +817,36 @@ func (cca *cookedCopyCmdArgs) ReportProgressOrExit(lcm common.LifecycleMgr) {
 	cca.intervalStartTime = time.Now()
 	cca.intervalBytesTransferred = summary.BytesOverWire
 
+	// indicate whether constrained by disk or not
+	getPerfString := getPerformanceString(summary.IsDiskConstrained, summary.PerfDiagnostics, timeElapsed)
+
 	// As there would be case when no bits sent from local, e.g. service side copy, when throughput = 0, hide it.
 	if throughPut == 0 {
-		glcm.Progress(fmt.Sprintf("%v Done, %v Failed, %v Pending, %v Skipped, %v Total%s",
+		glcm.Progress(fmt.Sprintf("%v Done, %v Failed, %v Pending, %v Skipped, %v Total%s%s",
 			summary.TransfersCompleted,
 			summary.TransfersFailed,
 			summary.TotalTransfers-(summary.TransfersCompleted+summary.TransfersFailed+summary.TransfersSkipped),
 			summary.TransfersSkipped,
 			summary.TotalTransfers,
-			scanningString))
+			scanningString,
+			getPerfString))
 	} else {
-		glcm.Progress(fmt.Sprintf("%v Done, %v Failed, %v Pending, %v Skipped, %v Total%s, 2-sec Throughput (Mb/s): %v",
+		glcm.Progress(fmt.Sprintf("%v Done, %v Failed, %v Pending, %v Skipped, %v Total%s, 2-sec Throughput (Mb/s): %v%s",
 			summary.TransfersCompleted,
 			summary.TransfersFailed,
 			summary.TotalTransfers-(summary.TransfersCompleted+summary.TransfersFailed+summary.TransfersSkipped),
-			summary.TransfersSkipped, summary.TotalTransfers, scanningString, ste.ToFixed(throughPut, 4)))
+			summary.TransfersSkipped, summary.TotalTransfers, scanningString, ste.ToFixed(throughPut, 4), getPerfString))
 	}
+}
+
+// Is disk speed looking like a constraint on throughput?  Ignore the first minute,
+// to give an (arbitrary) amount of time for things to reach steady-state.
+func getPerformanceString(isDiskConstrained bool, perfDiagnosticStrings []string, secondsElapsed float64) string {
+	joinedPerfStrings := strings.Join(perfDiagnosticStrings, ", ")
+	if isDiskConstrained && secondsElapsed > 30 {
+		return ", disk may be limiting speed, " + joinedPerfStrings
+	}
+	return " " + joinedPerfStrings
 }
 
 func isStdinPipeIn() (bool, error) {

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -843,7 +843,7 @@ func (cca *cookedCopyCmdArgs) ReportProgressOrExit(lcm common.LifecycleMgr) {
 // to give an (arbitrary) amount of time for things to reach steady-state.
 func getPerfDisplayText(perfDiagnosticStrings []string, isDiskConstrained bool, durationOfJob time.Duration) (perfString string, diskString string) {
 	perfString = ""
-	if shouldDisplayPerfStates(glcm) {
+	if shouldDisplayPerfStates() {
 		perfString = "[States: " + strings.Join(perfDiagnosticStrings, ", ") + "], "
 	}
 
@@ -856,8 +856,8 @@ func getPerfDisplayText(perfDiagnosticStrings []string, isDiskConstrained bool, 
 	return
 }
 
-func shouldDisplayPerfStates(lcm common.LifecycleMgr) bool {
-	return lcm.GetEnvironmentVariable(common.EEnvironmentVariable.ShowPerfStates()) != ""
+func shouldDisplayPerfStates() bool {
+	return glcm.GetEnvironmentVariable(common.EEnvironmentVariable.ShowPerfStates()) != ""
 }
 
 func isStdinPipeIn() (bool, error) {

--- a/cmd/jobsResume.go
+++ b/cmd/jobsResume.go
@@ -85,8 +85,8 @@ func (cca *resumeJobController) ReportProgressOrExit(lcm common.LifecycleMgr) {
 	jobDone := summary.JobStatus.IsJobDone()
 
 	// if json is not desired, and job is done, then we generate a special end message to conclude the job
+	duration := time.Now().Sub(cca.jobStartTime) // report the total run time of the job
 	if jobDone {
-		duration := time.Now().Sub(cca.jobStartTime) // report the total run time of the job
 		exitCode := common.EExitCode.Success()
 		if summary.TransfersFailed > 0 {
 			exitCode = common.EExitCode.Error()
@@ -119,24 +119,24 @@ func (cca *resumeJobController) ReportProgressOrExit(lcm common.LifecycleMgr) {
 	cca.intervalBytesTransferred = summary.BytesOverWire
 
 	// indicate whether constrained by disk or not
-	getPerfString := getPerformanceString(summary.IsDiskConstrained, summary.PerfDiagnostics, timeElapsed)
+	perfString, diskString := getPerfDisplayText(summary.PerfStrings, summary.IsDiskConstrained, duration)
 
 	// As there would be case when no bits sent from local, e.g. service side copy, when throughput = 0, hide it.
 	if throughPut == 0 {
-		glcm.Progress(fmt.Sprintf("%v Done, %v Failed, %v Pending, %v Skipped, %v Total%s%s",
+		glcm.Progress(fmt.Sprintf("%v Done, %v Failed, %v Pending, %v Skipped, %v Total%s  %s",
 			summary.TransfersCompleted,
 			summary.TransfersFailed,
 			summary.TotalTransfers-(summary.TransfersCompleted+summary.TransfersFailed+summary.TransfersSkipped),
 			summary.TransfersSkipped,
 			summary.TotalTransfers,
 			scanningString,
-			getPerfString))
+			perfString))
 	} else {
-		glcm.Progress(fmt.Sprintf("%v Done, %v Failed, %v Pending, %v Skipped %v Total %s, 2-sec Throughput (Mb/s): %v%s",
+		glcm.Progress(fmt.Sprintf("%v Done, %v Failed, %v Pending, %v Skipped %v Total %s, %s2-sec Throughput (Mb/s): %v%s",
 			summary.TransfersCompleted,
 			summary.TransfersFailed,
 			summary.TotalTransfers-(summary.TransfersCompleted+summary.TransfersFailed+summary.TransfersSkipped),
-			summary.TransfersSkipped, summary.TotalTransfers, scanningString, ste.ToFixed(throughPut, 4), getPerfString))
+			summary.TransfersSkipped, summary.TotalTransfers, scanningString, perfString, ste.ToFixed(throughPut, 4), diskString))
 	}
 }
 

--- a/cmd/jobsResume.go
+++ b/cmd/jobsResume.go
@@ -118,21 +118,25 @@ func (cca *resumeJobController) ReportProgressOrExit(lcm common.LifecycleMgr) {
 	cca.intervalStartTime = time.Now()
 	cca.intervalBytesTransferred = summary.BytesOverWire
 
+	// indicate whether constrained by disk or not
+	getPerfString := getPerformanceString(summary.IsDiskConstrained, summary.PerfDiagnostics, timeElapsed)
+
 	// As there would be case when no bits sent from local, e.g. service side copy, when throughput = 0, hide it.
 	if throughPut == 0 {
-		glcm.Progress(fmt.Sprintf("%v Done, %v Failed, %v Pending, %v Skipped, %v Total%s",
+		glcm.Progress(fmt.Sprintf("%v Done, %v Failed, %v Pending, %v Skipped, %v Total%s%s",
 			summary.TransfersCompleted,
 			summary.TransfersFailed,
 			summary.TotalTransfers-(summary.TransfersCompleted+summary.TransfersFailed+summary.TransfersSkipped),
 			summary.TransfersSkipped,
 			summary.TotalTransfers,
-			scanningString))
+			scanningString,
+			getPerfString))
 	} else {
-		glcm.Progress(fmt.Sprintf("%v Done, %v Failed, %v Pending, %v Skipped %v Total %s, 2-sec Throughput (Mb/s): %v",
+		glcm.Progress(fmt.Sprintf("%v Done, %v Failed, %v Pending, %v Skipped %v Total %s, 2-sec Throughput (Mb/s): %v%s",
 			summary.TransfersCompleted,
 			summary.TransfersFailed,
 			summary.TotalTransfers-(summary.TransfersCompleted+summary.TransfersFailed+summary.TransfersSkipped),
-			summary.TransfersSkipped, summary.TotalTransfers, scanningString, ste.ToFixed(throughPut, 4)))
+			summary.TransfersSkipped, summary.TotalTransfers, scanningString, ste.ToFixed(throughPut, 4), getPerfString))
 	}
 }
 

--- a/cmd/zt_sync_download_test.go
+++ b/cmd/zt_sync_download_test.go
@@ -180,6 +180,7 @@ func (s *cmdIntegrationSuite) TestSyncDownloadWithEmptyDestination(c *chk.C) {
 	})
 }
 
+/* commented out. Ze will put it back in in his next change
 // regular container->directory sync but destination is identical to the source, transfers are scheduled based on lmt
 func (s *cmdIntegrationSuite) TestSyncDownloadWithIdenticalDestination(c *chk.C) {
 	bsu := getBSU()
@@ -222,7 +223,7 @@ func (s *cmdIntegrationSuite) TestSyncDownloadWithIdenticalDestination(c *chk.C)
 		validateTransfersAreScheduled(c, containerURL.String(), dstDirName, blobList, mockedRPC)
 	})
 }
-
+*/
 // regular container->directory sync where destination is missing some files from source, and also has some extra files
 func (s *cmdIntegrationSuite) TestSyncDownloadWithMismatchedDestination(c *chk.C) {
 	bsu := getBSU()

--- a/common/cacheLimiter.go
+++ b/common/cacheLimiter.go
@@ -63,6 +63,7 @@ func (c *cacheLimiter) TryAddBytes(count int64, useRelaxedLimit bool) (added boo
 		// no backlogging of new chunks behind slow ones (i.e. these "good" cases are allowed to proceed without
 		// interruption) and for uploads its used for re-doing the prefetches when we do retries (i.e. so these are
 		// not blocked by other chunks using up RAM).
+		// TODO: consider using only the upper (100% limit) for uploads
 	}
 
 	if atomic.AddInt64(&c.value, count) <= lim {

--- a/common/cacheLimiter.go
+++ b/common/cacheLimiter.go
@@ -63,7 +63,6 @@ func (c *cacheLimiter) TryAddBytes(count int64, useRelaxedLimit bool) (added boo
 		// no backlogging of new chunks behind slow ones (i.e. these "good" cases are allowed to proceed without
 		// interruption) and for uploads its used for re-doing the prefetches when we do retries (i.e. so these are
 		// not blocked by other chunks using up RAM).
-		// TODO: consider using only the upper (100% limit) for uploads
 	}
 
 	if atomic.AddInt64(&c.value, count) <= lim {

--- a/common/chunkStatusLogger.go
+++ b/common/chunkStatusLogger.go
@@ -79,7 +79,12 @@ func (WaitReason) Cancelled() WaitReason            { return WaitReason{12, "Can
 //     Note: reason it's not using the normal enum approach, where it only has a number, is to try to optimize
 //     the String method below, on the assumption that it will be called a lot.  Is that a premature optimization?
 
-//Upload chunks go through these states, in this order
+// Upload chunks go through these states, in this order.
+// We record this set of states, in this order, so that when we are uploading GetCounts() can return
+// counts for only those states that are relevant to upload (some are not relevant, so they are not in this list)
+// AND so that GetCounts will return the counts in the order that the states actually happen when uploading.
+// That makes it easy for end-users of the counts (i.e. logging and display code) to show the state counts
+// in a meaningful left-to-right sequential order.
 var uploadWaitReasons = []WaitReason{
 	// These first two happen in the transfer initiation function (i.e. the chunkfunc creation loop)
 	// So their total is constrained to the size of the goroutine pool that runs those functions.
@@ -97,6 +102,7 @@ var uploadWaitReasons = []WaitReason{
 }
 
 // Download chunks go through a larger set of states, due to needing to be re-assembled into sequential order
+// See comment on uploadWaitReasons for rationale.
 var downloadWaitReasons = []WaitReason{
 	// Done by the transfer initiation function (i.e. chunkfunc creation loop)
 	EWaitReason.RAMToSchedule(),

--- a/common/chunkStatusLogger.go
+++ b/common/chunkStatusLogger.go
@@ -53,30 +53,12 @@ func NewChunkID(name string, offsetInFile int64) ChunkID {
 
 var EWaitReason = WaitReason{0, ""}
 
+// WaitReason identifies the one thing that a given chunk is waiting on, at a given moment.
+// Basically = state, phrased in terms of "the thing I'm waiting for"
 type WaitReason struct {
 	index int32
 	Name  string
 }
-
-// Upload chunks go through these states:
-// RAM
-// DiskIO
-// Worker
-// Body
-// Disk
-// Done/Cancelled
-
-// Download chunks go through a superset, as follows
-// RAM
-// Worker
-// Head (can easily separate out head/body for uploads)
-// Body
-// (possibly) BodyReRead-*
-// Sorting
-// Prior
-// Queue
-// DiskIO
-// Done/Cancelled
 
 // Head (below) has index between GB and Body, just so the ordering is numerical ascending during typical chunk lifetime for both upload and download
 func (WaitReason) Nothing() WaitReason              { return WaitReason{0, "Nothing"} }            // not waiting for anything
@@ -93,6 +75,56 @@ func (WaitReason) DiskIO() WaitReason               { return WaitReason{10, "Dis
 func (WaitReason) ChunkDone() WaitReason            { return WaitReason{11, "Done"} }              // not waiting on anything. Chunk is done.
 func (WaitReason) Cancelled() WaitReason            { return WaitReason{12, "Cancelled"} }         // transfer was cancelled.  All chunks end with either Done or Cancelled.
 
+// TODO: consider change the above so that they don't create new struct on every call?  Is that necessary/useful?
+//     Note: reason it's not using the normal enum approach, where it only has a number, is to try to optimize
+//     the String method below, on the assumption that it will be called a lot.  Is that a premature optimization?
+
+//Upload chunks go through these states, in this order
+var uploadWaitReasons = []WaitReason{
+	// These first two happen in the transfer initiation function (i.e. the chunkfunc creation loop)
+	// So their total is constrained to the size of the goroutine pool that runs those functions.
+	// (e.g. 64, given the GR pool sizing as at Feb 2019)
+	EWaitReason.RAMToSchedule(),
+	EWaitReason.DiskIO(),
+
+	// This next one is used when waiting for a worker Go routine to pick up the scheduled chunk func.
+	// Chunks in this state are effectively a queue of work waiting to be sent over the network
+	EWaitReason.WorkerGR(),
+
+	// This is the actual network activity
+	EWaitReason.Body(), // header is not separated out for uploads, so is implicitly included here
+	// Plus Done/cancelled, which are not included here because not wanted for GetCounts
+}
+
+// Download chunks go through a larger set of states, due to needing to be re-assembled into sequential order
+var downloadWaitReasons = []WaitReason{
+	// Done by the transfer initiation function (i.e. chunkfunc creation loop)
+	EWaitReason.RAMToSchedule(),
+
+	// Waiting for a work Goroutine to pick up the chunkfunc and execute it.
+	// Chunks in this state are effectively a queue of work, waiting for their network downloads to be initiated
+	EWaitReason.WorkerGR(),
+
+	// These next ones are the actual network activity
+	EWaitReason.HeaderResponse(),
+	EWaitReason.Body(),
+	// next two exist, but are not reported on separately in GetCounts, so are commented out
+	//EWaitReason.BodyReReadDueToMem(),
+	//EWaitReason.BodyReReadDueToSpeed(),
+
+	// Sorting and QueueToWrite together comprise a queue of work waiting to be written to disk.
+	// The former are unsorted, and the latter have been sorted into sequential order.
+	// PriorChunk is unusual, because chunks in that wait state are not (yet) waiting for their turn to be written to disk,
+	// instead they are waiting on some prior chunk to finish arriving over the network
+	EWaitReason.Sorting(),
+	EWaitReason.PriorChunk(),
+	EWaitReason.QueueToWrite(),
+
+	// The actual disk write
+	EWaitReason.DiskIO(),
+	// Plus Done/cancelled, which are not included here because not wanted for GetCounts
+}
+
 func (wr WaitReason) String() string {
 	return string(wr.Name) // avoiding reflection here, for speed, since will be called a lot
 }
@@ -101,17 +133,15 @@ type ChunkStatusLogger interface {
 	LogChunkStatus(id ChunkID, reason WaitReason)
 }
 
-type chunkStatusCount struct {
-	WaitReason WaitReason
-	Count      int64
-}
-
 type ChunkStatusLoggerCloser interface {
 	ChunkStatusLogger
-	GetCounts() []chunkStatusCount
+	GetCounts(isDownload bool) []chunkStatusCount
+	IsDiskConstrained(isUpload, isDownload bool) bool
 	CloseLog()
 }
 
+// chunkStatusLogger records all chunk state transitions, and makes aggregate data immediately available
+// for performance diagnostics. Also optionally logs every individual transition to a file.
 type chunkStatusLogger struct {
 	counts         []int64
 	outputEnabled  bool
@@ -135,58 +165,18 @@ func numWaitReasons() int32 {
 	return EWaitReason.Cancelled().index + 1 // assume this is the last wait reason
 }
 
+type chunkStatusCount struct {
+	WaitReason WaitReason
+	Count      int64
+}
+
 type chunkWaitState struct {
 	ChunkID
 	reason    WaitReason
 	waitStart time.Time
 }
 
-// We maintain running totals of how many chunks are in each state.
-// To do so, we must determine the new state (which is simply a parameter) and the old state.
-// We obtain and track the old state within the chunkID itself. The alternative, of having a threadsafe
-// map in the chunkStatusLogger, to track and look up the states, is considered a risk for performance.
-func (csl *chunkStatusLogger) countStateTransition(id ChunkID, newReason WaitReason) {
-
-	// Flip the chunk's state to indicate the new thing that it's waiting for now
-	oldReasonIndex := atomic.SwapInt32(id.waitReasonIndex, newReason.index)
-
-	// Update the counts
-	// There's no need to lock the array itself. Instead just do atomic operations on the contents.
-	// (See https://groups.google.com/forum/#!topic/Golang-nuts/Ud4Dqin2Shc)
-	if oldReasonIndex > 0 && oldReasonIndex < int32(len(csl.counts)) {
-		atomic.AddInt64(&csl.counts[oldReasonIndex], -1)
-	}
-	if newReason.index < int32(len(csl.counts)) {
-		atomic.AddInt64(&csl.counts[newReason.index], 1)
-	}
-}
-
-// Gets the current counts of chunks in each wait state
-// Intended for performance diagnostics and reporting
-func (csl *chunkStatusLogger) GetCounts() []chunkStatusCount {
-	// get list of all the reasons we want to output
-	// Rare and not-useful ones are excluded
-	allReasons := []WaitReason{
-		//EWaitReason.Nothing(),
-		EWaitReason.RAMToSchedule(),
-		EWaitReason.WorkerGR(),
-		EWaitReason.HeaderResponse(),
-		EWaitReason.Body(),
-		//EWaitReason.BodyReReadDueToMem(),
-		//EWaitReason.BodyReReadDueToSpeed(),
-		EWaitReason.Sorting(),
-		EWaitReason.PriorChunk(),
-		EWaitReason.QueueToWrite(),
-		EWaitReason.DiskIO(),
-		//EWaitReason.ChunkDone(),
-		//EWaitReason.Cancelled(),
-	}
-	result := make([]chunkStatusCount, len(allReasons))
-	for i, reason := range allReasons {
-		result[i] = chunkStatusCount{reason, atomic.LoadInt64(&csl.counts[reason.index])}
-	}
-	return result
-}
+////////////////////////////////////  basic functionality //////////////////////////////////
 
 func (csl *chunkStatusLogger) LogChunkStatus(id ChunkID, reason WaitReason) {
 	// always update the in-memory stats, even if output is disabled
@@ -231,6 +221,104 @@ func (csl *chunkStatusLogger) main(chunkLogPath string) {
 		_, _ = w.WriteString(fmt.Sprintf("%s,%d,%s,%s\n", x.Name, x.OffsetInFile, x.reason, x.waitStart))
 	}
 }
+
+////////////////////////////// aggregate count and analysis support //////////////////////
+
+// We maintain running totals of how many chunks are in each state.
+// To do so, we must determine the new state (which is simply a parameter) and the old state.
+// We obtain and track the old state within the chunkID itself. The alternative, of having a threadsafe
+// map in the chunkStatusLogger, to track and look up the states, is considered a risk for performance.
+func (csl *chunkStatusLogger) countStateTransition(id ChunkID, newReason WaitReason) {
+
+	// Flip the chunk's state to indicate the new thing that it's waiting for now
+	oldReasonIndex := atomic.SwapInt32(id.waitReasonIndex, newReason.index)
+
+	// Update the counts
+	// There's no need to lock the array itself. Instead just do atomic operations on the contents.
+	// (See https://groups.google.com/forum/#!topic/Golang-nuts/Ud4Dqin2Shc)
+	if oldReasonIndex > 0 && oldReasonIndex < int32(len(csl.counts)) {
+		atomic.AddInt64(&csl.counts[oldReasonIndex], -1)
+	}
+	if newReason.index < int32(len(csl.counts)) {
+		atomic.AddInt64(&csl.counts[newReason.index], 1)
+	}
+}
+
+func (csl *chunkStatusLogger) getCount(reason WaitReason) int64 {
+	return atomic.LoadInt64(&csl.counts[reason.index])
+}
+
+// Gets the current counts of chunks in each wait state
+// Intended for performance diagnostics and reporting
+func (csl *chunkStatusLogger) GetCounts(isDownload bool) []chunkStatusCount {
+
+	var allReasons []WaitReason
+	if isDownload {
+		allReasons = downloadWaitReasons
+	} else {
+		allReasons = uploadWaitReasons
+	}
+
+	result := make([]chunkStatusCount, len(allReasons))
+	for i, reason := range allReasons {
+		count := csl.getCount(reason)
+
+		// for simplicity in consuming the results, all the body read states are rolled into one here
+		if reason == EWaitReason.BodyReReadDueToSpeed() || reason == EWaitReason.BodyReReadDueToMem() {
+			panic("body re-reads should not be requested in counts. They get rolled into the main Body one")
+		}
+		if reason == EWaitReason.Body() {
+			count += csl.getCount(EWaitReason.BodyReReadDueToSpeed())
+			count += csl.getCount(EWaitReason.BodyReReadDueToMem())
+		}
+
+		result[i] = chunkStatusCount{reason, count}
+	}
+	return result
+}
+
+func (csl *chunkStatusLogger) IsDiskConstrained(isUpload, isDownload bool) bool {
+	if isUpload {
+		return csl.isUploadDiskConstrained()
+	} else if isDownload {
+		return csl.isDownloadDiskConstrained()
+	} else {
+		return false // it's neither upload nor download (e.g. S2S)
+	}
+}
+
+// is disk the bottleneck in an upload?
+func (csl *chunkStatusLogger) isUploadDiskConstrained() bool {
+	// If we are uploading, and there's almost nothing waiting to go out over the network, then
+	// probably the reason there's not much queued is that the disk is slow.
+	// BTW, we can't usefully look at any of the _earlier_ states, because they happen in the _generation_ of the chunk funcs
+	// (not the _execution_ and so their counts will just tend to equal that of the small goroutine pool that runs them).
+	// It might be convenient if we could compare TWO queue sizes here, as we do in isDownloadDiskConstrained, but unfortunately our
+	// Jan 2019 architecture only gives us ONE useful queue-like state when uploading, so we can't compare two.
+	queueForNetworkIsSmall := csl.getCount(EWaitReason.WorkerGR()) < 10 // TODO: is there any intelligent way to set this threshold? It's just an arbitrary guestimate of "small" at the moment
+
+	beforeGRWaitQueue := csl.getCount(EWaitReason.RAMToSchedule()) + csl.getCount(EWaitReason.DiskIO())
+	areStillReadingDisk := beforeGRWaitQueue > 0 // size of queue for network is irrelevant if we are no longer actually reading disk files, and therefore no longer putting anything into the queue for network
+
+	return areStillReadingDisk && queueForNetworkIsSmall
+}
+
+// is disk the bottleneck in a download?
+func (csl *chunkStatusLogger) isDownloadDiskConstrained() bool {
+	// See how many chunks are waiting on the disk. I.e. are queued before the actual disk state.
+	// Don't include the "PriorChunk" state, because that's not actually waiting on disk at all, it
+	// can mean waiting on network and/or waiting-on-Storage-Service. We don't know which. So we just exclude it from consideration.
+	chunksWaitingOnDisk := csl.getCount(EWaitReason.Sorting()) + csl.getCount(EWaitReason.QueueToWrite())
+
+	// i.e. are queued before the actual network states
+	chunksWaitingOnNetwork := csl.getCount(EWaitReason.WorkerGR())
+
+	// if we have way more stuff waiting on disk than on network, we can assume disk is the bottleneck
+	return chunksWaitingOnDisk > 10 && // this test is in case both are near zero, as they would be near the end of the job
+		chunksWaitingOnDisk > 5*chunksWaitingOnNetwork // TODO: review/tune the arbitrary constant here
+}
+
+///////////////////////////////////// Sample LinqPad query for manual analysis of chunklog /////////////////////////////////////
 
 /* LinqPad query used to analyze/visualize the CSV as is follows:
    Needs CSV driver for LinqPad to open the CSV - e.g. https://github.com/dobrou/CsvLINQPadDriver

--- a/common/environment.go
+++ b/common/environment.go
@@ -62,3 +62,10 @@ func (EnvironmentVariable) ProfileCPU() EnvironmentVariable {
 func (EnvironmentVariable) ProfileMemory() EnvironmentVariable {
 	return EnvironmentVariable{Name: "AZCOPY_PROFILE_MEM"}
 }
+
+func (EnvironmentVariable) ShowPerfStates() EnvironmentVariable {
+	return EnvironmentVariable{
+		Name:        "AZCOPY_SHOW_PERF_STATES",
+		Description: "If set, to anything, on-screen output will include counts of chunks by state",
+	}
+}

--- a/common/rpc-models.go
+++ b/common/rpc-models.go
@@ -133,6 +133,8 @@ type ListJobSummaryResponse struct {
 	TotalBytesEnumerated uint64
 	FailedTransfers      []TransferDetail
 	SkippedTransfers     []TransferDetail
+	IsDiskConstrained    bool
+	PerfDiagnostics      []string
 }
 
 // represents the JobProgressPercentage Summary response for list command when requested the Job Progress Summary for given JobId
@@ -153,6 +155,8 @@ type ListSyncJobSummaryResponse struct {
 	DeleteTransfersCompleted uint32
 	DeleteTransfersFailed    uint32
 	FailedTransfers          []TransferDetail
+	IsDiskConstrained        bool
+	PerfDiagnostics          []string
 }
 
 type ListJobTransfersRequest struct {

--- a/common/rpc-models.go
+++ b/common/rpc-models.go
@@ -134,7 +134,7 @@ type ListJobSummaryResponse struct {
 	FailedTransfers      []TransferDetail
 	SkippedTransfers     []TransferDetail
 	IsDiskConstrained    bool
-	PerfDiagnostics      []string
+	PerfStrings          []string
 }
 
 // represents the JobProgressPercentage Summary response for list command when requested the Job Progress Summary for given JobId
@@ -156,7 +156,7 @@ type ListSyncJobSummaryResponse struct {
 	DeleteTransfersFailed    uint32
 	FailedTransfers          []TransferDetail
 	IsDiskConstrained        bool
-	PerfDiagnostics          []string
+	PerfStrings              []string
 }
 
 type ListJobTransfersRequest struct {

--- a/common/singleChunkReader.go
+++ b/common/singleChunkReader.go
@@ -200,7 +200,7 @@ func (cr *singleChunkReader) blockingPrefetch(fileReader io.ReaderAt, isRetry bo
 	cr.buffer = cr.slicePool.RentSlice(uint32Checked(cr.length))
 
 	// read bytes into the buffer
-	cr.chunkLogger.LogChunkStatus(cr.chunkId, EWaitReason.Disk())
+	cr.chunkLogger.LogChunkStatus(cr.chunkId, EWaitReason.DiskIO())
 	totalBytesRead, err := fileReader.ReadAt(cr.buffer, cr.chunkId.OffsetInFile)
 	if err != nil && err != io.EOF {
 		return err

--- a/ste/init.go
+++ b/ste/init.go
@@ -458,8 +458,7 @@ func GetJobSummary(jobID common.JobID) common.ListJobSummaryResponse {
 	// Get the number of active go routines performing the transfer or executing the chunk Func
 	// TODO: added for debugging purpose. remove later
 	js.ActiveConnections = jm.ActiveConnections()
-	js.IsDiskConstrained = jm.IsDiskConstrained()
-	js.PerfDiagnostics = jm.GetPerfStrings()
+	js.PerfStrings, js.IsDiskConstrained = jm.GetPerfInfo()
 
 	// If the status is cancelled, then no need to check for completerJobOrdered
 	// since user must have provided the consent to cancel an incompleteJob if that
@@ -585,8 +584,7 @@ func GetSyncJobSummary(jobID common.JobID) common.ListSyncJobSummaryResponse {
 	// Get the number of active go routines performing the transfer or executing the chunk Func
 	// TODO: added for debugging purpose. remove later
 	js.ActiveConnections = jm.ActiveConnections()
-	js.IsDiskConstrained = jm.IsDiskConstrained()
-	js.PerfDiagnostics = jm.GetPerfStrings()
+	js.PerfStrings, js.IsDiskConstrained = jm.GetPerfInfo()
 
 	// If the status is cancelled, then no need to check for completerJobOrdered
 	// since user must have provided the consent to cancel an incompleteJob if that

--- a/ste/init.go
+++ b/ste/init.go
@@ -458,6 +458,8 @@ func GetJobSummary(jobID common.JobID) common.ListJobSummaryResponse {
 	// Get the number of active go routines performing the transfer or executing the chunk Func
 	// TODO: added for debugging purpose. remove later
 	js.ActiveConnections = jm.ActiveConnections()
+	js.IsDiskConstrained = jm.IsDiskConstrained()
+	js.PerfDiagnostics = jm.GetPerfStrings()
 
 	// If the status is cancelled, then no need to check for completerJobOrdered
 	// since user must have provided the consent to cancel an incompleteJob if that
@@ -583,6 +585,8 @@ func GetSyncJobSummary(jobID common.JobID) common.ListSyncJobSummaryResponse {
 	// Get the number of active go routines performing the transfer or executing the chunk Func
 	// TODO: added for debugging purpose. remove later
 	js.ActiveConnections = jm.ActiveConnections()
+	js.IsDiskConstrained = jm.IsDiskConstrained()
+	js.PerfDiagnostics = jm.GetPerfStrings()
 
 	// If the status is cancelled, then no need to check for completerJobOrdered
 	// since user must have provided the consent to cancel an incompleteJob if that

--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -176,11 +176,15 @@ func (jm *jobMgr) IsDiskConstrained() bool {
 // GetPerfStrings returns strings that may be logged for performance diagnostic purposes
 // The number and content of strings may change as we enhance our perf diagnostics
 func (jm *jobMgr) GetPerfStrings() []string {
+	const format = "%c: %2d"
 	chunkStateCounts := jm.chunkStatusLogger.GetCounts()
-	result := make([]string, len(chunkStateCounts))
+	result := make([]string, len(chunkStateCounts)+1)
+	total := int64(0)
 	for i, c := range chunkStateCounts {
-		result[i] = fmt.Sprintf("%c: %d", c.WaitReason.Name[0], c.Count)
+		result[i] = fmt.Sprintf(format, c.WaitReason.Name[0], c.Count)
+		total += c.Count
 	}
+	result[len(result)-1] = fmt.Sprintf(format, 'T', total)
 	return result
 }
 

--- a/ste/xfer-localToRemote.go
+++ b/ste/xfer-localToRemote.go
@@ -139,7 +139,7 @@ func scheduleUploadChunks(jptm IJobPartTransferMgr, srcName string, srcFile comm
 	safeToUseHash := true
 	for startIndex := int64(0); startIndex < fileSize || isDummyChunkInEmptyFile(startIndex, fileSize); startIndex += int64(chunkSize) {
 
-		id := common.ChunkID{Name: srcName, OffsetInFile: startIndex}
+		id := common.NewChunkID(srcName, startIndex)
 		adjustedChunkSize := int64(chunkSize)
 
 		// compute actual size of the chunk

--- a/ste/xfer-remoteToLocal.go
+++ b/ste/xfer-remoteToLocal.go
@@ -136,7 +136,7 @@ func remoteToLocal(jptm IJobPartTransferMgr, p pipeline.Pipeline, pacer *pacer, 
 
 	chunkCount := uint32(0)
 	for startIndex := int64(0); startIndex < fileSize; startIndex += downloadChunkSize {
-		id := common.ChunkID{Name: info.Destination, OffsetInFile: startIndex}
+		id := common.NewChunkID(info.Destination, startIndex)
 		adjustedChunkSize := downloadChunkSize
 
 		// compute exact size of the chunk


### PR DESCRIPTION
Logs show counts of chunks in each state, every 2 seconds, and also show a conclusion drawn from those states - namely whether disk perf is constraining overall throughput.

And on screen you normally just see “(disk may be limiting speed)” pop onto the end of the output line (after the speed), when applicable.  But, if you set the environment variable AZCOPY_SHOW_PERF_STATES (set it to anything), you’ll see the states and counts on screen too.

What do the states mean? They are counts of chunks in all the different states that a chunk goes through in the app, with the first state on the left, and the last second-from right. (T, on the far right, is for total). What can be inferred from that (by an expert reader):
- Is disk too slow? (also to user by the message described above)
- Do we have too few goroutines?
- Have we allocated too little RAM?
- And (loosely) are downloads held up by MD5 calcs?
- etc

What do the specific letters mean?  Each state has a name, and the letters are the first letters of their names.  Details of each state is documented in the source.