### PR TITLE
Reduce memory usage, especially with many small files

### DIFF
--- a/common/multiSizeSlicePool.go
+++ b/common/multiSizeSlicePool.go
@@ -187,7 +187,7 @@ func (mp *multiSizeSlicePool) ReturnSlice(slice []byte) {
 }
 
 // Prune inactive stuff in all the big slots if due (don't worry about the little ones, they don't eat much RAM)
-// Why do this? Because for the large slot sizes its hard to deal with slots that are full and IDLE idle.
+// Why do this? Because for the large slot sizes its hard to deal with slots that are full and IDLE.
 // I.e. we were using them, but now we're working with other files in the same job that have different chunk sizes,
 // so we have a pool slot that's full of slices that are no longer getting used.
 // Would it work to just give the slot a very small max capacity? Maybe. E.g. max number in slot = 4 for the 128 MB slot.

--- a/common/multiSizeSlicePool.go
+++ b/common/multiSizeSlicePool.go
@@ -29,6 +29,7 @@ import (
 type ByteSlicePooler interface {
 	RentSlice(desiredLength uint32) []byte
 	ReturnSlice(slice []byte)
+	Prune()
 }
 
 // Pools byte slices of a single size.
@@ -86,11 +87,16 @@ func NewMultiSizeSlicePool(maxSliceLength uint32) ByteSlicePooler {
 	maxSlotIndex, _ := getSlotInfo(maxSliceLength)
 	poolsBySize := make([]*simpleSlicePool, maxSlotIndex+1)
 	for i := 0; i <= maxSlotIndex; i++ {
-		poolsBySize[i] = newSimpleSlicePool(1000) // TODO: review capacity (setting too low doesn't break anything, since we don't block when full, so maybe only 100 or so is OK?)
+		maxCount := getMaxSliceCountInPool(i)
+		poolsBySize[i] = newSimpleSlicePool(maxCount)
 	}
 	return &multiSizeSlicePool{poolsBySize: poolsBySize}
 }
 
+var indexOf32KSlot, _ = getSlotInfo(32 * 1024)
+
+// For a given requested len(slice), this returns the slot index to use, and the max
+// cap(slice) of the slices that will be found at that index
 func getSlotInfo(exactSliceLength uint32) (slotIndex int, maxCapInSlot int) {
 	if exactSliceLength <= 0 {
 		panic("exact slice length must be greater than zero")
@@ -119,6 +125,24 @@ func getSlotInfo(exactSliceLength uint32) (slotIndex int, maxCapInSlot int) {
 	maxCapInSlot = 1 << uint(slotIndex)
 
 	return
+}
+
+func holdsSmallSlices(slotIndex int) bool {
+	return slotIndex <= indexOf32KSlot
+}
+
+// For a given slot index, this returns the max number of pooled slices which the pool at
+// that index should be allowed to hold.
+func getMaxSliceCountInPool(slotIndex int) int {
+	if holdsSmallSlices(slotIndex) {
+		// Choose something fairly high for these because there's no significant RAM
+		// cost in doing so, and small files are a tricky case for perf so let's give
+		// them all the pooling help we can
+		return 500
+	} else {
+		// Limit the medium and large ones a bit more strictly.
+		return 100
+	}
 }
 
 // RentSlice borrows a slice from the pool (or creates a new one if none of suitable capacity is available)
@@ -160,4 +184,25 @@ func (mp *multiSizeSlicePool) ReturnSlice(slice []byte) {
 
 	// put the slice back into the pool
 	pool.Put(slice)
+}
+
+// Prune inactive stuff in all the big slots if due (don't worry about the little ones, they don't eat much RAM)
+// Why do this? Because for the large slot sizes its hard to deal with slots that are full and IDLE idle.
+// I.e. we were using them, but now we're working with other files in the same job that have different chunk sizes,
+// so we have a pool slot that's full of slices that are no longer getting used.
+// Would it work to just give the slot a very small max capacity? Maybe. E.g. max number in slot = 4 for the 128 MB slot.
+// But can we be confident that 4 is enough for the pooling to have the desired benefits?  Not sure.
+// Hence the pruning, so that we don't need to set the fixed limits that low.  With pruning, the count will (gradually)
+// come down only when the slot is IDLE.
+func (mp *multiSizeSlicePool) Prune() {
+	for index := 0; index < len(mp.poolsBySize); index++ {
+		shouldPrune := !holdsSmallSlices(index)
+		if shouldPrune {
+			// Get one item from the pool and throw it away.
+			// With repeated calls of Prune, this will gradually drain idle pools.
+			// But, since Prune is not called very often,
+			// it won't have much adverse impact on active pools.
+			_ = mp.poolsBySize[index].Get()
+		}
+	}
 }

--- a/main.go
+++ b/main.go
@@ -66,6 +66,6 @@ func main() {
 func configureGC() {
 	go func() {
 		time.Sleep(20 * time.Second) // wait a little, so that our initial pool of buffers can get allocated without heaps of (unnecessary) GC activity
-		debug.SetGCPercent(20)       // active more aggressive/frequent GC than the default
+		debug.SetGCPercent(20)       // activate more aggressive/frequent GC than the default
 	}()
 }

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ import (
 	"log"
 	"os"
 	"runtime"
+	"runtime/debug"
 )
 
 // get the lifecycle manager to print messages
@@ -51,7 +52,16 @@ func main() {
 		log.Fatalf("initialization failed: %v", err)
 	}
 
+	configureGC()
+
 	ste.MainSTE(common.ComputeConcurrencyValue(runtime.NumCPU()), 2400, azcopyAppPathFolder, azcopyLogPathFolder)
 	cmd.Execute(azcopyAppPathFolder, azcopyLogPathFolder)
 	glcm.Exit("", common.EExitCode.Success())
+}
+
+// Golang's default behaviour is to GC when new objects = (100% of) total of objects surviving previous GC.
+// But our "survivors" add up to many GB, so its hard for users to be confident that we don't have
+// a memory leak (since with that default setting new GCs are very rare in our case). So configure them to be more frequent.
+func configureGC() {
+	debug.SetGCPercent(15)
 }

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"runtime"
 	"runtime/debug"
+	"time"
 )
 
 // get the lifecycle manager to print messages
@@ -63,5 +64,8 @@ func main() {
 // But our "survivors" add up to many GB, so its hard for users to be confident that we don't have
 // a memory leak (since with that default setting new GCs are very rare in our case). So configure them to be more frequent.
 func configureGC() {
-	debug.SetGCPercent(15)
+	go func() {
+		time.Sleep(20 * time.Second) // wait a little, so that our initial pool of buffers can get allocated without heaps of (unnecessary) GC activity
+		debug.SetGCPercent(20)       // active more aggressive/frequent GC than the default
+	}()
 }

--- a/ste/JobsAdmin.go
+++ b/ste/JobsAdmin.go
@@ -130,10 +130,12 @@ func initJobsAdmin(appCtx context.Context, concurrentConnections int, targetRate
 	// TODO: make ram usage configurable, with the following as just the default
 	// Decide on a max amount of RAM we are willing to use. This functions as a cap, and prevents excessive usage.
 	// There's no measure of physical RAM in the STD library, so we guestimate conservatively, based on  CPU count (logical, not phyiscal CPUs)
-	const gbToUsePerCpu = 0.6 // should be enough to support the amount of traffic 1 CPU can drive, and also less than the typical installed RAM-per-CPU
+	// Note that, as at Feb 2019, the multiSizeSlicePooler uses additional RAM, over this level, since it includes the cache of
+	// currently-unnused, re-useable slices, that is not tracked by cacheLimiter.
+	const gbToUsePerCpu = 0.5 // should be enough to support the amount of traffic 1 CPU can drive, and also less than the typical installed RAM-per-CPU
 	gbToUse := float32(runtime.NumCPU()) * gbToUsePerCpu
-	if gbToUse > 8 {
-		gbToUse = 8 // cap it. We don't need more than this. Even 6 is enough at 10 Gbps with standard chunk sizes, but allow a little extra here to help if larger blob block sizes are selected by user
+	if gbToUse > 10 {
+		gbToUse = 10 // cap it. Even 6 is enough at 10 Gbps with standard chunk sizes, but allow a little extra here to help if larger blob block sizes are selected by user
 	}
 	maxRamBytesToUse := int64(gbToUse * 1024 * 1024 * 1024)
 

--- a/ste/JobsAdmin.go
+++ b/ste/JobsAdmin.go
@@ -130,10 +130,10 @@ func initJobsAdmin(appCtx context.Context, concurrentConnections int, targetRate
 	// TODO: make ram usage configurable, with the following as just the default
 	// Decide on a max amount of RAM we are willing to use. This functions as a cap, and prevents excessive usage.
 	// There's no measure of physical RAM in the STD library, so we guestimate conservatively, based on  CPU count (logical, not phyiscal CPUs)
-	const gbToUsePerCpu = 0.6  // should be enough to support the amount of traffic 1 CPU can drive, and also less than the typical installed RAM-per-CPU
+	const gbToUsePerCpu = 0.6 // should be enough to support the amount of traffic 1 CPU can drive, and also less than the typical installed RAM-per-CPU
 	gbToUse := float32(runtime.NumCPU()) * gbToUsePerCpu
 	if gbToUse > 8 {
-		gbToUse = 8     // cap it. We don't need more than this. Even 6 is enough at 10 Gbps with standard chunk sizes, but allow a little extra here to help if larger blob block sizes are selected by user
+		gbToUse = 8 // cap it. We don't need more than this. Even 6 is enough at 10 Gbps with standard chunk sizes, but allow a little extra here to help if larger blob block sizes are selected by user
 	}
 	maxRamBytesToUse := int64(gbToUse * 1024 * 1024 * 1024)
 
@@ -164,6 +164,9 @@ func initJobsAdmin(appCtx context.Context, concurrentConnections int, targetRate
 	ja.appCtx = context.WithValue(ja.appCtx, ServiceAPIVersionOverride, DefaultServiceApiVersion)
 
 	JobsAdmin = ja
+
+	// Spin up slice pool pruner
+	go ja.slicePoolPruneLoop()
 
 	// One routine constantly monitors the partsChannel.  It takes the JobPartManager from
 	// the Channel and schedules the transfers of that JobPart.
@@ -212,7 +215,7 @@ func (ja *jobsAdmin) chunkProcessor(workerID int) {
 		// We check for suicides first to shrink goroutine pool
 		// Then, we check chunks: normal & low priority
 		select {
-		case <-ja.xferChannels.suicideCh:   // note: as at Dec 2018, this channel is not (yet) used
+		case <-ja.xferChannels.suicideCh: // note: as at Dec 2018, this channel is not (yet) used
 			return
 		default:
 			select {
@@ -224,10 +227,10 @@ func (ja *jobsAdmin) chunkProcessor(workerID int) {
 					chunkFunc(workerID)
 				default:
 					time.Sleep(100 * time.Millisecond) // Sleep before looping around
-					                                   // TODO: Question: In order to safely support high goroutine counts,
-					                                   // do we need to review sleep duration, or find an approach that does not require waking every x milliseconds
-					                                   // For now, duration has been increased substantially from the previous 1 ms, to reduce cost of
-					                                   // the wake-ups.
+					// TODO: Question: In order to safely support high goroutine counts,
+					// do we need to review sleep duration, or find an approach that does not require waking every x milliseconds
+					// For now, duration has been increased substantially from the previous 1 ms, to reduce cost of
+					// the wake-ups.
 				}
 			}
 		}
@@ -282,7 +285,7 @@ type jobsAdmin struct {
 	xferChannels        XferChannels
 	appCtx              context.Context
 	pacer               *pacer
-	slicePool 			common.ByteSlicePooler
+	slicePool           common.ByteSlicePooler
 	cacheLimiter        common.CacheLimiter
 }
 
@@ -477,6 +480,23 @@ func (ja *jobsAdmin) ShouldLog(level pipeline.LogLevel) bool  { return ja.logger
 func (ja *jobsAdmin) Log(level pipeline.LogLevel, msg string) { ja.logger.Log(level, msg) }
 func (ja *jobsAdmin) Panic(err error)                         { ja.logger.Panic(err) }
 func (ja *jobsAdmin) CloseLog()                               { ja.logger.CloseLog() }
+
+func (ja *jobsAdmin) slicePoolPruneLoop() {
+	// if something in the pool has been unused for this long, we probably don't need it
+	const pruneInterval = 5 * time.Second
+
+	ticker := time.NewTicker(pruneInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			ja.slicePool.Prune()
+		case <-ja.appCtx.Done():
+			break
+		}
+	}
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
For the small-files scenario:

* Reduce max slice count in pools
* Set GC Percent based on allocation patterns in this app. (I.e. lots of permanently-allocated big buffers up front, then nothing changes much... but we still want those relatively small later changes to be GC, even if they are small relative to the RAM occupied by the big buffers).

And, related, for big files:
* Gradually prune out contents of idle pools