### PR TITLE
Output the end-of-job summary to the log file

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/Azure/azure-pipeline-go/pipeline"
 	"time"
 
 	"net/url"
@@ -360,7 +361,7 @@ func (cca *cookedSyncCmdArgs) ReportProgressOrExit(lcm common.LifecycleMgr) {
 				return cca.getJsonOfSyncJobSummary(summary)
 			}
 
-			return fmt.Sprintf(
+			output := fmt.Sprintf(
 				`
 Job %s Summary
 Files Scanned at Source: %v
@@ -386,6 +387,12 @@ Final Job Status: %v
 				summary.TotalBytesEnumerated,
 				summary.JobStatus)
 
+			jobMan, exists := ste.JobsAdmin.JobMgr(summary.JobID)
+			if exists {
+				jobMan.Log(pipeline.LogInfo, output)
+			}
+
+			return output
 		}, exitCode)
 	}
 


### PR DESCRIPTION
Where's my staples button saying "that was easy"?

I would've __preferred__ to add this to `&lifecycleMgr.Exit()`, though I didn't want to change the function signature because there are other functions that don't have a summary or log. If you'd like me to move it over to `&lifecycleMgr.Exit()`, however, I'm more than happy to.