### PR TITLE
SAS Token auth on DFS endpoints

### DIFF
--- a/azbfs/parsing_urls.go
+++ b/azbfs/parsing_urls.go
@@ -14,6 +14,7 @@ type BfsURLParts struct {
 	FileSystemName      string // File System name, Ex: "myfilesystem"
 	DirectoryOrFilePath string // Path of directory or file, Ex: "mydirectory/myfile"
 	UnparsedParams      string
+	SAS                 SASQueryParameters
 
 	accountName       string // "" if not using IP endpoint style
 	isIPEndpointStyle bool   // Ex: "https://ip/accountname/filesystem"
@@ -75,6 +76,9 @@ func NewBfsURLParts(u url.URL) BfsURLParts {
 	// Convert the query parameters to a case-sensitive map & trim whitespace
 	paramsMap := u.Query()
 	up.UnparsedParams = paramsMap.Encode()
+
+	up.SAS = newSASQueryParameters(paramsMap, true)
+	up.UnparsedParams = paramsMap.Encode()
 	return up
 }
 
@@ -94,6 +98,14 @@ func (up BfsURLParts) URL() url.URL {
 	}
 
 	rawQuery := up.UnparsedParams
+
+	sas := up.SAS.Encode()
+	if sas != "" {
+		if len(rawQuery) >= 0 {
+			rawQuery += "&"
+		}
+		rawQuery += sas
+	}
 	u := url.URL{
 		Scheme:   up.Scheme,
 		Host:     up.Host,

--- a/azbfs/parsing_urls.go
+++ b/azbfs/parsing_urls.go
@@ -75,8 +75,6 @@ func NewBfsURLParts(u url.URL) BfsURLParts {
 
 	// Convert the query parameters to a case-sensitive map & trim whitespace
 	paramsMap := u.Query()
-	up.UnparsedParams = paramsMap.Encode()
-
 	up.SAS = newSASQueryParameters(paramsMap, true)
 	up.UnparsedParams = paramsMap.Encode()
 	return up

--- a/azbfs/zc_sas_account.go
+++ b/azbfs/zc_sas_account.go
@@ -1,0 +1,218 @@
+package azbfs
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// AccountSASSignatureValues is used to generate a Shared Access Signature (SAS) for an Azure Storage account.
+// For more information, see https://docs.microsoft.com/rest/api/storageservices/constructing-an-account-sas
+type AccountSASSignatureValues struct {
+	Version       string      `param:"sv"`  // If not specified, this defaults to SASVersion
+	Protocol      SASProtocol `param:"spr"` // See the SASProtocol* constants
+	StartTime     time.Time   `param:"st"`  // Not specified if IsZero
+	ExpiryTime    time.Time   `param:"se"`  // Not specified if IsZero
+	Permissions   string      `param:"sp"`  // Create by initializing a AccountSASPermissions and then call String()
+	IPRange       IPRange     `param:"sip"`
+	Services      string      `param:"ss"`  // Create by initializing AccountSASServices and then call String()
+	ResourceTypes string      `param:"srt"` // Create by initializing AccountSASResourceTypes and then call String()
+}
+
+// NewSASQueryParameters uses an account's shared key credential to sign this signature values to produce
+// the proper SAS query parameters.
+func (v AccountSASSignatureValues) NewSASQueryParameters(sharedKeyCredential *SharedKeyCredential) (SASQueryParameters, error) {
+	// https://docs.microsoft.com/en-us/rest/api/storageservices/Constructing-an-Account-SAS
+	if v.ExpiryTime.IsZero() || v.Permissions == "" || v.ResourceTypes == "" || v.Services == "" {
+		return SASQueryParameters{}, errors.New("account SAS is missing at least one of these: ExpiryTime, Permissions, Service, or ResourceType")
+	}
+	if v.Version == "" {
+		v.Version = SASVersion
+	}
+	perms := &AccountSASPermissions{}
+	if err := perms.Parse(v.Permissions); err != nil {
+		return SASQueryParameters{}, err
+	}
+	v.Permissions = perms.String()
+
+	startTime, expiryTime := FormatTimesForSASSigning(v.StartTime, v.ExpiryTime)
+
+	stringToSign := strings.Join([]string{
+		sharedKeyCredential.AccountName(),
+		v.Permissions,
+		v.Services,
+		v.ResourceTypes,
+		startTime,
+		expiryTime,
+		v.IPRange.String(),
+		string(v.Protocol),
+		v.Version,
+		""}, // That right, the account SAS requires a terminating extra newline
+		"\n")
+
+	signature := sharedKeyCredential.ComputeHMACSHA256(stringToSign)
+	p := SASQueryParameters{
+		// Common SAS parameters
+		version:     v.Version,
+		protocol:    v.Protocol,
+		startTime:   v.StartTime,
+		expiryTime:  v.ExpiryTime,
+		permissions: v.Permissions,
+		ipRange:     v.IPRange,
+
+		// Account-specific SAS parameters
+		services:      v.Services,
+		resourceTypes: v.ResourceTypes,
+
+		// Calculated SAS signature
+		signature: signature,
+	}
+	return p, nil
+}
+
+// The AccountSASPermissions type simplifies creating the permissions string for an Azure Storage Account SAS.
+// Initialize an instance of this type and then call its String method to set AccountSASSignatureValues's Permissions field.
+type AccountSASPermissions struct {
+	Read, Write, Delete, List, Add, Create, Update, Process bool
+}
+
+// String produces the SAS permissions string for an Azure Storage account.
+// Call this method to set AccountSASSignatureValues's Permissions field.
+func (p AccountSASPermissions) String() string {
+	var buffer bytes.Buffer
+	if p.Read {
+		buffer.WriteRune('r')
+	}
+	if p.Write {
+		buffer.WriteRune('w')
+	}
+	if p.Delete {
+		buffer.WriteRune('d')
+	}
+	if p.List {
+		buffer.WriteRune('l')
+	}
+	if p.Add {
+		buffer.WriteRune('a')
+	}
+	if p.Create {
+		buffer.WriteRune('c')
+	}
+	if p.Update {
+		buffer.WriteRune('u')
+	}
+	if p.Process {
+		buffer.WriteRune('p')
+	}
+	return buffer.String()
+}
+
+// Parse initializes the AccountSASPermissions's fields from a string.
+func (p *AccountSASPermissions) Parse(s string) error {
+	*p = AccountSASPermissions{} // Clear out the flags
+	for _, r := range s {
+		switch r {
+		case 'r':
+			p.Read = true
+		case 'w':
+			p.Write = true
+		case 'd':
+			p.Delete = true
+		case 'l':
+			p.List = true
+		case 'a':
+			p.Add = true
+		case 'c':
+			p.Create = true
+		case 'u':
+			p.Update = true
+		case 'p':
+			p.Process = true
+		default:
+			return fmt.Errorf("Invalid permission character: '%v'", r)
+		}
+	}
+	return nil
+}
+
+// The AccountSASServices type simplifies creating the services string for an Azure Storage Account SAS.
+// Initialize an instance of this type and then call its String method to set AccountSASSignatureValues's Services field.
+type AccountSASServices struct {
+	Blob, Queue, File bool
+}
+
+// String produces the SAS services string for an Azure Storage account.
+// Call this method to set AccountSASSignatureValues's Services field.
+func (s AccountSASServices) String() string {
+	var buffer bytes.Buffer
+	if s.Blob {
+		buffer.WriteRune('b')
+	}
+	if s.Queue {
+		buffer.WriteRune('q')
+	}
+	if s.File {
+		buffer.WriteRune('f')
+	}
+	return buffer.String()
+}
+
+// Parse initializes the AccountSASServices' fields from a string.
+func (a *AccountSASServices) Parse(s string) error {
+	*a = AccountSASServices{} // Clear out the flags
+	for _, r := range s {
+		switch r {
+		case 'b':
+			a.Blob = true
+		case 'q':
+			a.Queue = true
+		case 'f':
+			a.File = true
+		default:
+			return fmt.Errorf("Invalid service character: '%v'", r)
+		}
+	}
+	return nil
+}
+
+// The AccountSASResourceTypes type simplifies creating the resource types string for an Azure Storage Account SAS.
+// Initialize an instance of this type and then call its String method to set AccountSASSignatureValues's ResourceTypes field.
+type AccountSASResourceTypes struct {
+	Service, Container, Object bool
+}
+
+// String produces the SAS resource types string for an Azure Storage account.
+// Call this method to set AccountSASSignatureValues's ResourceTypes field.
+func (rt AccountSASResourceTypes) String() string {
+	var buffer bytes.Buffer
+	if rt.Service {
+		buffer.WriteRune('s')
+	}
+	if rt.Container {
+		buffer.WriteRune('c')
+	}
+	if rt.Object {
+		buffer.WriteRune('o')
+	}
+	return buffer.String()
+}
+
+// Parse initializes the AccountSASResourceType's fields from a string.
+func (rt *AccountSASResourceTypes) Parse(s string) error {
+	*rt = AccountSASResourceTypes{} // Clear out the flags
+	for _, r := range s {
+		switch r {
+		case 's':
+			rt.Service = true
+		case 'c':
+			rt.Container = true
+		case 'o':
+			rt.Object = true
+		default:
+			return fmt.Errorf("Invalid resource type: '%v'", r)
+		}
+	}
+	return nil
+}

--- a/azbfs/zc_sas_query_params.go
+++ b/azbfs/zc_sas_query_params.go
@@ -1,0 +1,261 @@
+package azbfs
+
+import (
+	"net"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// SASVersion indicates the SAS version.
+const SASVersion = ServiceVersion
+
+type SASProtocol string
+
+const (
+	// SASProtocolHTTPS can be specified for a SAS protocol
+	SASProtocolHTTPS SASProtocol = "https"
+
+	// SASProtocolHTTPSandHTTP can be specified for a SAS protocol
+	SASProtocolHTTPSandHTTP SASProtocol = "https,http"
+)
+
+// FormatTimesForSASSigning converts a time.Time to a snapshotTimeFormat string suitable for a
+// SASField's StartTime or ExpiryTime fields. Returns "" if value.IsZero().
+func FormatTimesForSASSigning(startTime, expiryTime time.Time) (string, string) {
+	ss := ""
+	if !startTime.IsZero() {
+		ss = startTime.Format(SASTimeFormat) // "yyyy-MM-ddTHH:mm:ssZ"
+	}
+	se := ""
+	if !expiryTime.IsZero() {
+		se = expiryTime.Format(SASTimeFormat) // "yyyy-MM-ddTHH:mm:ssZ"
+	}
+	return ss, se
+}
+
+// SASTimeFormat represents the format of a SAS start or expiry time. Use it when formatting/parsing a time.Time.
+const SASTimeFormat = "2006-01-02T15:04:05Z" //"2017-07-27T00:00:00Z" // ISO 8601
+
+// https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
+
+// A SASQueryParameters object represents the components that make up an Azure Storage SAS' query parameters.
+// You parse a map of query parameters into its fields by calling NewSASQueryParameters(). You add the components
+// to a query parameter map by calling AddToValues().
+// NOTE: Changing any field requires computing a new SAS signature using a XxxSASSignatureValues type.
+//
+// This type defines the components used by all Azure Storage resources (Containers, Blobs, Files, & Queues).
+type SASQueryParameters struct {
+	// All members are immutable or values so copies of this struct are goroutine-safe.
+	version            string      `param:"sv"`
+	services           string      `param:"ss"`
+	resourceTypes      string      `param:"srt"`
+	protocol           SASProtocol `param:"spr"`
+	startTime          time.Time   `param:"st"`
+	expiryTime         time.Time   `param:"se"`
+	ipRange            IPRange     `param:"sip"`
+	identifier         string      `param:"si"`
+	resource           string      `param:"sr"`
+	permissions        string      `param:"sp"`
+	signature          string      `param:"sig"`
+	cacheControl       string      `param:"rscc"`
+	contentDisposition string      `param:"rscd"`
+	contentEncoding    string      `param:"rsce"`
+	contentLanguage    string      `param:"rscl"`
+	contentType        string      `param:"rsct"`
+}
+
+func (p *SASQueryParameters) Version() string {
+	return p.version
+}
+
+func (p *SASQueryParameters) Services() string {
+	return p.services
+}
+func (p *SASQueryParameters) ResourceTypes() string {
+	return p.resourceTypes
+}
+func (p *SASQueryParameters) Protocol() SASProtocol {
+	return p.protocol
+}
+func (p *SASQueryParameters) StartTime() time.Time {
+	return p.startTime
+}
+func (p *SASQueryParameters) ExpiryTime() time.Time {
+	return p.expiryTime
+}
+
+func (p *SASQueryParameters) IPRange() IPRange {
+	return p.ipRange
+}
+
+func (p *SASQueryParameters) Identifier() string {
+	return p.identifier
+}
+
+func (p *SASQueryParameters) Resource() string {
+	return p.resource
+}
+func (p *SASQueryParameters) Permissions() string {
+	return p.permissions
+}
+
+func (p *SASQueryParameters) Signature() string {
+	return p.signature
+}
+
+func (p *SASQueryParameters) CacheControl() string {
+	return p.cacheControl
+}
+
+func (p *SASQueryParameters) ContentDisposition() string {
+	return p.contentDisposition
+}
+
+func (p *SASQueryParameters) ContentEncoding() string {
+	return p.contentEncoding
+}
+
+func (p *SASQueryParameters) ContentLanguage() string {
+	return p.contentLanguage
+}
+
+func (p *SASQueryParameters) ContentType() string {
+	return p.contentType
+}
+
+// IPRange represents a SAS IP range's start IP and (optionally) end IP.
+type IPRange struct {
+	Start net.IP // Not specified if length = 0
+	End   net.IP // Not specified if length = 0
+}
+
+// String returns a string representation of an IPRange.
+func (ipr *IPRange) String() string {
+	if len(ipr.Start) == 0 {
+		return ""
+	}
+	start := ipr.Start.String()
+	if len(ipr.End) == 0 {
+		return start
+	}
+	return start + "-" + ipr.End.String()
+}
+
+// NewSASQueryParameters creates and initializes a SASQueryParameters object based on the
+// query parameter map's passed-in values. If deleteSASParametersFromValues is true,
+// all SAS-related query parameters are removed from the passed-in map. If
+// deleteSASParametersFromValues is false, the map passed-in map is unaltered.
+func newSASQueryParameters(values url.Values, deleteSASParametersFromValues bool) SASQueryParameters {
+	p := SASQueryParameters{}
+	for k, v := range values {
+		val := v[0]
+		isSASKey := true
+		switch strings.ToLower(k) {
+		case "sv":
+			p.version = val
+		case "ss":
+			p.services = val
+		case "srt":
+			p.resourceTypes = val
+		case "spr":
+			p.protocol = SASProtocol(val)
+		case "st":
+			p.startTime, _ = time.Parse(SASTimeFormat, val)
+		case "se":
+			p.expiryTime, _ = time.Parse(SASTimeFormat, val)
+		case "sip":
+			dashIndex := strings.Index(val, "-")
+			if dashIndex == -1 {
+				p.ipRange.Start = net.ParseIP(val)
+			} else {
+				p.ipRange.Start = net.ParseIP(val[:dashIndex])
+				p.ipRange.End = net.ParseIP(val[dashIndex+1:])
+			}
+		case "si":
+			p.identifier = val
+		case "sr":
+			p.resource = val
+		case "sp":
+			p.permissions = val
+		case "sig":
+			p.signature = val
+		case "rscc":
+			p.cacheControl = val
+		case "rscd":
+			p.contentDisposition = val
+		case "rsce":
+			p.contentEncoding = val
+		case "rscl":
+			p.contentLanguage = val
+		case "rsct":
+			p.contentType = val
+		default:
+			isSASKey = false // We didn't recognize the query parameter
+		}
+		if isSASKey && deleteSASParametersFromValues {
+			delete(values, k)
+		}
+	}
+	return p
+}
+
+// AddToValues adds the SAS components to the specified query parameters map.
+func (p *SASQueryParameters) addToValues(v url.Values) url.Values {
+	if p.version != "" {
+		v.Add("sv", p.version)
+	}
+	if p.services != "" {
+		v.Add("ss", p.services)
+	}
+	if p.resourceTypes != "" {
+		v.Add("srt", p.resourceTypes)
+	}
+	if p.protocol != "" {
+		v.Add("spr", string(p.protocol))
+	}
+	if !p.startTime.IsZero() {
+		v.Add("st", p.startTime.Format(SASTimeFormat))
+	}
+	if !p.expiryTime.IsZero() {
+		v.Add("se", p.expiryTime.Format(SASTimeFormat))
+	}
+	if len(p.ipRange.Start) > 0 {
+		v.Add("sip", p.ipRange.String())
+	}
+	if p.identifier != "" {
+		v.Add("si", p.identifier)
+	}
+	if p.resource != "" {
+		v.Add("sr", p.resource)
+	}
+	if p.permissions != "" {
+		v.Add("sp", p.permissions)
+	}
+	if p.signature != "" {
+		v.Add("sig", p.signature)
+	}
+	if p.cacheControl != "" {
+		v.Add("rscc", p.cacheControl)
+	}
+	if p.contentDisposition != "" {
+		v.Add("rscd", p.contentDisposition)
+	}
+	if p.contentEncoding != "" {
+		v.Add("rsce", p.contentEncoding)
+	}
+	if p.contentLanguage != "" {
+		v.Add("rscl", p.contentLanguage)
+	}
+	if p.contentType != "" {
+		v.Add("rsct", p.contentType)
+	}
+	return v
+}
+
+// Encode encodes the SAS query parameters into URL encoded form sorted by key.
+func (p *SASQueryParameters) Encode() string {
+	v := url.Values{}
+	p.addToValues(v)
+	return v.Encode()
+}

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -693,8 +693,8 @@ func (cca *cookedCopyCmdArgs) processCopyJobPartOrders() (err error) {
 			Metadata:                 cca.metadata,
 			NoGuessMimeType:          cca.noGuessMimeType,
 			PreserveLastModifiedTime: cca.preserveLastModifiedTime,
-			PutMd5:              cca.putMd5,
-			MD5ValidationOption: cca.md5ValidationOption,
+			PutMd5:                   cca.putMd5,
+			MD5ValidationOption:      cca.md5ValidationOption,
 		},
 		// source sas is stripped from the source given by the user and it will not be stored in the part plan file.
 		SourceSAS: cca.sourceSAS,
@@ -809,17 +809,14 @@ func (cca *cookedCopyCmdArgs) processCopyJobPartOrders() (err error) {
 		fUrl := fileParts.URL()
 		cca.destination = fUrl.String()
 	case common.ELocation.BlobFS():
-		// as at April 2019 we don't actually support SAS for BlobFS, but here we similar processing as the others because
-		// (a) it also escapes spaces in the destination (and we need that done) and
-		// (b) if we ever do start supporting SASs for BlobFS, we don't want to forget to add code here to correctly process them
-		if redacted, _ := common.RedactSecretQueryParam(cca.destination, "sig"); redacted {
-			panic("SAS in BlobFS is not yet supported")
-		}
 		toUrl, err := url.Parse(cca.destination)
 		if err != nil {
 			return fmt.Errorf("error parsing the destination url %s. Failed with error %s", toUrl.String(), err.Error())
 		}
 		bfsParts := azbfs.NewBfsURLParts(*toUrl)
+		cca.destinationSAS = bfsParts.SAS.Encode()
+		jobPartOrder.DestinationSAS = cca.destinationSAS
+		bfsParts.SAS = azbfs.SASQueryParameters{}
 		bfsUrl := bfsParts.URL()
 		cca.destination = bfsUrl.String() // this escapes spaces in the destination
 	case common.ELocation.Local():

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -744,17 +744,14 @@ func (cca *cookedCopyCmdArgs) processCopyJobPartOrders() (err error) {
 		jobPartOrder.SourceRoot = fUrl.String()
 
 	case common.ELocation.BlobFS():
-		// as at April 2019 we don't actually support SAS for BlobFS, but here we similar processing as the others because
-		// (a) it also escapes spaces in the source (and we need that done) and
-		// (b) if we ever do start supporting SASs for BlobFS, we don't want to forget to add code here to correctly process them
-		if redacted, _ := common.RedactSecretQueryParam(cca.source, "sig"); redacted {
-			panic("SAS in BlobFS is not yet supported")
-		}
 		fromUrl, err := url.Parse(cca.source)
 		if err != nil {
 			return fmt.Errorf("error parsing the source url %s. Failed with error %s", fromUrl.String(), err.Error())
 		}
 		bfsParts := azbfs.NewBfsURLParts(*fromUrl)
+		cca.sourceSAS = bfsParts.SAS.Encode()
+		jobPartOrder.SourceSAS = cca.sourceSAS
+		bfsParts.SAS = azbfs.SASQueryParameters{}
 		bfsUrl := bfsParts.URL()
 		cca.source = bfsUrl.String() // this escapes spaces in the source
 

--- a/cmd/copyDownloadBlobFSEnumerator.go
+++ b/cmd/copyDownloadBlobFSEnumerator.go
@@ -30,6 +30,7 @@ func (e *copyDownloadBlobFSEnumerator) enumerate(cca *cookedCopyCmdArgs) error {
 
 	// attempt to parse the source url
 	sourceURL, err := url.Parse(cca.source)
+	sourceURL = gCopyUtil.appendQueryParamToUrl(sourceURL, cca.sourceSAS)
 	if err != nil {
 		return errors.New("cannot parse source URL")
 	}

--- a/cmd/make.go
+++ b/cmd/make.go
@@ -74,7 +74,7 @@ func (cma cookedMakeCmdArgs) getCredentialType(ctx context.Context) (credentialT
 
 	switch cma.resourceLocation {
 	case common.ELocation.BlobFS():
-		if credentialType, err = getBlobFSCredentialType(); err != nil {
+		if credentialType, err = getBlobFSCredentialType(ctx, cma.resourceURL.String(), false); err != nil {
 			return common.ECredentialType.Unknown(), err
 		}
 	case common.ELocation.Blob():

--- a/common/credentialFactory.go
+++ b/common/credentialFactory.go
@@ -184,6 +184,9 @@ func CreateBlobFSCredential(ctx context.Context, credInfo CredentialInfo, option
 		// create the shared key credentials
 		cred = azbfs.NewSharedKeyCredential(name, key)
 
+	case ECredentialType.Anonymous():
+		// do nothing
+
 	default:
 		options.panicError(fmt.Errorf("invalid state, credential type %v is not supported", credInfo.CredentialType))
 	}

--- a/common/credentialFactory.go
+++ b/common/credentialFactory.go
@@ -31,8 +31,8 @@ import (
 	"time"
 
 	"github.com/Azure/azure-storage-azcopy/azbfs"
-	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/azure-storage-blob-go/azblob"
+	"github.com/Azure/go-autorest/autorest/adal"
 	minio "github.com/minio/minio-go"
 	"github.com/minio/minio-go/pkg/credentials"
 )
@@ -158,6 +158,8 @@ func refreshBlobToken(ctx context.Context, tokenInfo OAuthTokenInfo, tokenCreden
 
 // CreateBlobFSCredential creates BlobFS credential according to credential info.
 func CreateBlobFSCredential(ctx context.Context, credInfo CredentialInfo, options CredentialOpOptions) azbfs.Credential {
+	cred := azbfs.NewAnonymousCredential()
+
 	switch credInfo.CredentialType {
 	case ECredentialType.OAuthToken():
 		if credInfo.OAuthTokenInfo.IsEmpty() {
@@ -165,7 +167,7 @@ func CreateBlobFSCredential(ctx context.Context, credInfo CredentialInfo, option
 		}
 
 		// Create TokenCredential with refresher.
-		return azbfs.NewTokenCredential(
+		cred = azbfs.NewTokenCredential(
 			credInfo.OAuthTokenInfo.AccessToken,
 			func(credential azbfs.TokenCredential) time.Duration {
 				return refreshBlobFSToken(ctx, credInfo.OAuthTokenInfo, credential, options)
@@ -180,13 +182,13 @@ func CreateBlobFSCredential(ctx context.Context, credInfo CredentialInfo, option
 			options.panicError(errors.New("ACCOUNT_NAME and ACCOUNT_KEY environment variables must be set before creating the blobfs SharedKey credential"))
 		}
 		// create the shared key credentials
-		return azbfs.NewSharedKeyCredential(name, key)
+		cred = azbfs.NewSharedKeyCredential(name, key)
 
 	default:
 		options.panicError(fmt.Errorf("invalid state, credential type %v is not supported", credInfo.CredentialType))
 	}
 
-	panic("work around the compiling, logic wouldn't reach here")
+	return cred
 }
 
 // CreateS3Credential creates AWS S3 credential according to credential info.


### PR DESCRIPTION
The following 3 commits enable the use of a SAS token to authenticate uploads and downloads on `dfs.core.windows.net` endpoints.

In order to facilitate this addition, some core files were shared to azbfs (namely relating to SAS tokens). Namely, `zc_sas_account.go` and `zc_sas_query_params.go`.

As usual, some changes are as a result of the automatic `go fmt` execution configured in my Goland setup.
