### PR TITLE
Enable long file paths usage on Windows & patch issues with using . shortcut for current working directory

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,12 @@
 
 ## Version XX.XX.XX 
 
-### Bug fixes
+### Breaking change
+
+1. Jobs created with earlier releases cannot be resumed with this release. We recommend
+you update to this release only when you have no partially-completed jobs that you want to resume.
+
+### Bug fix
 
 1. AzCopy v10 now outputs a sensible error & warning when attempting to authenticate a storage account business-to-business
 1. Long file paths are now supported on Windows without registry changes.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@
 ### Bug fixes
 
 1. AzCopy v10 now outputs a sensible error & warning when attempting to authenticate a storage account business-to-business
+1. Long file paths are now supported on Windows without registry changes.
+2. Using `.` to specify the current working directory no longer causes an out-of-bounds panic on download
 
 ## Version 10.1.2
 

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/Azure/azure-pipeline-go/pipeline"
+	"path/filepath"
 
 	"io"
 	"net/url"
@@ -148,14 +149,49 @@ func (raw rawCopyCmdArgs) blockSizeInBytes() uint32 {
 func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 	cooked := cookedCopyCmdArgs{}
 
-	fromTo, err := validateFromTo(raw.src, raw.dst, raw.fromTo) // TODO: src/dst
+	var err error
+	cooked.fromTo, err = validateFromTo(raw.src, raw.dst, raw.fromTo) // TODO: src/dst
 	if err != nil {
 		return cooked, err
 	}
+
+	//Convert local paths to long filepaths on windows, get absolute filepath everywhere.
+	//This ensures that long file paths work on Windows and that relative filepaths using . work everywhere.
+	if cooked.fromTo.From() == common.ELocation.Local() {
+		raw.src, err = filepath.Abs(raw.src)
+		if err != nil {
+			return cooked, err
+		}
+
+		if common.OS_PATH_SEPARATOR == `\` {
+			raw.src = common.ToLongPath(raw.src)
+			common.AZCOPY_PATH_SEPARATOR_STRING, common.AZCOPY_PATH_SEPARATOR_CHAR = `\`, '\\'
+			if fi, err := os.Stat(raw.src); err == nil {
+				if fi.IsDir() && !strings.HasSuffix(raw.src, `\`) {
+					raw.src += `\`
+				}
+			}
+		}
+	}
+	if cooked.fromTo.To() == common.ELocation.Local() {
+		raw.dst, err = filepath.Abs(raw.dst)
+		if err != nil {
+			return cooked, err
+		}
+
+		if common.OS_PATH_SEPARATOR == `\` {
+			raw.dst = common.ToLongPath(raw.dst)
+			common.AZCOPY_PATH_SEPARATOR_STRING, common.AZCOPY_PATH_SEPARATOR_CHAR = `\`, '\\'
+			if fi, err := os.Stat(raw.dst); err == nil {
+				if fi.IsDir() && !strings.HasSuffix(raw.dst, `\`) {
+					raw.dst += `\`
+				}
+			}
+		}
+	}
+
 	cooked.source = raw.src
 	cooked.destination = raw.dst
-
-	cooked.fromTo = fromTo
 
 	// copy&transform flags to type-safety
 	cooked.recursive = raw.recursive

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -26,8 +26,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"path/filepath"
-
 	"io"
 	"net/url"
 	"os"
@@ -158,35 +156,15 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 	//Convert local paths to long filepaths on windows, get absolute filepath everywhere.
 	//This ensures that long file paths work on Windows and that relative filepaths using . work everywhere.
 	if cooked.fromTo.From() == common.ELocation.Local() {
-		raw.src, err = filepath.Abs(raw.src)
+		raw.src, err = common.PreparePath(raw.src)
 		if err != nil {
 			return cooked, err
-		}
-
-		if common.OS_PATH_SEPARATOR == `\` {
-			raw.src = common.ToLongPath(raw.src)
-			common.AZCOPY_PATH_SEPARATOR_STRING, common.AZCOPY_PATH_SEPARATOR_CHAR = `\`, '\\'
-			if fi, err := os.Stat(raw.src); err == nil {
-				if fi.IsDir() && !strings.HasSuffix(raw.src, `\`) {
-					raw.src += `\`
-				}
-			}
 		}
 	}
 	if cooked.fromTo.To() == common.ELocation.Local() {
-		raw.dst, err = filepath.Abs(raw.dst)
+		raw.dst, err = common.PreparePath(raw.dst)
 		if err != nil {
 			return cooked, err
-		}
-
-		if common.OS_PATH_SEPARATOR == `\` {
-			raw.dst = common.ToLongPath(raw.dst)
-			common.AZCOPY_PATH_SEPARATOR_STRING, common.AZCOPY_PATH_SEPARATOR_CHAR = `\`, '\\'
-			if fi, err := os.Stat(raw.dst); err == nil {
-				if fi.IsDir() && !strings.HasSuffix(raw.dst, `\`) {
-					raw.dst += `\`
-				}
-			}
 		}
 	}
 

--- a/cmd/copyDownloadBlobEnumerator.go
+++ b/cmd/copyDownloadBlobEnumerator.go
@@ -156,7 +156,10 @@ func (e *copyDownloadBlobEnumerator) enumerate(cca *cookedCopyCmdArgs) error {
 				}
 				// check for the special character in blob relative path and get path without special character.
 				blobRelativePath = util.blobPathWOSpecialCharacters(blobRelativePath)
-
+				// force path to be AZCOPY_PATH_SEPARATOR_STRING, only really important on Windows.
+				if common.AZCOPY_PATH_SEPARATOR_STRING == `\` {
+					blobRelativePath = strings.Replace(blobRelativePath, "/", common.AZCOPY_PATH_SEPARATOR_STRING, -1)
+				}
 				e.addTransfer(common.CopyTransfer{
 					Source:           util.stripSASFromBlobUrl(util.createBlobUrlFromContainer(blobUrlParts, blobPath)).String(),
 					Destination:      util.generateLocalPath(cca.destination, blobRelativePath),
@@ -211,6 +214,10 @@ func (e *copyDownloadBlobEnumerator) enumerate(cca *cookedCopyCmdArgs) error {
 
 					// check for the special character in blob relative path and get path without special character.
 					blobRelativePath = util.blobPathWOSpecialCharacters(blobRelativePath)
+					// force path to be AZCOPY_PATH_SEPARATOR_STRING, only really important on Windows.
+					if common.AZCOPY_PATH_SEPARATOR_STRING == `\` {
+						blobRelativePath = strings.Replace(blobRelativePath, "/", common.AZCOPY_PATH_SEPARATOR_STRING, -1)
+					}
 					e.addTransfer(common.CopyTransfer{
 						Source:           util.stripSASFromBlobUrl(util.createBlobUrlFromContainer(blobUrlParts, blobInfo.Name)).String(),
 						Destination:      util.generateLocalPath(cca.destination, blobRelativePath),
@@ -303,6 +310,10 @@ func (e *copyDownloadBlobEnumerator) enumerate(cca *cookedCopyCmdArgs) error {
 			}
 			// check for the special character in blob relative path and get path without special character.
 			blobRelativePath = util.blobPathWOSpecialCharacters(blobRelativePath)
+			// force path to be AZCOPY_PATH_SEPARATOR_STRING, only really important on Windows.
+			if common.AZCOPY_PATH_SEPARATOR_STRING == `\` {
+				blobRelativePath = strings.Replace(blobRelativePath, "/", common.AZCOPY_PATH_SEPARATOR_STRING, -1)
+			}
 			e.addTransfer(common.CopyTransfer{
 				Source:           util.stripSASFromBlobUrl(util.createBlobUrlFromContainer(blobUrlParts, blobInfo.Name)).String(),
 				Destination:      util.generateLocalPath(cca.destination, blobRelativePath),

--- a/cmd/copyUploadEnumerator.go
+++ b/cmd/copyUploadEnumerator.go
@@ -34,7 +34,7 @@ func (e *copyUploadEnumerator) enumerate(cca *cookedCopyCmdArgs) error {
 	// ...and then give it back to everything
 	for k, v := range listOfFilesAndDirectories {
 		if common.OS_PATH_SEPARATOR == `\` {
-			listOfFilesAndDirectories[k] = common.ToLongPath(v)
+			listOfFilesAndDirectories[k] = common.ToExtendedPath(v)
 		}
 	}
 

--- a/cmd/copyUtil.go
+++ b/cmd/copyUtil.go
@@ -324,6 +324,12 @@ func (util copyHandlerUtil) isPathALocalDirectory(pathString string) bool {
 
 func (util copyHandlerUtil) generateLocalPath(directoryPath, fileName string) string {
 	var result string
+
+	//Because \ and / can't be used interchangeably with the long file path discriminator (\\?\), filter forward slash out
+	if strings.HasPrefix(directoryPath, `\\?\`) {
+		fileName = strings.Replace(fileName, `/`, `\`, -1)
+	}
+
 	// check if the directory path ends with the path separator
 	if strings.LastIndex(directoryPath, common.AZCOPY_PATH_SEPARATOR_STRING) == len(directoryPath)-1 {
 		result = fmt.Sprintf("%s%s", directoryPath, fileName)

--- a/cmd/copyUtil.go
+++ b/cmd/copyUtil.go
@@ -326,7 +326,7 @@ func (util copyHandlerUtil) generateLocalPath(directoryPath, fileName string) st
 	var result string
 
 	//Because \ and / can't be used interchangeably with the long file path discriminator (\\?\), filter forward slash out
-	if strings.HasPrefix(directoryPath, `\\?\`) {
+	if strings.HasPrefix(directoryPath, common.EXTENDED_PATH_PREFIX) {
 		fileName = strings.Replace(fileName, `/`, `\`, -1)
 	}
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -103,40 +103,19 @@ func (raw *rawSyncCmdArgs) cook() (cookedSyncCmdArgs, error) {
 
 	cooked.fromTo = inferFromTo(raw.src, raw.dst)
 
+	var err error
 	//Convert local paths to long filepaths on windows, get absolute filepath everywhere.
 	//This ensures that long file paths work on Windows and that relative filepaths using . work everywhere.
 	if cooked.fromTo.From() == common.ELocation.Local() {
-		var err error
-		raw.src, err = filepath.Abs(raw.src)
+		raw.src, err = common.PreparePath(raw.src)
 		if err != nil {
 			return cooked, err
-		}
-
-		if common.OS_PATH_SEPARATOR == `\` {
-			raw.src = common.ToLongPath(raw.src)
-			common.AZCOPY_PATH_SEPARATOR_STRING, common.AZCOPY_PATH_SEPARATOR_CHAR = `\`, '\\'
-			if fi, err := os.Stat(raw.src); err == nil {
-				if fi.IsDir() && !strings.HasSuffix(raw.src, `\`) {
-					raw.src += `\`
-				}
-			}
 		}
 	}
 	if cooked.fromTo.To() == common.ELocation.Local() {
-		var err error
-		raw.dst, err = filepath.Abs(raw.dst)
+		raw.dst, err = common.PreparePath(raw.dst)
 		if err != nil {
 			return cooked, err
-		}
-
-		if common.OS_PATH_SEPARATOR == `\` {
-			raw.dst = common.ToLongPath(raw.dst)
-			common.AZCOPY_PATH_SEPARATOR_STRING, common.AZCOPY_PATH_SEPARATOR_CHAR = `\`, '\\'
-			if fi, err := os.Stat(raw.dst); err == nil {
-				if fi.IsDir() && !strings.HasSuffix(raw.dst, `\`) {
-					raw.dst += `\`
-				}
-			}
 		}
 	}
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -25,8 +25,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"os"
-	"path/filepath"
 	"time"
 
 	"net/url"
@@ -139,7 +137,7 @@ func (raw *rawSyncCmdArgs) cook() (cookedSyncCmdArgs, error) {
 	cooked.recursive = raw.recursive
 
 	// determine whether we should prompt the user to delete extra files
-	err := cooked.deleteDestination.Parse(raw.deleteDestination)
+	err = cooked.deleteDestination.Parse(raw.deleteDestination)
 	if err != nil {
 		return cooked, err
 	}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -25,6 +25,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/Azure/azure-pipeline-go/pipeline"
+	"os"
+	"path/filepath"
 	"time"
 
 	"net/url"
@@ -100,6 +102,44 @@ func (raw *rawSyncCmdArgs) cook() (cookedSyncCmdArgs, error) {
 	cooked := cookedSyncCmdArgs{}
 
 	cooked.fromTo = inferFromTo(raw.src, raw.dst)
+
+	//Convert local paths to long filepaths on windows, get absolute filepath everywhere.
+	//This ensures that long file paths work on Windows and that relative filepaths using . work everywhere.
+	if cooked.fromTo.From() == common.ELocation.Local() {
+		var err error
+		raw.src, err = filepath.Abs(raw.src)
+		if err != nil {
+			return cooked, err
+		}
+
+		if common.OS_PATH_SEPARATOR == `\` {
+			raw.src = common.ToLongPath(raw.src)
+			common.AZCOPY_PATH_SEPARATOR_STRING, common.AZCOPY_PATH_SEPARATOR_CHAR = `\`, '\\'
+			if fi, err := os.Stat(raw.src); err == nil {
+				if fi.IsDir() && !strings.HasSuffix(raw.src, `\`) {
+					raw.src += `\`
+				}
+			}
+		}
+	}
+	if cooked.fromTo.To() == common.ELocation.Local() {
+		var err error
+		raw.dst, err = filepath.Abs(raw.dst)
+		if err != nil {
+			return cooked, err
+		}
+
+		if common.OS_PATH_SEPARATOR == `\` {
+			raw.dst = common.ToLongPath(raw.dst)
+			common.AZCOPY_PATH_SEPARATOR_STRING, common.AZCOPY_PATH_SEPARATOR_CHAR = `\`, '\\'
+			if fi, err := os.Stat(raw.dst); err == nil {
+				if fi.IsDir() && !strings.HasSuffix(raw.dst, `\`) {
+					raw.dst += `\`
+				}
+			}
+		}
+	}
+
 	if cooked.fromTo == common.EFromTo.Unknown() {
 		return cooked, fmt.Errorf("Unable to infer the source '%s' / destination '%s'. ", raw.src, raw.dst)
 	} else if cooked.fromTo == common.EFromTo.LocalBlob() {

--- a/cmd/syncTraverser.go
+++ b/cmd/syncTraverser.go
@@ -38,7 +38,8 @@ func newLocalTraverserForSync(cca *cookedSyncCmdArgs, isSource bool) (*localTrav
 		fullPath = cca.destination
 	}
 
-	if strings.ContainsAny(fullPath, "*?") {
+	//Trim the offending prefix and then check if it has any pattern matching
+	if strings.ContainsAny(strings.TrimPrefix(fullPath, `\\?\`), "*?") {
 		return nil, errors.New("illegal local path, no pattern matching allowed for sync command")
 	}
 

--- a/cmd/syncTraverser.go
+++ b/cmd/syncTraverser.go
@@ -23,6 +23,7 @@ package cmd
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-storage-azcopy/common"
 	"github.com/Azure/azure-storage-azcopy/ste"
 	"net/url"
 	"strings"
@@ -39,7 +40,7 @@ func newLocalTraverserForSync(cca *cookedSyncCmdArgs, isSource bool) (*localTrav
 	}
 
 	//Trim the offending prefix and then check if it has any pattern matching
-	if strings.ContainsAny(strings.TrimPrefix(fullPath, `\\?\`), "*?") {
+	if strings.ContainsAny(strings.TrimPrefix(fullPath, common.EXTENDED_PATH_PREFIX), "*?") {
 		return nil, errors.New("illegal local path, no pattern matching allowed for sync command")
 	}
 

--- a/cmd/zc_traverser_blob.go
+++ b/cmd/zc_traverser_blob.go
@@ -111,6 +111,8 @@ func (t *blobTraverser) traverse(processor objectProcessor, filters []objectFilt
 			var relativePath string
 			if common.AZCOPY_PATH_SEPARATOR_STRING == `\` {
 				relativePath = strings.Replace(strings.TrimPrefix(blobInfo.Name, searchPrefix), `/`, common.AZCOPY_PATH_SEPARATOR_STRING, -1)
+			} else {
+				relativePath = strings.TrimPrefix(blobInfo.Name, searchPrefix)
 			}
 
 			// if recursive

--- a/cmd/zc_traverser_blob.go
+++ b/cmd/zc_traverser_blob.go
@@ -107,7 +107,11 @@ func (t *blobTraverser) traverse(processor objectProcessor, filters []objectFilt
 				continue
 			}
 
-			relativePath := strings.TrimPrefix(blobInfo.Name, searchPrefix)
+			//format relative path for current path separator
+			var relativePath string
+			if common.AZCOPY_PATH_SEPARATOR_STRING == `\` {
+				relativePath = strings.Replace(strings.TrimPrefix(blobInfo.Name, searchPrefix), `/`, common.AZCOPY_PATH_SEPARATOR_STRING, -1)
+			}
 
 			// if recursive
 			if !t.recursive && strings.Contains(relativePath, common.AZCOPY_PATH_SEPARATOR_STRING) {

--- a/cmd/zc_traverser_local.go
+++ b/cmd/zc_traverser_local.go
@@ -139,7 +139,7 @@ func newLocalTraverser(fullPath string, recursive bool, incrementEnumerationCoun
 func cleanLocalPath(localPath string) string {
 	normalizedPath := path.Clean(replacePathSeparators(localPath))
 
-	if strings.HasPrefix(localPath, `\\?\`) {
+	if strings.HasPrefix(localPath, common.EXTENDED_PATH_PREFIX) {
 		//Nothing needs to be done, we've already cleaned it.
 		return localPath
 	}

--- a/cmd/zc_traverser_local.go
+++ b/cmd/zc_traverser_local.go
@@ -139,6 +139,11 @@ func newLocalTraverser(fullPath string, recursive bool, incrementEnumerationCoun
 func cleanLocalPath(localPath string) string {
 	normalizedPath := path.Clean(replacePathSeparators(localPath))
 
+	if strings.HasPrefix(localPath, `\\?\`) {
+		//Nothing needs to be done, we've already cleaned it.
+		return localPath
+	}
+
 	// detect if we are targeting a network share
 	if strings.HasPrefix(localPath, "//") || strings.HasPrefix(localPath, `\\`) {
 		// if yes, we have trimmed away one of the leading slashes, so add it back

--- a/common/LongPathHandler.go
+++ b/common/LongPathHandler.go
@@ -25,9 +25,9 @@ func ToExtendedPath(short string) string {
 func ToShortPath(long string) string {
 	if os.PathSeparator == '\\' {
 		if strings.HasPrefix(long, EXTENDED_UNC_PATH_PREFIX) {
-			return strings.Replace(`\`+long[7:], `\`, `/`, -1)
+			return `\` + long[7:] //Return what we stole from it
 		} else if strings.HasPrefix(long, EXTENDED_PATH_PREFIX) {
-			return strings.Replace(long[4:], `\`, `/`, -1)
+			return long[4:]
 		}
 	}
 

--- a/common/LongPathHandler.go
+++ b/common/LongPathHandler.go
@@ -9,12 +9,12 @@ import (
 //ToExtendedPath converts short paths to an extended path.
 func ToExtendedPath(short string) string {
 	if os.PathSeparator == '\\' {
-		if strings.HasPrefix(short, `\\?\`) {
+		if strings.HasPrefix(short, EXTENDED_PATH_PREFIX) {
 			return strings.Replace(short, `/`, `\`, -1)
 		} else if strings.HasPrefix(short, `\\`) {
-			return strings.Replace(`\\?\UNC`+short[1:], `/`, `\`, -1)
+			return strings.Replace(EXTENDED_UNC_PATH_PREFIX+short[1:], `/`, `\`, -1)
 		} else {
-			return strings.Replace(`\\?\`+short, `/`, `\`, -1)
+			return strings.Replace(EXTENDED_PATH_PREFIX+short, `/`, `\`, -1)
 		}
 	}
 
@@ -24,9 +24,9 @@ func ToExtendedPath(short string) string {
 //ToShortPath converts an extended path to a short path.
 func ToShortPath(long string) string {
 	if os.PathSeparator == '\\' {
-		if strings.HasPrefix(long, `\\?\UNC`) {
+		if strings.HasPrefix(long, EXTENDED_UNC_PATH_PREFIX) {
 			return strings.Replace(`\`+long[7:], `\`, `/`, -1)
-		} else if strings.HasPrefix(long, `\\?\`) {
+		} else if strings.HasPrefix(long, EXTENDED_PATH_PREFIX) {
 			return strings.Replace(long[4:], `\`, `/`, -1)
 		}
 	}

--- a/common/LongPathHandler.go
+++ b/common/LongPathHandler.go
@@ -1,0 +1,32 @@
+package common
+
+import (
+	"os"
+	"strings"
+)
+
+func ToLongPath(short string) string {
+	if os.PathSeparator == '\\' {
+		if strings.HasPrefix(short, `\\?\`) {
+			return strings.Replace(short, `/`, `\`, -1)
+		} else if strings.HasPrefix(short, `\\`) {
+			return strings.Replace(`\\?\UNC`+short[1:], `/`, `\`, -1)
+		} else {
+			return strings.Replace(`\\?\`+short, `/`, `\`, -1)
+		}
+	}
+
+	return short
+}
+
+func ToShortPath(long string) string {
+	if os.PathSeparator == '\\' {
+		if strings.HasPrefix(long, `\\?\UNC`) {
+			return strings.Replace(`\`+long[7:], `\`, `/`, -1)
+		} else if strings.HasPrefix(long, `\\?\`) {
+			return strings.Replace(long[4:], `\`, `/`, -1)
+		}
+	}
+
+	return long
+}

--- a/common/LongPathHandler.go
+++ b/common/LongPathHandler.go
@@ -2,10 +2,12 @@ package common
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 )
 
-func ToLongPath(short string) string {
+//ToExtendedPath converts short paths to an extended path.
+func ToExtendedPath(short string) string {
 	if os.PathSeparator == '\\' {
 		if strings.HasPrefix(short, `\\?\`) {
 			return strings.Replace(short, `/`, `\`, -1)
@@ -19,6 +21,7 @@ func ToLongPath(short string) string {
 	return short
 }
 
+//ToShortPath converts an extended path to a short path.
 func ToShortPath(long string) string {
 	if os.PathSeparator == '\\' {
 		if strings.HasPrefix(long, `\\?\UNC`) {
@@ -29,4 +32,25 @@ func ToShortPath(long string) string {
 	}
 
 	return long
+}
+
+//PreparePath prepares a path by getting its absolute path and then converting it to an extended path
+func PreparePath(path string) (string, error) {
+	var err error
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return path, err
+	}
+
+	if OS_PATH_SEPARATOR == `\` {
+		path = ToExtendedPath(path)
+		AZCOPY_PATH_SEPARATOR_STRING, AZCOPY_PATH_SEPARATOR_CHAR = `\`, '\\'
+		if fi, err := os.Stat(path); err == nil {
+			if fi.IsDir() && !strings.HasSuffix(path, `\`) {
+				path += `\`
+			}
+		}
+	}
+
+	return path, nil
 }

--- a/common/LongPathHandler.go
+++ b/common/LongPathHandler.go
@@ -6,6 +6,14 @@ import (
 	"strings"
 )
 
+//https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file#maximum-path-length-limitation
+//Because windows doesn't (by default) support strings above 260 characters,
+//we need to provide a special prefix to tell it to support paths up to 32,767 characters.
+
+//Furthermore, we don't use the built-in long path support in the Go SDK commit 231aa9d6d7
+//because it fails to support long UNC paths. As a result, we opt to wrap things such as filepath.Glob()
+//to safely use them with long UNC paths.
+
 //ToExtendedPath converts short paths to an extended path.
 func ToExtendedPath(short string) string {
 	if os.PathSeparator == '\\' {

--- a/common/LongPathHandler_test.go
+++ b/common/LongPathHandler_test.go
@@ -1,0 +1,31 @@
+package common
+
+import (
+	chk "gopkg.in/check.v1"
+)
+
+type pathHandlerSuite struct{}
+
+var _ = chk.Suite(&pathHandlerSuite{})
+
+func (p *pathHandlerSuite) TestShortToLong(c *chk.C) {
+	if OS_PATH_SEPARATOR == `\` {
+		c.Assert(ToLongPath(`C:\myPath`), chk.Equals, `\\?\C:\myPath`)
+		c.Assert(ToLongPath(`\\myHost\myPath`), chk.Equals, `\\?\UNC\myHost\myPath`)
+		c.Assert(ToLongPath(`\\?\C:\myPath`), chk.Equals, `\\?\C:\myPath`)
+		c.Assert(ToLongPath(`\\?\UNC\myHost\myPath`), chk.Equals, `\\?\UNC\myHost\myPath`)
+	} else {
+		c.Skip("Test only pertains to Windows.")
+	}
+}
+
+func (p *pathHandlerSuite) TestLongToShort(c *chk.C) {
+	if OS_PATH_SEPARATOR == `\` {
+		c.Assert(ToShortPath(`\\?\C:\myPath`), chk.Equals, `C:\myPath`)
+		c.Assert(ToShortPath(`\\?\UNC\myHost\myPath`), chk.Equals, `\\myHost\myPath`)
+		c.Assert(ToShortPath(`\\myHost\myPath`), chk.Equals, `\\myHost\myPath`)
+		c.Assert(ToShortPath(`C:\myPath`), chk.Equals, `C:\myPath`)
+	} else {
+		c.Skip("Test only pertains to Windows.")
+	}
+}

--- a/common/LongPathHandler_test.go
+++ b/common/LongPathHandler_test.go
@@ -10,10 +10,10 @@ var _ = chk.Suite(&pathHandlerSuite{})
 
 func (p *pathHandlerSuite) TestShortToLong(c *chk.C) {
 	if OS_PATH_SEPARATOR == `\` {
-		c.Assert(ToLongPath(`C:\myPath`), chk.Equals, `\\?\C:\myPath`)
-		c.Assert(ToLongPath(`\\myHost\myPath`), chk.Equals, `\\?\UNC\myHost\myPath`)
-		c.Assert(ToLongPath(`\\?\C:\myPath`), chk.Equals, `\\?\C:\myPath`)
-		c.Assert(ToLongPath(`\\?\UNC\myHost\myPath`), chk.Equals, `\\?\UNC\myHost\myPath`)
+		c.Assert(ToExtendedPath(`C:\myPath`), chk.Equals, `\\?\C:\myPath`)
+		c.Assert(ToExtendedPath(`\\myHost\myPath`), chk.Equals, `\\?\UNC\myHost\myPath`)
+		c.Assert(ToExtendedPath(`\\?\C:\myPath`), chk.Equals, `\\?\C:\myPath`)
+		c.Assert(ToExtendedPath(`\\?\UNC\myHost\myPath`), chk.Equals, `\\?\UNC\myHost\myPath`)
 	} else {
 		c.Skip("Test only pertains to Windows.")
 	}

--- a/common/fe-ste-models.go
+++ b/common/fe-ste-models.go
@@ -47,7 +47,12 @@ var (
 
 const (
 	OS_PATH_SEPARATOR = string(os.PathSeparator)
-	Dev_Null          = "/dev/null"
+
+	//Windows handles long file paths (without a registry fix) by adding the prefix \\?\
+	EXTENDED_PATH_PREFIX     = `\\?\`
+	EXTENDED_UNC_PATH_PREFIX = `\\?\UNC`
+
+	Dev_Null = "/dev/null"
 
 	//  this is the perm that AzCopy has used throughout its preview.  So, while we considered relaxing it to 0666
 	//  we decided that the best option was to leave it as is, and only relax it if user feedback so requires.

--- a/common/fe-ste-models.go
+++ b/common/fe-ste-models.go
@@ -39,11 +39,15 @@ import (
 	"github.com/JeffreyRichter/enum/enum"
 )
 
+//Change these to vars to manipulate them when needbe.
+var (
+	AZCOPY_PATH_SEPARATOR_STRING       = "/"
+	AZCOPY_PATH_SEPARATOR_CHAR   uint8 = '/'
+)
+
 const (
-	AZCOPY_PATH_SEPARATOR_STRING = "/"
-	AZCOPY_PATH_SEPARATOR_CHAR   = '/'
-	OS_PATH_SEPARATOR            = string(os.PathSeparator)
-	Dev_Null                     = "/dev/null"
+	OS_PATH_SEPARATOR = string(os.PathSeparator)
+	Dev_Null          = "/dev/null"
 
 	//  this is the perm that AzCopy has used throughout its preview.  So, while we considered relaxing it to 0666
 	//  we decided that the best option was to leave it as is, and only relax it if user feedback so requires.

--- a/ste/JobPartPlan.go
+++ b/ste/JobPartPlan.go
@@ -14,7 +14,7 @@ import (
 // dataSchemaVersion defines the data schema version of JobPart order files supported by
 // current version of azcopy
 // To be Incremented every time when we release azcopy with changed dataSchema
-const DataSchemaVersion common.Version = 7
+const DataSchemaVersion common.Version = 8
 
 const (
 	CustomHeaderMaxBytes = 256


### PR DESCRIPTION
Manually tested for all upload & download scenarios. Mixes with wildcard characters.

Fixes issues #104 #376 and #398.