### PR TITLE
Enabled copying to/from various blob types S2S

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 services:
 - docker
 script:
-- make test build # Drop OSX build temporarily
+- make all # Drop OSX build temporarily
 - mkdir test-temp
 - export AZCOPY_EXECUTABLE_PATH=$(pwd)/azcopy_linux_amd64
 - export TEST_SUITE_EXECUTABLE_LOCATION=$(pwd)/test-validator

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 services:
 - docker
 script:
-- make all
+- make test build # Drop OSX build temporarily
 - mkdir test-temp
 - export AZCOPY_EXECUTABLE_PATH=$(pwd)/azcopy_linux_amd64
 - export TEST_SUITE_EXECUTABLE_LOCATION=$(pwd)/test-validator

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,10 @@
 1. `--log-level=none` now drops no logs, and has a listing in `--help`
 1. Fixed bug where piping was not picking up the service version override, making it not work well against Azure Stack.
 
+### New features
+
+1. Enabled copying from page/block/append blob to another blob of a different type
+
 ## Version 10.1.2
 
 ### Breaking change

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -368,12 +368,6 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 			cooked.pageBlobTier != common.EPageBlobTier.None() {
 			return cooked, fmt.Errorf("blob-tier is not supported while copying from sevice to service")
 		}
-		// Disabling blob type override.
-		// i.e. not support block -> append/page, append -> block/page, page -> append/block,
-		// and when file and s3 is source, only block blob destination is supported.
-		if cooked.blobType != common.EBlobType.None() {
-			return cooked, fmt.Errorf("blob-type is not supported while coping from service to service")
-		}
 		if cooked.noGuessMimeType {
 			return cooked, fmt.Errorf("no-guess-mime-type is not supported while copying from service to service")
 		}

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -364,6 +364,12 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 		}
 		// Disabling blob tier override, when copying block -> block blob or page -> page blob, blob tier will be kept,
 		// For s3 and file, only hot block blob tier is supported.
+		if cooked.fromTo == common.EFromTo.FileBlob() && cooked.blobType != common.EBlobType.None() {
+			return cooked, fmt.Errorf("file -> blob is not a supported direction while copying from service to service")
+		}
+		if cooked.fromTo == common.EFromTo.S3Blob() && cooked.blobType != common.EBlobType.None() {
+			return cooked, fmt.Errorf("custom blob type is not supported while copying from s3 to blob")
+		}
 		if cooked.blockBlobTier != common.EBlockBlobTier.None() ||
 			cooked.pageBlobTier != common.EPageBlobTier.None() {
 			return cooked, fmt.Errorf("blob-tier is not supported while copying from sevice to service")

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -365,10 +365,10 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 		// Disabling blob tier override, when copying block -> block blob or page -> page blob, blob tier will be kept,
 		// For s3 and file, only hot block blob tier is supported.
 		if cooked.fromTo == common.EFromTo.FileBlob() && cooked.blobType != common.EBlobType.None() {
-			return cooked, fmt.Errorf("file -> blob is not a supported direction while copying from service to service")
+			return cooked, fmt.Errorf("blob-type is not supported while copying from file to blob")
 		}
 		if cooked.fromTo == common.EFromTo.S3Blob() && cooked.blobType != common.EBlobType.None() {
-			return cooked, fmt.Errorf("custom blob type is not supported while copying from s3 to blob")
+			return cooked, fmt.Errorf("blob-type is not supported while copying from s3 to blob")
 		}
 		if cooked.blockBlobTier != common.EBlockBlobTier.None() ||
 			cooked.pageBlobTier != common.EPageBlobTier.None() {

--- a/cmd/copyS2SMigrationBlobEnumerator.go
+++ b/cmd/copyS2SMigrationBlobEnumerator.go
@@ -68,7 +68,7 @@ func (e *copyS2SMigrationBlobEnumerator) enumerate(cca *cookedCopyCmdArgs) error
 				*e.destURL = urlExtension{*e.destURL}.generateObjectPath(fileName)
 			}
 			if cca.blobType == cca.blobType.PageBlob() && blobProperties.ContentLength()%512 != 0 {
-				return errors.New("page blobs must be a modulus of 512 bytes exactly")
+				return errors.New("page blobs must be a multiple of 512 bytes in length")
 			}
 			err := e.createDestBucket(ctx, *e.destURL, nil)
 			if err != nil {
@@ -93,7 +93,7 @@ func (e *copyS2SMigrationBlobEnumerator) enumerate(cca *cookedCopyCmdArgs) error
 	if isAccountLevel, containerPrefix := e.srcBlobURLPartExtension.isBlobAccountLevelSearch(); isAccountLevel {
 		glcm.Info(infoCopyFromAccount)
 		if cca.blobType == cca.blobType.PageBlob() {
-			glcm.Info("Copying entire account to page blobs will fail on files without a content length of modulus 512 bytes")
+			glcm.Info("Copying entire account to page blobs will fail on files without a content length that is a multiple of 512 bytes")
 		}
 		if !cca.recursive {
 			return fmt.Errorf("cannot copy the entire account without recursive flag. Please use --recursive flag")
@@ -114,7 +114,7 @@ func (e *copyS2SMigrationBlobEnumerator) enumerate(cca *cookedCopyCmdArgs) error
 	} else { // Case-3: Source is a blob container or directory
 		glcm.Info(infoCopyFromContainerDirectoryListOfFiles)
 		if cca.blobType == cca.blobType.PageBlob() {
-			glcm.Info("Copying directory to page blobs will fail on files without a content length of modulus 512 bytes")
+			glcm.Info("Copying directory to page blobs will fail on files without a content length that is a multiple of 512 bytes")
 		}
 		blobPrefix, blobNamePattern, isWildcardSearch := e.srcBlobURLPartExtension.searchPrefixFromBlobURL()
 		if blobNamePattern == "*" && !cca.recursive && !isWildcardSearch {

--- a/cmd/copyS2SMigrationBlobEnumerator.go
+++ b/cmd/copyS2SMigrationBlobEnumerator.go
@@ -2,12 +2,13 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"github.com/Azure/azure-storage-azcopy/common"
 	"net/url"
 	"strings"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/common"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 )
 
@@ -66,6 +67,9 @@ func (e *copyS2SMigrationBlobEnumerator) enumerate(cca *cookedCopyCmdArgs) error
 				fileName := gCopyUtil.getFileNameFromPath(e.srcBlobURLPartExtension.BlobName)
 				*e.destURL = urlExtension{*e.destURL}.generateObjectPath(fileName)
 			}
+			if cca.blobType == cca.blobType.PageBlob() && blobProperties.ContentLength()%512 != 0 {
+				return errors.New("page blobs must be a modulus of 512 bytes exactly")
+			}
 			err := e.createDestBucket(ctx, *e.destURL, nil)
 			if err != nil {
 				return err
@@ -88,6 +92,9 @@ func (e *copyS2SMigrationBlobEnumerator) enumerate(cca *cookedCopyCmdArgs) error
 	// b: https://<blob-service>/containerprefix*/vd/blob
 	if isAccountLevel, containerPrefix := e.srcBlobURLPartExtension.isBlobAccountLevelSearch(); isAccountLevel {
 		glcm.Info(infoCopyFromAccount)
+		if cca.blobType == cca.blobType.PageBlob() {
+			glcm.Info("Copying entire account to page blobs will fail on files without a content length of modulus 512 bytes")
+		}
 		if !cca.recursive {
 			return fmt.Errorf("cannot copy the entire account without recursive flag. Please use --recursive flag")
 		}
@@ -106,6 +113,9 @@ func (e *copyS2SMigrationBlobEnumerator) enumerate(cca *cookedCopyCmdArgs) error
 		}
 	} else { // Case-3: Source is a blob container or directory
 		glcm.Info(infoCopyFromContainerDirectoryListOfFiles)
+		if cca.blobType == cca.blobType.PageBlob() {
+			glcm.Info("Copying directory to page blobs will fail on files without a content length of modulus 512 bytes")
+		}
 		blobPrefix, blobNamePattern, isWildcardSearch := e.srcBlobURLPartExtension.searchPrefixFromBlobURL()
 		if blobNamePattern == "*" && !cca.recursive && !isWildcardSearch {
 			return fmt.Errorf("cannot copy the entire container or directory without recursive flag. Please use --recursive flag")

--- a/cmd/zt_copy_blob_download_test.go
+++ b/cmd/zt_copy_blob_download_test.go
@@ -36,7 +36,7 @@ func (s *cmdIntegrationSuite) TestDownloadSingleBlobToFile(c *chk.C) {
 	for _, blobName := range []string{"singleblobisbest", "打麻将.txt", "%4509%4254$85140&"} {
 		// set up the container with a single blob
 		blobList := []string{blobName}
-		scenarioHelper{}.generateBlobsFromList(c, containerURL, blobList)
+		scenarioHelper{}.generateBlobsFromList(c, containerURL, blobList, blockBlobDefaultData)
 		c.Assert(containerURL, chk.NotNil)
 
 		// set up the destination as a single file
@@ -186,7 +186,7 @@ func (s *cmdIntegrationSuite) TestDownloadBlobContainerWithPattern(c *chk.C) {
 
 	// add special blobs that we wish to include
 	blobsToInclude := []string{"important.pdf", "includeSub/amazing.pdf", "includeSub/wow/amazing.pdf"}
-	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobsToInclude)
+	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobsToInclude, blockBlobDefaultData)
 
 	// set up the destination with an empty folder
 	dstDirName := scenarioHelper{}.generateLocalDirectory(c)

--- a/cmd/zt_copy_blob_upload_test.go
+++ b/cmd/zt_copy_blob_upload_test.go
@@ -42,7 +42,7 @@ func (s *cmdIntegrationSuite) TestUploadSingleFileToBlob(c *chk.C) {
 
 		// set up the destination container with a single blob
 		dstBlobName := "whatever"
-		scenarioHelper{}.generateBlobsFromList(c, containerURL, []string{dstBlobName})
+		scenarioHelper{}.generateBlobsFromList(c, containerURL, []string{dstBlobName}, blockBlobDefaultData)
 		c.Assert(containerURL, chk.NotNil)
 
 		// set up interceptor

--- a/cmd/zt_copy_s2smigration_test.go
+++ b/cmd/zt_copy_s2smigration_test.go
@@ -935,9 +935,9 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromSingleBlobToBlobContainer(c *chk.C)
 		c.Assert(err, chk.IsNil)
 
 		// validate that the right number of transfers were scheduled
-		c.Assert(len(mockedRPC.transfers), chk.Equals, 2)
+		c.Assert(len(mockedRPC.transfers), chk.Equals, 1)
 
-		c.Assert(mockedRPC.transfers[1].Destination, chk.Equals, "/file2")
+		c.Assert(mockedRPC.transfers[0].Destination, chk.Equals, "/file2")
 	})
 }
 

--- a/cmd/zt_copy_s2smigration_test.go
+++ b/cmd/zt_copy_s2smigration_test.go
@@ -624,7 +624,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromPageToBlockBlob(c *chk.C) {
 	runCopyAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)
 
-		c.Assert(len(mockedRPC.transfers), chk.Equals, 1)
+		c.Assert(len(mockedRPC.transfers), chk.Equals, 2)
 
 		c.Assert(mockedRPC.transfers[0].Destination, chk.Equals, "/file2")
 	})
@@ -676,7 +676,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromBlockToPageBlob(c *chk.C) {
 	runCopyAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)
 
-		c.Assert(len(mockedRPC.transfers), chk.Equals, 1)
+		c.Assert(len(mockedRPC.transfers), chk.Equals, 2)
 
 		c.Assert(mockedRPC.transfers[0].Destination, chk.Equals, "/file2")
 	})
@@ -728,7 +728,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromBlockToAppendBlob(c *chk.C) {
 	runCopyAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)
 
-		c.Assert(len(mockedRPC.transfers), chk.Equals, 1)
+		c.Assert(len(mockedRPC.transfers), chk.Equals, 2)
 
 		c.Assert(mockedRPC.transfers[0].Destination, chk.Equals, "/file2")
 	})
@@ -780,7 +780,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromAppendToBlockBlob(c *chk.C) {
 	runCopyAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)
 
-		c.Assert(len(mockedRPC.transfers), chk.Equals, 1)
+		c.Assert(len(mockedRPC.transfers), chk.Equals, 2)
 
 		c.Assert(mockedRPC.transfers[0].Destination, chk.Equals, "/file2")
 	})
@@ -832,7 +832,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromPageToAppendBlob(c *chk.C) {
 	runCopyAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)
 
-		c.Assert(len(mockedRPC.transfers), chk.Equals, 1)
+		c.Assert(len(mockedRPC.transfers), chk.Equals, 2)
 
 		c.Assert(mockedRPC.transfers[0].Destination, chk.Equals, "/file2")
 	})
@@ -884,7 +884,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromAppendToPageBlob(c *chk.C) {
 	runCopyAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)
 
-		c.Assert(len(mockedRPC.transfers), chk.Equals, 1)
+		c.Assert(len(mockedRPC.transfers), chk.Equals, 2)
 
 		c.Assert(mockedRPC.transfers[0].Destination, chk.Equals, "/file2")
 	})
@@ -935,7 +935,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromSingleBlobToBlobContainer(c *chk.C)
 		c.Assert(err, chk.IsNil)
 
 		// validate that the right number of transfers were scheduled
-		c.Assert(len(mockedRPC.transfers), chk.Equals, 1)
+		c.Assert(len(mockedRPC.transfers), chk.Equals, 2)
 
 		c.Assert(mockedRPC.transfers[0].Destination, chk.Equals, "/file2")
 	})

--- a/cmd/zt_copy_s2smigration_test.go
+++ b/cmd/zt_copy_s2smigration_test.go
@@ -626,7 +626,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromPageToBlockBlob(c *chk.C) {
 
 		c.Assert(len(mockedRPC.transfers), chk.Equals, 2)
 
-		c.Assert(mockedRPC.transfers[0].Destination, chk.Equals, "/file2")
+		c.Assert(mockedRPC.transfers[1].Destination, chk.Equals, "/file2")
 	})
 }
 
@@ -678,7 +678,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromBlockToPageBlob(c *chk.C) {
 
 		c.Assert(len(mockedRPC.transfers), chk.Equals, 2)
 
-		c.Assert(mockedRPC.transfers[0].Destination, chk.Equals, "/file2")
+		c.Assert(mockedRPC.transfers[1].Destination, chk.Equals, "/file2")
 	})
 }
 
@@ -730,7 +730,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromBlockToAppendBlob(c *chk.C) {
 
 		c.Assert(len(mockedRPC.transfers), chk.Equals, 2)
 
-		c.Assert(mockedRPC.transfers[0].Destination, chk.Equals, "/file2")
+		c.Assert(mockedRPC.transfers[1].Destination, chk.Equals, "/file2")
 	})
 }
 
@@ -782,7 +782,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromAppendToBlockBlob(c *chk.C) {
 
 		c.Assert(len(mockedRPC.transfers), chk.Equals, 2)
 
-		c.Assert(mockedRPC.transfers[0].Destination, chk.Equals, "/file2")
+		c.Assert(mockedRPC.transfers[1].Destination, chk.Equals, "/file2")
 	})
 }
 
@@ -834,7 +834,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromPageToAppendBlob(c *chk.C) {
 
 		c.Assert(len(mockedRPC.transfers), chk.Equals, 2)
 
-		c.Assert(mockedRPC.transfers[0].Destination, chk.Equals, "/file2")
+		c.Assert(mockedRPC.transfers[1].Destination, chk.Equals, "/file2")
 	})
 }
 
@@ -886,7 +886,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromAppendToPageBlob(c *chk.C) {
 
 		c.Assert(len(mockedRPC.transfers), chk.Equals, 2)
 
-		c.Assert(mockedRPC.transfers[0].Destination, chk.Equals, "/file2")
+		c.Assert(mockedRPC.transfers[1].Destination, chk.Equals, "/file2")
 	})
 }
 
@@ -937,7 +937,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromSingleBlobToBlobContainer(c *chk.C)
 		// validate that the right number of transfers were scheduled
 		c.Assert(len(mockedRPC.transfers), chk.Equals, 2)
 
-		c.Assert(mockedRPC.transfers[0].Destination, chk.Equals, "/file2")
+		c.Assert(mockedRPC.transfers[1].Destination, chk.Equals, "/file2")
 	})
 }
 

--- a/cmd/zt_copy_s2smigration_test.go
+++ b/cmd/zt_copy_s2smigration_test.go
@@ -578,30 +578,34 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromContainerToContainerNoPreserveBlobT
 	})
 }
 
+//Attempt to copy from a page blob to a block blob
 func (s *cmdIntegrationSuite) TestS2SCopyFromPageToBlockBlob(c *chk.C) {
 	bsu := getBSU()
 
+	// Generate source container and blobs
 	srcContainerURL, srcContainerName := createNewContainer(c, bsu)
 	defer deleteContainer(c, srcContainerURL)
 	c.Assert(srcContainerURL, chk.NotNil)
-
-	//Generate page blobs
 	objectList := []string{"file", "sub/file2"}
 	scenarioHelper{}.generatePageBlobsFromList(c, srcContainerURL, objectList)
 
+	// Create destination container
 	dstContainerURL, dstContainerName := createNewContainer(c, bsu)
 	defer deleteContainer(c, dstContainerURL)
 	c.Assert(dstContainerURL, chk.NotNil)
 
+	// Set up interceptor
 	mockedRPC := interceptor{}
 	Rpc = mockedRPC.intercept
 	mockedRPC.init()
 
+	// Prepare copy command
 	rawSrcBlobURL := scenarioHelper{}.getRawBlobURLWithSAS(c, srcContainerName, "file")
 	rawDstContainerUrlWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, dstContainerName)
 	raw := getDefaultRawCopyInput(rawSrcBlobURL.String(), rawDstContainerUrlWithSAS.String())
 	raw.blobType = "BlockBlob"
 
+	// Run copy command
 	runCopyAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)
 
@@ -610,11 +614,13 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromPageToBlockBlob(c *chk.C) {
 		c.Assert(mockedRPC.transfers[0].Destination, chk.Equals, "/file")
 	})
 
+	// Prepare copy command
 	rawSrcBlobURL = scenarioHelper{}.getRawBlobURLWithSAS(c, srcContainerName, "sub/file2")
 	rawDstContainerUrlWithSAS = scenarioHelper{}.getRawContainerURLWithSAS(c, dstContainerName)
 	raw = getDefaultRawCopyInput(rawSrcBlobURL.String(), rawDstContainerUrlWithSAS.String())
 	raw.blobType = "BlockBlob"
 
+	// Run copy command
 	runCopyAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)
 
@@ -624,30 +630,34 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromPageToBlockBlob(c *chk.C) {
 	})
 }
 
+//Attempt to copy from a block blob to a page blob
 func (s *cmdIntegrationSuite) TestS2SCopyFromBlockToPageBlob(c *chk.C) {
 	bsu := getBSU()
 
+	// Generate source container and blobs
 	srcContainerURL, srcContainerName := createNewContainer(c, bsu)
 	defer deleteContainer(c, srcContainerURL)
 	c.Assert(srcContainerURL, chk.NotNil)
-
-	//Generate page blobs
 	objectList := []string{"file", "sub/file2"}
 	scenarioHelper{}.generateBlobsFromListForPageCopy(c, srcContainerURL, objectList)
 
+	// Create destination container
 	dstContainerURL, dstContainerName := createNewContainer(c, bsu)
 	defer deleteContainer(c, dstContainerURL)
 	c.Assert(dstContainerURL, chk.NotNil)
 
+	// Set up interceptor
 	mockedRPC := interceptor{}
 	Rpc = mockedRPC.intercept
 	mockedRPC.init()
 
+	// Prepare copy command
 	rawSrcBlobURL := scenarioHelper{}.getRawBlobURLWithSAS(c, srcContainerName, "file")
 	rawDstContainerUrlWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, dstContainerName)
 	raw := getDefaultRawCopyInput(rawSrcBlobURL.String(), rawDstContainerUrlWithSAS.String())
 	raw.blobType = "PageBlob"
 
+	// Run copy command
 	runCopyAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)
 
@@ -656,11 +666,13 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromBlockToPageBlob(c *chk.C) {
 		c.Assert(mockedRPC.transfers[0].Destination, chk.Equals, "/file")
 	})
 
+	// Prepare copy command
 	rawSrcBlobURL = scenarioHelper{}.getRawBlobURLWithSAS(c, srcContainerName, "sub/file2")
 	rawDstContainerUrlWithSAS = scenarioHelper{}.getRawContainerURLWithSAS(c, dstContainerName)
 	raw = getDefaultRawCopyInput(rawSrcBlobURL.String(), rawDstContainerUrlWithSAS.String())
 	raw.blobType = "PageBlob"
 
+	// Run copy command
 	runCopyAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)
 
@@ -670,30 +682,34 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromBlockToPageBlob(c *chk.C) {
 	})
 }
 
+//Attempt to copy from a block blob to an append blob
 func (s *cmdIntegrationSuite) TestS2SCopyFromBlockToAppendBlob(c *chk.C) {
 	bsu := getBSU()
 
+	// Generate source container and blobs
 	srcContainerURL, srcContainerName := createNewContainer(c, bsu)
 	defer deleteContainer(c, srcContainerURL)
 	c.Assert(srcContainerURL, chk.NotNil)
-
-	//Generate page blobs
 	objectList := []string{"file", "sub/file2"}
 	scenarioHelper{}.generateBlobsFromList(c, srcContainerURL, objectList)
 
+	// Create destination container
 	dstContainerURL, dstContainerName := createNewContainer(c, bsu)
 	defer deleteContainer(c, dstContainerURL)
 	c.Assert(dstContainerURL, chk.NotNil)
 
+	// Set up interceptor
 	mockedRPC := interceptor{}
 	Rpc = mockedRPC.intercept
 	mockedRPC.init()
 
+	// Prepare copy command
 	rawSrcBlobURL := scenarioHelper{}.getRawBlobURLWithSAS(c, srcContainerName, "file")
 	rawDstContainerUrlWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, dstContainerName)
 	raw := getDefaultRawCopyInput(rawSrcBlobURL.String(), rawDstContainerUrlWithSAS.String())
 	raw.blobType = "AppendBlob"
 
+	// Run copy command
 	runCopyAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)
 
@@ -702,11 +718,13 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromBlockToAppendBlob(c *chk.C) {
 		c.Assert(mockedRPC.transfers[0].Destination, chk.Equals, "/file")
 	})
 
+	// Prepare copy command
 	rawSrcBlobURL = scenarioHelper{}.getRawBlobURLWithSAS(c, srcContainerName, "sub/file2")
 	rawDstContainerUrlWithSAS = scenarioHelper{}.getRawContainerURLWithSAS(c, dstContainerName)
 	raw = getDefaultRawCopyInput(rawSrcBlobURL.String(), rawDstContainerUrlWithSAS.String())
 	raw.blobType = "AppendBlob"
 
+	// Run copy command
 	runCopyAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)
 
@@ -716,30 +734,34 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromBlockToAppendBlob(c *chk.C) {
 	})
 }
 
+//Attempt to copy from an append blob to a block blob
 func (s *cmdIntegrationSuite) TestS2SCopyFromAppendToBlockBlob(c *chk.C) {
 	bsu := getBSU()
 
+	// Generate source container and blobs
 	srcContainerURL, srcContainerName := createNewContainer(c, bsu)
 	defer deleteContainer(c, srcContainerURL)
 	c.Assert(srcContainerURL, chk.NotNil)
-
-	//Generate page blobs
 	objectList := []string{"file", "sub/file2"}
 	scenarioHelper{}.generateAppendBlobsFromList(c, srcContainerURL, objectList)
 
+	// Create destination container
 	dstContainerURL, dstContainerName := createNewContainer(c, bsu)
 	defer deleteContainer(c, dstContainerURL)
 	c.Assert(dstContainerURL, chk.NotNil)
 
+	// Set up interceptor
 	mockedRPC := interceptor{}
 	Rpc = mockedRPC.intercept
 	mockedRPC.init()
 
+	// Prepare copy command
 	rawSrcBlobURL := scenarioHelper{}.getRawBlobURLWithSAS(c, srcContainerName, "file")
 	rawDstContainerUrlWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, dstContainerName)
 	raw := getDefaultRawCopyInput(rawSrcBlobURL.String(), rawDstContainerUrlWithSAS.String())
 	raw.blobType = "BlockBlob"
 
+	// Run copy command
 	runCopyAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)
 
@@ -748,11 +770,13 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromAppendToBlockBlob(c *chk.C) {
 		c.Assert(mockedRPC.transfers[0].Destination, chk.Equals, "/file")
 	})
 
+	// Prepare copy command
 	rawSrcBlobURL = scenarioHelper{}.getRawBlobURLWithSAS(c, srcContainerName, "sub/file2")
 	rawDstContainerUrlWithSAS = scenarioHelper{}.getRawContainerURLWithSAS(c, dstContainerName)
 	raw = getDefaultRawCopyInput(rawSrcBlobURL.String(), rawDstContainerUrlWithSAS.String())
 	raw.blobType = "BlockBlob"
 
+	// Run copy command
 	runCopyAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)
 
@@ -762,30 +786,34 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromAppendToBlockBlob(c *chk.C) {
 	})
 }
 
+//Attempt to copy from a page blob to an append blob
 func (s *cmdIntegrationSuite) TestS2SCopyFromPageToAppendBlob(c *chk.C) {
 	bsu := getBSU()
 
+	// Generate source container and blobs
 	srcContainerURL, srcContainerName := createNewContainer(c, bsu)
 	defer deleteContainer(c, srcContainerURL)
 	c.Assert(srcContainerURL, chk.NotNil)
-
-	//Generate page blobs
 	objectList := []string{"file", "sub/file2"}
 	scenarioHelper{}.generatePageBlobsFromList(c, srcContainerURL, objectList)
 
+	// Create destination container
 	dstContainerURL, dstContainerName := createNewContainer(c, bsu)
 	defer deleteContainer(c, dstContainerURL)
 	c.Assert(dstContainerURL, chk.NotNil)
 
+	// Set up interceptor
 	mockedRPC := interceptor{}
 	Rpc = mockedRPC.intercept
 	mockedRPC.init()
 
+	// Prepare copy command
 	rawSrcBlobURL := scenarioHelper{}.getRawBlobURLWithSAS(c, srcContainerName, "file")
 	rawDstContainerUrlWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, dstContainerName)
 	raw := getDefaultRawCopyInput(rawSrcBlobURL.String(), rawDstContainerUrlWithSAS.String())
 	raw.blobType = "AppendBlob"
 
+	// Run copy command
 	runCopyAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)
 
@@ -794,11 +822,13 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromPageToAppendBlob(c *chk.C) {
 		c.Assert(mockedRPC.transfers[0].Destination, chk.Equals, "/file")
 	})
 
+	// Prepare copy command
 	rawSrcBlobURL = scenarioHelper{}.getRawBlobURLWithSAS(c, srcContainerName, "sub/file2")
 	rawDstContainerUrlWithSAS = scenarioHelper{}.getRawContainerURLWithSAS(c, dstContainerName)
 	raw = getDefaultRawCopyInput(rawSrcBlobURL.String(), rawDstContainerUrlWithSAS.String())
 	raw.blobType = "AppendBlob"
 
+	// Run copy command
 	runCopyAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)
 
@@ -808,30 +838,34 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromPageToAppendBlob(c *chk.C) {
 	})
 }
 
+//Attempt to copy from an append blob to a page blob
 func (s *cmdIntegrationSuite) TestS2SCopyFromAppendToPageBlob(c *chk.C) {
 	bsu := getBSU()
 
+	// Generate source container and blobs
 	srcContainerURL, srcContainerName := createNewContainer(c, bsu)
 	defer deleteContainer(c, srcContainerURL)
 	c.Assert(srcContainerURL, chk.NotNil)
-
-	//Generate page blobs
 	objectList := []string{"file", "sub/file2"}
 	scenarioHelper{}.generateAppendBlobsFromListForPageCopy(c, srcContainerURL, objectList)
 
+	// Create destination container
 	dstContainerURL, dstContainerName := createNewContainer(c, bsu)
 	defer deleteContainer(c, dstContainerURL)
 	c.Assert(dstContainerURL, chk.NotNil)
 
+	// Set up interceptor
 	mockedRPC := interceptor{}
 	Rpc = mockedRPC.intercept
 	mockedRPC.init()
 
+	// Prepare copy command
 	rawSrcBlobURL := scenarioHelper{}.getRawBlobURLWithSAS(c, srcContainerName, "file")
 	rawDstContainerUrlWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, dstContainerName)
 	raw := getDefaultRawCopyInput(rawSrcBlobURL.String(), rawDstContainerUrlWithSAS.String())
 	raw.blobType = "PageBlob"
 
+	// Run copy command
 	runCopyAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)
 
@@ -840,11 +874,13 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromAppendToPageBlob(c *chk.C) {
 		c.Assert(mockedRPC.transfers[0].Destination, chk.Equals, "/file")
 	})
 
+	// Prepare copy command
 	rawSrcBlobURL = scenarioHelper{}.getRawBlobURLWithSAS(c, srcContainerName, "sub/file2")
 	rawDstContainerUrlWithSAS = scenarioHelper{}.getRawContainerURLWithSAS(c, dstContainerName)
 	raw = getDefaultRawCopyInput(rawSrcBlobURL.String(), rawDstContainerUrlWithSAS.String())
 	raw.blobType = "PageBlob"
 
+	// Run copy command
 	runCopyAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)
 

--- a/cmd/zt_copy_s2smigration_test.go
+++ b/cmd/zt_copy_s2smigration_test.go
@@ -587,7 +587,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromPageToBlockBlob(c *chk.C) {
 	defer deleteContainer(c, srcContainerURL)
 	c.Assert(srcContainerURL, chk.NotNil)
 	objectList := []string{"file", "sub/file2"}
-	scenarioHelper{}.generatePageBlobsFromList(c, srcContainerURL, objectList)
+	scenarioHelper{}.generatePageBlobsFromList(c, srcContainerURL, objectList, pageBlobDefaultData)
 
 	// Create destination container
 	dstContainerURL, dstContainerName := createNewContainer(c, bsu)
@@ -639,7 +639,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromBlockToPageBlob(c *chk.C) {
 	defer deleteContainer(c, srcContainerURL)
 	c.Assert(srcContainerURL, chk.NotNil)
 	objectList := []string{"file", "sub/file2"}
-	scenarioHelper{}.generateBlobsFromListForPageCopy(c, srcContainerURL, objectList)
+	scenarioHelper{}.generateBlobsFromList(c, srcContainerURL, objectList, pageBlobDefaultData)
 
 	// Create destination container
 	dstContainerURL, dstContainerName := createNewContainer(c, bsu)
@@ -691,7 +691,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromBlockToAppendBlob(c *chk.C) {
 	defer deleteContainer(c, srcContainerURL)
 	c.Assert(srcContainerURL, chk.NotNil)
 	objectList := []string{"file", "sub/file2"}
-	scenarioHelper{}.generateBlobsFromList(c, srcContainerURL, objectList)
+	scenarioHelper{}.generateBlobsFromList(c, srcContainerURL, objectList, blockBlobDefaultData)
 
 	// Create destination container
 	dstContainerURL, dstContainerName := createNewContainer(c, bsu)
@@ -743,7 +743,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromAppendToBlockBlob(c *chk.C) {
 	defer deleteContainer(c, srcContainerURL)
 	c.Assert(srcContainerURL, chk.NotNil)
 	objectList := []string{"file", "sub/file2"}
-	scenarioHelper{}.generateAppendBlobsFromList(c, srcContainerURL, objectList)
+	scenarioHelper{}.generateAppendBlobsFromList(c, srcContainerURL, objectList, appendBlobDefaultData)
 
 	// Create destination container
 	dstContainerURL, dstContainerName := createNewContainer(c, bsu)
@@ -795,7 +795,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromPageToAppendBlob(c *chk.C) {
 	defer deleteContainer(c, srcContainerURL)
 	c.Assert(srcContainerURL, chk.NotNil)
 	objectList := []string{"file", "sub/file2"}
-	scenarioHelper{}.generatePageBlobsFromList(c, srcContainerURL, objectList)
+	scenarioHelper{}.generatePageBlobsFromList(c, srcContainerURL, objectList, pageBlobDefaultData)
 
 	// Create destination container
 	dstContainerURL, dstContainerName := createNewContainer(c, bsu)
@@ -847,7 +847,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromAppendToPageBlob(c *chk.C) {
 	defer deleteContainer(c, srcContainerURL)
 	c.Assert(srcContainerURL, chk.NotNil)
 	objectList := []string{"file", "sub/file2"}
-	scenarioHelper{}.generateAppendBlobsFromListForPageCopy(c, srcContainerURL, objectList)
+	scenarioHelper{}.generateAppendBlobsFromList(c, srcContainerURL, objectList, pageBlobDefaultData)
 
 	// Create destination container
 	dstContainerURL, dstContainerName := createNewContainer(c, bsu)
@@ -898,7 +898,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromSingleBlobToBlobContainer(c *chk.C)
 	c.Assert(srcContainerURL, chk.NotNil)
 
 	objectList := []string{"file", "sub/file2"}
-	scenarioHelper{}.generateBlobsFromList(c, srcContainerURL, objectList)
+	scenarioHelper{}.generateBlobsFromList(c, srcContainerURL, objectList, blockBlobDefaultData)
 
 	dstContainerURL, dstContainerName := createNewContainer(c, bsu)
 	defer deleteContainer(c, dstContainerURL)

--- a/cmd/zt_generic_processor_test.go
+++ b/cmd/zt_generic_processor_test.go
@@ -106,7 +106,7 @@ func (s *genericProcessorSuite) TestCopyTransferProcessorSingleFile(c *chk.C) {
 
 	// set up the container with a single blob
 	blobList := []string{"singlefile101"}
-	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobList)
+	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobList, blockBlobDefaultData)
 	c.Assert(containerURL, chk.NotNil)
 
 	// set up the directory with a single file

--- a/cmd/zt_generic_traverser_test.go
+++ b/cmd/zt_generic_traverser_test.go
@@ -50,7 +50,7 @@ func (s *genericTraverserSuite) TestTraverserWithSingleObject(c *chk.C) {
 	for _, storedObjectName := range []string{"sub1/sub2/singleblobisbest", "nosubsingleblob", "满汉全席.txt"} {
 		// set up the container with a single blob
 		blobList := []string{storedObjectName}
-		scenarioHelper{}.generateBlobsFromList(c, containerURL, blobList)
+		scenarioHelper{}.generateBlobsFromList(c, containerURL, blobList, blockBlobDefaultData)
 
 		// set up the directory as a single file
 		dstDirName := scenarioHelper{}.generateLocalDirectory(c)

--- a/cmd/zt_remove_blob_test.go
+++ b/cmd/zt_remove_blob_test.go
@@ -34,7 +34,7 @@ func (s *cmdIntegrationSuite) TestRemoveSingleBlob(c *chk.C) {
 	for _, blobName := range []string{"top/mid/low/singleblobisbest", "打麻将.txt", "%4509%4254$85140&"} {
 		// set up the container with a single blob
 		blobList := []string{blobName}
-		scenarioHelper{}.generateBlobsFromList(c, containerURL, blobList)
+		scenarioHelper{}.generateBlobsFromList(c, containerURL, blobList, blockBlobDefaultData)
 		c.Assert(containerURL, chk.NotNil)
 
 		// set up interceptor
@@ -158,7 +158,7 @@ func (s *cmdIntegrationSuite) TestRemoveWithIncludeFlag(c *chk.C) {
 
 	// add special blobs that we wish to include
 	blobsToInclude := []string{"important.pdf", "includeSub/amazing.jpeg", "exactName"}
-	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobsToInclude)
+	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobsToInclude, blockBlobDefaultData)
 	includeString := "*.pdf;*.jpeg;exactName"
 
 	// set up interceptor
@@ -191,7 +191,7 @@ func (s *cmdIntegrationSuite) TestRemoveWithExcludeFlag(c *chk.C) {
 
 	// add special blobs that we wish to exclude
 	blobsToExclude := []string{"notGood.pdf", "excludeSub/lame.jpeg", "exactName"}
-	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobsToExclude)
+	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobsToExclude, blockBlobDefaultData)
 	excludeString := "*.pdf;*.jpeg;exactName"
 
 	// set up interceptor
@@ -224,13 +224,13 @@ func (s *cmdIntegrationSuite) TestRemoveWithIncludeAndExcludeFlag(c *chk.C) {
 
 	// add special blobs that we wish to include
 	blobsToInclude := []string{"important.pdf", "includeSub/amazing.jpeg"}
-	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobsToInclude)
+	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobsToInclude, blockBlobDefaultData)
 	includeString := "*.pdf;*.jpeg;exactName"
 
 	// add special blobs that we wish to exclude
 	// note that the excluded files also match the include string
 	blobsToExclude := []string{"sorry.pdf", "exclude/notGood.jpeg", "exactName", "sub/exactName"}
-	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobsToExclude)
+	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobsToExclude, blockBlobDefaultData)
 	excludeString := "so*;not*;exactName"
 
 	// set up interceptor

--- a/cmd/zt_scenario_helpers_for_test.go
+++ b/cmd/zt_scenario_helpers_for_test.go
@@ -175,6 +175,104 @@ func (scenarioHelper) generateBlobsFromList(c *chk.C, containerURL azblob.Contai
 	time.Sleep(time.Millisecond * 1500)
 }
 
+func (scenarioHelper) generateBlobsFromListForPageCopy(c *chk.C, containerURL azblob.ContainerURL, blobList []string) {
+	for _, blobName := range blobList {
+		blob := containerURL.NewBlockBlobURL(blobName)
+		cResp, err := blob.Upload(ctx, strings.NewReader(pageBlobDefaultData), azblob.BlobHTTPHeaders{},
+			nil, azblob.BlobAccessConditions{})
+		c.Assert(err, chk.IsNil)
+		c.Assert(cResp.StatusCode(), chk.Equals, 201)
+	}
+
+	// sleep a bit so that the blobs' lmts are guaranteed to be in the past
+	time.Sleep(time.Millisecond * 1500)
+}
+
+func (scenarioHelper) generatePageBlobsFromList(c *chk.C, containerURL azblob.ContainerURL, blobList []string) {
+	for _, blobName := range blobList {
+		//Create the blob (PUT blob)
+		blob := containerURL.NewPageBlobURL(blobName)
+		cResp, err := blob.Create(ctx,
+			int64(len(pageBlobDefaultData)),
+			0,
+			azblob.BlobHTTPHeaders{
+				ContentType: "text/random",
+			},
+			azblob.Metadata{},
+			azblob.BlobAccessConditions{},
+		)
+		c.Assert(err, chk.IsNil)
+		c.Assert(cResp.StatusCode(), chk.Equals, 201)
+
+		//Create the page (PUT page)
+		uResp, err := blob.UploadPages(ctx,
+			0,
+			strings.NewReader(pageBlobDefaultData),
+			azblob.PageBlobAccessConditions{},
+			nil,
+		)
+		c.Assert(err, chk.IsNil)
+		c.Assert(uResp.StatusCode(), chk.Equals, 201)
+	}
+
+	// sleep a bit so that the blobs' lmts are guaranteed to be in the past
+	time.Sleep(time.Millisecond * 1500)
+}
+
+func (scenarioHelper) generateAppendBlobsFromList(c *chk.C, containerURL azblob.ContainerURL, blobList []string) {
+	for _, blobName := range blobList {
+		//Create the blob (PUT blob)
+		blob := containerURL.NewAppendBlobURL(blobName)
+		cResp, err := blob.Create(ctx,
+			azblob.BlobHTTPHeaders{
+				ContentType: "text/random",
+			},
+			azblob.Metadata{},
+			azblob.BlobAccessConditions{},
+		)
+		c.Assert(err, chk.IsNil)
+		c.Assert(cResp.StatusCode(), chk.Equals, 201)
+
+		//Append a block (PUT block)
+		uResp, err := blob.AppendBlock(ctx,
+			strings.NewReader(blockBlobDefaultData),
+			azblob.AppendBlobAccessConditions{},
+			nil)
+		c.Assert(err, chk.IsNil)
+		c.Assert(uResp.StatusCode(), chk.Equals, 201)
+	}
+
+	// sleep a bit so that the blobs' lmts are guaranteed to be in the past
+	time.Sleep(time.Millisecond * 1500)
+}
+
+func (scenarioHelper) generateAppendBlobsFromListForPageCopy(c *chk.C, containerURL azblob.ContainerURL, blobList []string) {
+	for _, blobName := range blobList {
+		//Create the blob (PUT blob)
+		blob := containerURL.NewAppendBlobURL(blobName)
+		cResp, err := blob.Create(ctx,
+			azblob.BlobHTTPHeaders{
+				ContentType: "text/random",
+			},
+			azblob.Metadata{},
+			azblob.BlobAccessConditions{},
+		)
+		c.Assert(err, chk.IsNil)
+		c.Assert(cResp.StatusCode(), chk.Equals, 201)
+
+		//Append a block (PUT block)
+		uResp, err := blob.AppendBlock(ctx,
+			strings.NewReader(pageBlobDefaultData),
+			azblob.AppendBlobAccessConditions{},
+			nil)
+		c.Assert(err, chk.IsNil)
+		c.Assert(uResp.StatusCode(), chk.Equals, 201)
+	}
+
+	// sleep a bit so that the blobs' lmts are guaranteed to be in the past
+	time.Sleep(time.Millisecond * 1500)
+}
+
 func (scenarioHelper) generateBlockBlobWithAccessTier(c *chk.C, containerURL azblob.ContainerURL, blobName string, accessTier azblob.AccessTierType) {
 	blob := containerURL.NewBlockBlobURL(blobName)
 	cResp, err := blob.Upload(ctx, strings.NewReader(blockBlobDefaultData), azblob.BlobHTTPHeaders{},

--- a/cmd/zt_scenario_helpers_for_test.go
+++ b/cmd/zt_scenario_helpers_for_test.go
@@ -162,10 +162,10 @@ func (scenarioHelper) generateCommonRemoteScenarioForAzureFile(c *chk.C, shareUR
 }
 
 // create the demanded blobs
-func (scenarioHelper) generateBlobsFromList(c *chk.C, containerURL azblob.ContainerURL, blobList []string) {
+func (scenarioHelper) generateBlobsFromList(c *chk.C, containerURL azblob.ContainerURL, blobList []string, data string) {
 	for _, blobName := range blobList {
 		blob := containerURL.NewBlockBlobURL(blobName)
-		cResp, err := blob.Upload(ctx, strings.NewReader(blockBlobDefaultData), azblob.BlobHTTPHeaders{},
+		cResp, err := blob.Upload(ctx, strings.NewReader(data), azblob.BlobHTTPHeaders{},
 			nil, azblob.BlobAccessConditions{})
 		c.Assert(err, chk.IsNil)
 		c.Assert(cResp.StatusCode(), chk.Equals, 201)
@@ -175,25 +175,12 @@ func (scenarioHelper) generateBlobsFromList(c *chk.C, containerURL azblob.Contai
 	time.Sleep(time.Millisecond * 1500)
 }
 
-func (scenarioHelper) generateBlobsFromListForPageCopy(c *chk.C, containerURL azblob.ContainerURL, blobList []string) {
-	for _, blobName := range blobList {
-		blob := containerURL.NewBlockBlobURL(blobName)
-		cResp, err := blob.Upload(ctx, strings.NewReader(pageBlobDefaultData), azblob.BlobHTTPHeaders{},
-			nil, azblob.BlobAccessConditions{})
-		c.Assert(err, chk.IsNil)
-		c.Assert(cResp.StatusCode(), chk.Equals, 201)
-	}
-
-	// sleep a bit so that the blobs' lmts are guaranteed to be in the past
-	time.Sleep(time.Millisecond * 1500)
-}
-
-func (scenarioHelper) generatePageBlobsFromList(c *chk.C, containerURL azblob.ContainerURL, blobList []string) {
+func (scenarioHelper) generatePageBlobsFromList(c *chk.C, containerURL azblob.ContainerURL, blobList []string, data string) {
 	for _, blobName := range blobList {
 		//Create the blob (PUT blob)
 		blob := containerURL.NewPageBlobURL(blobName)
 		cResp, err := blob.Create(ctx,
-			int64(len(pageBlobDefaultData)),
+			int64(len(data)),
 			0,
 			azblob.BlobHTTPHeaders{
 				ContentType: "text/random",
@@ -207,7 +194,7 @@ func (scenarioHelper) generatePageBlobsFromList(c *chk.C, containerURL azblob.Co
 		//Create the page (PUT page)
 		uResp, err := blob.UploadPages(ctx,
 			0,
-			strings.NewReader(pageBlobDefaultData),
+			strings.NewReader(data),
 			azblob.PageBlobAccessConditions{},
 			nil,
 		)
@@ -219,7 +206,7 @@ func (scenarioHelper) generatePageBlobsFromList(c *chk.C, containerURL azblob.Co
 	time.Sleep(time.Millisecond * 1500)
 }
 
-func (scenarioHelper) generateAppendBlobsFromList(c *chk.C, containerURL azblob.ContainerURL, blobList []string) {
+func (scenarioHelper) generateAppendBlobsFromList(c *chk.C, containerURL azblob.ContainerURL, blobList []string, data string) {
 	for _, blobName := range blobList {
 		//Create the blob (PUT blob)
 		blob := containerURL.NewAppendBlobURL(blobName)
@@ -235,34 +222,7 @@ func (scenarioHelper) generateAppendBlobsFromList(c *chk.C, containerURL azblob.
 
 		//Append a block (PUT block)
 		uResp, err := blob.AppendBlock(ctx,
-			strings.NewReader(blockBlobDefaultData),
-			azblob.AppendBlobAccessConditions{},
-			nil)
-		c.Assert(err, chk.IsNil)
-		c.Assert(uResp.StatusCode(), chk.Equals, 201)
-	}
-
-	// sleep a bit so that the blobs' lmts are guaranteed to be in the past
-	time.Sleep(time.Millisecond * 1500)
-}
-
-func (scenarioHelper) generateAppendBlobsFromListForPageCopy(c *chk.C, containerURL azblob.ContainerURL, blobList []string) {
-	for _, blobName := range blobList {
-		//Create the blob (PUT blob)
-		blob := containerURL.NewAppendBlobURL(blobName)
-		cResp, err := blob.Create(ctx,
-			azblob.BlobHTTPHeaders{
-				ContentType: "text/random",
-			},
-			azblob.Metadata{},
-			azblob.BlobAccessConditions{},
-		)
-		c.Assert(err, chk.IsNil)
-		c.Assert(cResp.StatusCode(), chk.Equals, 201)
-
-		//Append a block (PUT block)
-		uResp, err := blob.AppendBlock(ctx,
-			strings.NewReader(pageBlobDefaultData),
+			strings.NewReader(data),
 			azblob.AppendBlobAccessConditions{},
 			nil)
 		c.Assert(err, chk.IsNil)

--- a/cmd/zt_sync_download_test.go
+++ b/cmd/zt_sync_download_test.go
@@ -44,7 +44,7 @@ func (s *cmdIntegrationSuite) TestSyncDownloadWithSingleFile(c *chk.C) {
 	for _, blobName := range []string{"singleblobisbest", "打麻将.txt", "%4509%4254$85140&"} {
 		// set up the container with a single blob
 		blobList := []string{blobName}
-		scenarioHelper{}.generateBlobsFromList(c, containerURL, blobList)
+		scenarioHelper{}.generateBlobsFromList(c, containerURL, blobList, blockBlobDefaultData)
 		c.Assert(containerURL, chk.NotNil)
 
 		// set up the destination as a single file
@@ -70,7 +70,7 @@ func (s *cmdIntegrationSuite) TestSyncDownloadWithSingleFile(c *chk.C) {
 		})
 
 		// recreate the blob to have a later last modified time
-		scenarioHelper{}.generateBlobsFromList(c, containerURL, blobList)
+		scenarioHelper{}.generateBlobsFromList(c, containerURL, blobList, blockBlobDefaultData)
 		mockedRPC.reset()
 
 		runSyncAndVerify(c, raw, func(err error) {
@@ -160,7 +160,7 @@ func (s *cmdIntegrationSuite) TestSyncDownloadWithIdenticalDestination(c *chk.C)
 	})
 
 	// refresh the blobs' last modified time so that they are newer
-	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobList)
+	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobList, blockBlobDefaultData)
 	mockedRPC.reset()
 
 	runSyncAndVerify(c, raw, func(err error) {
@@ -225,7 +225,7 @@ func (s *cmdIntegrationSuite) TestSyncDownloadWithIncludeFlag(c *chk.C) {
 
 	// add special blobs that we wish to include
 	blobsToInclude := []string{"important.pdf", "includeSub/amazing.jpeg", "exactName"}
-	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobsToInclude)
+	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobsToInclude, blockBlobDefaultData)
 	includeString := "*.pdf;*.jpeg;exactName"
 
 	// set up the destination with an empty folder
@@ -260,7 +260,7 @@ func (s *cmdIntegrationSuite) TestSyncDownloadWithExcludeFlag(c *chk.C) {
 
 	// add special blobs that we wish to exclude
 	blobsToExclude := []string{"notGood.pdf", "excludeSub/lame.jpeg", "exactName"}
-	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobsToExclude)
+	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobsToExclude, blockBlobDefaultData)
 	excludeString := "*.pdf;*.jpeg;exactName"
 
 	// set up the destination with an empty folder
@@ -295,13 +295,13 @@ func (s *cmdIntegrationSuite) TestSyncDownloadWithIncludeAndExcludeFlag(c *chk.C
 
 	// add special blobs that we wish to include
 	blobsToInclude := []string{"important.pdf", "includeSub/amazing.jpeg"}
-	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobsToInclude)
+	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobsToInclude, blockBlobDefaultData)
 	includeString := "*.pdf;*.jpeg;exactName"
 
 	// add special blobs that we wish to exclude
 	// note that the excluded files also match the include string
 	blobsToExclude := []string{"sorry.pdf", "exclude/notGood.jpeg", "exactName", "sub/exactName"}
-	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobsToExclude)
+	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobsToExclude, blockBlobDefaultData)
 	excludeString := "so*;not*;exactName"
 
 	// set up the destination with an empty folder
@@ -409,7 +409,7 @@ func (s *cmdIntegrationSuite) TestSyncMismatchBlobAndDirectory(c *chk.C) {
 	blobName := "singleblobisbest"
 	blobList := []string{blobName}
 	containerURL, containerName := createNewContainer(c, bsu)
-	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobList)
+	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobList, blockBlobDefaultData)
 	defer deleteContainer(c, containerURL)
 	c.Assert(containerURL, chk.NotNil)
 

--- a/cmd/zt_sync_processor_test.go
+++ b/cmd/zt_sync_processor_test.go
@@ -68,7 +68,7 @@ func (s *syncProcessorSuite) TestBlobDeleter(c *chk.C) {
 	// set up the blob to delete
 	containerURL, containerName := createNewContainer(c, bsu)
 	defer deleteContainer(c, containerURL)
-	scenarioHelper{}.generateBlobsFromList(c, containerURL, []string{blobName})
+	scenarioHelper{}.generateBlobsFromList(c, containerURL, []string{blobName}, blockBlobDefaultData)
 
 	// validate that the blob exists
 	blobURL := containerURL.NewBlobURL(blobName)

--- a/cmd/zt_sync_upload_test.go
+++ b/cmd/zt_sync_upload_test.go
@@ -43,7 +43,7 @@ func (s *cmdIntegrationSuite) TestSyncUploadWithSingleFile(c *chk.C) {
 
 		// set up the destination container with a single blob
 		dstBlobName := srcFileName
-		scenarioHelper{}.generateBlobsFromList(c, containerURL, []string{dstBlobName})
+		scenarioHelper{}.generateBlobsFromList(c, containerURL, []string{dstBlobName}, blockBlobDefaultData)
 		c.Assert(containerURL, chk.NotNil)
 
 		// set up interceptor
@@ -134,7 +134,7 @@ func (s *cmdIntegrationSuite) TestSyncUploadWithIdenticalDestination(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 
 	// wait for 1 second so that the last modified times of the blobs are guaranteed to be newer
-	scenarioHelper{}.generateBlobsFromList(c, containerURL, fileList)
+	scenarioHelper{}.generateBlobsFromList(c, containerURL, fileList, blockBlobDefaultData)
 
 	// set up interceptor
 	mockedRPC := interceptor{}
@@ -175,8 +175,8 @@ func (s *cmdIntegrationSuite) TestSyncUploadWithMismatchedDestination(c *chk.C) 
 	extraBlobs := []string{"extraFile1.pdf, extraFile2.txt"}
 	containerURL, containerName := createNewContainer(c, bsu)
 	defer deleteContainer(c, containerURL)
-	scenarioHelper{}.generateBlobsFromList(c, containerURL, fileList[0:len(fileList)/2])
-	scenarioHelper{}.generateBlobsFromList(c, containerURL, extraBlobs)
+	scenarioHelper{}.generateBlobsFromList(c, containerURL, fileList[0:len(fileList)/2], blockBlobDefaultData)
+	scenarioHelper{}.generateBlobsFromList(c, containerURL, extraBlobs, blockBlobDefaultData)
 	expectedOutput := fileList[len(fileList)/2:]
 
 	// set up interceptor

--- a/cmd/zt_test.go
+++ b/cmd/zt_test.go
@@ -55,6 +55,9 @@ const (
 	containerPrefix      = "container"
 	blobPrefix           = "blob"
 	blockBlobDefaultData = "AzCopy Random Test Data"
+	//512 bytes of alphanumeric random data
+	pageBlobDefaultData   = "lEYvPHhS2c9T7DDNtM7f0gccgbqe7DMYByLj7d1XS6jV5Y0Cuiz5i86e5llkBwzCahnR4n1MUvfpniNBxgRgJ4oNk8oaIlCevtsPaCZgOMpKdPohp7yYTfawiz8MtHlTwM8OmfgngbH2BNiqtSFEx9GArvkwkVF0dPoG6RRBug0BqHiWyMd0mZifrBTneG13bqKg7A8EjRmBHIqCMGoxOYo1ufojJjYKiv8dfBYGib4pNpfrcxlEWrMKEPcgs3YG3AGg2lIKrMVs7yWnSzwqeEnl9oMFjdwc7XB2e7y2IH1JLt8CzaYgW6qvaPzhFXWbUkIJ6KznQAaKExJt9my625REjn8G4WT5tfo82J2gpdJNAveaF1O09Irjb93Yg07CfeSOrUBo4WwORrfJ60O4nc3MWWvHT2CsJ4b3MtjtVR0nb084SQpRycXPSF9rMympZrwmP0mutBYCVOEWDjsaLOQJoHo2UOiBD2sM5rm4N5mqt0mEInyGO8pKnV7NKn0N"
+	appendBlobDefaultData = "AzCopy Random Append Test Data"
 
 	bucketPrefix      = "s3bucket"
 	objectPrefix      = "s3object"

--- a/testSuite/scripts/test_service_to_service_copy.py
+++ b/testSuite/scripts/test_service_to_service_copy.py
@@ -647,10 +647,6 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
             result = result.add_flags("blob-type", dstBlobType)
 
         result = result.execute_azcopy_copy_command()  # nice "dynamic typing"
-        if not result:
-            output = result.execute_azcopy_operation_get_output()
-            print(output)
-
         self.assertTrue(result)
 
         # Downloading the copied file for validation

--- a/testSuite/scripts/test_service_to_service_copy.py
+++ b/testSuite/scripts/test_service_to_service_copy.py
@@ -645,7 +645,12 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
             add_flags("log-level", "info")
         if dstBlobType != "":
             result = result.add_flags("blob-type", dstBlobType)
+
         result = result.execute_azcopy_copy_command()  # nice "dynamic typing"
+        if not result:
+            output = result.execute_azcopy_operation_get_output()
+            print(output)
+
         self.assertTrue(result)
 
         # Downloading the copied file for validation

--- a/testSuite/scripts/test_service_to_service_copy.py
+++ b/testSuite/scripts/test_service_to_service_copy.py
@@ -29,6 +29,42 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
         dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
         self.util_test_copy_single_file_from_x_to_x(src_container_url, "Blob", dst_container_url, "Blob", 1)
 
+    def test_copy_single_512b_file_from_page_to_block_blob(self):
+        src_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
+        dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
+        self.util_test_copy_single_file_from_x_to_x(src_container_url, "Blob", dst_container_url, "Blob", 512,
+                                                    srcBlobType="PageBlob", dstBlobType="BlockBlob")
+
+    def test_copy_single_512b_file_from_block_to_page_blob(self):
+        src_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
+        dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
+        self.util_test_copy_single_file_from_x_to_x(src_container_url, "Blob", dst_container_url, "Blob", 512,
+                                                    srcBlobType="BlockBlob", dstBlobType="PageBlob")
+
+    def test_copy_single_512b_file_from_page_to_append_blob(self):
+        src_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
+        dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
+        self.util_test_copy_single_file_from_x_to_x(src_container_url, "Blob", dst_container_url, "Blob", 512,
+                                                    srcBlobType="PageBlob", dstBlobType="AppendBlob")
+
+    def test_copy_single_512b_file_from_append_to_page_blob(self):
+        src_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
+        dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
+        self.util_test_copy_single_file_from_x_to_x(src_container_url, "Blob", dst_container_url, "Blob", 512,
+                                                    srcBlobType="AppendBlob", dstBlobType="PageBlob")
+
+    def test_copy_single_512b_file_from_block_to_append_blob(self):
+        src_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
+        dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
+        self.util_test_copy_single_file_from_x_to_x(src_container_url, "Blob", dst_container_url, "Blob", 512,
+                                                    srcBlobType="BlockBlob", dstBlobType="AppendBlob")
+
+    def test_copy_single_512b_file_from_append_to_block_blob(self):
+        src_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
+        dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
+        self.util_test_copy_single_file_from_x_to_x(src_container_url, "Blob", dst_container_url, "Blob", 512,
+                                                    srcBlobType="AppendBlob", dstBlobType="BlockBlob")
+
     def test_copy_single_0kb_file_from_blob_to_blob(self):
         src_container_url = util.get_object_sas(util.test_s2s_src_blob_account_url, self.bucket_name)
         dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
@@ -215,7 +251,7 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
         src_share_url = util.get_object_sas(util.test_s2s_src_file_account_url, self.bucket_name_file_blob)
         dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name_file_blob)
         self.util_test_overwrite_copy_single_file_from_x_to_x(
-            src_share_url, 
+            src_share_url,
             "File", 
             dst_container_url, 
             "Blob",
@@ -576,7 +612,9 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
         dstType,
         sizeInKB=1,
         oAuth=False,
-        customizedFileName=""):
+        customizedFileName="",
+        srcBlobType="",
+        dstBlobType=""):
         # create source bucket
         result = util.Command("create").add_arguments(srcBucketURL).add_flags("serviceType", srcType). \
             add_flags("resourceType", "Bucket").execute_azcopy_create()
@@ -600,11 +638,14 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
         
 
         # Upload file.
-        self.util_upload_to_src(file_path, srcType, srcFileURL)
+        self.util_upload_to_src(file_path, srcType, srcFileURL, blobType=srcBlobType)
 
         # Copy file using azcopy from srcURL to destURL
         result = util.Command("copy").add_arguments(srcFileURL).add_arguments(dstFileURL). \
-            add_flags("log-level", "info").execute_azcopy_copy_command()
+            add_flags("log-level", "info")
+        if dstBlobType != "":
+            result = result.add_flags("blob-type", dstBlobType)
+        result = result.execute_azcopy_copy_command()  # nice "dynamic typing"
         self.assertTrue(result)
 
         # Downloading the copied file for validation

--- a/testSuite/scripts/test_service_to_service_copy.py
+++ b/testSuite/scripts/test_service_to_service_copy.py
@@ -30,37 +30,37 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
         self.util_test_copy_single_file_from_x_to_x(src_container_url, "Blob", dst_container_url, "Blob", 1)
 
     def test_copy_single_512b_file_from_page_to_block_blob(self):
-        src_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
+        src_container_url = util.get_object_sas(util.test_s2s_src_blob_account_url, self.bucket_name)
         dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
         self.util_test_copy_single_file_from_x_to_x(src_container_url, "Blob", dst_container_url, "Blob", 512,
                                                     srcBlobType="PageBlob", dstBlobType="BlockBlob")
 
     def test_copy_single_512b_file_from_block_to_page_blob(self):
-        src_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
+        src_container_url = util.get_object_sas(util.test_s2s_src_blob_account_url, self.bucket_name)
         dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
         self.util_test_copy_single_file_from_x_to_x(src_container_url, "Blob", dst_container_url, "Blob", 512,
                                                     srcBlobType="BlockBlob", dstBlobType="PageBlob")
 
     def test_copy_single_512b_file_from_page_to_append_blob(self):
-        src_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
+        src_container_url = util.get_object_sas(util.test_s2s_src_blob_account_url, self.bucket_name)
         dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
         self.util_test_copy_single_file_from_x_to_x(src_container_url, "Blob", dst_container_url, "Blob", 512,
                                                     srcBlobType="PageBlob", dstBlobType="AppendBlob")
 
     def test_copy_single_512b_file_from_append_to_page_blob(self):
-        src_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
+        src_container_url = util.get_object_sas(util.test_s2s_src_blob_account_url, self.bucket_name)
         dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
         self.util_test_copy_single_file_from_x_to_x(src_container_url, "Blob", dst_container_url, "Blob", 512,
                                                     srcBlobType="AppendBlob", dstBlobType="PageBlob")
 
     def test_copy_single_512b_file_from_block_to_append_blob(self):
-        src_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
+        src_container_url = util.get_object_sas(util.test_s2s_src_blob_account_url, self.bucket_name)
         dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
         self.util_test_copy_single_file_from_x_to_x(src_container_url, "Blob", dst_container_url, "Blob", 512,
                                                     srcBlobType="BlockBlob", dstBlobType="AppendBlob")
 
     def test_copy_single_512b_file_from_append_to_block_blob(self):
-        src_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
+        src_container_url = util.get_object_sas(util.test_s2s_src_blob_account_url, self.bucket_name)
         dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
         self.util_test_copy_single_file_from_x_to_x(src_container_url, "Blob", dst_container_url, "Blob", 512,
                                                     srcBlobType="AppendBlob", dstBlobType="BlockBlob")
@@ -647,8 +647,6 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
             result = result.add_flags("blob-type", dstBlobType)
 
         r = result.execute_azcopy_copy_command()  # nice "dynamic typing"
-        strout = result.execute_azcopy_operation_get_output()
-        print(strout)
         self.assertTrue(r)
 
         # Downloading the copied file for validation

--- a/testSuite/scripts/test_service_to_service_copy.py
+++ b/testSuite/scripts/test_service_to_service_copy.py
@@ -646,8 +646,10 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
         if dstBlobType != "":
             result = result.add_flags("blob-type", dstBlobType)
 
-        result = result.execute_azcopy_copy_command()  # nice "dynamic typing"
-        self.assertTrue(result)
+        r = result.execute_azcopy_copy_command()  # nice "dynamic typing"
+        strout = result.execute_azcopy_operation_get_output()
+        print(strout)
+        self.assertTrue(r)
 
         # Downloading the copied file for validation
         validate_dir_name = "validate_copy_single_%dKB_file_from_%s_to_%s_%s" % (sizeInKB, srcType, dstType, customizedFileName)

--- a/testSuite/scripts/utility.py
+++ b/testSuite/scripts/utility.py
@@ -408,7 +408,10 @@ def create_test_html_file(filename):
 
 # creates a dir with given inside test directory
 def create_test_dir(dir_name):
+    # If the directory exists, remove it.
     dir_path = os.path.join(test_directory_path, dir_name)
+    if os.path.isdir(dir_path):
+        shutil.rmtree(dir_path)
     try:
         os.mkdir(dir_path)
     except:


### PR DESCRIPTION
This commit enables various copy types (such as block -> append/page, etc.) and adds tests for each type of blob copy direction.