### PR TITLE
Platform independent DevNull

### DIFF
--- a/common/fe-ste-models.go
+++ b/common/fe-ste-models.go
@@ -43,7 +43,7 @@ const (
 	AZCOPY_PATH_SEPARATOR_STRING = "/"
 	AZCOPY_PATH_SEPARATOR_CHAR   = '/'
 	OS_PATH_SEPARATOR            = string(os.PathSeparator)
-	Dev_Null                     = "/dev/null"
+	Dev_Null                     = os.DevNull
 
 	//  this is the perm that AzCopy has used throughout its preview.  So, while we considered relaxing it to 0666
 	//  we decided that the best option was to leave it as is, and only relax it if user feedback so requires.


### PR DESCRIPTION
When running on windows, if you use the window equivalent of `/dev/null/`, `NUL ` you get an error saying that the directory does not exist.

By using `os.DevNull` you get the correct string representing dev null for the target platform.