### PR TITLE
Never hang if fail to resolve URL of version file

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"time"
 )
 
 var azcopyAppPathFolder string
@@ -65,8 +66,9 @@ var rootCmd = &cobra.Command{
 		// spawn a routine to fetch and compare the local application's version against the latest version available
 		// if there's a newer version that can be used, then write the suggestion to stderr
 		// however if this takes too long the message won't get printed
-		// Note: this function is only triggered for non-help commands
-		go detectNewVersion()
+		// Note: this function is neccessary for non-help, non-login commands, since they don't reach the corresponding
+		// beginDetectNewVersion call in Execute (below)
+		beginDetectNewVersion()
 
 		return nil
 	},
@@ -86,9 +88,13 @@ func Execute(azsAppPathFolder, logPathFolder string, maxFileAndSocketHandles int
 		glcm.Error(err.Error())
 	} else {
 		// our commands all control their own life explicitly with the lifecycle manager
-		// only help commands reach this point
-		// execute synchronously before exiting
-		detectNewVersion()
+		// only commands that don't explicitly exit actually reach this point (e.g. help commands and login commands)
+		select {
+		case <-beginDetectNewVersion():
+			// noop
+		case <-time.After(time.Second * 8):
+			// don't wait too long
+		}
 		glcm.Exit(nil, common.EExitCode.Success())
 	}
 }
@@ -115,63 +121,76 @@ func init() {
 	rootCmd.PersistentFlags().MarkHidden("send-random-data-ext")
 }
 
-func detectNewVersion() {
-	const versionMetadataUrl = "https://aka.ms/azcopyv10-version-metadata"
+// always spins up a new goroutine, because sometimes the aka.ms URL can't be reached (e.g. a constrained environment where
+// aka.ms is not resolvable to a reachable IP address). In such cases, this routine will run for ever, and the caller should
+// just give up on it.
+// We spin up the GR here, not in the caller, so that the need to use a separate GC can never be forgotten
+// (if do it synchronously, and can't resolve URL, this blocks caller for ever)
+func beginDetectNewVersion() chan struct{} {
+	completionChannel := make(chan struct{})
+	go func() {
+		const versionMetadataUrl = "https://aka.ms/azcopyv10-version-metadata"
 
-	// step 0: check the Stderr before checking version
-	_, err := os.Stderr.Stat()
-	if err != nil {
-		return
-	}
+		// step 0: check the Stderr before checking version
+		_, err := os.Stderr.Stat()
+		if err != nil {
+			return
+		}
 
-	// step 1: initialize pipeline
-	p, err := createBlobPipeline(context.TODO(), common.CredentialInfo{CredentialType: common.ECredentialType.Anonymous()})
-	if err != nil {
-		return
-	}
+		// step 1: initialize pipeline
+		p, err := createBlobPipeline(context.TODO(), common.CredentialInfo{CredentialType: common.ECredentialType.Anonymous()})
+		if err != nil {
+			return
+		}
 
-	// step 2: parse source url
-	u, err := url.Parse(versionMetadataUrl)
-	if err != nil {
-		return
-	}
+		// step 2: parse source url
+		u, err := url.Parse(versionMetadataUrl)
+		if err != nil {
+			return
+		}
 
-	// step 3: start download
-	blobURL := azblob.NewBlobURL(*u, p)
-	blobStream, err := blobURL.Download(context.TODO(), 0, azblob.CountToEnd, azblob.BlobAccessConditions{}, false)
-	if err != nil {
-		return
-	}
+		// step 3: start download
+		blobURL := azblob.NewBlobURL(*u, p)
+		blobStream, err := blobURL.Download(context.TODO(), 0, azblob.CountToEnd, azblob.BlobAccessConditions{}, false)
+		if err != nil {
+			return
+		}
 
-	blobBody := blobStream.Body(azblob.RetryReaderOptions{MaxRetryRequests: ste.MaxRetryPerDownloadBody})
-	defer blobBody.Close()
+		blobBody := blobStream.Body(azblob.RetryReaderOptions{MaxRetryRequests: ste.MaxRetryPerDownloadBody})
+		defer blobBody.Close()
 
-	// step 4: read newest version str
-	buf := new(bytes.Buffer)
-	n, err := buf.ReadFrom(blobBody)
-	if n == 0 || err != nil {
-		return
-	}
-	// only take the first line, in case the version metadata file is upgraded in the future
-	remoteVersion := strings.Split(buf.String(), "\n")[0]
+		// step 4: read newest version str
+		buf := new(bytes.Buffer)
+		n, err := buf.ReadFrom(blobBody)
+		if n == 0 || err != nil {
+			return
+		}
+		// only take the first line, in case the version metadata file is upgraded in the future
+		remoteVersion := strings.Split(buf.String(), "\n")[0]
 
-	// step 5: compare remote version to local version to see if there's a newer AzCopy
-	v1, err := NewVersion(common.AzcopyVersion)
-	if err != nil {
-		return
-	}
-	v2, err := NewVersion(remoteVersion)
-	if err != nil {
-		return
-	}
+		// step 5: compare remote version to local version to see if there's a newer AzCopy
+		v1, err := NewVersion(common.AzcopyVersion)
+		if err != nil {
+			return
+		}
+		v2, err := NewVersion(remoteVersion)
+		if err != nil {
+			return
+		}
 
-	if v1.OlderThan(*v2) {
-		executablePathSegments := strings.Split(strings.Replace(os.Args[0], "\\", "/", -1), "/")
-		executableName := executablePathSegments[len(executablePathSegments)-1]
+		if v1.OlderThan(*v2) {
+			executablePathSegments := strings.Split(strings.Replace(os.Args[0], "\\", "/", -1), "/")
+			executableName := executablePathSegments[len(executablePathSegments)-1]
 
-		// output in info mode instead of stderr, as it was crashing CI jobs of some people
-		glcm.Info(executableName + ": A newer version " + remoteVersion + " is available to download\n")
-	}
+			// output in info mode instead of stderr, as it was crashing CI jobs of some people
+			glcm.Info(executableName + ": A newer version " + remoteVersion + " is available to download\n")
+		}
+
+		// let caller know we have finished, if they want to know
+		close(completionChannel)
+	}()
+
+	return completionChannel
 }
 
 // ComputeConcurrentFilesLimit finds a number of concurrently-openable files


### PR DESCRIPTION
Prior to this fix, login and help commands would hang if aka.ms couldn't be found