### PR TITLE
Tackling incorrect error presented in #199

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Version XX.XX.XX 
+
+### Bug fixes
+
+1. AzCopy v10 now outputs a sensible error & warning when attempting to authenticate a storage account business-to-business
+
 ## Version 10.1.0 (GA)
 
 ### Breaking changes

--- a/cmd/copyDownloadBlobEnumerator.go
+++ b/cmd/copyDownloadBlobEnumerator.go
@@ -84,7 +84,9 @@ func (e *copyDownloadBlobEnumerator) enumerate(cca *cookedCopyCmdArgs) error {
 			}
 			return nil
 		} else {
-			handleSingleFileValidationErrorForBlob(err)
+			if handleSingleFileValidationErrorForBlob(err) {
+				return err
+			}
 		}
 	}
 

--- a/cmd/copyDownloadBlobEnumerator.go
+++ b/cmd/copyDownloadBlobEnumerator.go
@@ -84,7 +84,7 @@ func (e *copyDownloadBlobEnumerator) enumerate(cca *cookedCopyCmdArgs) error {
 			}
 			return nil
 		} else {
-			if handleSingleFileValidationErrorForBlob(err) {
+			if isFatal := handleSingleFileValidationErrorForBlob(err); isFatal {
 				return err
 			}
 		}

--- a/cmd/copyDownloadBlobFSEnumerator.go
+++ b/cmd/copyDownloadBlobFSEnumerator.go
@@ -69,7 +69,7 @@ func (e *copyDownloadBlobFSEnumerator) enumerate(cca *cookedCopyCmdArgs) error {
 	}
 
 	if err != nil {
-		if handleSingleFileValidationErrorForADLSGen2(err) {
+		if isFatal := handleSingleFileValidationErrorForADLSGen2(err); isFatal {
 			return err
 		}
 	}

--- a/cmd/copyDownloadBlobFSEnumerator.go
+++ b/cmd/copyDownloadBlobFSEnumerator.go
@@ -69,7 +69,9 @@ func (e *copyDownloadBlobFSEnumerator) enumerate(cca *cookedCopyCmdArgs) error {
 	}
 
 	if err != nil {
-		handleSingleFileValidationErrorForADLSGen2(err)
+		if handleSingleFileValidationErrorForADLSGen2(err) {
+			return err
+		}
 	}
 
 	glcm.Info(infoCopyFromDirectoryListOfFiles)

--- a/cmd/copyDownloadFileEnumerator.go
+++ b/cmd/copyDownloadFileEnumerator.go
@@ -54,7 +54,7 @@ func (e *copyDownloadFileEnumerator) enumerate(cca *cookedCopyCmdArgs) error {
 			}
 			return e.dispatchFinalPart(cca)
 		} else {
-			if handleSingleFileValidationErrorForAzureFile(err) {
+			if isFatal := handleSingleFileValidationErrorForAzureFile(err); isFatal {
 				return err
 			}
 		}

--- a/cmd/copyDownloadFileEnumerator.go
+++ b/cmd/copyDownloadFileEnumerator.go
@@ -54,7 +54,9 @@ func (e *copyDownloadFileEnumerator) enumerate(cca *cookedCopyCmdArgs) error {
 			}
 			return e.dispatchFinalPart(cca)
 		} else {
-			handleSingleFileValidationErrorForAzureFile(err)
+			if handleSingleFileValidationErrorForAzureFile(err) {
+				return err
+			}
 		}
 	}
 

--- a/cmd/copyEnumeratorHelper.go
+++ b/cmd/copyEnumeratorHelper.go
@@ -84,46 +84,73 @@ var infoCopyFromBucketDirectoryListOfFiles = "trying to copy the source as bucke
 var infoCopyFromDirectoryListOfFiles = "trying to copy the source as directory/list of files"
 var infoCopyFromAccount = "trying to copy the source account"
 
-func handleSingleFileValidationErrorForBlob(err error) {
+func handleSingleFileValidationErrorForBlob(err error) (stop bool) {
 	errRootCause := err.Error()
 	stgErr, isStgErr := err.(azblob.StorageError)
 	if isStgErr {
-		if stgErr.ServiceCode() == azblob.ServiceCodeAuthenticationFailed {
+		if stgErr.ServiceCode() == azblob.ServiceCodeInvalidAuthenticationInfo {
+			errRootCause = fmt.Sprintf("%s, Please ensure all login details are correct (or that you are signed into the correct tenant for this blob)", stgErr.ServiceCode())
+			stop = true
+		} else if stgErr.ServiceCode() == azblob.ServiceCodeAuthenticationFailed {
 			errRootCause = fmt.Sprintf("%s, please check if SAS or OAuth is used properly, or source is a public blob", stgErr.ServiceCode())
+			stop = true
 		} else {
 			errRootCause = string(stgErr.ServiceCode())
 		}
 	}
 
-	glcm.Info(fmt.Sprintf(handleSingleFileValidationErrStr, errRootCause))
+	if stop {
+		glcm.Info(errRootCause)
+	} else {
+		glcm.Info(fmt.Sprintf(handleSingleFileValidationErrStr, errRootCause))
+	}
+	return
 }
 
-func handleSingleFileValidationErrorForAzureFile(err error) {
+func handleSingleFileValidationErrorForAzureFile(err error) (stop bool) {
 	errRootCause := err.Error()
 	stgErr, isStgErr := err.(azfile.StorageError)
 	if isStgErr {
-		if stgErr.ServiceCode() == azfile.ServiceCodeAuthenticationFailed {
+		if stgErr.ServiceCode() == azfile.ServiceCodeInvalidAuthenticationInfo {
+			errRootCause = fmt.Sprintf("%s, Please ensure all login details are correct (or that you are signed into the correct tenant for this blob)", stgErr.ServiceCode())
+			stop = true
+		} else if stgErr.ServiceCode() == azfile.ServiceCodeAuthenticationFailed {
 			errRootCause = fmt.Sprintf("%s, please check if SAS is set properly", stgErr.ServiceCode())
+			stop = true
 		} else {
 			errRootCause = string(stgErr.ServiceCode())
 		}
 	}
 
-	glcm.Info(fmt.Sprintf(handleSingleFileValidationErrStr, errRootCause))
+	if stop {
+		glcm.Info(errRootCause)
+	} else {
+		glcm.Info(fmt.Sprintf(handleSingleFileValidationErrStr, errRootCause))
+	}
+	return
 }
 
-func handleSingleFileValidationErrorForADLSGen2(err error) {
+func handleSingleFileValidationErrorForADLSGen2(err error) (stop bool) {
 	errRootCause := err.Error()
 	stgErr, isStgErr := err.(azbfs.StorageError)
 	if isStgErr {
-		if stgErr.ServiceCode() == azbfs.ServiceCodeAuthenticationFailed {
+		if stgErr.ServiceCode() == azbfs.ServiceCodeInvalidAuthenticationInfo {
+			errRootCause = fmt.Sprintf("%s, Please ensure all login details are correct (or that you are signed into the correct tenant for this blob)", stgErr.ServiceCode())
+			stop = true
+		} else if stgErr.ServiceCode() == azbfs.ServiceCodeAuthenticationFailed {
 			errRootCause = fmt.Sprintf("%s, please check if AccessKey or OAuth is used properly", stgErr.ServiceCode())
+			stop = true
 		} else {
 			errRootCause = string(stgErr.ServiceCode())
 		}
 	}
 
-	glcm.Info(fmt.Sprintf(handleSingleFileValidationErrStr, errRootCause))
+	if stop {
+		glcm.Info(errRootCause)
+	} else {
+		glcm.Info(fmt.Sprintf(handleSingleFileValidationErrStr, errRootCause))
+	}
+	return
 }
 
 func handleSingleFileValidationErrorForS3(err error) {

--- a/cmd/copyEnumeratorHelper.go
+++ b/cmd/copyEnumeratorHelper.go
@@ -89,7 +89,7 @@ func handleSingleFileValidationErrorForBlob(err error) (stop bool) {
 	stgErr, isStgErr := err.(azblob.StorageError)
 	if isStgErr {
 		if stgErr.ServiceCode() == azblob.ServiceCodeInvalidAuthenticationInfo {
-			errRootCause = fmt.Sprintf("%s, Please ensure all login details are correct (or that you are signed into the correct tenant for this blob)", stgErr.ServiceCode())
+			errRootCause = fmt.Sprintf("%s, Please ensure all login details are correct (or that you are signed into the correct tenant for this storage account)", stgErr.ServiceCode())
 			stop = true
 		} else if stgErr.ServiceCode() == azblob.ServiceCodeAuthenticationFailed {
 			errRootCause = fmt.Sprintf("%s, please check if SAS or OAuth is used properly, or source is a public blob", stgErr.ServiceCode())
@@ -112,7 +112,7 @@ func handleSingleFileValidationErrorForAzureFile(err error) (stop bool) {
 	stgErr, isStgErr := err.(azfile.StorageError)
 	if isStgErr {
 		if stgErr.ServiceCode() == azfile.ServiceCodeInvalidAuthenticationInfo {
-			errRootCause = fmt.Sprintf("%s, Please ensure all login details are correct (or that you are signed into the correct tenant for this blob)", stgErr.ServiceCode())
+			errRootCause = fmt.Sprintf("%s, Please ensure all login details are correct (or that you are signed into the correct tenant for this storage account)", stgErr.ServiceCode())
 			stop = true
 		} else if stgErr.ServiceCode() == azfile.ServiceCodeAuthenticationFailed {
 			errRootCause = fmt.Sprintf("%s, please check if SAS is set properly", stgErr.ServiceCode())
@@ -135,7 +135,7 @@ func handleSingleFileValidationErrorForADLSGen2(err error) (stop bool) {
 	stgErr, isStgErr := err.(azbfs.StorageError)
 	if isStgErr {
 		if stgErr.ServiceCode() == azbfs.ServiceCodeInvalidAuthenticationInfo {
-			errRootCause = fmt.Sprintf("%s, Please ensure all login details are correct (or that you are signed into the correct tenant for this blob)", stgErr.ServiceCode())
+			errRootCause = fmt.Sprintf("%s, Please ensure all login details are correct (or that you are signed into the correct tenant for this storage account)", stgErr.ServiceCode())
 			stop = true
 		} else if stgErr.ServiceCode() == azbfs.ServiceCodeAuthenticationFailed {
 			errRootCause = fmt.Sprintf("%s, please check if AccessKey or OAuth is used properly", stgErr.ServiceCode())

--- a/cmd/copyS2SMigrationBlobEnumerator.go
+++ b/cmd/copyS2SMigrationBlobEnumerator.go
@@ -77,7 +77,9 @@ func (e *copyS2SMigrationBlobEnumerator) enumerate(cca *cookedCopyCmdArgs) error
 			}
 			return e.dispatchFinalPart(cca)
 		} else {
-			handleSingleFileValidationErrorForBlob(err)
+			if isFatal := handleSingleFileValidationErrorForBlob(err); isFatal {
+				return err
+			}
 		}
 	}
 

--- a/cmd/copyS2SMigrationFileEnumerator.go
+++ b/cmd/copyS2SMigrationFileEnumerator.go
@@ -81,7 +81,9 @@ func (e *copyS2SMigrationFileEnumerator) enumerate(cca *cookedCopyCmdArgs) error
 			}
 			return e.dispatchFinalPart(cca)
 		} else {
-			handleSingleFileValidationErrorForAzureFile(err)
+			if isFatal := handleSingleFileValidationErrorForAzureFile(err); isFatal {
+				return err
+			}
 		}
 	}
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -103,6 +103,11 @@ func (lca loginCmdArgs) process() error {
 		return err
 	}
 
+	if lca.tenantID == "" || lca.tenantID == "common" {
+		glcm.Info("WARNING: Logging in under the \"Common\" tenant. This will log the account in under its' home tenant, NOT under your target tenant.")
+		glcm.Info("If you plan to use azcopy for B2B storage accounts, please sign in under the target tenant with --tenant-id")
+	}
+
 	uotm := GetUserOAuthTokenManagerInstance()
 	// Persist the token to cache, if login fulfilled successfully.
 	if lca.identity {

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -104,8 +104,8 @@ func (lca loginCmdArgs) process() error {
 	}
 
 	if lca.tenantID == "" || lca.tenantID == "common" {
-		glcm.Info("WARNING: Logging in under the \"Common\" tenant. This will log the account in under its home tenant, NOT under your target tenant.")
-		glcm.Info("If you plan to use AzCopy for B2B Storage Accounts, please sign in under the target tenant with --tenant-id")
+		glcm.Info("Logging in under the \"Common\" tenant. This will log the account in under its home tenant.")
+		glcm.Info("If you plan to use AzCopy with a B2B account (where the account's home tenant is separate from the tenant of the target storage account), please sign in under the target tenant with --tenant-id\n")
 	}
 
 	uotm := GetUserOAuthTokenManagerInstance()

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -104,8 +104,8 @@ func (lca loginCmdArgs) process() error {
 	}
 
 	if lca.tenantID == "" || lca.tenantID == "common" {
-		glcm.Info("WARNING: Logging in under the \"Common\" tenant. This will log the account in under its' home tenant, NOT under your target tenant.")
-		glcm.Info("If you plan to use azcopy for B2B storage accounts, please sign in under the target tenant with --tenant-id")
+		glcm.Info("WARNING: Logging in under the \"Common\" tenant. This will log the account in under its home tenant, NOT under your target tenant.")
+		glcm.Info("If you plan to use AzCopy for B2B Storage Accounts, please sign in under the target tenant with --tenant-id")
 	}
 
 	uotm := GetUserOAuthTokenManagerInstance()

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -103,11 +103,6 @@ func (lca loginCmdArgs) process() error {
 		return err
 	}
 
-	if lca.tenantID == "" || lca.tenantID == "common" {
-		glcm.Info("Logging in under the \"Common\" tenant. This will log the account in under its home tenant.")
-		glcm.Info("If you plan to use AzCopy with a B2B account (where the account's home tenant is separate from the tenant of the target storage account), please sign in under the target tenant with --tenant-id\n")
-	}
-
 	uotm := GetUserOAuthTokenManagerInstance()
 	// Persist the token to cache, if login fulfilled successfully.
 	if lca.identity {

--- a/common/oauthTokenManager.go
+++ b/common/oauthTokenManager.go
@@ -170,7 +170,12 @@ func (uotm *UserOAuthTokenManager) UserLogin(tenantID, activeDirectoryEndpoint s
 	}
 
 	// Display the authentication message
-	fmt.Println(*deviceCode.Message)
+	fmt.Println(*deviceCode.Message + "\n")
+
+	if tenantID == "" || tenantID == "common" {
+		fmt.Println("INFO: Logging in under the \"Common\" tenant. This will log the account in under its home tenant.")
+		fmt.Println("INFO: If you plan to use AzCopy with a B2B account (where the account's home tenant is separate from the tenant of the target storage account), please sign in under the target tenant with --tenant-id")
+	}
 
 	// Wait here until the user is authenticated
 	// TODO: check if adal Go SDK has new method which supports context, currently ctrl-C can stop the login in console interactively.


### PR DESCRIPTION
These commits change how error handling works in download scenarios in the following ways:
- Enables a way for certain errors to stop their host enumerator in a clean way (Because if we don't stop it, the command continues even though we already know auth won't work)
- Adds catches for InvalidAuthenticationInfo ServiceCodes, generated primarily by errors related to an incorrect token issuer, etc.

Furthermore, it adds a warning to `azcopy login` in order to warn users in advance that they are logging in under the common tenant.

As a result, this solves issue #199 by providing relevant errors and warnings when a B2B user attempts to authenticate a storage account from the wrong tenant (as well as when a user attempts to log in from the common tenant).