### PR TITLE
Implement a S3 traverser

### DIFF
--- a/cmd/zc_traverser_s3.go
+++ b/cmd/zc_traverser_s3.go
@@ -1,0 +1,128 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/minio/minio-go"
+
+	"github.com/Azure/azure-storage-azcopy/common"
+)
+
+type s3Traverser struct {
+	rawURL    *url.URL // No pipeline needed for S3
+	ctx       context.Context
+	recursive bool
+
+	s3URLParts s3URLPartsExtension
+	s3Client   *minio.Client
+
+	// A generic function to notify that a new stored object has been enumerated
+	incrementEnumerationCounter func()
+}
+
+func (t *s3Traverser) traverse(processor objectProcessor, filters []objectFilter) (err error) {
+	// Check if resource is a single object.
+	if t.s3URLParts.IsObjectSyntactically() && !t.s3URLParts.IsDirectorySyntactically() && !t.s3URLParts.IsBucketSyntactically() {
+		objectPath := strings.Split(t.s3URLParts.ObjectKey, "/")
+		objectName := objectPath[len(objectPath)-1]
+
+		oi, err := t.s3Client.StatObject(t.s3URLParts.BucketName, t.s3URLParts.ObjectKey, minio.StatObjectOptions{})
+
+		if err != nil {
+			return err
+		}
+
+		err = processIfPassedFilters(filters, newStoredObject(
+			objectName,
+			"", // No need for relative path when we already know the object location
+			oi.LastModified,
+			oi.Size,
+			nil,
+			blobTypeNA,
+		), processor)
+
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	// Check if the resource is a service level URL
+	if t.s3URLParts.IsServiceSyntactically() {
+		// TODO: Let's just figure this one out later.
+		return errors.New("service-level enumeration is not allowed")
+	}
+
+	searchPrefix, _, wildcard := t.s3URLParts.searchObjectPrefixAndPatternFromS3URL()
+
+	if wildcard {
+		return fmt.Errorf("cannot traverse s3 with wildcard")
+	}
+
+	// It's a bucket or virtual directory.
+	for objectInfo := range t.s3Client.ListObjectsV2(t.s3URLParts.BucketName, searchPrefix, t.recursive, t.ctx.Done()) {
+		if objectInfo.Err != nil {
+			return fmt.Errorf("cannot list objects, %v", objectInfo.Err)
+		}
+
+		if objectInfo.StorageClass == "" {
+			// Directories are the only objects without storage classes.
+			continue
+		}
+
+		objectPath := strings.Split(objectInfo.Key, "/")
+		objectName := objectPath[len(objectPath)-1]
+
+		relativePath := strings.TrimPrefix(objectInfo.Key, searchPrefix)
+
+		err = processIfPassedFilters(filters,
+			newStoredObject(
+				objectName,
+				relativePath,
+				objectInfo.LastModified,
+				objectInfo.Size,
+				nil,
+				blobTypeNA,
+			),
+			processor)
+
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+func newS3Traverser(rawURL *url.URL, ctx context.Context, recursive bool, incrementEnumerationCounter func()) (t *s3Traverser, err error) {
+	t = &s3Traverser{rawURL: rawURL, ctx: ctx, recursive: recursive, incrementEnumerationCounter: incrementEnumerationCounter}
+
+	// initialize S3 client and URL parts
+	var s3URLParts common.S3URLParts
+	s3URLParts, err = common.NewS3URLParts(*t.rawURL)
+
+	if err != nil {
+		return
+	} else {
+		t.s3URLParts = s3URLPartsExtension{s3URLParts}
+	}
+
+	t.s3Client, err = common.CreateS3Client(
+		t.ctx,
+		common.CredentialInfo{
+			CredentialType: common.ECredentialType.S3AccessKey(),
+			S3CredentialInfo: common.S3CredentialInfo{
+				Endpoint: t.s3URLParts.Endpoint,
+				Region:   t.s3URLParts.Region,
+			},
+		},
+		common.CredentialOpOptions{
+			LogError: glcm.Error,
+		})
+
+	return
+}

--- a/cmd/zt_generic_traverser_test.go
+++ b/cmd/zt_generic_traverser_test.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/Azure/azure-storage-file-go/azfile"
@@ -52,6 +53,11 @@ func (s *genericTraverserSuite) TestTraverserWithSingleObject(c *chk.C) {
 	bfsu := GetBFSSU()
 	filesystemURL, _ := createNewFilesystem(c, bfsu)
 	defer deleteFilesystem(c, filesystemURL)
+
+	s3Client, err := createS3ClientWithMinio(createS3ResOptions{})
+	c.Assert(err, chk.IsNil)
+	bucketName := createNewBucket(c, s3Client, createS3ResOptions{})
+	defer deleteBucket(c, s3Client, bucketName)
 
 	// test two scenarios, either blob is at the root virtual dir, or inside sub virtual dirs
 	for _, storedObjectName := range []string{"sub1/sub2/singleblobisbest", "nosubsingleblob", "满汉全席.txt"} {
@@ -128,6 +134,23 @@ func (s *genericTraverserSuite) TestTraverserWithSingleObject(c *chk.C) {
 
 		c.Assert(localDummyProcessor.record[0].relativePath, chk.Equals, bfsDummyProcessor.record[0].relativePath)
 		c.Assert(localDummyProcessor.record[0].name, chk.Equals, bfsDummyProcessor.record[0].name)
+
+		// set up the bucket with a single file
+		s3List := []string{storedObjectName}
+		scenarioHelper{}.generateObjects(c, s3Client, bucketName, s3List)
+
+		// construct a s3 traverser
+		url := scenarioHelper{}.getRawS3ObjectURL(c, "", bucketName, storedObjectName)
+		S3Traverser, err := newS3Traverser(&url, ctx, false, func() {})
+		c.Assert(err, chk.IsNil)
+
+		s3DummyProcessor := dummyProcessor{}
+		err = S3Traverser.traverse(s3DummyProcessor.process, nil)
+		c.Assert(err, chk.IsNil)
+		c.Assert(len(s3DummyProcessor.record), chk.Equals, 1)
+
+		c.Assert(localDummyProcessor.record[0].relativePath, chk.Equals, s3DummyProcessor.record[0].relativePath)
+		c.Assert(localDummyProcessor.record[0].name, chk.Equals, s3DummyProcessor.record[0].name)
 	}
 }
 
@@ -146,6 +169,11 @@ func (s *genericTraverserSuite) TestTraverserContainerAndLocalDirectory(c *chk.C
 	filesystemURL, _ := createNewFilesystem(c, bfsu)
 	defer deleteFilesystem(c, filesystemURL)
 
+	s3Client, err := createS3ClientWithMinio(createS3ResOptions{})
+	c.Assert(err, chk.IsNil)
+	bucketName := createNewBucket(c, s3Client, createS3ResOptions{})
+	defer deleteBucket(c, s3Client, bucketName)
+
 	// set up the container with numerous blobs
 	fileList := scenarioHelper{}.generateCommonRemoteScenarioForBlob(c, containerURL, "")
 	c.Assert(containerURL, chk.NotNil)
@@ -155,6 +183,9 @@ func (s *genericTraverserSuite) TestTraverserContainerAndLocalDirectory(c *chk.C
 
 	// set up a filesystem with the same files
 	scenarioHelper{}.generateBFSPathsFromList(c, filesystemURL, fileList)
+
+	// set up a bucket with the same files
+	scenarioHelper{}.generateObjects(c, s3Client, bucketName, fileList)
 
 	dstDirName := scenarioHelper{}.generateLocalDirectory(c)
 	scenarioHelper{}.generateLocalFilesFromList(c, dstDirName, fileList)
@@ -200,12 +231,22 @@ func (s *genericTraverserSuite) TestTraverserContainerAndLocalDirectory(c *chk.C
 		bfsTraverser := newBlobFSTraverser(&rawFilesystemURL, bfsPipeline, ctx, isRecursiveOn, func() {})
 		bfsDummyProcessor := dummyProcessor{}
 		err = bfsTraverser.traverse(bfsDummyProcessor.process, nil)
+		c.Assert(err, chk.IsNil)
+
+		// construct and run a S3 traverser
+		rawS3URL := scenarioHelper{}.getRawS3BucketURL(c, "", bucketName)
+		S3Traverser, err := newS3Traverser(&rawS3URL, ctx, isRecursiveOn, func() {})
+		c.Assert(err, chk.IsNil)
+		s3DummyProcessor := dummyProcessor{}
+		err = S3Traverser.traverse(s3DummyProcessor.process, nil)
+		c.Assert(err, chk.IsNil)
 
 		// make sure the results are the same
 		c.Assert(len(blobDummyProcessor.record), chk.Equals, len(localIndexer.indexMap))
 		c.Assert(len(fileDummyProcessor.record), chk.Equals, len(localIndexer.indexMap))
 		c.Assert(len(bfsDummyProcessor.record), chk.Equals, len(localIndexer.indexMap))
-		for _, storedObject := range append(append(blobDummyProcessor.record, fileDummyProcessor.record...), bfsDummyProcessor.record...) {
+		c.Assert(len(s3DummyProcessor.record), chk.Equals, len(localIndexer.indexMap))
+		for _, storedObject := range append(append(append(blobDummyProcessor.record, fileDummyProcessor.record...), bfsDummyProcessor.record...), s3DummyProcessor.record...) {
 			correspondingLocalFile, present := localIndexer.indexMap[storedObject.relativePath]
 
 			c.Assert(present, chk.Equals, true)
@@ -233,6 +274,11 @@ func (s *genericTraverserSuite) TestTraverserWithVirtualAndLocalDirectory(c *chk
 	filesystemURL, _ := createNewFilesystem(c, bfsu)
 	defer deleteFilesystem(c, filesystemURL)
 
+	s3Client, err := createS3ClientWithMinio(createS3ResOptions{})
+	c.Assert(err, chk.IsNil)
+	bucketName := createNewBucket(c, s3Client, createS3ResOptions{})
+	defer deleteBucket(c, s3Client, bucketName)
+
 	// set up the container with numerous blobs
 	virDirName := "virdir"
 	fileList := scenarioHelper{}.generateCommonRemoteScenarioForBlob(c, containerURL, virDirName+"/")
@@ -243,6 +289,10 @@ func (s *genericTraverserSuite) TestTraverserWithVirtualAndLocalDirectory(c *chk
 
 	// set up the filesystem with the same files
 	scenarioHelper{}.generateBFSPathsFromList(c, filesystemURL, fileList)
+
+	// Set up the bucket with the same files
+	scenarioHelper{}.generateObjects(c, s3Client, bucketName, fileList)
+	time.Sleep(time.Second * 2) // Ensure the objects' LMTs are in the past
 
 	// set up the destination with a folder that have the exact same files
 	dstDirName := scenarioHelper{}.generateLocalDirectory(c)
@@ -290,15 +340,27 @@ func (s *genericTraverserSuite) TestTraverserWithVirtualAndLocalDirectory(c *chk
 		bfsDummyProcessor := dummyProcessor{}
 		err = bfsTraverser.traverse(bfsDummyProcessor.process, nil)
 
+		// construct and run a S3 traverser
+		// directory object keys always end with / in S3
+		rawS3URL := scenarioHelper{}.getRawS3ObjectURL(c, "", bucketName, virDirName+"/")
+		S3Traverser, err := newS3Traverser(&rawS3URL, ctx, isRecursiveOn, func() {})
+		c.Assert(err, chk.IsNil)
+		s3DummyProcessor := dummyProcessor{}
+		err = S3Traverser.traverse(s3DummyProcessor.process, nil)
+		c.Assert(err, chk.IsNil)
+
 		// make sure the results are the same
 		c.Assert(len(blobDummyProcessor.record), chk.Equals, len(localIndexer.indexMap))
 		c.Assert(len(fileDummyProcessor.record), chk.Equals, len(localIndexer.indexMap))
 		c.Assert(len(bfsDummyProcessor.record), chk.Equals, len(localIndexer.indexMap))
-		for _, storedObject := range append(append(blobDummyProcessor.record, fileDummyProcessor.record...), bfsDummyProcessor.record...) {
+		c.Assert(len(s3DummyProcessor.record), chk.Equals, len(localIndexer.indexMap))
+		for _, storedObject := range append(append(append(blobDummyProcessor.record, fileDummyProcessor.record...), bfsDummyProcessor.record...), s3DummyProcessor.record...) {
 			correspondingLocalFile, present := localIndexer.indexMap[storedObject.relativePath]
 
 			c.Assert(present, chk.Equals, true)
 			c.Assert(correspondingLocalFile.name, chk.Equals, storedObject.name)
+			// Say, here's a good question, why do we have this last check?
+			// None of the other tests have it.
 			c.Assert(correspondingLocalFile.isMoreRecentThan(storedObject), chk.Equals, true)
 
 			if !isRecursiveOn {


### PR DESCRIPTION
S3 Traverser to add to S2S functionality in the refactor.

This is a draft until we decide upon how to implement service-level traversal. At that point, this will contain S3 service level traversal.