### PR TITLE
Fixed minor bug in percent complete calculations (divide by 0)

### DIFF
--- a/ste/init.go
+++ b/ste/init.go
@@ -450,7 +450,12 @@ func GetJobSummary(jobID common.JobID) common.ListJobSummaryResponse {
 
 	// Add on byte count from files in flight, to get a more accurate running total
 	js.TotalBytesTransferred += JobsAdmin.SuccessfulBytesInActiveFiles()
-	js.PercentComplete = 100 * float32(js.TotalBytesTransferred) / float32(js.TotalBytesExpected)
+	if js.TotalBytesExpected == 0 {
+		// if no bytes expected, the job is concluded, and we should avoid dividing by 0 (which results in NaN)
+		js.PercentComplete = 100
+	} else {
+		js.PercentComplete = 100 * float32(js.TotalBytesTransferred) / float32(js.TotalBytesExpected)
+	}
 
 	// This is added to let FE to continue fetching the Job Progress Summary
 	// in case of resume. In case of resume, the Job is already completely

--- a/ste/init.go
+++ b/ste/init.go
@@ -451,7 +451,7 @@ func GetJobSummary(jobID common.JobID) common.ListJobSummaryResponse {
 	// Add on byte count from files in flight, to get a more accurate running total
 	js.TotalBytesTransferred += JobsAdmin.SuccessfulBytesInActiveFiles()
 	if js.TotalBytesExpected == 0 {
-		// if no bytes expected, the job is concluded, and we should avoid dividing by 0 (which results in NaN)
+		// if no bytes expected, and we should avoid dividing by 0 (which results in NaN)
 		js.PercentComplete = 100
 	} else {
 		js.PercentComplete = 100 * float32(js.TotalBytesTransferred) / float32(js.TotalBytesExpected)
@@ -597,7 +597,12 @@ func GetSyncJobSummary(jobID common.JobID) common.ListSyncJobSummaryResponse {
 
 	// Add on byte count from files in flight, to get a more accurate running total
 	js.TotalBytesTransferred += JobsAdmin.SuccessfulBytesInActiveFiles()
-	js.PercentComplete = 100 * float32(js.TotalBytesTransferred) / float32(js.TotalBytesExpected)
+	if js.TotalBytesExpected == 0 {
+		// if no bytes expected, we should avoid dividing by 0 (which results in NaN)
+		js.PercentComplete = 100
+	} else {
+		js.PercentComplete = 100 * float32(js.TotalBytesTransferred) / float32(js.TotalBytesExpected)
+	}
 
 	// This is added to let FE to continue fetching the Job Progress Summary
 	// in case of resume. In case of resume, the Job is already completely


### PR DESCRIPTION
When the job finishes, PercentComplete becomes NaN as TotalBytesExpected is 0. It fails the JSON marshaling when --output-type=json