### PR TITLE
Added ADLS Gen2 support for rm command

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -887,6 +887,16 @@ func (cca *cookedCopyCmdArgs) processCopyJobPartOrders() (err error) {
 		}
 
 		err = e.enumerate()
+	case common.EFromTo.BlobFSTrash():
+		msg, err := removeBfsResource(cca)
+		if err == nil {
+			glcm.Exit(func(format common.OutputFormat) string {
+				return msg
+			}, common.EExitCode.Success())
+		}
+
+		return err
+
 	case common.EFromTo.BlobBlob():
 		e := copyS2SMigrationBlobEnumerator{
 			copyS2SMigrationEnumeratorBase: copyS2SMigrationEnumeratorBase{

--- a/cmd/credentialUtil.go
+++ b/cmd/credentialUtil.go
@@ -246,6 +246,10 @@ func getCredentialType(ctx context.Context, raw rawFromToInfo) (credentialType c
 		if credentialType, err = getBlobCredentialType(ctx, raw.source, false, raw.sourceSAS != ""); err != nil {
 			return common.ECredentialType.Unknown(), err
 		}
+	case common.EFromTo.BlobFSTrash():
+		if credentialType, err = getBlobFSCredentialType(ctx, raw.source, raw.sourceSAS != ""); err != nil {
+			return common.ECredentialType.Unknown(), err
+		}
 	case common.EFromTo.BlobLocal(), common.EFromTo.BlobPipe():
 		if credentialType, err = getBlobCredentialType(ctx, raw.source, true, raw.sourceSAS != ""); err != nil {
 			return common.ECredentialType.Unknown(), err

--- a/cmd/helpMessages.go
+++ b/cmd/helpMessages.go
@@ -206,9 +206,9 @@ const makeCmdExample = `
 `
 
 // ===================================== REMOVE COMMAND ===================================== //
-const removeCmdShortDescription = "Delete blobs or files from Azure Storage"
+const removeCmdShortDescription = "Delete entities from Azure Storage Blob/File/ADLS Gen2"
 
-const removeCmdLongDescription = `Delete blobs or files from Azure Storage.`
+const removeCmdLongDescription = `Delete entities from Azure Storage Blob/File/ADLS Gen2.`
 
 const removeCmdExample = `
 Remove a single blob with SAS:
@@ -225,6 +225,12 @@ Remove a subset of blobs in a virtual directory (ex: only jpg and pdf files, or 
 
 Remove an entire virtual directory but exclude certain blobs from the scope (ex: every blob that starts with foo or ends with bar):
   - azcopy rm "https://[account].blob.core.windows.net/[container]/[path/to/directory]?[SAS]" --recursive=true --exclude="foo*;*bar"
+
+Remove a single file from ADLS Gen2 (include/exclude not supported):
+  - azcopy rm "https://[account].dfs.core.windows.net/[container]/[path/to/file]?[SAS]"
+
+Remove a single directory from ADLS Gen2 (include/exclude not supported):
+  - azcopy rm "https://[account].dfs.core.windows.net/[container]/[path/to/directory]?[SAS]"
 `
 
 // ===================================== SYNC COMMAND ===================================== //

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -53,8 +53,10 @@ func init() {
 				raw.fromTo = common.EFromTo.BlobTrash().String()
 			} else if srcLocationType == common.ELocation.File() {
 				raw.fromTo = common.EFromTo.FileTrash().String()
+			} else if srcLocationType == common.ELocation.BlobFS() {
+				raw.fromTo = common.EFromTo.BlobFSTrash().String()
 			} else {
-				return fmt.Errorf("invalid source type %s pased to delete. azcopy support removing blobs and files only", srcLocationType.String())
+				return fmt.Errorf("invalid source type %s to delete. azcopy support removing blobs/files/adls gen2", srcLocationType.String())
 			}
 
 			// Since remove uses the copy command arguments cook, set the blobType to None and validation option
@@ -67,12 +69,12 @@ func init() {
 		Run: func(cmd *cobra.Command, args []string) {
 			cooked, err := raw.cook()
 			if err != nil {
-				glcm.Error("failed to parse user input due to error " + err.Error())
+				glcm.Error("failed to parse user input due to error: " + err.Error())
 			}
 			cooked.commandString = copyHandlerUtil{}.ConstructCommandStringFromArgs()
 			err = cooked.process()
 			if err != nil {
-				glcm.Error("failed to perform copy command due to error " + err.Error())
+				glcm.Error("failed to perform remove command due to error: " + err.Error())
 			}
 
 			glcm.SurrenderControl()

--- a/cmd/validators.go
+++ b/cmd/validators.go
@@ -46,7 +46,7 @@ func validateFromTo(src, dst string, userSpecifiedFromTo string) (common.FromTo,
 		return common.EFromTo.Unknown(), fmt.Errorf("invalid --from-to value specified: %q", userSpecifiedFromTo)
 	}
 	if inferredFromTo == common.EFromTo.Unknown() || inferredFromTo == userFromTo ||
-		userFromTo == common.EFromTo.BlobTrash() || userFromTo == common.EFromTo.FileTrash() {
+		userFromTo == common.EFromTo.BlobTrash() || userFromTo == common.EFromTo.FileTrash() || userFromTo == common.EFromTo.BlobFSTrash() {
 		// We couldn't infer the FromTo or what we inferred matches what the user specified
 		// We'll accept what the user specified
 		return userFromTo, nil

--- a/cmd/zt_remove_adls_test.go
+++ b/cmd/zt_remove_adls_test.go
@@ -128,7 +128,7 @@ func (s *cmdIntegrationSuite) TestRemoveFile(c *chk.C) {
 	c.Assert(err, chk.IsNil)
 
 	// delete single file
-	fileURLWithSAS := serviceURLWithSAS.NewFileSystemURL(fsName)
+	fileURLWithSAS := serviceURLWithSAS.NewFileSystemURL(fsName).NewDirectoryURL(parentDirName).NewFileURL(fileName)
 	raw := getDefaultRemoveRawInput(fileURLWithSAS.String())
 	runCopyAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)

--- a/cmd/zt_remove_adls_test.go
+++ b/cmd/zt_remove_adls_test.go
@@ -1,0 +1,140 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cmd
+
+import (
+	"context"
+	"github.com/Azure/azure-storage-azcopy/azbfs"
+	chk "gopkg.in/check.v1"
+)
+
+func (s *cmdIntegrationSuite) TestRemoveFilesystem(c *chk.C) {
+	// invoke the interceptor so lifecycle manager does not shut down the tests
+	mockedRPC := interceptor{}
+	mockedRPC.init()
+	ctx := context.Background()
+
+	// get service SAS for raw input
+	serviceURLWithSAS := scenarioHelper{}.getRawAdlsServiceURLWithSAS(c)
+
+	// set up the filesystem to be deleted
+	bfsServiceURL := getBfsSU()
+	fsURL, fsName := createNewFileSystem(c, bfsServiceURL)
+
+	// set up directory + file as children of the filesystem to delete
+	dirURL := fsURL.NewDirectoryURL(generateName("dir", 0))
+	_, err := dirURL.Create(ctx)
+	c.Assert(err, chk.IsNil)
+	fileURL := dirURL.NewFileURL(generateName("file", 0))
+	_, err = fileURL.Create(ctx, azbfs.BlobFSHTTPHeaders{})
+	c.Assert(err, chk.IsNil)
+
+	// removing the filesystem
+	fsURLWithSAS := serviceURLWithSAS.NewFileSystemURL(fsName).URL()
+	raw := getDefaultRemoveRawInput(fsURLWithSAS.String())
+	runCopyAndVerify(c, raw, func(err error) {
+		c.Assert(err, chk.IsNil)
+
+		// make sure the directory does not exist anymore
+		_, err = fsURL.GetProperties(ctx)
+		c.Assert(err, chk.NotNil)
+	})
+}
+
+func (s *cmdIntegrationSuite) TestRemoveDirectory(c *chk.C) {
+	// invoke the interceptor so lifecycle manager does not shut down the tests
+	mockedRPC := interceptor{}
+	mockedRPC.init()
+	ctx := context.Background()
+
+	// get service SAS for raw input
+	serviceURLWithSAS := scenarioHelper{}.getRawAdlsServiceURLWithSAS(c)
+
+	// set up the file system
+	bfsServiceURL := getBfsSU()
+	fsURL, fsName := createNewFileSystem(c, bfsServiceURL)
+	defer deleteFileSystem(c, fsURL)
+
+	// set up the directory to be deleted
+	dirName := generateName("dir", 0)
+	dirURL := fsURL.NewDirectoryURL(dirName)
+	_, err := dirURL.Create(ctx)
+	c.Assert(err, chk.IsNil)
+	fileURL := dirURL.NewFileURL(generateName("file", 0))
+	_, err = fileURL.Create(ctx, azbfs.BlobFSHTTPHeaders{})
+	c.Assert(err, chk.IsNil)
+
+	// trying to remove the dir with recursive=false should fail
+	dirURLWithSAS := serviceURLWithSAS.NewFileSystemURL(fsName).NewDirectoryURL(dirName)
+	raw := getDefaultRemoveRawInput(dirURLWithSAS.String())
+	raw.recursive = false
+	runCopyAndVerify(c, raw, func(err error) {
+		c.Assert(err, chk.NotNil)
+	})
+
+	// removing the dir with recursive=true should succeed
+	raw.recursive = true
+	runCopyAndVerify(c, raw, func(err error) {
+		c.Assert(err, chk.IsNil)
+
+		// make sure the directory does not exist anymore
+		_, err = dirURL.GetProperties(ctx)
+		c.Assert(err, chk.NotNil)
+	})
+}
+
+func (s *cmdIntegrationSuite) TestRemoveFile(c *chk.C) {
+	// invoke the interceptor so lifecycle manager does not shut down the tests
+	mockedRPC := interceptor{}
+	mockedRPC.init()
+	ctx := context.Background()
+
+	// get service SAS for raw input
+	serviceURLWithSAS := scenarioHelper{}.getRawAdlsServiceURLWithSAS(c)
+
+	// set up the file system
+	bfsServiceURL := getBfsSU()
+	fsURL, fsName := createNewFileSystem(c, bfsServiceURL)
+	defer deleteFileSystem(c, fsURL)
+
+	// set up the parent of the file to be deleted
+	parentDirName := generateName("dir", 0)
+	parentDirURL := fsURL.NewDirectoryURL(parentDirName)
+	_, err := parentDirURL.Create(ctx)
+	c.Assert(err, chk.IsNil)
+
+	// set up the file to be deleted
+	fileName := generateName("file", 0)
+	fileURL := parentDirURL.NewFileURL(fileName)
+	_, err = fileURL.Create(ctx, azbfs.BlobFSHTTPHeaders{})
+	c.Assert(err, chk.IsNil)
+
+	// delete single file
+	fileURLWithSAS := serviceURLWithSAS.NewFileSystemURL(fsName)
+	raw := getDefaultRemoveRawInput(fileURLWithSAS.String())
+	runCopyAndVerify(c, raw, func(err error) {
+		c.Assert(err, chk.IsNil)
+
+		// make sure the file does not exist anymore
+		_, err = fileURL.GetProperties(ctx)
+		c.Assert(err, chk.NotNil)
+	})
+}

--- a/cmd/zt_remove_blob_test.go
+++ b/cmd/zt_remove_blob_test.go
@@ -44,7 +44,7 @@ func (s *cmdIntegrationSuite) TestRemoveSingleBlob(c *chk.C) {
 
 		// construct the raw input to simulate user input
 		rawBlobURLWithSAS := scenarioHelper{}.getRawBlobURLWithSAS(c, containerName, blobList[0])
-		raw := getDefaultRemoveRawInput(rawBlobURLWithSAS.String(), true)
+		raw := getDefaultRemoveRawInput(rawBlobURLWithSAS.String())
 
 		runCopyAndVerify(c, raw, func(err error) {
 			c.Assert(err, chk.IsNil)
@@ -72,7 +72,7 @@ func (s *cmdIntegrationSuite) TestRemoveBlobsUnderContainer(c *chk.C) {
 
 	// construct the raw input to simulate user input
 	rawContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, containerName)
-	raw := getDefaultRemoveRawInput(rawContainerURLWithSAS.String(), true)
+	raw := getDefaultRemoveRawInput(rawContainerURLWithSAS.String())
 	raw.recursive = true
 
 	runCopyAndVerify(c, raw, func(err error) {
@@ -117,7 +117,7 @@ func (s *cmdIntegrationSuite) TestRemoveBlobsUnderVirtualDir(c *chk.C) {
 
 	// construct the raw input to simulate user input
 	rawVirtualDirectoryURLWithSAS := scenarioHelper{}.getRawBlobURLWithSAS(c, containerName, vdirName)
-	raw := getDefaultRemoveRawInput(rawVirtualDirectoryURLWithSAS.String(), true)
+	raw := getDefaultRemoveRawInput(rawVirtualDirectoryURLWithSAS.String())
 	raw.recursive = true
 
 	runCopyAndVerify(c, raw, func(err error) {
@@ -168,7 +168,7 @@ func (s *cmdIntegrationSuite) TestRemoveWithIncludeFlag(c *chk.C) {
 
 	// construct the raw input to simulate user input
 	rawContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, containerName)
-	raw := getDefaultRemoveRawInput(rawContainerURLWithSAS.String(), true)
+	raw := getDefaultRemoveRawInput(rawContainerURLWithSAS.String())
 	raw.include = includeString
 	raw.recursive = true
 
@@ -201,7 +201,7 @@ func (s *cmdIntegrationSuite) TestRemoveWithExcludeFlag(c *chk.C) {
 
 	// construct the raw input to simulate user input
 	rawContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, containerName)
-	raw := getDefaultRemoveRawInput(rawContainerURLWithSAS.String(), true)
+	raw := getDefaultRemoveRawInput(rawContainerURLWithSAS.String())
 	raw.exclude = excludeString
 	raw.recursive = true
 
@@ -240,7 +240,7 @@ func (s *cmdIntegrationSuite) TestRemoveWithIncludeAndExcludeFlag(c *chk.C) {
 
 	// construct the raw input to simulate user input
 	rawContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, containerName)
-	raw := getDefaultRemoveRawInput(rawContainerURLWithSAS.String(), true)
+	raw := getDefaultRemoveRawInput(rawContainerURLWithSAS.String())
 	raw.include = includeString
 	raw.exclude = excludeString
 	raw.recursive = true

--- a/cmd/zt_remove_file_test.go
+++ b/cmd/zt_remove_file_test.go
@@ -44,7 +44,7 @@ func (s *cmdIntegrationSuite) TestRemoveSingleFile(c *chk.C) {
 
 		// construct the raw input to simulate user input
 		rawFileURLWithSAS := scenarioHelper{}.getRawFileURLWithSAS(c, shareName, fileList[0])
-		raw := getDefaultRemoveRawInput(rawFileURLWithSAS.String(), true)
+		raw := getDefaultRemoveRawInput(rawFileURLWithSAS.String())
 
 		runCopyAndVerify(c, raw, func(err error) {
 			c.Assert(err, chk.IsNil)
@@ -72,7 +72,7 @@ func (s *cmdIntegrationSuite) TestRemoveFilesUnderShare(c *chk.C) {
 
 	// construct the raw input to simulate user input
 	rawShareURLWithSAS := scenarioHelper{}.getRawShareURLWithSAS(c, shareName)
-	raw := getDefaultRemoveRawInput(rawShareURLWithSAS.String(), false)
+	raw := getDefaultRemoveRawInput(rawShareURLWithSAS.String())
 	raw.recursive = true
 
 	runCopyAndVerify(c, raw, func(err error) {
@@ -117,7 +117,7 @@ func (s *cmdIntegrationSuite) TestRemoveFilesUnderDirectory(c *chk.C) {
 
 	// construct the raw input to simulate user input
 	rawDirectoryURLWithSAS := scenarioHelper{}.getRawFileURLWithSAS(c, shareName, dirName)
-	raw := getDefaultRemoveRawInput(rawDirectoryURLWithSAS.String(), false)
+	raw := getDefaultRemoveRawInput(rawDirectoryURLWithSAS.String())
 	raw.recursive = true
 
 	runCopyAndVerify(c, raw, func(err error) {
@@ -168,7 +168,7 @@ func (s *cmdIntegrationSuite) TestRemoveFilesWithIncludeFlag(c *chk.C) {
 
 	// construct the raw input to simulate user input
 	rawShareURLWithSAS := scenarioHelper{}.getRawShareURLWithSAS(c, shareName)
-	raw := getDefaultRemoveRawInput(rawShareURLWithSAS.String(), false)
+	raw := getDefaultRemoveRawInput(rawShareURLWithSAS.String())
 	raw.include = includeString
 	raw.recursive = true
 
@@ -201,7 +201,7 @@ func (s *cmdIntegrationSuite) TestRemoveFilesWithExcludeFlag(c *chk.C) {
 
 	// construct the raw input to simulate user input
 	rawShareURLWithSAS := scenarioHelper{}.getRawShareURLWithSAS(c, shareName)
-	raw := getDefaultRemoveRawInput(rawShareURLWithSAS.String(), false)
+	raw := getDefaultRemoveRawInput(rawShareURLWithSAS.String())
 	raw.exclude = excludeString
 	raw.recursive = true
 
@@ -240,7 +240,7 @@ func (s *cmdIntegrationSuite) TestRemoveFilesWithIncludeAndExcludeFlag(c *chk.C)
 
 	// construct the raw input to simulate user input
 	rawShareURLWithSAS := scenarioHelper{}.getRawShareURLWithSAS(c, shareName)
-	raw := getDefaultRemoveRawInput(rawShareURLWithSAS.String(), false)
+	raw := getDefaultRemoveRawInput(rawShareURLWithSAS.String())
 	raw.include = includeString
 	raw.exclude = excludeString
 	raw.recursive = true

--- a/cmd/zt_scenario_helpers_for_test.go
+++ b/cmd/zt_scenario_helpers_for_test.go
@@ -23,6 +23,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"github.com/Azure/azure-storage-azcopy/azbfs"
 	"io/ioutil"
 	"net/url"
 	"os"
@@ -35,7 +36,7 @@ import (
 	"github.com/Azure/azure-storage-file-go/azfile"
 	chk "gopkg.in/check.v1"
 
-	minio "github.com/minio/minio-go"
+	"github.com/minio/minio-go"
 )
 
 const defaultFileSize = 1024
@@ -364,6 +365,13 @@ func (scenarioHelper) getRawBlobServiceURLWithSAS(c *chk.C) url.URL {
 	return getServiceURLWithSAS(c, *credential).URL()
 }
 
+func (scenarioHelper) getRawAdlsServiceURLWithSAS(c *chk.C) azbfs.ServiceURL {
+	accountName, accountKey := getAccountAndKey()
+	credential := azbfs.NewSharedKeyCredential(accountName, accountKey)
+
+	return getAdlsServiceURLWithSAS(c, *credential)
+}
+
 func (scenarioHelper) getBlobServiceURL(c *chk.C) azblob.ServiceURL {
 	accountName, accountKey := getAccountAndKey()
 	credential, err := azblob.NewSharedKeyCredential(accountName, accountKey)
@@ -549,10 +557,14 @@ func getDefaultCopyRawInput(src string, dst string) rawCopyCmdArgs {
 	}
 }
 
-func getDefaultRemoveRawInput(src string, targetingBlob bool) rawCopyCmdArgs {
+func getDefaultRemoveRawInput(src string) rawCopyCmdArgs {
 	fromTo := common.EFromTo.BlobTrash()
-	if !targetingBlob {
+	srcURL, _ := url.Parse(src)
+
+	if strings.Contains(srcURL.Host, "file") {
 		fromTo = common.EFromTo.FileTrash()
+	} else if strings.Contains(srcURL.Host, "dfs") {
+		fromTo = common.EFromTo.BlobFSTrash()
 	}
 
 	return rawCopyCmdArgs{

--- a/cmd/zt_test.go
+++ b/cmd/zt_test.go
@@ -424,6 +424,9 @@ func cleanS3Account(c *chk.C, client *minio.Client) {
 	c.Assert(err, chk.IsNil)
 
 	for _, bucket := range buckets {
+		if strings.Contains(bucket.Name, "elastic") {
+			continue
+		}
 		deleteBucket(c, client, bucket.Name)
 	}
 }

--- a/common/fe-ste-models.go
+++ b/common/fe-ste-models.go
@@ -329,17 +329,20 @@ var EFromTo = FromTo(0)
 // represents the to location
 type FromTo uint16
 
-func (FromTo) Unknown() FromTo     { return FromTo(0) }
-func (FromTo) LocalBlob() FromTo   { return FromTo(fromToValue(ELocation.Local(), ELocation.Blob())) }
-func (FromTo) LocalFile() FromTo   { return FromTo(fromToValue(ELocation.Local(), ELocation.File())) }
-func (FromTo) BlobLocal() FromTo   { return FromTo(fromToValue(ELocation.Blob(), ELocation.Local())) }
-func (FromTo) FileLocal() FromTo   { return FromTo(fromToValue(ELocation.File(), ELocation.Local())) }
-func (FromTo) BlobPipe() FromTo    { return FromTo(fromToValue(ELocation.Blob(), ELocation.Pipe())) }
-func (FromTo) PipeBlob() FromTo    { return FromTo(fromToValue(ELocation.Pipe(), ELocation.Blob())) }
-func (FromTo) FilePipe() FromTo    { return FromTo(fromToValue(ELocation.File(), ELocation.Pipe())) }
-func (FromTo) PipeFile() FromTo    { return FromTo(fromToValue(ELocation.Pipe(), ELocation.File())) }
-func (FromTo) BlobTrash() FromTo   { return FromTo(fromToValue(ELocation.Blob(), ELocation.Unknown())) }
-func (FromTo) FileTrash() FromTo   { return FromTo(fromToValue(ELocation.File(), ELocation.Unknown())) }
+func (FromTo) Unknown() FromTo   { return FromTo(0) }
+func (FromTo) LocalBlob() FromTo { return FromTo(fromToValue(ELocation.Local(), ELocation.Blob())) }
+func (FromTo) LocalFile() FromTo { return FromTo(fromToValue(ELocation.Local(), ELocation.File())) }
+func (FromTo) BlobLocal() FromTo { return FromTo(fromToValue(ELocation.Blob(), ELocation.Local())) }
+func (FromTo) FileLocal() FromTo { return FromTo(fromToValue(ELocation.File(), ELocation.Local())) }
+func (FromTo) BlobPipe() FromTo  { return FromTo(fromToValue(ELocation.Blob(), ELocation.Pipe())) }
+func (FromTo) PipeBlob() FromTo  { return FromTo(fromToValue(ELocation.Pipe(), ELocation.Blob())) }
+func (FromTo) FilePipe() FromTo  { return FromTo(fromToValue(ELocation.File(), ELocation.Pipe())) }
+func (FromTo) PipeFile() FromTo  { return FromTo(fromToValue(ELocation.Pipe(), ELocation.File())) }
+func (FromTo) BlobTrash() FromTo { return FromTo(fromToValue(ELocation.Blob(), ELocation.Unknown())) }
+func (FromTo) FileTrash() FromTo { return FromTo(fromToValue(ELocation.File(), ELocation.Unknown())) }
+func (FromTo) BlobFSTrash() FromTo {
+	return FromTo(fromToValue(ELocation.BlobFS(), ELocation.Unknown()))
+}
 func (FromTo) LocalBlobFS() FromTo { return FromTo(fromToValue(ELocation.Local(), ELocation.BlobFS())) }
 func (FromTo) BlobFSLocal() FromTo { return FromTo(fromToValue(ELocation.BlobFS(), ELocation.Local())) }
 func (FromTo) BlobBlob() FromTo    { return FromTo(fromToValue(ELocation.Blob(), ELocation.Blob())) }

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,9 @@
 module github.com/Azure/azure-storage-azcopy
 
 require (
-	// TODO: update pipleline to a new version tag rather than the branch commit, before merge this PR
-	github.com/Azure/azure-pipeline-go v0.1.10-0.20190627050904-93822ffd0d75
-	github.com/Azure/azure-storage-blob-go v0.6.0
-	github.com/Azure/azure-storage-file-go v0.0.0-20190108093629-d93e19c84c2a
+	github.com/Azure/azure-pipeline-go v0.2.1
+	github.com/Azure/azure-storage-blob-go v0.7.0
+	github.com/Azure/azure-storage-file-go v0.5.0
 	github.com/Azure/go-autorest v10.15.2+incompatible
 	github.com/JeffreyRichter/enum v0.0.0-20180725232043-2567042f9cda
 	github.com/danieljoos/wincred v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/Azure/azure-pipeline-go v0.1.10-0.20190627033337-61edb010a1f6 h1:APbF
 github.com/Azure/azure-pipeline-go v0.1.10-0.20190627033337-61edb010a1f6/go.mod h1:XA1kFWRVhSK+KNFiOhfv83Fv8L9achrP7OxIzeTn1Yg=
 github.com/Azure/azure-pipeline-go v0.1.10-0.20190627050904-93822ffd0d75 h1:AZv++5sTAHJn+5Azo4yVkydrQUQVsm3HQbeMEi3IZJI=
 github.com/Azure/azure-pipeline-go v0.1.10-0.20190627050904-93822ffd0d75/go.mod h1:XA1kFWRVhSK+KNFiOhfv83Fv8L9achrP7OxIzeTn1Yg=
+github.com/Azure/azure-pipeline-go v0.2.1 h1:OLBdZJ3yvOn2MezlWvbrBMTEUQC72zAftRZOMdj5HYo=
+github.com/Azure/azure-pipeline-go v0.2.1/go.mod h1:UGSo8XybXnIGZ3epmeBw7Jdz+HiUVpqIlpz/HKHylF4=
 github.com/Azure/azure-storage-blob-go v0.0.0-20181022225951-5152f14ace1c h1:Y5ueznoCekgCWBytF1Q9lTpZ3tJeX37dQtCcGjMCLYI=
 github.com/Azure/azure-storage-blob-go v0.0.0-20181022225951-5152f14ace1c/go.mod h1:oGfmITT1V6x//CswqY2gtAHND+xIP64/qL7a5QJix0Y=
 github.com/Azure/azure-storage-blob-go v0.0.0-20190123011202-457680cc0804 h1:QjGHsWFbJyl312t0BtgkmZy2TTYA++FF0UakGbr3ZhQ=
@@ -14,8 +16,12 @@ github.com/Azure/azure-storage-blob-go v0.0.0-20190316203758-94d352293d76 h1:ULs
 github.com/Azure/azure-storage-blob-go v0.0.0-20190316203758-94d352293d76/go.mod h1:oGfmITT1V6x//CswqY2gtAHND+xIP64/qL7a5QJix0Y=
 github.com/Azure/azure-storage-blob-go v0.6.0 h1:SEATKb3LIHcaSIX+E6/K4kJpwfuozFEsmt5rS56N6CE=
 github.com/Azure/azure-storage-blob-go v0.6.0/go.mod h1:oGfmITT1V6x//CswqY2gtAHND+xIP64/qL7a5QJix0Y=
+github.com/Azure/azure-storage-blob-go v0.7.0 h1:MuueVOYkufCxJw5YZzF842DY2MBsp+hLuh2apKY0mck=
+github.com/Azure/azure-storage-blob-go v0.7.0/go.mod h1:f9YQKtsG1nMisotuTPpO0tjNuEjKRYAcJU8/ydDI++4=
 github.com/Azure/azure-storage-file-go v0.0.0-20190108093629-d93e19c84c2a h1:5OfEqciJHSMkxAWgJP1b3JTmzWNRlq9L9IgOxPNlBOM=
 github.com/Azure/azure-storage-file-go v0.0.0-20190108093629-d93e19c84c2a/go.mod h1:IX9TBV4sH9NUhkuO4XZCQ0Wd8Tzr+DGKud7OBvk2K3I=
+github.com/Azure/azure-storage-file-go v0.5.0 h1:/eSx3Gyuo5ypeRR0qeOFI4Ge/fi9fRQTUIjSuKAWbbM=
+github.com/Azure/azure-storage-file-go v0.5.0/go.mod h1:KydIlTDlpKjrmhEqu7S36HofRc7Ede+OYOi0+l3gWPc=
 github.com/Azure/go-autorest v10.15.2+incompatible h1:oZpnRzZie83xGV5txbT1aa/7zpCPvURGhV6ThJij2bs=
 github.com/Azure/go-autorest v10.15.2+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/JeffreyRichter/enum v0.0.0-20180725232043-2567042f9cda h1:NOo6+gM9NNPJ3W56nxOKb4164LEw094U0C8zYQM8mQU=
@@ -36,8 +42,6 @@ github.com/jiacfan/keychain v0.0.0-20180920053336-f2c902a3d807 h1:QKbdbbQIbiiWJk
 github.com/jiacfan/keychain v0.0.0-20180920053336-f2c902a3d807/go.mod h1:IGH0VO3mMxCgF6yPROjtYw4wnCO6EviEgJwiMeNHXdw=
 github.com/jiacfan/keyctl v0.0.0-20160328205232-988d05162bc5 h1:Gojlrp28zWGRHDSl2DD6fOl6Wqi+E0bTzyzwkbsGm28=
 github.com/jiacfan/keyctl v0.0.0-20160328205232-988d05162bc5/go.mod h1:GPrz+MB+TkX2uTBDoAKBaGTLTtr2+Y7VwOgEJ7O/jyY=
-github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
-github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/jiacfan/keyctl v0.0.0-20190628004520-0635e3b65b3a h1:u7gmXuPqxW1v1c7kmJNVaeu0ORJwyglWXkGbjhIzrpo=
 github.com/jiacfan/keyctl v0.0.0-20190628004520-0635e3b65b3a/go.mod h1:GPrz+MB+TkX2uTBDoAKBaGTLTtr2+Y7VwOgEJ7O/jyY=
 github.com/jiacfan/keyctl v0.0.0-20190628012402-beefb2538fcc h1:Avan19tcPO8Wc0yR9V2xJ9oeWWMIiqVFKEIHMzf6s54=
@@ -48,9 +52,12 @@ github.com/jiacfan/keyctl v0.0.0-20190628040148-9c65f5bee7e1 h1:aJWLN3jjh952iQzN
 github.com/jiacfan/keyctl v0.0.0-20190628040148-9c65f5bee7e1/go.mod h1:GPrz+MB+TkX2uTBDoAKBaGTLTtr2+Y7VwOgEJ7O/jyY=
 github.com/jiacfan/keyctl v0.3.1 h1:mpdRpuFeQHXnApGVvIUSavAxwElf7S4XcdLlCIDCXJA=
 github.com/jiacfan/keyctl v0.3.1/go.mod h1:GPrz+MB+TkX2uTBDoAKBaGTLTtr2+Y7VwOgEJ7O/jyY=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
+github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/mattn/go-ieproxy v0.0.0-20190607195407-a1ba01f4d182/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
@@ -83,6 +90,8 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20190107173414-20be8e55dc7b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb h1:fgwFCsaw9buMuxNd6+DQfAuSFqbNiQZpcgJQAgJsK6k=
+golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=

--- a/ste/sender-appendBlobFromURL.go
+++ b/ste/sender-appendBlobFromURL.go
@@ -65,7 +65,7 @@ func (c *urlToAppendBlobCopier) GenerateCopyFunc(id common.ChunkID, blockIndex i
 		_, err := c.destAppendBlobURL.AppendBlockFromURL(ctxWithLatestServiceVersion, c.srcURL, id.OffsetInFile, adjustedChunkSize,
 			azblob.AppendBlobAccessConditions{
 				AppendPositionAccessConditions: azblob.AppendPositionAccessConditions{IfAppendPositionEqual: id.OffsetInFile},
-			}, nil)
+			}, azblob.ModifiedAccessConditions{}, nil)
 		if err != nil {
 			c.jptm.FailActiveS2SCopy("Appending block from URL", err)
 			return

--- a/ste/sender-blockBlobFromURL.go
+++ b/ste/sender-blockBlobFromURL.go
@@ -138,7 +138,8 @@ func (c *urlToBlockBlobCopier) generatePutBlockFromURL(id common.ChunkID, blockI
 		if err := c.pacer.RequestTrafficAllocation(c.jptm.Context(), adjustedChunkSize); err != nil {
 			c.jptm.FailActiveUpload("Pacing block", err)
 		}
-		_, err := c.destBlockBlobURL.StageBlockFromURL(ctxWithLatestServiceVersion, encodedBlockID, c.srcURL, id.OffsetInFile, adjustedChunkSize, azblob.LeaseAccessConditions{})
+		_, err := c.destBlockBlobURL.StageBlockFromURL(ctxWithLatestServiceVersion, encodedBlockID, c.srcURL,
+			id.OffsetInFile, adjustedChunkSize, azblob.LeaseAccessConditions{}, azblob.ModifiedAccessConditions{})
 		if err != nil {
 			c.jptm.FailActiveSend("Staging block from URL", err)
 			return

--- a/ste/sender-pageBlobFromURL.go
+++ b/ste/sender-pageBlobFromURL.go
@@ -90,7 +90,8 @@ func (c *urlToPageBlobCopier) GenerateCopyFunc(id common.ChunkID, blockIndex int
 			c.jptm.FailActiveUpload("Pacing block (global level)", err)
 		}
 		_, err := c.destPageBlobURL.UploadPagesFromURL(
-			enrichedContext, c.srcURL, id.OffsetInFile, id.OffsetInFile, adjustedChunkSize, azblob.PageBlobAccessConditions{}, nil)
+			enrichedContext, c.srcURL, id.OffsetInFile, id.OffsetInFile, adjustedChunkSize, nil,
+			azblob.PageBlobAccessConditions{}, azblob.ModifiedAccessConditions{})
 		if err != nil {
 			c.jptm.FailActiveS2SCopy("Uploading page from URL", err)
 			return


### PR DESCRIPTION
There are still some work left to do (docs and more tests). I'm posting it as daft to get some feedbacks.

I looked at the code path for remove transfers, and was really hesitant to add a bunch of code only to throw them away after inter-op. Since the feature ask was to just enable the remove scenarios, I think it might be better to implement it 'the lazy way' and simply invoke the azbfs SDK to delete files/directories directly, instead of doing a full traversal. This does mean that include/exclude flags would not be supported when deleting adls gen2 resources, but one of the main advantages of this service is to delete/rename directories atomically, so I'm not sure how useful these filters would be even if they are implemented. 

Please let me know your thoughts.