### PR TITLE
Fix single wildcard match uploads

### DIFF
--- a/cmd/copyUploadEnumerator.go
+++ b/cmd/copyUploadEnumerator.go
@@ -49,7 +49,7 @@ func (e *copyUploadEnumerator) enumerate(cca *cookedCopyCmdArgs) error {
 				return fmt.Errorf("for the use of include flag, source needs to be a directory")
 			}
 			// append file name as blob name in case the given URL is a container
-			if (e.FromTo == common.EFromTo.LocalBlob() && util.urlIsContainerOrShare(destinationURL)) ||
+			if (e.FromTo == common.EFromTo.LocalBlob() && util.urlIsContainer(destinationURL)) ||
 				(e.FromTo == common.EFromTo.LocalFile() && util.urlIsAzureFileDirectory(ctx, destinationURL)) {
 				destinationURL.Path = util.generateObjectPath(destinationURL.Path, f.Name())
 			}

--- a/cmd/copyUploadEnumerator.go
+++ b/cmd/copyUploadEnumerator.go
@@ -30,9 +30,8 @@ func (e *copyUploadEnumerator) enumerate(cca *cookedCopyCmdArgs) error {
 		return fmt.Errorf("cannot find source to upload")
 	}
 
-	// if the user specifies a virtual directory ex: /container_name/extra_path
-	// then we should extra_path as a prefix while uploading
-	// temporarily save the path of the container
+	// If the user specifies a virtual directory, (ex: /container/extra_path)
+	// we should add the extra path as a prefix to the destination.
 	cleanContainerPath := destinationURL.Path
 
 	// when a single file is being uploaded, we need to treat this case differently, as the destinationURL might be a blob
@@ -69,9 +68,6 @@ func (e *copyUploadEnumerator) enumerate(cca *cookedCopyCmdArgs) error {
 			}
 
 			cleanedSource := strings.Replace(listOfFilesAndDirectories[0], common.OS_PATH_SEPARATOR, common.AZCOPY_PATH_SEPARATOR_STRING, -1)
-			if destinationURL.Path[len(destinationURL.Path)-1:] == `/` {
-				destinationURL.Path = util.generateObjectPath(cleanContainerPath, f.Name())
-			}
 			err = e.addTransfer(common.CopyTransfer{
 				Source:           cleanedSource,
 				Destination:      destinationURL.String(),

--- a/cmd/copyUploadEnumerator.go
+++ b/cmd/copyUploadEnumerator.go
@@ -49,7 +49,7 @@ func (e *copyUploadEnumerator) enumerate(cca *cookedCopyCmdArgs) error {
 				return fmt.Errorf("for the use of include flag, source needs to be a directory")
 			}
 			// append file name as blob name in case the given URL is a container
-			if (e.FromTo == common.EFromTo.LocalBlob() && util.urlIsContainer(destinationURL)) ||
+			if (e.FromTo == common.EFromTo.LocalBlob() && util.urlIsContainerOrVirtualDirectory(destinationURL)) ||
 				(e.FromTo == common.EFromTo.LocalFile() && util.urlIsAzureFileDirectory(ctx, destinationURL)) {
 				destinationURL.Path = util.generateObjectPath(destinationURL.Path, f.Name())
 			}

--- a/cmd/copyUtil.go
+++ b/cmd/copyUtil.go
@@ -56,7 +56,7 @@ func (copyHandlerUtil) numOfWildcardInURL(url url.URL) int {
 
 // checks if a given url points to a container, as opposed to a blob or prefix match
 func (util copyHandlerUtil) urlIsContainerOrShare(url *url.URL) bool {
-	if azblob.NewBlobURLParts(*url).IPEndpointStyleInfo.AccountName != "" {
+	if azblob.NewBlobURLParts(*url).IPEndpointStyleInfo.AccountName == "" {
 		//Typical endpoint style
 		//If there's no slashes after the first, it's a container.
 		//If there's a slash on the end, it's a virtual directory/container.

--- a/cmd/copyUtil.go
+++ b/cmd/copyUtil.go
@@ -55,7 +55,7 @@ func (copyHandlerUtil) numOfWildcardInURL(url url.URL) int {
 }
 
 // checks if a given url points to a container, as opposed to a blob or prefix match
-func (util copyHandlerUtil) urlIsContainerOrShare(url *url.URL) bool {
+func (util copyHandlerUtil) urlIsContainer(url *url.URL) bool {
 	if azblob.NewBlobURLParts(*url).IPEndpointStyleInfo.AccountName == "" {
 		//Typical endpoint style
 		//If there's no slashes after the first, it's a container.
@@ -63,7 +63,7 @@ func (util copyHandlerUtil) urlIsContainerOrShare(url *url.URL) bool {
 		//Otherwise, it's just a blob.
 		return strings.HasSuffix(url.Path, "/") || strings.Count(url.Path[1:], "/") == 0
 	} else {
-		//URL endpoint style: https://IP:port/accountname/container
+		//IP endpoint style: https://IP:port/accountname/container
 		//If there's 2 or less slashes after the first, it's a container.
 		//OR If there's a slash on the end, it's a virtual directory/container.
 		//Otherwise, it's just a blob.
@@ -135,7 +135,7 @@ func (util copyHandlerUtil) ConstructCommandStringFromArgs() string {
 }
 
 func (util copyHandlerUtil) urlIsBFSFileSystemOrDirectory(ctx context.Context, url *url.URL, p pipeline.Pipeline) bool {
-	if util.urlIsContainerOrShare(url) {
+	if util.urlIsContainer(url) {
 		return true
 	}
 	// Need to get the resource properties and verify if it is a file or directory
@@ -145,7 +145,7 @@ func (util copyHandlerUtil) urlIsBFSFileSystemOrDirectory(ctx context.Context, u
 
 func (util copyHandlerUtil) urlIsAzureFileDirectory(ctx context.Context, url *url.URL) bool {
 	// Azure file share case
-	if util.urlIsContainerOrShare(url) {
+	if util.urlIsContainer(url) {
 		return true
 	}
 

--- a/cmd/copyUtil.go
+++ b/cmd/copyUtil.go
@@ -57,17 +57,17 @@ func (copyHandlerUtil) numOfWildcardInURL(url url.URL) int {
 // checks if a given url points to a container or virtual directory, as opposed to a blob or prefix match
 func (util copyHandlerUtil) urlIsContainerOrVirtualDirectory(url *url.URL) bool {
 	if azblob.NewBlobURLParts(*url).IPEndpointStyleInfo.AccountName == "" {
-		//Typical endpoint style
-		//If there's no slashes after the first, it's a container.
-		//If there's a slash on the end, it's a virtual directory/container.
-		//Otherwise, it's just a blob.
+		// Typical endpoint style
+		// If there's no slashes after the first, it's a container.
+		// If there's a slash on the end, it's a virtual directory/container.
+		// Otherwise, it's just a blob.
 		return strings.HasSuffix(url.Path, "/") || strings.Count(url.Path[1:], "/") == 0
 	} else {
-		//IP endpoint style: https://IP:port/accountname/container
-		//If there's 2 or less slashes after the first, it's a container.
-		//OR If there's a slash on the end, it's a virtual directory/container.
-		//Otherwise, it's just a blob.
-		return strings.HasSuffix(url.Path, "/") || strings.Count(url.Path[1:], "/") <= 2
+		// IP endpoint style: https://IP:port/accountname/container
+		// If there's 2 or less slashes after the first, it's a container.
+		// OR If there's a slash on the end, it's a virtual directory/container.
+		// Otherwise, it's just a blob.
+		return strings.HasSuffix(url.Path, "/") || strings.Count(url.Path[1:], "/") <= 1
 	}
 }
 

--- a/cmd/copyUtil.go
+++ b/cmd/copyUtil.go
@@ -69,10 +69,14 @@ func (util copyHandlerUtil) urlIsContainerOrShare(url *url.URL) bool {
 	numOfSlashes := strings.Count(url.Path[1:], "/")
 	isIPEndpointStyle := util.isIPEndpointStyle(*url)
 
-	if (!isIPEndpointStyle && numOfSlashes == 0) || (isIPEndpointStyle && numOfSlashes == 1) {
-		return true
-	} else if ((!isIPEndpointStyle && numOfSlashes == 1) || (isIPEndpointStyle && numOfSlashes == 2)) && strings.HasSuffix(url.Path, "/") { // this checks if container_name/ was given
-		return true
+	if isIPEndpointStyle {
+		if numOfSlashes <= 2 || strings.HasPrefix(url.Path, `/`) {
+			return true
+		}
+	} else {
+		if numOfSlashes <= 1 || strings.HasPrefix(url.Path, `/`) {
+			return true
+		}
 	}
 	return false
 }

--- a/cmd/copyUtil.go
+++ b/cmd/copyUtil.go
@@ -54,8 +54,8 @@ func (copyHandlerUtil) numOfWildcardInURL(url url.URL) int {
 	return strings.Count(url.String(), wildCard)
 }
 
-// checks if a given url points to a container, as opposed to a blob or prefix match
-func (util copyHandlerUtil) urlIsContainer(url *url.URL) bool {
+// checks if a given url points to a container or virtual directory, as opposed to a blob or prefix match
+func (util copyHandlerUtil) urlIsContainerOrVirtualDirectory(url *url.URL) bool {
 	if azblob.NewBlobURLParts(*url).IPEndpointStyleInfo.AccountName == "" {
 		//Typical endpoint style
 		//If there's no slashes after the first, it's a container.
@@ -135,7 +135,7 @@ func (util copyHandlerUtil) ConstructCommandStringFromArgs() string {
 }
 
 func (util copyHandlerUtil) urlIsBFSFileSystemOrDirectory(ctx context.Context, url *url.URL, p pipeline.Pipeline) bool {
-	if util.urlIsContainer(url) {
+	if util.urlIsContainerOrVirtualDirectory(url) {
 		return true
 	}
 	// Need to get the resource properties and verify if it is a file or directory
@@ -145,7 +145,7 @@ func (util copyHandlerUtil) urlIsBFSFileSystemOrDirectory(ctx context.Context, u
 
 func (util copyHandlerUtil) urlIsAzureFileDirectory(ctx context.Context, url *url.URL) bool {
 	// Azure file share case
-	if util.urlIsContainer(url) {
+	if util.urlIsContainerOrVirtualDirectory(url) {
 		return true
 	}
 

--- a/cmd/copyUtil.go
+++ b/cmd/copyUtil.go
@@ -64,21 +64,10 @@ func (util copyHandlerUtil) isIPEndpointStyle(url url.URL) bool {
 
 // checks if a given url points to a container, as opposed to a blob or prefix match
 func (util copyHandlerUtil) urlIsContainerOrShare(url *url.URL) bool {
-	// When it's IP endpoint style, if the path contains more than two "/", then it means it points to a blob, and not a container.
-	// When it's not IP endpoint style, if the path contains more than one "/", then it means it points to a blob, and not a container.
-	numOfSlashes := strings.Count(url.Path[1:], "/")
-	isIPEndpointStyle := util.isIPEndpointStyle(*url)
-
-	if isIPEndpointStyle {
-		if numOfSlashes <= 2 || strings.HasPrefix(url.Path, `/`) {
-			return true
-		}
-	} else {
-		if numOfSlashes <= 1 || strings.HasPrefix(url.Path, `/`) {
-			return true
-		}
-	}
-	return false
+	//If there's no slashes after the first, it's a container.
+	//If there's a slash on the end, it's a virtual directory.
+	//Otherwise, it's just a blob.
+	return strings.HasSuffix(url.Path, "/") || strings.Count(url.Path[1:], "/") == 0
 }
 
 func (util copyHandlerUtil) appendQueryParamToUrl(url *url.URL, queryParam string) *url.URL {

--- a/cmd/copyUtil_test.go
+++ b/cmd/copyUtil_test.go
@@ -63,5 +63,19 @@ func (s *copyUtilTestSuite) TestIPIsContainerOrBlob(c *chk.C) {
 	isContainerURL := util.urlIsContainerOrVirtualDirectory(&testURL)
 	c.Assert(isContainerIP, chk.Equals, true)   // IP endpoints contain the account in the path, making the container the second entry
 	c.Assert(isContainerURL, chk.Equals, false) // URL endpoints do not contain the account in the path, making the container the first entry.
-	//The behaviour isn't too different from here.
+
+	testURL.Path = "/account/container/folder"
+	testIP.Path = "/account/container/folder"
+	isContainerIP = util.urlIsContainerOrVirtualDirectory(&testIP)
+	isContainerURL = util.urlIsContainerOrVirtualDirectory(&testURL)
+	c.Assert(isContainerIP, chk.Equals, false)  // IP endpoints contain the account in the path, making the container the second entry
+	c.Assert(isContainerURL, chk.Equals, false) // URL endpoints do not contain the account in the path, making the container the first entry.
+
+	testURL.Path = "/account/container/folder/"
+	testIP.Path = "/account/container/folder/"
+	isContainerIP = util.urlIsContainerOrVirtualDirectory(&testIP)
+	isContainerURL = util.urlIsContainerOrVirtualDirectory(&testURL)
+	c.Assert(isContainerIP, chk.Equals, true)  // IP endpoints contain the account in the path, making the container the second entry
+	c.Assert(isContainerURL, chk.Equals, true) // URL endpoints do not contain the account in the path, making the container the first entry.
+	// The behaviour isn't too different from here.
 }

--- a/cmd/copyUtil_test.go
+++ b/cmd/copyUtil_test.go
@@ -33,24 +33,24 @@ func (s *copyUtilTestSuite) TestUrlIsContainerOrBlob(c *chk.C) {
 	util := copyHandlerUtil{}
 
 	testUrl := url.URL{Path: "/container/dir1"}
-	isContainer := util.urlIsContainer(&testUrl)
+	isContainer := util.urlIsContainerOrVirtualDirectory(&testUrl)
 	c.Assert(isContainer, chk.Equals, false)
 
 	testUrl.Path = "/container/dir1/dir2"
-	isContainer = util.urlIsContainer(&testUrl)
+	isContainer = util.urlIsContainerOrVirtualDirectory(&testUrl)
 	c.Assert(isContainer, chk.Equals, false)
 
 	testUrl.Path = "/container/"
-	isContainer = util.urlIsContainer(&testUrl)
+	isContainer = util.urlIsContainerOrVirtualDirectory(&testUrl)
 	c.Assert(isContainer, chk.Equals, true)
 
 	testUrl.Path = "/container"
-	isContainer = util.urlIsContainer(&testUrl)
+	isContainer = util.urlIsContainerOrVirtualDirectory(&testUrl)
 	c.Assert(isContainer, chk.Equals, true)
 
 	// root container
 	testUrl.Path = "/"
-	isContainer = util.urlIsContainer(&testUrl)
+	isContainer = util.urlIsContainerOrVirtualDirectory(&testUrl)
 	c.Assert(isContainer, chk.Equals, true)
 }
 
@@ -59,8 +59,8 @@ func (s *copyUtilTestSuite) TestIPIsContainerOrBlob(c *chk.C) {
 
 	testIP := url.URL{Host: "127.0.0.1:8256", Path: "/account/container"}
 	testURL := url.URL{Path: "/account/container"}
-	isContainerIP := util.urlIsContainer(&testIP)
-	isContainerURL := util.urlIsContainer(&testURL)
+	isContainerIP := util.urlIsContainerOrVirtualDirectory(&testIP)
+	isContainerURL := util.urlIsContainerOrVirtualDirectory(&testURL)
 	c.Assert(isContainerIP, chk.Equals, true)   // IP endpoints contain the account in the path, making the container the second entry
 	c.Assert(isContainerURL, chk.Equals, false) // URL endpoints do not contain the account in the path, making the container the first entry.
 	//The behaviour isn't too different from here.

--- a/cmd/copyUtil_test.go
+++ b/cmd/copyUtil_test.go
@@ -29,27 +29,39 @@ type copyUtilTestSuite struct{}
 
 var _ = chk.Suite(&copyUtilTestSuite{})
 
-func (s *copyUtilTestSuite) TestUrlIsContainerOrShare(c *chk.C) {
+func (s *copyUtilTestSuite) TestUrlIsContainerOrBlob(c *chk.C) {
 	util := copyHandlerUtil{}
 
 	testUrl := url.URL{Path: "/container/dir1"}
-	isContainerOrShare := util.urlIsContainerOrShare(&testUrl)
-	c.Assert(isContainerOrShare, chk.Equals, false)
+	isContainer := util.urlIsContainer(&testUrl)
+	c.Assert(isContainer, chk.Equals, false)
 
 	testUrl.Path = "/container/dir1/dir2"
-	isContainerOrShare = util.urlIsContainerOrShare(&testUrl)
-	c.Assert(isContainerOrShare, chk.Equals, false)
+	isContainer = util.urlIsContainer(&testUrl)
+	c.Assert(isContainer, chk.Equals, false)
 
 	testUrl.Path = "/container/"
-	isContainerOrShare = util.urlIsContainerOrShare(&testUrl)
-	c.Assert(isContainerOrShare, chk.Equals, true)
+	isContainer = util.urlIsContainer(&testUrl)
+	c.Assert(isContainer, chk.Equals, true)
 
 	testUrl.Path = "/container"
-	isContainerOrShare = util.urlIsContainerOrShare(&testUrl)
-	c.Assert(isContainerOrShare, chk.Equals, true)
+	isContainer = util.urlIsContainer(&testUrl)
+	c.Assert(isContainer, chk.Equals, true)
 
 	// root container
 	testUrl.Path = "/"
-	isContainerOrShare = util.urlIsContainerOrShare(&testUrl)
-	c.Assert(isContainerOrShare, chk.Equals, true)
+	isContainer = util.urlIsContainer(&testUrl)
+	c.Assert(isContainer, chk.Equals, true)
+}
+
+func (s *copyUtilTestSuite) TestIPIsContainerOrBlob(c *chk.C) {
+	util := copyHandlerUtil{}
+
+	testIP := url.URL{Host: "127.0.0.1:8256", Path: "/account/container"}
+	testURL := url.URL{Path: "/account/container"}
+	isContainerIP := util.urlIsContainer(&testIP)
+	isContainerURL := util.urlIsContainer(&testURL)
+	c.Assert(isContainerIP, chk.Equals, true)   // IP endpoints contain the account in the path, making the container the second entry
+	c.Assert(isContainerURL, chk.Equals, false) // URL endpoints do not contain the account in the path, making the container the first entry.
+	//The behaviour isn't too different from here.
 }

--- a/cmd/credentialUtil.go
+++ b/cmd/credentialUtil.go
@@ -111,7 +111,7 @@ func getBlobCredentialType(ctx context.Context, blobResourceURL string, canBePub
 				},
 			})
 
-		isContainer := copyHandlerUtil{}.urlIsContainer(resourceURL)
+		isContainer := copyHandlerUtil{}.urlIsContainerOrVirtualDirectory(resourceURL)
 		isPublicResource := false
 
 		if isContainer {

--- a/cmd/credentialUtil.go
+++ b/cmd/credentialUtil.go
@@ -34,8 +34,8 @@ import (
 	"github.com/Azure/azure-storage-azcopy/azbfs"
 	"github.com/Azure/azure-storage-azcopy/common"
 	"github.com/Azure/azure-storage-azcopy/ste"
-	"github.com/Azure/azure-storage-file-go/azfile"
 	"github.com/Azure/azure-storage-blob-go/azblob"
+	"github.com/Azure/azure-storage-file-go/azfile"
 )
 
 var once sync.Once
@@ -111,7 +111,7 @@ func getBlobCredentialType(ctx context.Context, blobResourceURL string, canBePub
 				},
 			})
 
-		isContainer := copyHandlerUtil{}.urlIsContainerOrShare(resourceURL)
+		isContainer := copyHandlerUtil{}.urlIsContainer(resourceURL)
 		isPublicResource := false
 
 		if isContainer {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -130,7 +130,7 @@ func HandleListContainerCommand(source string) (err error) {
 	// get the search prefix to query the service
 	searchPrefix := ""
 	// if the source is container url, then searchPrefix is empty
-	if !util.urlIsContainerOrShare(sourceURL) {
+	if !util.urlIsContainer(sourceURL) {
 		searchPrefix = util.getBlobNameFromURL(sourceURL.Path)
 	}
 	if len(searchPrefix) > 0 {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -130,7 +130,7 @@ func HandleListContainerCommand(source string) (err error) {
 	// get the search prefix to query the service
 	searchPrefix := ""
 	// if the source is container url, then searchPrefix is empty
-	if !util.urlIsContainer(sourceURL) {
+	if !util.urlIsContainerOrVirtualDirectory(sourceURL) {
 		searchPrefix = util.getBlobNameFromURL(sourceURL.Path)
 	}
 	if len(searchPrefix) > 0 {

--- a/cmd/zt_copy_blob_upload_test.go
+++ b/cmd/zt_copy_blob_upload_test.go
@@ -29,6 +29,65 @@ import (
 )
 
 // regular local file->blob upload
+func (s *cmdIntegrationSuite) TestUploadSingleFileToBlobFolder(c *chk.C) {
+	bsu := getBSU()
+	containerURL, containerName := createNewContainer(c, bsu)
+	defer deleteContainer(c, containerURL)
+
+	for _, srcFileName := range []string{"singleblobisbest", "打麻将.txt", "%4509%4254$85140&"} {
+		// set up the source as a single file
+		srcDirName := scenarioHelper{}.generateLocalDirectory(c)
+		fileList := []string{srcFileName}
+		scenarioHelper{}.generateLocalFilesFromList(c, srcDirName, fileList)
+
+		// set up the destination container with a single blob
+		dstBlobName := "testfolder/"
+
+		// set up interceptor
+		mockedRPC := interceptor{}
+		Rpc = mockedRPC.intercept
+		mockedRPC.init()
+
+		// construct the raw input to simulate user input
+		rawBlobURLWithSAS := scenarioHelper{}.getRawBlobURLWithSAS(c, containerName, dstBlobName)
+		raw := getDefaultCopyRawInput(filepath.Join(srcDirName, srcFileName), rawBlobURLWithSAS.String())
+
+		// the blob was created after the file, so no sync should happen
+		runCopyAndVerify(c, raw, func(err error) {
+			c.Assert(err, chk.IsNil)
+
+			// Validate that the destination is the file name (within the folder).
+			// The destination being the folder *was* the issue in the past.
+			// The service would just name the file as the folder if we didn't explicitly specify it.
+			c.Assert(len(mockedRPC.transfers), chk.Equals, 1)
+			d, err := url.PathUnescape(mockedRPC.transfers[0].Destination) //Unescape the destination, as we have special characters.
+			c.Assert(err, chk.IsNil)
+			c.Assert(d, chk.Equals, srcFileName)
+		})
+
+		// clean the RPC for the next test
+		mockedRPC.reset()
+
+		// now target the destination container, the result should be the same
+		rawContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, containerName)
+		raw = getDefaultCopyRawInput(filepath.Join(srcDirName, srcFileName), rawContainerURLWithSAS.String())
+
+		// the file was created after the blob, so no sync should happen
+		runCopyAndVerify(c, raw, func(err error) {
+			c.Assert(err, chk.IsNil)
+
+			// verify explicitly since the source and destination names will be different:
+			// the source is "" since the given URL points to the blob itself
+			// the destination should be the blob name, since the given local path points to the parent dir
+			c.Assert(len(mockedRPC.transfers), chk.Equals, 1)
+
+			c.Assert(mockedRPC.transfers[0].Source, chk.Equals, "")
+			c.Assert(mockedRPC.transfers[0].Destination, chk.Equals, common.AZCOPY_PATH_SEPARATOR_STRING+url.PathEscape(srcFileName))
+		})
+	}
+}
+
+// regular local file->blob upload
 func (s *cmdIntegrationSuite) TestUploadSingleFileToBlob(c *chk.C) {
 	bsu := getBSU()
 	containerURL, containerName := createNewContainer(c, bsu)

--- a/cmd/zt_copy_blob_upload_test.go
+++ b/cmd/zt_copy_blob_upload_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 // regular local file->blob upload
-func (s *cmdIntegrationSuite) TestUploadSingleFileToBlobFolder(c *chk.C) {
+func (s *cmdIntegrationSuite) TestUploadSingleFileToBlobVirtualDirectory(c *chk.C) {
 	bsu := getBSU()
 	containerURL, containerName := createNewContainer(c, bsu)
 	defer deleteContainer(c, containerURL)


### PR DESCRIPTION
We were initially going to just create a failing test for this and get to it in the refactor. *HOWEVER*, I discovered it was such a trivial fix that I just went right through with it. Best to have it in the June release, anyway.

If you're wondering, no, this change actually doesn't break plan files. It indirectly FIXES this functionality on past versions when resuming.

If you're curious as to _what_ was even happening before, consider the following request:

`PUT https://<account>.blob.core.windows.net/<container>/test/?timeout=901`

The service was inferring our file name as `test`, and thus plopping it under `test/test`. With this change, the request then becomes

`PUT https://<account>.blob.core.windows.net/<container>/test/<file>?timeout=901`

Fixes the following issues: #410, #397