### PR TITLE
Drop logging the stack on HTTP errors

### DIFF
--- a/ste/xferLogPolicy.go
+++ b/ste/xferLogPolicy.go
@@ -98,9 +98,6 @@ func NewRequestLogPolicyFactory(o RequestLogOptions) pipeline.Factory {
 				}
 
 				pipeline.WriteRequestWithResponse(b, prepareRequestForLogging(request), response.Response(), err)
-				if logLevel <= pipeline.LogError {
-					b.Write(stack()) // For errors (or lower levels), we append the stack trace (an expensive operation)
-				}
 				msg := b.String()
 
 				if forceLog {

--- a/ste/xferLogPolicy.go
+++ b/ste/xferLogPolicy.go
@@ -98,6 +98,8 @@ func NewRequestLogPolicyFactory(o RequestLogOptions) pipeline.Factory {
 				}
 
 				pipeline.WriteRequestWithResponse(b, prepareRequestForLogging(request), response.Response(), err)
+				//Dropping HTTP errors as grabbing the stack is an expensive operation & fills the log too much
+				//for a set of harmless errors. HTTP requests ultimately will be retried.
 				if logLevel <= pipeline.LogError && !httpError {
 					b.Write(stack())
 				}


### PR DESCRIPTION
As discussed with Ze and John, this is an expensive operation that fills the log file far too much. PR coming to azure-pipeline-go soon with more log reductions.