### PR TITLE
Allow upload of smaller VHD to larger managed disk

### DIFF
--- a/ste/sender-pageBlob.go
+++ b/ste/sender-pageBlob.go
@@ -56,7 +56,7 @@ type pageBlobSenderBase struct {
 
 const (
 	managedDiskImportExportAccountPrefix = "md-impexp-"
-	
+
 	// Start high(ish), because it auto-tunes downwards faster than it auto-tunes upwards
 	pageBlobInitialBytesPerSecond = (4 * 1000 * 1000 * 1000) / 8
 )
@@ -146,22 +146,21 @@ func (s *pageBlobSenderBase) Prologue(ps common.PrologueState) {
 	// Create file pacer now.  Safe to create now, because we know that if Prologue is called the Epilogue will be to
 	// so we know that the pacer will be closed.  // TODO: consider re-factor xfer-anyToRemote so that epilogue is always called if uploader is constructed, and move this to constructor
 	s.filePacer = newPageBlobAutoPacer(s.jptm.Context(), pageBlobInitialBytesPerSecond, s.ChunkSize(), false, s.jptm.(common.ILogger))
-	
+
 	if s.isInManagedDiskImportExportAccount() {
 		// Target will already exist (and CANNOT be created through the REST API, because
 		// managed-disk import-export accounts have restricted API surface)
 
 		// Check its length, since it already has a size, and the upload will fail at the end if you what
 		// upload to it is bigger than its existing size. (And, for big files, it may be hours until you discover that
-		// difference if we don't check here).  Also, if the uploaded file is smaller, then can end up with
-		// two footers at the end (the one uploaded and the one that was already there at the end of the target blob).
+		// difference if we don't check here).
 		p, err := s.destPageBlobURL.GetProperties(s.jptm.Context(), azblob.BlobAccessConditions{})
 		if err != nil {
 			s.jptm.FailActiveSend("Checking size of managed disk blob", err)
 			return
 		}
-		if s.srcSize != p.ContentLength() {
-			sizeErr := errors.New(fmt.Sprintf("source file is not the same size as the destination page blob. Source size is %d bytes but destination size is %d bytes",
+		if s.srcSize > p.ContentLength() {
+			sizeErr := errors.New(fmt.Sprintf("source file is too big for the destination page blob. Source size is %d bytes but destination size is %d bytes",
 				s.srcSize, p.ContentLength()))
 			s.jptm.FailActiveSend("Checking size of managed disk blob", sizeErr)
 			return


### PR DESCRIPTION
After discussions with managed disk team, we no longer require exact equality of size