### PR TITLE
Support for custom headers on ADLS Gen 2

### DIFF
--- a/azbfs/url_file.go
+++ b/azbfs/url_file.go
@@ -128,16 +128,6 @@ func (f FileURL) GetProperties(ctx context.Context) (*PathGetPropertiesResponse,
 		nil, nil, nil, nil, nil)
 }
 
-func (f FileURL) SetProperties(ctx context.Context, headers BlobFSHTTPHeaders) (*PathUpdateResponse, error) {
-	overrideHttpVerb := "PATCH"
-
-	return f.fileClient.Update(ctx, PathUpdateActionSetProperties, f.fileSystemName, f.path, nil,
-		nil, nil, nil, nil,
-		&headers.CacheControl, &headers.ContentType, &headers.ContentDisposition, &headers.ContentEncoding, &headers.ContentLanguage,
-		nil, nil, nil, nil, nil, nil, nil,
-		nil, nil, nil, &overrideHttpVerb, nil, nil, nil, nil)
-}
-
 // UploadRange writes bytes to a file.
 // offset indiciates the offset at which to begin writing, in bytes.
 // custom headers are not valid on this operation

--- a/azbfs/url_file.go
+++ b/azbfs/url_file.go
@@ -17,9 +17,8 @@ type FileURL struct {
 	path           string
 }
 
-//rename me?
-// BlobFSFileHTTPHeaders represents the set of custom headers available for defining information about the content.
-type BlobFSFileHTTPHeaders struct {
+// BlobFSHTTPHeaders represents the set of custom headers available for defining information about the content.
+type BlobFSHTTPHeaders struct {
 	ContentType        string
 	ContentEncoding    string
 	ContentLanguage    string
@@ -56,7 +55,7 @@ func (f FileURL) WithPipeline(p pipeline.Pipeline) FileURL {
 
 // Create creates a new file or replaces a file. Note that this method only initializes the file.
 // For more information, see https://docs.microsoft.com/en-us/rest/api/storageservices/create-file.
-func (f FileURL) Create(ctx context.Context, headers BlobFSFileHTTPHeaders) (*PathCreateResponse, error) {
+func (f FileURL) Create(ctx context.Context, headers BlobFSHTTPHeaders) (*PathCreateResponse, error) {
 	return f.fileClient.Create(ctx, f.fileSystemName, f.path, PathResourceFile,
 		nil, PathRenameModeNone, nil, nil, nil, nil,
 		&headers.CacheControl, &headers.ContentType, &headers.ContentEncoding, &headers.ContentLanguage, &headers.ContentDisposition,
@@ -129,7 +128,7 @@ func (f FileURL) GetProperties(ctx context.Context) (*PathGetPropertiesResponse,
 		nil, nil, nil, nil, nil)
 }
 
-func (f FileURL) SetProperties(ctx context.Context, headers BlobFSFileHTTPHeaders) (*PathUpdateResponse, error) {
+func (f FileURL) SetProperties(ctx context.Context, headers BlobFSHTTPHeaders) (*PathUpdateResponse, error) {
 	overrideHttpVerb := "PATCH"
 
 	return f.fileClient.Update(ctx, PathUpdateActionSetProperties, f.fileSystemName, f.path, nil,
@@ -176,7 +175,7 @@ func (f FileURL) AppendData(ctx context.Context, offset int64, body io.ReadSeeke
 
 // flushes writes previously uploaded data to a file
 // The contentMd5 parameter, if not nil, should represent the MD5 hash that has been computed for the file as whole
-func (f FileURL) FlushData(ctx context.Context, fileSize int64, contentMd5 []byte, headers BlobFSFileHTTPHeaders) (*PathUpdateResponse, error) {
+func (f FileURL) FlushData(ctx context.Context, fileSize int64, contentMd5 []byte, headers BlobFSHTTPHeaders) (*PathUpdateResponse, error) {
 	if fileSize < 0 {
 		panic("fileSize must be >= 0")
 	}

--- a/azbfs/url_file.go
+++ b/azbfs/url_file.go
@@ -17,6 +17,16 @@ type FileURL struct {
 	path           string
 }
 
+//rename me?
+// BlobFSFileHTTPHeaders represents the set of custom headers available for defining information about the content.
+type BlobFSFileHTTPHeaders struct {
+	ContentType        string
+	ContentEncoding    string
+	ContentLanguage    string
+	ContentDisposition string
+	CacheControl       string
+}
+
 // NewFileURL creates a FileURL object using the specified URL and request policy pipeline.
 func NewFileURL(url url.URL, p pipeline.Pipeline) FileURL {
 	if p == nil {
@@ -46,10 +56,10 @@ func (f FileURL) WithPipeline(p pipeline.Pipeline) FileURL {
 
 // Create creates a new file or replaces a file. Note that this method only initializes the file.
 // For more information, see https://docs.microsoft.com/en-us/rest/api/storageservices/create-file.
-func (f FileURL) Create(ctx context.Context) (*PathCreateResponse, error) {
+func (f FileURL) Create(ctx context.Context, headers BlobFSFileHTTPHeaders) (*PathCreateResponse, error) {
 	return f.fileClient.Create(ctx, f.fileSystemName, f.path, PathResourceFile,
 		nil, PathRenameModeNone, nil, nil, nil, nil,
-		nil, nil, nil, nil, nil,
+		&headers.CacheControl, &headers.ContentType, &headers.ContentEncoding, &headers.ContentLanguage, &headers.ContentDisposition,
 		nil, nil, nil, nil, nil, nil,
 		nil, nil, nil, nil, nil,
 		nil, nil, nil, nil, nil,
@@ -119,8 +129,19 @@ func (f FileURL) GetProperties(ctx context.Context) (*PathGetPropertiesResponse,
 		nil, nil, nil, nil, nil)
 }
 
+func (f FileURL) SetProperties(ctx context.Context, headers BlobFSFileHTTPHeaders) (*PathUpdateResponse, error) {
+	overrideHttpVerb := "PATCH"
+
+	return f.fileClient.Update(ctx, PathUpdateActionSetProperties, f.fileSystemName, f.path, nil,
+		nil, nil, nil, nil,
+		&headers.CacheControl, &headers.ContentType, &headers.ContentDisposition, &headers.ContentEncoding, &headers.ContentLanguage,
+		nil, nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, &overrideHttpVerb, nil, nil, nil, nil)
+}
+
 // UploadRange writes bytes to a file.
 // offset indiciates the offset at which to begin writing, in bytes.
+// custom headers are not valid on this operation
 func (f FileURL) AppendData(ctx context.Context, offset int64, body io.ReadSeeker) (*PathUpdateResponse, error) {
 	if offset < 0 {
 		panic("offset must be >= 0")
@@ -155,7 +176,7 @@ func (f FileURL) AppendData(ctx context.Context, offset int64, body io.ReadSeeke
 
 // flushes writes previously uploaded data to a file
 // The contentMd5 parameter, if not nil, should represent the MD5 hash that has been computed for the file as whole
-func (f FileURL) FlushData(ctx context.Context, fileSize int64, contentMd5 []byte) (*PathUpdateResponse, error) {
+func (f FileURL) FlushData(ctx context.Context, fileSize int64, contentMd5 []byte, headers BlobFSFileHTTPHeaders) (*PathUpdateResponse, error) {
 	if fileSize < 0 {
 		panic("fileSize must be >= 0")
 	}
@@ -182,8 +203,8 @@ func (f FileURL) FlushData(ctx context.Context, fileSize int64, contentMd5 []byt
 
 	// TransactionalContentMD5 isn't supported currently.
 	return f.fileClient.Update(ctx, PathUpdateActionFlush, f.fileSystemName, f.path, &fileSize,
-		&retainUncommittedData, &closeParameter, nil, nil, nil, nil,
-		nil, nil, nil, md5InBase64, nil,
-		nil, nil, nil, nil, nil, nil, nil,
-		nil, &overrideHttpVerb, nil, nil, nil, nil)
+		&retainUncommittedData, &closeParameter, nil, nil,
+		&headers.CacheControl, &headers.ContentType, &headers.ContentDisposition, &headers.ContentEncoding, &headers.ContentLanguage,
+		md5InBase64, nil, nil, nil, nil, nil, nil, nil,
+		nil, nil, &overrideHttpVerb, nil, nil, nil, nil)
 }

--- a/azbfs/zt_test.go
+++ b/azbfs/zt_test.go
@@ -141,7 +141,7 @@ func createNewFileFromFileSystem(c *chk.C, fileSystem azbfs.FileSystemURL) (file
 
 	file, name = getFileURLFromDirectory(c, dir)
 
-	cResp, err := file.Create(ctx, azbfs.BlobFSFileHTTPHeaders{})
+	cResp, err := file.Create(ctx, azbfs.BlobFSHTTPHeaders{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(cResp.StatusCode(), chk.Equals, 201)
 

--- a/azbfs/zt_test.go
+++ b/azbfs/zt_test.go
@@ -141,7 +141,7 @@ func createNewFileFromFileSystem(c *chk.C, fileSystem azbfs.FileSystemURL) (file
 
 	file, name = getFileURLFromDirectory(c, dir)
 
-	cResp, err := file.Create(ctx)
+	cResp, err := file.Create(ctx, azbfs.BlobFSFileHTTPHeaders{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(cResp.StatusCode(), chk.Equals, 201)
 

--- a/azbfs/zt_url_directory_test.go
+++ b/azbfs/zt_url_directory_test.go
@@ -126,7 +126,7 @@ func (dus *DirectoryUrlSuite) TestCreateDirectoryAndFiles(c *chk.C) {
 
 	// Create fileUrl from directoryUrl and create file inside the directory
 	fileUrl, _ := getFileURLFromDirectory(c, dirUrl)
-	fresp, err := fileUrl.Create(context.Background())
+	fresp, err := fileUrl.Create(context.Background(), azbfs.BlobFSFileHTTPHeaders{})
 	defer delFile(c, fileUrl)
 
 	c.Assert(err, chk.IsNil)
@@ -175,7 +175,7 @@ func (dus *DirectoryUrlSuite) TestDirectoryStructure(c *chk.C) {
 
 	// Create a file inside directory
 	fileUrl, _ := getFileURLFromDirectory(c, dirUrl)
-	fresp, err := fileUrl.Create(context.Background())
+	fresp, err := fileUrl.Create(context.Background(), azbfs.BlobFSFileHTTPHeaders{})
 	defer delFile(c, fileUrl)
 
 	c.Assert(err, chk.IsNil)
@@ -188,7 +188,7 @@ func (dus *DirectoryUrlSuite) TestDirectoryStructure(c *chk.C) {
 
 	// create a file inside the sub-dir created above
 	subDirfileUrl, _ := getFileURLFromDirectory(c, subDirUrl)
-	fresp, err = subDirfileUrl.Create(context.Background())
+	fresp, err = subDirfileUrl.Create(context.Background(), azbfs.BlobFSFileHTTPHeaders{})
 	defer delFile(c, subDirfileUrl)
 
 	c.Assert(err, chk.IsNil)
@@ -230,7 +230,7 @@ func (dus *DirectoryUrlSuite) TestListDirectoryWithSpaces(c *chk.C) {
 
 	// Create a file inside directory
 	fileUrl, _ := getFileURLFromDirectory(c, dirUrl)
-	_, err = fileUrl.Create(context.Background())
+	_, err = fileUrl.Create(context.Background(), azbfs.BlobFSFileHTTPHeaders{})
 	defer delFile(c, fileUrl)
 
 	// list the directory created above.

--- a/azbfs/zt_url_directory_test.go
+++ b/azbfs/zt_url_directory_test.go
@@ -126,7 +126,7 @@ func (dus *DirectoryUrlSuite) TestCreateDirectoryAndFiles(c *chk.C) {
 
 	// Create fileUrl from directoryUrl and create file inside the directory
 	fileUrl, _ := getFileURLFromDirectory(c, dirUrl)
-	fresp, err := fileUrl.Create(context.Background(), azbfs.BlobFSFileHTTPHeaders{})
+	fresp, err := fileUrl.Create(context.Background(), azbfs.BlobFSHTTPHeaders{})
 	defer delFile(c, fileUrl)
 
 	c.Assert(err, chk.IsNil)
@@ -175,7 +175,7 @@ func (dus *DirectoryUrlSuite) TestDirectoryStructure(c *chk.C) {
 
 	// Create a file inside directory
 	fileUrl, _ := getFileURLFromDirectory(c, dirUrl)
-	fresp, err := fileUrl.Create(context.Background(), azbfs.BlobFSFileHTTPHeaders{})
+	fresp, err := fileUrl.Create(context.Background(), azbfs.BlobFSHTTPHeaders{})
 	defer delFile(c, fileUrl)
 
 	c.Assert(err, chk.IsNil)
@@ -188,7 +188,7 @@ func (dus *DirectoryUrlSuite) TestDirectoryStructure(c *chk.C) {
 
 	// create a file inside the sub-dir created above
 	subDirfileUrl, _ := getFileURLFromDirectory(c, subDirUrl)
-	fresp, err = subDirfileUrl.Create(context.Background(), azbfs.BlobFSFileHTTPHeaders{})
+	fresp, err = subDirfileUrl.Create(context.Background(), azbfs.BlobFSHTTPHeaders{})
 	defer delFile(c, subDirfileUrl)
 
 	c.Assert(err, chk.IsNil)
@@ -230,7 +230,7 @@ func (dus *DirectoryUrlSuite) TestListDirectoryWithSpaces(c *chk.C) {
 
 	// Create a file inside directory
 	fileUrl, _ := getFileURLFromDirectory(c, dirUrl)
-	_, err = fileUrl.Create(context.Background(), azbfs.BlobFSFileHTTPHeaders{})
+	_, err = fileUrl.Create(context.Background(), azbfs.BlobFSHTTPHeaders{})
 	defer delFile(c, fileUrl)
 
 	// list the directory created above.

--- a/azbfs/zt_url_file_test.go
+++ b/azbfs/zt_url_file_test.go
@@ -47,7 +47,7 @@ func (s *FileURLSuite) TestFileCreateDelete(c *chk.C) {
 	// Create and delete file in root directory.
 	file, _ := getFileURLFromFileSystem(c, fsURL)
 
-	cResp, err := file.Create(context.Background(), azbfs.BlobFSFileHTTPHeaders{})
+	cResp, err := file.Create(context.Background(), azbfs.BlobFSHTTPHeaders{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(cResp.Response().StatusCode, chk.Equals, http.StatusCreated)
 	c.Assert(cResp.ETag(), chk.Not(chk.Equals), "")
@@ -69,7 +69,7 @@ func (s *FileURLSuite) TestFileCreateDelete(c *chk.C) {
 	// Create and delete file in named directory.
 	file, _ = getFileURLFromDirectory(c, dirURL)
 
-	cResp, err = file.Create(context.Background(), azbfs.BlobFSFileHTTPHeaders{})
+	cResp, err = file.Create(context.Background(), azbfs.BlobFSHTTPHeaders{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(cResp.Response().StatusCode, chk.Equals, http.StatusCreated)
 	c.Assert(cResp.ETag(), chk.Not(chk.Equals), "")
@@ -96,7 +96,7 @@ func (s *FileURLSuite) TestFileCreateDeleteNonExistingParent(c *chk.C) {
 	file, _ := getFileURLFromDirectory(c, dirNotExist)
 
 	// Verify that the file was created even though its parent directory does not exist yet
-	cResp, err := file.Create(context.Background(), azbfs.BlobFSFileHTTPHeaders{})
+	cResp, err := file.Create(context.Background(), azbfs.BlobFSHTTPHeaders{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(cResp.Response().StatusCode, chk.Equals, http.StatusCreated)
 	c.Assert(cResp.ETag(), chk.Not(chk.Equals), "")
@@ -193,7 +193,7 @@ func (s *FileURLSuite) TestUploadDownloadRoundTrip(c *chk.C) {
 	c.Assert(pResp.Date(), chk.Not(chk.Equals), "")
 
 	// Flush data
-	fResp, err := fileURL.FlushData(context.Background(), 4096, make([]byte, 0), azbfs.BlobFSFileHTTPHeaders{})
+	fResp, err := fileURL.FlushData(context.Background(), 4096, make([]byte, 0), azbfs.BlobFSHTTPHeaders{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(fResp.StatusCode(), chk.Equals, http.StatusOK)
 	c.Assert(fResp.ETag(), chk.Not(chk.Equals), "")

--- a/azbfs/zt_url_file_test.go
+++ b/azbfs/zt_url_file_test.go
@@ -47,7 +47,7 @@ func (s *FileURLSuite) TestFileCreateDelete(c *chk.C) {
 	// Create and delete file in root directory.
 	file, _ := getFileURLFromFileSystem(c, fsURL)
 
-	cResp, err := file.Create(context.Background())
+	cResp, err := file.Create(context.Background(), azbfs.BlobFSFileHTTPHeaders{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(cResp.Response().StatusCode, chk.Equals, http.StatusCreated)
 	c.Assert(cResp.ETag(), chk.Not(chk.Equals), "")
@@ -69,7 +69,7 @@ func (s *FileURLSuite) TestFileCreateDelete(c *chk.C) {
 	// Create and delete file in named directory.
 	file, _ = getFileURLFromDirectory(c, dirURL)
 
-	cResp, err = file.Create(context.Background())
+	cResp, err = file.Create(context.Background(), azbfs.BlobFSFileHTTPHeaders{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(cResp.Response().StatusCode, chk.Equals, http.StatusCreated)
 	c.Assert(cResp.ETag(), chk.Not(chk.Equals), "")
@@ -96,7 +96,7 @@ func (s *FileURLSuite) TestFileCreateDeleteNonExistingParent(c *chk.C) {
 	file, _ := getFileURLFromDirectory(c, dirNotExist)
 
 	// Verify that the file was created even though its parent directory does not exist yet
-	cResp, err := file.Create(context.Background())
+	cResp, err := file.Create(context.Background(), azbfs.BlobFSFileHTTPHeaders{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(cResp.Response().StatusCode, chk.Equals, http.StatusCreated)
 	c.Assert(cResp.ETag(), chk.Not(chk.Equals), "")
@@ -193,7 +193,7 @@ func (s *FileURLSuite) TestUploadDownloadRoundTrip(c *chk.C) {
 	c.Assert(pResp.Date(), chk.Not(chk.Equals), "")
 
 	// Flush data
-	fResp, err := fileURL.FlushData(context.Background(), 4096, make([]byte, 0))
+	fResp, err := fileURL.FlushData(context.Background(), 4096, make([]byte, 0), azbfs.BlobFSFileHTTPHeaders{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(fResp.StatusCode(), chk.Equals, http.StatusOK)
 	c.Assert(fResp.ETag(), chk.Not(chk.Equals), "")

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -298,10 +298,6 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 	// Example1: for Local to Blob, preserve-last-modified-time flag should not be set to true
 	// Example2: for Blob to Local, follow-symlinks, blob-tier flags should not be provided with values.
 	switch cooked.fromTo {
-	case common.EFromTo.LocalBlobFS():
-		if cooked.blobType != common.EBlobType.None() || cooked.contentType != "" || cooked.contentDisposition != "" || cooked.contentLanguage != "" || cooked.contentEncoding != "" || cooked.cacheControl != "" {
-			return cooked, fmt.Errorf("cannot use blob-type, content-type, content-disposition, content-language, content-encoding, or cache-control with ADLS Gen 2")
-		}
 	case common.EFromTo.LocalBlob():
 		if cooked.preserveLastModifiedTime {
 			return cooked, fmt.Errorf("preserve-last-modified-time is not supported while uploading")

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -298,6 +298,10 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 	// Example1: for Local to Blob, preserve-last-modified-time flag should not be set to true
 	// Example2: for Blob to Local, follow-symlinks, blob-tier flags should not be provided with values.
 	switch cooked.fromTo {
+	case common.EFromTo.LocalBlobFS():
+		if cooked.blobType != common.EBlobType.None() {
+			return cooked, fmt.Errorf("blob-type is not supported on ADLS Gen 2")
+		}
 	case common.EFromTo.LocalBlob():
 		if cooked.preserveLastModifiedTime {
 			return cooked, fmt.Errorf("preserve-last-modified-time is not supported while uploading")

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -207,9 +207,9 @@ type jobPartMgr struct {
 	planMMF *JobPartPlanMMF // This Job part plan's MMF
 
 	// Additional data shared by all of this Job Part's transfers; initialized when this jobPartMgr is created
-	blobHTTPHeaders    azblob.BlobHTTPHeaders
-	fileHTTPHeaders    azfile.FileHTTPHeaders
-	bfsFileHTTPHeaders azbfs.BlobFSFileHTTPHeaders
+	blobHTTPHeaders   azblob.BlobHTTPHeaders
+	fileHTTPHeaders   azfile.FileHTTPHeaders
+	blobFSHTTPHeaders azbfs.BlobFSHTTPHeaders
 
 	// Additional data shared by all of this Job Part's transfers; initialized when this jobPartMgr is created
 	blockBlobTier common.BlockBlobTier
@@ -272,7 +272,7 @@ func (jpm *jobPartMgr) ScheduleTransfers(jobCtx context.Context) {
 		CacheControl:       string(dstData.CacheControl[:dstData.CacheControlLength]),
 	}
 
-	jpm.bfsFileHTTPHeaders = azbfs.BlobFSFileHTTPHeaders{
+	jpm.blobFSHTTPHeaders = azbfs.BlobFSHTTPHeaders{
 		ContentType:        string(dstData.ContentType[:dstData.ContentTypeLength]),
 		ContentEncoding:    string(dstData.ContentEncoding[:dstData.ContentEncodingLength]),
 		ContentDisposition: string(dstData.ContentDisposition[:dstData.ContentDispositionLength]),
@@ -547,11 +547,11 @@ func (jpm *jobPartMgr) fileDstData(fullFilePath string, dataFileToXfer []byte) (
 	return azfile.FileHTTPHeaders{ContentType: jpm.inferContentType(fullFilePath, dataFileToXfer), ContentLanguage: jpm.fileHTTPHeaders.ContentLanguage, ContentEncoding: jpm.fileHTTPHeaders.ContentEncoding, ContentDisposition: jpm.fileHTTPHeaders.ContentDisposition, CacheControl: jpm.fileHTTPHeaders.CacheControl}, jpm.fileMetadata
 }
 
-func (jpm *jobPartMgr) bfsDstData(fullFilePath string, dataFileToXfer []byte) (headers azbfs.BlobFSFileHTTPHeaders) {
+func (jpm *jobPartMgr) bfsDstData(fullFilePath string, dataFileToXfer []byte) (headers azbfs.BlobFSHTTPHeaders) {
 	if jpm.planMMF.Plan().DstBlobData.NoGuessMimeType || dataFileToXfer == nil {
-		return jpm.bfsFileHTTPHeaders
-	} //TODO: come back!
-	return azbfs.BlobFSFileHTTPHeaders{ContentType: jpm.inferContentType(fullFilePath, dataFileToXfer), ContentLanguage: jpm.bfsFileHTTPHeaders.ContentLanguage, ContentEncoding: jpm.bfsFileHTTPHeaders.ContentEncoding, ContentDisposition: jpm.bfsFileHTTPHeaders.ContentDisposition, CacheControl: jpm.bfsFileHTTPHeaders.CacheControl}
+		return jpm.blobFSHTTPHeaders
+	}
+	return azbfs.BlobFSHTTPHeaders{ContentType: jpm.inferContentType(fullFilePath, dataFileToXfer), ContentLanguage: jpm.blobFSHTTPHeaders.ContentLanguage, ContentEncoding: jpm.blobFSHTTPHeaders.ContentEncoding, ContentDisposition: jpm.blobFSHTTPHeaders.ContentDisposition, CacheControl: jpm.blobFSHTTPHeaders.CacheControl}
 }
 
 func (jpm *jobPartMgr) inferContentType(fullFilePath string, dataFileToXfer []byte) string {
@@ -603,7 +603,7 @@ func (jpm *jobPartMgr) Close() {
 	jpm.blobMetadata = azblob.Metadata{}
 	jpm.fileHTTPHeaders = azfile.FileHTTPHeaders{}
 	jpm.fileMetadata = azfile.Metadata{}
-	jpm.bfsFileHTTPHeaders = azbfs.BlobFSFileHTTPHeaders{}
+	jpm.blobFSHTTPHeaders = azbfs.BlobFSHTTPHeaders{}
 	jpm.preserveLastModifiedTime = false
 	// TODO: Delete file?
 	/*if err := os.Remove(jpm.planFile.Name()); err != nil {

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -21,6 +21,7 @@ type IJobPartTransferMgr interface {
 	Info() TransferInfo
 	BlobDstData(dataFileToXfer []byte) (headers azblob.BlobHTTPHeaders, metadata azblob.Metadata)
 	FileDstData(dataFileToXfer []byte) (headers azfile.FileHTTPHeaders, metadata azfile.Metadata)
+	BfsDstData(dataFileToXfer []byte) (headers azbfs.BlobFSFileHTTPHeaders)
 	LastModifiedTime() time.Time
 	PreserveLastModifiedTime() (time.Time, bool)
 	ShouldPutMd5() bool
@@ -249,6 +250,10 @@ func (jptm *jobPartTransferMgr) BlobDstData(dataFileToXfer []byte) (headers azbl
 
 func (jptm *jobPartTransferMgr) FileDstData(dataFileToXfer []byte) (headers azfile.FileHTTPHeaders, metadata azfile.Metadata) {
 	return jptm.jobPartMgr.(*jobPartMgr).fileDstData(jptm.Info().Source, dataFileToXfer)
+}
+
+func (jptm *jobPartTransferMgr) BfsDstData(dataFileToXfer []byte) (headers azbfs.BlobFSFileHTTPHeaders) {
+	return jptm.jobPartMgr.(*jobPartMgr).bfsDstData(jptm.Info().Source, dataFileToXfer)
 }
 
 // TODO refactor into something like jptm.IsLastModifiedTimeEqual() so that there is NO LastModifiedTime method and people therefore CAN'T do it wrong due to time zone

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -21,7 +21,7 @@ type IJobPartTransferMgr interface {
 	Info() TransferInfo
 	BlobDstData(dataFileToXfer []byte) (headers azblob.BlobHTTPHeaders, metadata azblob.Metadata)
 	FileDstData(dataFileToXfer []byte) (headers azfile.FileHTTPHeaders, metadata azfile.Metadata)
-	BfsDstData(dataFileToXfer []byte) (headers azbfs.BlobFSFileHTTPHeaders)
+	BfsDstData(dataFileToXfer []byte) (headers azbfs.BlobFSHTTPHeaders)
 	LastModifiedTime() time.Time
 	PreserveLastModifiedTime() (time.Time, bool)
 	ShouldPutMd5() bool
@@ -252,7 +252,7 @@ func (jptm *jobPartTransferMgr) FileDstData(dataFileToXfer []byte) (headers azfi
 	return jptm.jobPartMgr.(*jobPartMgr).fileDstData(jptm.Info().Source, dataFileToXfer)
 }
 
-func (jptm *jobPartTransferMgr) BfsDstData(dataFileToXfer []byte) (headers azbfs.BlobFSFileHTTPHeaders) {
+func (jptm *jobPartTransferMgr) BfsDstData(dataFileToXfer []byte) (headers azbfs.BlobFSHTTPHeaders) {
 	return jptm.jobPartMgr.(*jobPartMgr).bfsDstData(jptm.Info().Source, dataFileToXfer)
 }
 

--- a/ste/uploader-blobFS.go
+++ b/ste/uploader-blobFS.go
@@ -174,7 +174,7 @@ func (u *blobFSUploader) Epilogue() {
 		md5Hash, ok := <-u.md5Channel
 		if ok {
 			//Type assertions aren't my favorite thing to do but it does work when you need it to.
-			_, err := u.fileURL.FlushData(jptm.Context(), jptm.Info().SourceSize, md5Hash, jptm.(*jobPartTransferMgr).jobPartMgr.(*jobPartMgr).bfsFileHTTPHeaders)
+			_, err := u.fileURL.FlushData(jptm.Context(), jptm.Info().SourceSize, md5Hash, jptm.(*jobPartTransferMgr).jobPartMgr.(*jobPartMgr).blobFSHTTPHeaders)
 			if err != nil {
 				jptm.FailActiveUpload("Flushing data", err)
 				// don't return, since need cleanup below

--- a/ste/uploader-blobFS.go
+++ b/ste/uploader-blobFS.go
@@ -173,7 +173,8 @@ func (u *blobFSUploader) Epilogue() {
 	if jptm.TransferStatus() > 0 {
 		md5Hash, ok := <-u.md5Channel
 		if ok {
-			_, err := u.fileURL.FlushData(jptm.Context(), jptm.Info().SourceSize, md5Hash, azbfs.BlobFSFileHTTPHeaders{})
+			//Type assertions aren't my favorite thing to do but it does work when you need it to.
+			_, err := u.fileURL.FlushData(jptm.Context(), jptm.Info().SourceSize, md5Hash, jptm.(*jobPartTransferMgr).jobPartMgr.(*jobPartMgr).bfsFileHTTPHeaders)
 			if err != nil {
 				jptm.FailActiveUpload("Flushing data", err)
 				// don't return, since need cleanup below


### PR DESCRIPTION
Enables the support for custom headers on ADLS Gen 2.

The following custom headers are supported:
- content-language
- content-type
- content-disposition
- content-encoding
- cache-control

Manually tested with the following command:
`azcopy cp "C:\Users\v-adreed\foobar" "https://adeledevtestadls1.dfs.core.windows.net/sasauthtest/test" --content-language=fr --content-type=text/random --content-disposition=why --content-encoding=utf8 --cache-control=butwhy`