### PR TITLE
Flush as we go on ADLS Gen 2

### DIFF
--- a/azbfs/url_file.go
+++ b/azbfs/url_file.go
@@ -165,7 +165,7 @@ func (f FileURL) AppendData(ctx context.Context, offset int64, body io.ReadSeeke
 
 // flushes writes previously uploaded data to a file
 // The contentMd5 parameter, if not nil, should represent the MD5 hash that has been computed for the file as whole
-func (f FileURL) FlushData(ctx context.Context, fileSize int64, contentMd5 []byte, headers BlobFSHTTPHeaders, retainUncommited bool, closeParameter bool) (*PathUpdateResponse, error) {
+func (f FileURL) FlushData(ctx context.Context, fileSize int64, contentMd5 []byte, headers BlobFSHTTPHeaders, retainUncommittedData bool, closeFile bool) (*PathUpdateResponse, error) {
 	if fileSize < 0 {
 		panic("fileSize must be >= 0")
 	}
@@ -183,7 +183,7 @@ func (f FileURL) FlushData(ctx context.Context, fileSize int64, contentMd5 []byt
 
 	// TransactionalContentMD5 isn't supported currently.
 	return f.fileClient.Update(ctx, PathUpdateActionFlush, f.fileSystemName, f.path, &fileSize,
-		&retainUncommited, &closeParameter, nil, nil,
+		&retainUncommittedData, &closeFile, nil, nil,
 		&headers.CacheControl, &headers.ContentType, &headers.ContentDisposition, &headers.ContentEncoding, &headers.ContentLanguage,
 		md5InBase64, nil, nil, nil, nil, nil, nil, nil,
 		nil, nil, &overrideHttpVerb, nil, nil, nil, nil)

--- a/azbfs/zt_url_file_test.go
+++ b/azbfs/zt_url_file_test.go
@@ -193,7 +193,7 @@ func (s *FileURLSuite) TestUploadDownloadRoundTrip(c *chk.C) {
 	c.Assert(pResp.Date(), chk.Not(chk.Equals), "")
 
 	// Flush data
-	fResp, err := fileURL.FlushData(context.Background(), 4096, make([]byte, 0), azbfs.BlobFSHTTPHeaders{})
+	fResp, err := fileURL.FlushData(context.Background(), 4096, make([]byte, 0), azbfs.BlobFSHTTPHeaders{}, false, true)
 	c.Assert(err, chk.IsNil)
 	c.Assert(fResp.StatusCode(), chk.Equals, http.StatusOK)
 	c.Assert(fResp.ETag(), chk.Not(chk.Equals), "")

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -1177,4 +1177,8 @@ func init() {
 	cpCmd.PersistentFlags().MarkHidden("cancel-from-stdin")
 	cpCmd.PersistentFlags().MarkHidden("s2s-get-properties-in-backend")
 	cpCmd.PersistentFlags().MarkHidden("with-snapshots") // TODO this flag is not supported right now
+
+	// Hide the flush-threshold flag since it is implemented only for CI.
+	cpCmd.PersistentFlags().Uint32Var(&ste.ADLSFlushThreshold, "flush-threshold", 7500, "Adjust the number of blocks to flush at once on ADLS gen 2")
+	cpCmd.PersistentFlags().MarkHidden("flush-threshold")
 }

--- a/ste/uploader-blobFS.go
+++ b/ste/uploader-blobFS.go
@@ -140,7 +140,7 @@ func (u *blobFSUploader) RemoteFileExists() (bool, error) {
 func (u *blobFSUploader) Prologue(state common.PrologueState) {
 	jptm := u.jptm
 
-	u.flushThreshold = int64(u.chunkSize * 7500)
+	u.flushThreshold = int64(u.chunkSize * ADLSFlushThreshold)
 
 	h := jptm.BfsDstData(state.LeadingBytes)
 	u.creationTimeHeaders = &h
@@ -182,7 +182,7 @@ func (u *blobFSUploader) Epilogue() {
 		md5Hash, ok := <-u.md5Channel
 		if ok {
 			// Flush incrementally to avoid timeouts on a full flush
-			for i := int64(math.Min(float64(ss), float64(u.flushThreshold))); i <= ss; i = int64(math.Min(float64(ss), float64(i+u.flushThreshold))) {
+			for i := int64(math.Min(float64(ss), float64(u.flushThreshold))); ; i = int64(math.Min(float64(ss), float64(i+u.flushThreshold))) {
 				// Close only at the end of the file, keep all uncommitted data before then.
 				_, err := u.fileURL.FlushData(jptm.Context(), i, md5Hash, *u.creationTimeHeaders, i != ss, i == ss)
 				if err != nil {

--- a/ste/uploader-blobFS.go
+++ b/ste/uploader-blobFS.go
@@ -139,6 +139,11 @@ func (u *blobFSUploader) RemoteFileExists() (bool, error) {
 func (u *blobFSUploader) Prologue(state common.PrologueState) {
 	jptm := u.jptm
 
+	if !thresholdSetup {
+		setupThreshold(int64(u.chunkSize))
+		thresholdSetup = true
+	}
+
 	h := jptm.BfsDstData(state.LeadingBytes)
 	u.creationTimeHeaders = &h
 	// Create file with the source size
@@ -170,7 +175,20 @@ func (u *blobFSUploader) GenerateUploadFunc(id common.ChunkID, blockIndex int32,
 	})
 }
 
-var flushThreshold int64 = (1024 ^ 3) * 20 //20 GB flush threshold
+var flushThreshold int64 = (1024 * 1024 * 1024) * 20 //20GB
+//TODO: Should a flag be present for the threshold?
+var thresholdSetup bool
+
+func setupThreshold(blockSize int64) {
+	//Find the closest multiple of the block size to the flush threshold
+	m := flushThreshold % blockSize
+
+	if math.Abs(float64(m)) < math.Abs(float64((flushThreshold-m+blockSize)-flushThreshold)) {
+		flushThreshold -= m
+	} else {
+		flushThreshold = (flushThreshold - m) + blockSize
+	}
+}
 
 func (u *blobFSUploader) Epilogue() {
 	jptm := u.jptm
@@ -180,11 +198,13 @@ func (u *blobFSUploader) Epilogue() {
 		md5Hash, ok := <-u.md5Channel
 		ss := jptm.Info().SourceSize
 		if ok {
+			// Flush incrementally to avoid timeouts on a full flush
 			for i := int64(math.Min(float64(ss), float64(flushThreshold))); i <= ss; i = int64(math.Min(float64(ss), float64(i+flushThreshold))) {
-				_, err := u.fileURL.FlushData(jptm.Context(), i, md5Hash, *u.creationTimeHeaders)
+				// Close only at the end of the file, keep all uncommitted data before then.
+				_, err := u.fileURL.FlushData(jptm.Context(), i, md5Hash, *u.creationTimeHeaders, i != ss, i == ss)
 				if err != nil {
 					jptm.FailActiveUpload("Flushing data", err)
-					// don't return, since need cleanup below
+					break // don't return, since need cleanup below
 				}
 
 				if i == ss {
@@ -192,8 +212,7 @@ func (u *blobFSUploader) Epilogue() {
 				}
 			}
 		} else {
-			jptm.FailActiveUpload("Getting hash", errNoHash)
-			// don't return, since need cleanup below
+			jptm.FailActiveUpload("Getting hash", errNoHash) // don't return, since need cleanup below
 		}
 	}
 

--- a/ste/xfer.go
+++ b/ste/xfer.go
@@ -34,6 +34,8 @@ const UploadTryTimeout = time.Minute * 15
 const UploadRetryDelay = time.Second * 1
 const UploadMaxRetryDelay = time.Second * 60
 
+var ADLSFlushThreshold uint32 = 7500 // The # of blocks to flush at a time-- Implemented only for CI.
+
 // download related
 const MaxRetryPerDownloadBody = 5
 

--- a/testSuite/scripts/test_blobfs_upload_oauth.py
+++ b/testSuite/scripts/test_blobfs_upload_oauth.py
@@ -57,7 +57,7 @@ class BlobFs_Upload_OAuth_User_Scenarios(unittest.TestCase):
         file_path = util.create_test_file(filename, 64*1024*1024)
         # Upload the file using AzCopy @ 1MB blocks, 15 block flushes (5 flushes, 4 15 blocks, 1 4 blocks)
         cmd = util.Command("copy").add_arguments(file_path).add_arguments(util.test_bfs_account_url). \
-            add_flags("block-size-mb", 1).add_flags("flush-threshold", "15").add_flags("log-level", "Info")
+            add_flags("block-size-mb", "1").add_flags("flush-threshold", "15").add_flags("log-level", "Info")
         util.process_oauth_command(
             cmd,
             "LocalBlobFS" if explicitFromTo else "")
@@ -77,7 +77,7 @@ class BlobFs_Upload_OAuth_User_Scenarios(unittest.TestCase):
         file_path = util.create_test_file(filename, 64 * 1024 * 1024)
         # Upload the file using AzCopy @ 1MB blocks, 16 block flushes (4 16 block flushes)
         cmd = util.Command("copy").add_arguments(file_path).add_arguments(util.test_bfs_account_url). \
-            add_flags("block-size-mb", 1).add_flags("flush-threshold", "16").add_flags("log-level", "Info")
+            add_flags("block-size-mb", "1").add_flags("flush-threshold", "16").add_flags("log-level", "Info")
         util.process_oauth_command(
             cmd,
             "LocalBlobFS" if explicitFromTo else "")

--- a/testSuite/scripts/test_blobfs_upload_oauth.py
+++ b/testSuite/scripts/test_blobfs_upload_oauth.py
@@ -49,6 +49,46 @@ class BlobFs_Upload_OAuth_User_Scenarios(unittest.TestCase):
         result = util.Command("testBlobFS").add_arguments(file_path).add_arguments(fileUrl).execute_azcopy_verify()
         self.assertTrue(result)
 
+    def util_test_blobfs_upload_uneven_multiflush_file(
+        self,
+        explicitFromTo=False):
+        # create test file of size 64MB
+        filename = "test_uneven_multiflush_64MB_file.txt"
+        file_path = util.create_test_file(filename, 64*1024*1024)
+        # Upload the file using AzCopy @ 1MB blocks, 15 block flushes (5 flushes, 4 15 blocks, 1 4 blocks)
+        cmd = util.Command("copy").add_arguments(file_path).add_arguments(util.test_bfs_account_url). \
+            add_flags("block-size-mb", 1).add_flags("flush-threshold", "15").add_flags("log-level", "Info")
+        util.process_oauth_command(
+            cmd,
+            "LocalBlobFS" if explicitFromTo else "")
+        result = cmd.execute_azcopy_copy_command()
+        self.assertTrue(result)
+
+        # Validate the file uploaded
+        fileUrl = util.test_bfs_account_url + filename
+        result = util.Command("testBlobFS").add_arguments(file_path).add_arguments(fileUrl).execute_azcopy_verify()
+        self.assertTrue(result)
+
+    def util_test_blobfs_upload_even_multiflush_file(
+            self,
+            explicitFromTo=False):
+        # create test file of size 64MB
+        filename = "test_even_multiflush_64MB_file.txt"
+        file_path = util.create_test_file(filename, 64 * 1024 * 1024)
+        # Upload the file using AzCopy @ 1MB blocks, 16 block flushes (4 16 block flushes)
+        cmd = util.Command("copy").add_arguments(file_path).add_arguments(util.test_bfs_account_url). \
+            add_flags("block-size-mb", 1).add_flags("flush-threshold", "16").add_flags("log-level", "Info")
+        util.process_oauth_command(
+            cmd,
+            "LocalBlobFS" if explicitFromTo else "")
+        result = cmd.execute_azcopy_copy_command()
+        self.assertTrue(result)
+
+        # Validate the file uploaded
+        fileUrl = util.test_bfs_account_url + filename
+        result = util.Command("testBlobFS").add_arguments(file_path).add_arguments(fileUrl).execute_azcopy_verify()
+        self.assertTrue(result)
+
     def util_test_blobfs_upload_100_1Kb_file(
         self,
         explictFromTo=False):
@@ -80,3 +120,9 @@ class BlobFs_Upload_OAuth_User_Scenarios(unittest.TestCase):
 
     def test_blobfs_upload_100_1Kb_file_with_oauth(self):
         self.util_test_blobfs_upload_100_1Kb_file()
+
+    def test_blobfs_upload_uneven_multiflush_with_oauth(self):
+        self.util_test_blobfs_upload_uneven_multiflush_file()
+
+    def test_blobfs_upload_even_multiflush_with_oauth(self):
+        self.util_test_blobfs_upload_even_multiflush_file()

--- a/testSuite/scripts/utility.py
+++ b/testSuite/scripts/utility.py
@@ -42,7 +42,7 @@ class Command(object):
             # iterating through all the values in dict and combining them.
         if len(self.flags) > 0:
             for key, value in self.flags.items():
-                command += " --" + key + "=" + '"' + value + '"'
+                command += " --" + key + "=" + '"' + str(value) + '"'
         return command
 
     # this api is used to execute a azcopy copy command.


### PR DESCRIPTION
**NOTE** this is not a finished PR. This is purely here to gather thoughts.

@JohnRusk I know you "discovered" this-- wanted to see what you think of this implementation. I know it eats a goroutine but I attempted to make it sleep as much as possible.

@zezha-msft I'd like to see what you think as well.

Here are my concerns:
1. We were suggested to flush either after a certain data size or a certain number of blocks. I'm happy to switch between them.
2. How should we init bfsTrackerTodo? Check the comment below it for details.
3. Any other concerns from you guys?

I don't intend this to make it into the next release, so get to this at your leisure.