### PR TITLE
Prevent Go SDK from automatically decompressing gzipped files

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,10 @@
 ### New features
 
 1. On-Screen job summary is output to log file @ end of job
+1. Files with `Content-Encoding: gzip` are now downloaded in compressed form. Previous versions tried to save a 
+   decompressed version of the file. But they incorrectly truncated it at the original _compressed_ length. By changing
+   AzCopy to to save the compressed version, that problem is solved, and Content-MD5 checks now work for such files. (It is 
+   assumed that the Content-MD5 hash is the hash of the _compressed_ file.)
 
 ## Version 10.1.1
 

--- a/common/oauthTokenManager.go
+++ b/common/oauthTokenManager.go
@@ -80,7 +80,7 @@ func newAzcopyHTTPClient() *http.Client {
 			TLSHandshakeTimeout:    10 * time.Second,
 			ExpectContinueTimeout:  1 * time.Second,
 			DisableKeepAlives:      false,
-			DisableCompression:     false,
+			DisableCompression:     true,
 			MaxResponseHeaderBytes: 0,
 			//ResponseHeaderTimeout:  time.Duration{},
 			//ExpectContinueTimeout:  time.Duration{},

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -103,7 +103,7 @@ func NewAzcopyHTTPClient() *http.Client {
 			TLSHandshakeTimeout:    10 * time.Second,
 			ExpectContinueTimeout:  1 * time.Second,
 			DisableKeepAlives:      false,
-			DisableCompression:     false,
+			DisableCompression:     true, // must disable the auto-decompression of gzipped files, and just download the gzipped version. See https://github.com/Azure/azure-storage-azcopy/issues/374
 			MaxResponseHeaderBytes: 0,
 			//ResponseHeaderTimeout:  time.Duration{},
 			//ExpectContinueTimeout:  time.Duration{},


### PR DESCRIPTION
Fix for issue #374