### PR TITLE
Fix/too many open files in download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -318,6 +318,7 @@ __pycache__/
 
 # Project executable
 azure-storage-azcopy.exe
+azure-storage-azcopy
 testSuite/testSuite.exe
 *.exe
 

--- a/cmd/credentialUtil.go
+++ b/cmd/credentialUtil.go
@@ -277,7 +277,8 @@ func createBlobPipeline(ctx context.Context, credInfo common.CredentialInfo) (pi
 			RetryDelay:    ste.UploadRetryDelay,
 			MaxRetryDelay: ste.UploadMaxRetryDelay,
 		},
-		nil), nil
+		nil,
+		ste.NewAzcopyHTTPClient()), nil
 }
 
 func createBlobFSPipeline(ctx context.Context, credInfo common.CredentialInfo) (pipeline.Pipeline, error) {

--- a/common/cacheLimiter.go
+++ b/common/cacheLimiter.go
@@ -29,14 +29,15 @@ import (
 
 type Predicate func() bool
 
-// Used to limit the amount of in-flight data in RAM, to keep it an an acceptable level.
-// For downloads, network is producer and disk is consumer, while for uploads the roles are reversed.
+// Used to limit the amounts of things. E.g. amount of in-flight data in RAM, to keep it an an acceptable level.
+// Also used for number of open files (since that's limited on Linux).
+// In the case of RAM usage, for downloads, network is producer and disk is consumer, while for uploads the roles are reversed.
 // In either case, if the producer is faster than the consumer, this CacheLimiter is necessary
-// prevent unbounded RAM usage
+// prevent unbounded RAM usage.
 type CacheLimiter interface {
-	TryAddBytes(count int64, useRelaxedLimit bool) (added bool)
-	WaitUntilAddBytes(ctx context.Context, count int64, useRelaxedLimit Predicate) error
-	RemoveBytes(count int64)
+	TryAdd(count int64, useRelaxedLimit bool) (added bool)
+	WaitUntilAdd(ctx context.Context, count int64, useRelaxedLimit Predicate) error
+	Remove(count int64)
 }
 
 type cacheLimiter struct {
@@ -49,7 +50,7 @@ func NewCacheLimiter(limit int64) CacheLimiter {
 }
 
 // TryAddBytes tries to add a memory allocation within the limit.  Returns true if it could be (and was) added
-func (c *cacheLimiter) TryAddBytes(count int64, useRelaxedLimit bool) (added bool) {
+func (c *cacheLimiter) TryAdd(count int64, useRelaxedLimit bool) (added bool) {
 	lim := c.limit
 
 	// Above the "strict" limit, there's a bit of extra room, which we use
@@ -63,6 +64,8 @@ func (c *cacheLimiter) TryAddBytes(count int64, useRelaxedLimit bool) (added boo
 		// no backlogging of new chunks behind slow ones (i.e. these "good" cases are allowed to proceed without
 		// interruption) and for uploads its used for re-doing the prefetches when we do retries (i.e. so these are
 		// not blocked by other chunks using up RAM).
+		// TODO: now that cacheLimiter is used for multiple purposes, the hard-coding of the distinction between
+		//   relaxed and strict limits is less appropriate. Refactor to make it a configuration param of the instance?
 	}
 
 	if atomic.AddInt64(&c.value, count) <= lim {
@@ -74,10 +77,10 @@ func (c *cacheLimiter) TryAddBytes(count int64, useRelaxedLimit bool) (added boo
 }
 
 /// WaitUntilAddBytes blocks until it completes a successful call to TryAddBytes
-func (c *cacheLimiter) WaitUntilAddBytes(ctx context.Context, count int64, useRelaxedLimit Predicate) error {
+func (c *cacheLimiter) WaitUntilAdd(ctx context.Context, count int64, useRelaxedLimit Predicate) error {
 	for {
 		// Proceed if there's room in the cache
-		if c.TryAddBytes(count, useRelaxedLimit()) {
+		if c.TryAdd(count, useRelaxedLimit()) {
 			return nil
 		}
 
@@ -97,7 +100,7 @@ func (c *cacheLimiter) WaitUntilAddBytes(ctx context.Context, count int64, useRe
 	}
 }
 
-func (c *cacheLimiter) RemoveBytes(count int64) {
+func (c *cacheLimiter) Remove(count int64) {
 	negativeDelta := -count
 	atomic.AddInt64(&c.value, negativeDelta)
 }

--- a/common/cacheLimiter.go
+++ b/common/cacheLimiter.go
@@ -38,6 +38,7 @@ type CacheLimiter interface {
 	TryAdd(count int64, useRelaxedLimit bool) (added bool)
 	WaitUntilAdd(ctx context.Context, count int64, useRelaxedLimit Predicate) error
 	Remove(count int64)
+	Limit() int64
 }
 
 type cacheLimiter struct {
@@ -103,4 +104,8 @@ func (c *cacheLimiter) WaitUntilAdd(ctx context.Context, count int64, useRelaxed
 func (c *cacheLimiter) Remove(count int64) {
 	negativeDelta := -count
 	atomic.AddInt64(&c.value, negativeDelta)
+}
+
+func (c *cacheLimiter) Limit() int64 {
+	return c.limit
 }

--- a/common/singleChunkReader.go
+++ b/common/singleChunkReader.go
@@ -194,7 +194,7 @@ func (cr *singleChunkReader) blockingPrefetch(fileReader io.ReaderAt, isRetry bo
 	// here doing retries, but no RAM _will_ become available because its
 	// all used by queued chunkfuncs (that can't be processed because all goroutines are active).
 	cr.chunkLogger.LogChunkStatus(cr.chunkId, EWaitReason.RAMToSchedule())
-	err := cr.cacheLimiter.WaitUntilAddBytes(cr.ctx, cr.length, func() bool { return isRetry })
+	err := cr.cacheLimiter.WaitUntilAdd(cr.ctx, cr.length, func() bool { return isRetry })
 	if err != nil {
 		return err
 	}
@@ -318,7 +318,7 @@ func (cr *singleChunkReader) returnBuffer() {
 		return
 	}
 	cr.slicePool.ReturnSlice(cr.buffer)
-	cr.cacheLimiter.RemoveBytes(int64(len(cr.buffer)))
+	cr.cacheLimiter.Remove(int64(len(cr.buffer)))
 	cr.buffer = nil
 }
 

--- a/main_windows.go
+++ b/main_windows.go
@@ -21,6 +21,7 @@
 package main
 
 import (
+	"math"
 	"os"
 	"os/exec"
 	"path"
@@ -39,9 +40,14 @@ func osModifyProcessCommand(cmd *exec.Cmd) *exec.Cmd {
 // ProcessOSSpecificInitialization chnages the soft limit for filedescriptor for process
 // return the filedescriptor limit for process. If the function fails with some, it returns
 // the error
-// TODO: this api is implemented for windows as well but not required.
+// TODO: this api is implemented for windows as well but not required because Windows
+// does not default to a precise low limit like Linux does
 func ProcessOSSpecificInitialization() (int, error) {
-	return 0, nil
+
+	// this exaggerates what's possible, but is accurate enough for our purposes, in which our goal is simply to apply no specific limit on Windows
+	const effectivelyUnlimited = math.MaxInt32
+
+	return effectivelyUnlimited, nil
 }
 
 // GetAzCopyAppPath returns the path of Azcopy in local appdata.

--- a/ste/JobsAdmin.go
+++ b/ste/JobsAdmin.go
@@ -182,10 +182,12 @@ func initJobsAdmin(appCtx context.Context, concurrentConnections int, concurrent
 	// out progress on already-scheduled chunks. (Not sure whether that can really happen, but this protects against it
 	// anyway.)
 	// Perhaps MORE importantly, doing this separately gives us more CONTROL over how we interact with the file system.
-	for cc := 0; cc < 64; cc++ {
+	for cc := 0; cc < NumTransferInitiationRoutines; cc++ {
 		go ja.transferProcessor(cc)
 	}
 }
+
+const NumTransferInitiationRoutines = 64 // TODO make this configurable
 
 // QueueJobParts puts the given JobPartManager into the partChannel
 // from where this JobPartMgr will be picked by a routine and

--- a/ste/init.go
+++ b/ste/init.go
@@ -49,9 +49,9 @@ func ToFixed(num float64, precision int) float64 {
 }
 
 // MainSTE initializes the Storage Transfer Engine
-func MainSTE(concurrentConnections int, targetRateInMBps int64, azcopyAppPathFolder, azcopyLogPathFolder string) error {
+func MainSTE(concurrentConnections int, concurrentFilesLimit int, targetRateInMBps int64, azcopyAppPathFolder, azcopyLogPathFolder string) error {
 	// Initialize the JobsAdmin, resurrect Job plan files
-	initJobsAdmin(steCtx, concurrentConnections, targetRateInMBps, azcopyAppPathFolder, azcopyLogPathFolder)
+	initJobsAdmin(steCtx, concurrentConnections, concurrentFilesLimit, targetRateInMBps, azcopyAppPathFolder, azcopyLogPathFolder)
 	// No need to read the existing JobPartPlan files since Azcopy is running in process
 	//JobsAdmin.ResurrectJobParts()
 	// TODO: We may want to list listen first and terminate if there is already an instance listening

--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -212,8 +212,9 @@ func (jm *jobMgr) AddJobPart(partNum PartNumber, planFile JobPartPlanFileName, s
 	destinationSAS string, scheduleTransfers bool) IJobPartMgr {
 	jpm := &jobPartMgr{jobMgr: jm, filename: planFile, sourceSAS: sourceSAS,
 		destinationSAS: destinationSAS, pacer: JobsAdmin.(*jobsAdmin).pacer,
-		slicePool:    JobsAdmin.(*jobsAdmin).slicePool,
-		cacheLimiter: JobsAdmin.(*jobsAdmin).cacheLimiter}
+		slicePool:        JobsAdmin.(*jobsAdmin).slicePool,
+		cacheLimiter:     JobsAdmin.(*jobsAdmin).cacheLimiter,
+		fileCountLimiter: JobsAdmin.(*jobsAdmin).fileCountLimiter}
 	jpm.planMMF = jpm.filename.Map()
 	jm.jobPartMgrs.Set(partNum, jpm)
 	jm.finalPartOrdered = jpm.planMMF.Plan().IsFinalPart

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -70,6 +70,8 @@ func NewVersionPolicyFactory() pipeline.Factory {
 	})
 }
 
+const AzCopyMaxIdleConnsPerHost = 500
+
 func newAzcopyHTTPClient() *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{
@@ -81,7 +83,7 @@ func newAzcopyHTTPClient() *http.Client {
 				DualStack: true,
 			}).Dial, /*Context*/
 			MaxIdleConns:           0, // No limit
-			MaxIdleConnsPerHost:    1000,
+			MaxIdleConnsPerHost:    AzCopyMaxIdleConnsPerHost,
 			IdleConnTimeout:        180 * time.Second,
 			TLSHandshakeTimeout:    10 * time.Second,
 			ExpectContinueTimeout:  1 * time.Second,

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -70,6 +70,15 @@ func NewVersionPolicyFactory() pipeline.Factory {
 	})
 }
 
+// Max number of idle connections per host, to be held in the connection pool inside HTTP client.
+// This use to be 1000, but each consumes a handle, and on Linux total file/network handle counts can be
+// tightly constrained, possibly to as low as 1024 in total. So we want a lower figure than 1000.
+// 500 ought to be enough because this figure is about pooling temporarily un-used connections.
+// Our max number of USED connections, at any one moment in time, is set by AZCOPY_CONCURRENCY_VALUE
+// which, as at Mar 2019, defaults to 300.  Because connections are constantly released and use by that pool
+// of 300 goroutines, its reasonable to assume that the total number of momentarily-
+// UNused connections will be much smaller than the number USED, i.e. much less than 300.  So this figure
+// we set here should be MORE than enough.
 const AzCopyMaxIdleConnsPerHost = 500
 
 // NewAzcopyHTTPClient creates a new HTTP client.

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -39,6 +39,7 @@ type IJobPartMgr interface {
 	ReleaseAConnection()
 	SlicePool() common.ByteSlicePooler
 	CacheLimiter() common.CacheLimiter
+	FileCountLimiter() common.CacheLimiter
 	LogChunkStatus(id common.ChunkID, reason common.WaitReason)
 	common.ILogger
 	SourceProviderPipeline() pipeline.Pipeline
@@ -210,7 +211,8 @@ type jobPartMgr struct {
 
 	slicePool common.ByteSlicePooler
 
-	cacheLimiter common.CacheLimiter
+	cacheLimiter     common.CacheLimiter
+	fileCountLimiter common.CacheLimiter
 
 	pipeline pipeline.Pipeline // ordered list of Factory objects and an object implementing the HTTPSender interface
 
@@ -472,6 +474,10 @@ func (jpm *jobPartMgr) SlicePool() common.ByteSlicePooler {
 
 func (jpm *jobPartMgr) CacheLimiter() common.CacheLimiter {
 	return jpm.cacheLimiter
+}
+
+func (jpm *jobPartMgr) FileCountLimiter() common.CacheLimiter {
+	return jpm.fileCountLimiter
 }
 
 func (jpm *jobPartMgr) StartJobXfer(jptm IJobPartTransferMgr) {

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -30,6 +30,7 @@ type IJobPartTransferMgr interface {
 	Context() context.Context
 	SlicePool() common.ByteSlicePooler
 	CacheLimiter() common.CacheLimiter
+	FileCountLimiter() common.CacheLimiter
 	StartJobXfer()
 	IsForceWriteTrue() bool
 	ReportChunkDone(id common.ChunkID) (lastChunk bool, chunksDone uint32)
@@ -225,6 +226,10 @@ func (jptm *jobPartTransferMgr) SlicePool() common.ByteSlicePooler {
 
 func (jptm *jobPartTransferMgr) CacheLimiter() common.CacheLimiter {
 	return jptm.jobPartMgr.CacheLimiter()
+}
+
+func (jptm *jobPartTransferMgr) FileCountLimiter() common.CacheLimiter {
+	return jptm.jobPartMgr.FileCountLimiter()
 }
 
 func (jptm *jobPartTransferMgr) RescheduleTransfer() {

--- a/testSuite/cmd/testblob.go
+++ b/testSuite/cmd/testblob.go
@@ -147,7 +147,8 @@ func verifyBlockBlobDirUpload(testBlobCmd TestBlobCommand) {
 			TryTimeout:    10 * time.Minute,
 			RetryDelay:    ste.UploadRetryDelay,
 			MaxRetryDelay: ste.UploadMaxRetryDelay},
-		nil)
+		nil,
+		ste.NewAzcopyHTTPClient())
 	containerUrl := azblob.NewContainerURL(*sasUrl, p)
 
 	testCtx := context.WithValue(context.Background(), ste.ServiceAPIVersionOverride, defaultServiceApiVersion)
@@ -285,7 +286,8 @@ func verifySinglePageBlobUpload(testBlobCmd TestBlobCommand) {
 			TryTimeout:    10 * time.Minute,
 			RetryDelay:    ste.UploadRetryDelay,
 			MaxRetryDelay: ste.UploadMaxRetryDelay},
-		nil)
+		nil,
+		ste.NewAzcopyHTTPClient())
 
 	testCtx := context.WithValue(context.Background(), ste.ServiceAPIVersionOverride, defaultServiceApiVersion)
 	pageBlobUrl := azblob.NewPageBlobURL(*sourceURL, p)
@@ -451,7 +453,8 @@ func verifySingleBlockBlob(testBlobCmd TestBlobCommand) {
 			TryTimeout:    10 * time.Minute,
 			RetryDelay:    ste.UploadRetryDelay,
 			MaxRetryDelay: ste.UploadMaxRetryDelay},
-		nil)
+		nil,
+		ste.NewAzcopyHTTPClient())
 
 	testCtx := context.WithValue(context.Background(), ste.ServiceAPIVersionOverride, defaultServiceApiVersion)
 
@@ -612,7 +615,8 @@ func verifySingleAppendBlob(testBlobCmd TestBlobCommand) {
 			TryTimeout:    10 * time.Minute,
 			RetryDelay:    ste.UploadRetryDelay,
 			MaxRetryDelay: ste.UploadMaxRetryDelay},
-		nil)
+		nil,
+		ste.NewAzcopyHTTPClient())
 
 	testCtx := context.WithValue(context.Background(), ste.ServiceAPIVersionOverride, defaultServiceApiVersion)
 	appendBlobURL := azblob.NewAppendBlobURL(*sourceURL, p)


### PR DESCRIPTION
Fixes issue #243 by controlling both the number of open files when downloading, and the number of open network handles (since the latter also count as files on Linux)