### PR TITLE
Removed max file limit for sync

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -39,9 +39,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// a max is set because we cannot buffer infinite amount of destination file info in memory
-const MaxNumberOfFilesAllowedInSync = 10000000
-
 type rawSyncCmdArgs struct {
 	src       string
 	dst       string

--- a/cmd/syncIndexer.go
+++ b/cmd/syncIndexer.go
@@ -20,10 +20,6 @@
 
 package cmd
 
-import (
-	"fmt"
-)
-
 // the objectIndexer is essential for the generic sync enumerator to work
 // it can serve as a:
 // 		1. objectProcessor: accumulate a lookup map with given storedObjects
@@ -39,9 +35,8 @@ func newObjectIndexer() *objectIndexer {
 
 // process the given stored object by indexing it using its relative path
 func (i *objectIndexer) store(storedObject storedObject) (err error) {
-	if i.counter == MaxNumberOfFilesAllowedInSync {
-		return fmt.Errorf("the maxium number of file allowed in sync is: %v", MaxNumberOfFilesAllowedInSync)
-	}
+	// TODO we might buffer too much data in memory, figure out whether we should limit the max number of files
+	// TODO previously we used 10M as the max, but it was proven to be too small for some users
 
 	i.indexMap[storedObject.relativePath] = storedObject
 	i.counter += 1


### PR DESCRIPTION
We picked 10M as the limit in the initial design (and kept it through the rewrite with modular enumerators), as an arbitrary restraint on the total number of files that could be indexed in a sync operation. We were mainly worried about using too much memory. But as proven in #540, it is too small for some scenarios. 

After thinking about it for a bit, I don't think we should have such hard-coded limit, as it's not helping anyone:

1. Low-end setups are most likely not protected and could see problems way before hitting the 10M mark.
2. High-end setups are blocked from performing the desired operation.

I've added an item to look in this more and see if we can have better protection. Whatever we do, it doesn't make sense to have a hard limit.