### PR TITLE
Fix/prevent double counting

### DIFF
--- a/ste/uploader.go
+++ b/ste/uploader.go
@@ -112,7 +112,7 @@ func createChunkFunc(setDoneStatusOnExit bool, jptm IJobPartTransferMgr, id comm
 	return func(workerId int) {
 
 		// BEGIN standard prefix that all chunk funcs need
-		defer jptm.ReportChunkDone() // whether successful or failed, it's always "done" and we must always tell the jptm
+		defer jptm.ReportChunkDone(id) // whether successful or failed, it's always "done" and we must always tell the jptm
 
 		jptm.OccupyAConnection() // TODO: added the two operations for debugging purpose. remove later
 		defer jptm.ReleaseAConnection()

--- a/ste/xfer-URLToBlob.go
+++ b/ste/xfer-URLToBlob.go
@@ -229,7 +229,7 @@ func (bbc *blockBlobCopy) generateCopyURLToBlockBlobFunc(chunkId int32, startInd
 			if bbc.jptm.ShouldLog(pipeline.LogDebug) {
 				bbc.jptm.Log(pipeline.LogDebug, fmt.Sprintf("Transfer cancelled. not picking up chunk %d", chunkId))
 			}
-			if lastChunk, _ := bbc.jptm.ReportChunkDone(); lastChunk {
+			if lastChunk, _ := bbc.jptm.UnsafeReportChunkDone(); lastChunk {
 				if bbc.jptm.ShouldLog(pipeline.LogDebug) {
 					bbc.jptm.Log(pipeline.LogDebug, "Finalizing transfer cancellation")
 				}
@@ -266,7 +266,7 @@ func (bbc *blockBlobCopy) generateCopyURLToBlockBlobFunc(chunkId int32, startInd
 				}
 			}
 
-			if lastChunk, _ := bbc.jptm.ReportChunkDone(); lastChunk {
+			if lastChunk, _ := bbc.jptm.UnsafeReportChunkDone(); lastChunk {
 				if bbc.jptm.ShouldLog(pipeline.LogDebug) {
 					bbc.jptm.Log(pipeline.LogDebug, "Finalizing transfer cancellation")
 				}
@@ -276,7 +276,7 @@ func (bbc *blockBlobCopy) generateCopyURLToBlockBlobFunc(chunkId int32, startInd
 		}
 
 		// step 4: check if this is the last chunk
-		if lastChunk, _ := bbc.jptm.ReportChunkDone(); lastChunk {
+		if lastChunk, _ := bbc.jptm.UnsafeReportChunkDone(); lastChunk {
 			// If the transfer gets cancelled before the putblock list
 			if bbc.jptm.WasCanceled() {
 				transferDone()


### PR DESCRIPTION
Defensive programming to protect against a couple of potential errors which would hurt file integrity.  This change guards against double counting of chunks or transfers.