### PR TITLE
Added commands to clean up job files

### DIFF
--- a/cmd/helpMessages.go
+++ b/cmd/helpMessages.go
@@ -150,12 +150,16 @@ Remove all files associated with the given job ID.
 
 Note that the location of log files and job plan files can be customized. Please refer to the env command.`
 
+const removeJobsCmdExample = "  azcopy jobs rm e52247de-0323-b14d-4cc8-76e0be2e2d44"
+
 const cleanJobsCmdShortDescription = "Clean up log files and job plan files (used for progress tracking and resuming) for jobs"
 
 const cleanJobsCmdLongDescription = `
 Clean up log files and job plan files (used for progress tracking and resuming) for jobs.
 
 Note that the location of log files and job plan files can be customized. Please refer to the env command.`
+
+const cleanJobsCmdExample = "  azcopy jobs clean --with-status=completed"
 
 // ===================================== LIST COMMAND ===================================== //
 const listCmdShortDescription = "List the entities in a given resource"

--- a/cmd/helpMessages.go
+++ b/cmd/helpMessages.go
@@ -143,6 +143,20 @@ const resumeJobsCmdShortDescription = "Resume the existing job with the given jo
 const resumeJobsCmdLongDescription = `
 Resume the existing job with the given job ID.`
 
+const removeJobsCmdShortDescription = "Remove all files associated with the given job ID"
+
+const removeJobsCmdLongDescription = `
+Remove all files associated with the given job ID.
+
+Note that the location of log files and job plan files can be customized. Please refer to the env command.`
+
+const cleanJobsCmdShortDescription = "Clean up log files and job plan files (used for progress tracking and resuming) for jobs"
+
+const cleanJobsCmdLongDescription = `
+Clean up log files and job plan files (used for progress tracking and resuming) for jobs.
+
+Note that the location of log files and job plan files can be customized. Please refer to the env command.`
+
 // ===================================== LIST COMMAND ===================================== //
 const listCmdShortDescription = "List the entities in a given resource"
 

--- a/cmd/jobsClean.go
+++ b/cmd/jobsClean.go
@@ -1,0 +1,132 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	type JobsCleanReq struct {
+		withStatus string
+	}
+
+	commandLineInput := JobsCleanReq{}
+
+	// remove a single job's log and plan file
+	jobsCleanCmd := &cobra.Command{
+		Use:     "clean",
+		Aliases: []string{"cl"},
+		Short:   "", // TODO
+		Long:    "", // TODO
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return errors.New("clean command does not accept arguments")
+			}
+			return nil
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			withStatus := common.EJobStatus
+			err := withStatus.Parse(commandLineInput.withStatus)
+			if err != nil {
+				glcm.Error(fmt.Sprintf("Failed to parse --with-status due to error: %s.", err))
+			}
+
+			err = handleCleanJobsCommand(withStatus)
+			if err == nil {
+				if withStatus == common.EJobStatus.All() {
+					glcm.Exit(func(format common.OutputFormat) string {
+						return fmt.Sprintf("Successfully removed all jobs.")
+					}, common.EExitCode.Success())
+				} else {
+					glcm.Exit(func(format common.OutputFormat) string {
+						return fmt.Sprintf("Successfully removed jobs with status: %s.", withStatus)
+					}, common.EExitCode.Success())
+				}
+			} else {
+				glcm.Error(fmt.Sprintf("Failed to remove log/plan files due to error: %s.", err))
+			}
+		},
+	}
+
+	jobsCmd.AddCommand(jobsCleanCmd)
+
+	// NOTE: we have way more job status than we normally need, only show the most common ones
+	jobsCleanCmd.PersistentFlags().StringVar(&commandLineInput.withStatus, "with-status", "All",
+		"only remove the jobs with this status, available values: Cancelled, Completed, Failed, InProgress, All")
+}
+
+func handleCleanJobsCommand(givenStatus common.JobStatus) error {
+	if givenStatus == common.EJobStatus.All() {
+		return blindDeleteAllJobFiles()
+	}
+
+	// we must query the jobs and find out which one to remove
+	resp := common.ListJobsResponse{}
+	Rpc(common.ERpcCmd.ListJobs(), nil, &resp)
+
+	if resp.ErrorMessage != "" {
+		return errors.New("failed to query the list of jobs")
+	}
+
+	for _, job := range resp.JobIDDetails {
+		// delete all jobs matching the givenStatus
+		if job.JobStatus == givenStatus {
+			err := handleRemoveSingleJob(job.JobId)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func blindDeleteAllJobFiles() error {
+	// get rid of the job plan files
+	_, err := removeFilesWithPrefix(azcopyJobPlanFolder, func(s string) bool {
+		if strings.Contains(s, ".steV") {
+			return true
+		}
+		return false
+	})
+	if err != nil {
+		return err
+	}
+
+	// get rid of the logs
+	_, err = removeFilesWithPrefix(azcopyLogPathFolder, func(s string) bool {
+		if strings.HasSuffix(s, ".log") {
+			return true
+		}
+		return false
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/jobsClean.go
+++ b/cmd/jobsClean.go
@@ -42,6 +42,7 @@ func init() {
 		Aliases: []string{"cl"},
 		Short:   cleanJobsCmdShortDescription,
 		Long:    cleanJobsCmdLongDescription,
+		Example: cleanJobsCmdExample,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 0 {
 				return errors.New("clean command does not accept arguments")

--- a/cmd/jobsList.go
+++ b/cmd/jobsList.go
@@ -92,9 +92,10 @@ func PrintExistingJobIds(listJobResponse common.ListJobsResponse) error {
 		sb.WriteString("Existing Jobs \n")
 		for index := 0; index < len(listJobResponse.JobIDDetails); index++ {
 			jobDetail := listJobResponse.JobIDDetails[index]
-			sb.WriteString(fmt.Sprintf("JobId: %s\nStart Time: %s\nCommand: %s\n\n",
+			sb.WriteString(fmt.Sprintf("JobId: %s\nStart Time: %s\nStatus: %s\nCommand: %s\n\n",
 				jobDetail.JobId.String(),
 				time.Unix(0, jobDetail.StartTime).Format(time.RFC850),
+				jobDetail.JobStatus,
 				jobDetail.CommandString))
 		}
 		return sb.String()

--- a/cmd/jobsRemove.go
+++ b/cmd/jobsRemove.go
@@ -45,6 +45,7 @@ func init() {
 		Aliases: []string{"rm"},
 		Short:   removeJobsCmdShortDescription,
 		Long:    removeJobsCmdLongDescription,
+		Example: removeJobsCmdExample,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return errors.New("remove job command requires the JobID")

--- a/cmd/jobsRemove.go
+++ b/cmd/jobsRemove.go
@@ -1,0 +1,127 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	type JobsRemoveReq struct {
+		JobID common.JobID
+	}
+
+	commandLineInput := JobsRemoveReq{}
+
+	// remove a single job's log and plan file
+	jobsRemoveCmd := &cobra.Command{
+		Use:     "remove [jobID]",
+		Aliases: []string{"rm"},
+		Short:   "", // TODO
+		Long:    "", // TODO
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return errors.New("showJob requires only the JobID")
+			}
+			// Parse the JobId
+			jobId, err := common.ParseJobID(args[0])
+			if err != nil {
+				return errors.New("invalid jobId given " + args[0])
+			}
+			commandLineInput.JobID = jobId
+			return nil
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			err := handleRemoveSingleJob(commandLineInput.JobID)
+			if err == nil {
+				glcm.Exit(func(format common.OutputFormat) string {
+					return fmt.Sprintf("Successfully removed log/plan files for job %s.", commandLineInput.JobID)
+				}, common.EExitCode.Success())
+			} else {
+				glcm.Error(fmt.Sprintf("Failed to remove log/plan files for job %s due to error: %s.", commandLineInput.JobID, err))
+			}
+		},
+	}
+
+	jobsCmd.AddCommand(jobsRemoveCmd)
+}
+
+func handleRemoveSingleJob(jobID common.JobID) error {
+	// get rid of the job plan files
+	numPlanFileRemoved, err := removeFilesWithPrefix(azcopyJobPlanFolder, func(s string) bool {
+		if strings.Contains(s, jobID.String()) && strings.Contains(s, ".steV") {
+			return true
+		}
+		return false
+	})
+	if err != nil {
+		return err
+	}
+
+	// get rid of the logs
+	// even though we only have 1 file right now, still scan the directory since we may change the
+	// way we name the logs in the future (with suffix or whatnot)
+	numLogFileRemoved, err := removeFilesWithPrefix(azcopyLogPathFolder, func(s string) bool {
+		if strings.Contains(s, jobID.String()) && strings.HasSuffix(s, ".log") {
+			return true
+		}
+		return false
+	})
+	if err != nil {
+		return err
+	}
+
+	if numLogFileRemoved+numPlanFileRemoved == 0 {
+		return errors.New("cannot find any log or job plan file with the specified ID")
+	}
+
+	return nil
+}
+
+// remove all files whose names are approved by the predicate in the targetFolder
+func removeFilesWithPrefix(targetFolder string, predicate func(string) bool) (int, error) {
+	count := 0
+	files, err := ioutil.ReadDir(targetFolder)
+	if err != nil {
+		return count, err
+	}
+
+	// go through the files and return if any of them fail to be removed
+	for _, singleFile := range files {
+		if predicate(singleFile.Name()) {
+			err := os.Remove(path.Join(targetFolder, singleFile.Name()))
+			if err != nil {
+				return count, err
+			}
+			count += 1
+		}
+	}
+
+	return count, nil
+}

--- a/cmd/jobsShow.go
+++ b/cmd/jobsShow.go
@@ -46,7 +46,7 @@ func init() {
 		Long:  showJobsCmdLongDescription,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
-				return errors.New("showJob requires only the JobID")
+				return errors.New("show job command requires only the JobID")
 			}
 			// Parse the JobId
 			jobId, err := common.ParseJobID(args[0])

--- a/cmd/jobsShow.go
+++ b/cmd/jobsShow.go
@@ -45,11 +45,8 @@ func init() {
 		Short: showJobsCmdShortDescription,
 		Long:  showJobsCmdLongDescription,
 		Args: func(cmd *cobra.Command, args []string) error {
-
-			// if there is any argument passed
-			// it is an error
-			if len(args) == 0 {
-				return errors.New("showJob require at least the JobID")
+			if len(args) != 1 {
+				return errors.New("showJob requires only the JobID")
 			}
 			// Parse the JobId
 			jobId, err := common.ParseJobID(args[0])

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,18 +23,20 @@ package cmd
 import (
 	"bytes"
 	"context"
-	"github.com/Azure/azure-storage-azcopy/common"
-	"github.com/Azure/azure-storage-azcopy/ste"
-	"github.com/Azure/azure-storage-blob-go/azblob"
-	"github.com/spf13/cobra"
 	"net/url"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/ste"
+	"github.com/Azure/azure-storage-blob-go/azblob"
+	"github.com/spf13/cobra"
 )
 
 var azcopyAppPathFolder string
 var azcopyLogPathFolder string
+var azcopyJobPlanFolder string
 var azcopyMaxFileAndSocketHandles int
 var outputFormatRaw string
 var azcopyOutputFormat common.OutputFormat
@@ -56,7 +58,7 @@ var rootCmd = &cobra.Command{
 
 		// startup of the STE happens here, so that the startup can access the values of command line parameters that are defined for "root" command
 		concurrencySettings := ste.NewConcurrencySettings(azcopyMaxFileAndSocketHandles)
-		err = ste.MainSTE(concurrencySettings, int64(cmdLineCapMegaBitsPerSecond), azcopyAppPathFolder, azcopyLogPathFolder)
+		err = ste.MainSTE(concurrencySettings, int64(cmdLineCapMegaBitsPerSecond), azcopyJobPlanFolder, azcopyLogPathFolder)
 		if err != nil {
 			return err
 		}
@@ -77,9 +79,10 @@ var glcm = common.GetLifecycleMgr()
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute(azsAppPathFolder, logPathFolder string, maxFileAndSocketHandles int) {
+func Execute(azsAppPathFolder, logPathFolder string, jobPlanFolder string, maxFileAndSocketHandles int) {
 	azcopyAppPathFolder = azsAppPathFolder
 	azcopyLogPathFolder = logPathFolder
+	azcopyJobPlanFolder = jobPlanFolder
 	azcopyMaxFileAndSocketHandles = maxFileAndSocketHandles
 
 	if err := rootCmd.Execute(); err != nil {

--- a/common/environment.go
+++ b/common/environment.go
@@ -32,6 +32,7 @@ var VisibleEnvironmentVariables = []EnvironmentVariable{
 	EEnvironmentVariable.ConcurrencyValue(),
 	EEnvironmentVariable.TransferInitiationPoolSize(),
 	EEnvironmentVariable.LogLocation(),
+	EEnvironmentVariable.JobPlanLocation(),
 	EEnvironmentVariable.BufferGB(),
 	EEnvironmentVariable.AWSAccessKeyID(),
 	EEnvironmentVariable.AWSSecretAccessKey(),
@@ -78,6 +79,13 @@ func (EnvironmentVariable) LogLocation() EnvironmentVariable {
 	return EnvironmentVariable{
 		Name:        "AZCOPY_LOG_LOCATION",
 		Description: "Overrides where the log files are stored, to avoid filling up a disk.",
+	}
+}
+
+func (EnvironmentVariable) JobPlanLocation() EnvironmentVariable {
+	return EnvironmentVariable{
+		Name:        "AZCOPY_JOB_PLAN_LOCATION",
+		Description: "Overrides where the job plan files (used for progress tracking and resuming) are stored, to avoid filling up a disk.",
 	}
 }
 

--- a/common/fe-ste-models.go
+++ b/common/fe-ste-models.go
@@ -331,6 +331,7 @@ func (j *JobStatus) IsJobDone() bool {
 		*j == EJobStatus.Failed()
 }
 
+func (JobStatus) All() JobStatus                           { return JobStatus(100) }
 func (JobStatus) InProgress() JobStatus                    { return JobStatus(0) }
 func (JobStatus) Paused() JobStatus                        { return JobStatus(1) }
 func (JobStatus) Cancelling() JobStatus                    { return JobStatus(2) }

--- a/common/rpc-models.go
+++ b/common/rpc-models.go
@@ -117,6 +117,7 @@ type JobIDDetails struct {
 	JobId         JobID
 	CommandString string
 	StartTime     int64
+	JobStatus     JobStatus
 }
 
 // ListJobsResponse represent the Job with JobId and

--- a/main.go
+++ b/main.go
@@ -48,6 +48,9 @@ func main() {
 	if azcopyLogPathFolder == "" {
 		azcopyLogPathFolder = azcopyAppPathFolder
 	}
+	if err := os.Mkdir(azcopyLogPathFolder, os.ModeDir|os.ModePerm); err != nil && !os.IsExist(err) {
+		common.PanicIfErr(err)
+	}
 
 	// the user can optionally put the plan files somewhere else
 	azcopyJobPlanFolder := common.GetLifecycleMgr().GetEnvironmentVariable(common.EEnvironmentVariable.JobPlanLocation())

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ package main
 import (
 	"log"
 	"os"
+	"path"
 	"runtime"
 	"runtime/debug"
 	"time"
@@ -38,20 +39,32 @@ var glcm = common.GetLifecycleMgr()
 func main() {
 	pipeline.SetLogSanitizer(common.NewAzCopyLogSanitizer()) // make sure ForceLog logs get secrets redacted
 
+	// note: azcopyAppPathFolder is the default location for all AzCopy data (logs, job plans, oauth token on Windows)
+	// but both logs and job plans can be put elsewhere as they can become very large
 	azcopyAppPathFolder := GetAzCopyAppPath()
+
+	// the user can optionally put the log files somewhere else
 	azcopyLogPathFolder := common.GetLifecycleMgr().GetEnvironmentVariable(common.EEnvironmentVariable.LogLocation())
 	if azcopyLogPathFolder == "" {
 		azcopyLogPathFolder = azcopyAppPathFolder
 	}
 
+	// the user can optionally put the plan files somewhere else
+	azcopyJobPlanFolder := common.GetLifecycleMgr().GetEnvironmentVariable(common.EEnvironmentVariable.JobPlanLocation())
+	if azcopyJobPlanFolder == "" {
+		azcopyJobPlanFolder = path.Join(azcopyAppPathFolder, "plans")
+	}
+	if err := os.Mkdir(azcopyJobPlanFolder, os.ModeDir|os.ModePerm); err != nil && !os.IsExist(err) {
+		common.PanicIfErr(err)
+	}
+
 	// If insufficient arguments, show usage & terminate
 	if len(os.Args) == 1 {
-		cmd.Execute(azcopyAppPathFolder, azcopyLogPathFolder, 0)
+		cmd.Execute(azcopyAppPathFolder, azcopyLogPathFolder, azcopyJobPlanFolder, 0)
 		return
 	}
 
 	configureGoMaxProcs()
-
 	configureGC()
 
 	// Perform os specific initialization
@@ -60,7 +73,7 @@ func main() {
 		log.Fatalf("initialization failed: %v", err)
 	}
 
-	cmd.Execute(azcopyAppPathFolder, azcopyLogPathFolder, maxFileAndSocketHandles)
+	cmd.Execute(azcopyAppPathFolder, azcopyLogPathFolder, azcopyJobPlanFolder, maxFileAndSocketHandles)
 	glcm.Exit(nil, common.EExitCode.Success())
 }
 

--- a/ste/JobsAdmin.go
+++ b/ste/JobsAdmin.go
@@ -33,8 +33,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"path"
-
 	"github.com/Azure/azure-pipeline-go/pipeline"
 	"github.com/Azure/azure-storage-azcopy/common"
 )
@@ -102,7 +100,7 @@ var JobsAdmin interface {
 	common.ILoggerCloser
 }
 
-func initJobsAdmin(appCtx context.Context, concurrency ConcurrencySettings, targetRateInMegaBitsPerSec int64, azcopyAppPathFolder string, azcopyLogPathFolder string) {
+func initJobsAdmin(appCtx context.Context, concurrency ConcurrencySettings, targetRateInMegaBitsPerSec int64, azcopyJobPlanFolder string, azcopyLogPathFolder string) {
 	if JobsAdmin != nil {
 		panic("initJobsAdmin was already called once")
 	}
@@ -129,11 +127,6 @@ func initJobsAdmin(appCtx context.Context, concurrency ConcurrencySettings, targ
 	// TODO: this is not used. Remove it.
 	suicideCh := make(chan SuicideJob, concurrency.MainPoolSize.Value)
 
-	planDir := path.Join(azcopyAppPathFolder, "plans")
-	if err := os.Mkdir(planDir, os.ModeDir|os.ModePerm); err != nil && !os.IsExist(err) {
-		common.PanicIfErr(err)
-	}
-
 	maxRamBytesToUse := getMaxRamForChunks()
 
 	// default to a pacer that doesn't actually control the rate
@@ -153,7 +146,7 @@ func initJobsAdmin(appCtx context.Context, concurrency ConcurrencySettings, targ
 		logger:           common.NewAppLogger(pipeline.LogInfo, azcopyLogPathFolder),
 		jobIDToJobMgr:    newJobIDToJobMgr(),
 		logDir:           azcopyLogPathFolder,
-		planDir:          planDir,
+		planDir:          azcopyJobPlanFolder,
 		pacer:            pacer,
 		slicePool:        common.NewMultiSizeSlicePool(common.MaxBlockBlobBlockSize),
 		cacheLimiter:     common.NewCacheLimiter(maxRamBytesToUse),

--- a/ste/init.go
+++ b/ste/init.go
@@ -49,9 +49,9 @@ func ToFixed(num float64, precision int) float64 {
 }
 
 // MainSTE initializes the Storage Transfer Engine
-func MainSTE(concurrency ConcurrencySettings, targetRateInMegaBitsPerSec int64, azcopyAppPathFolder, azcopyLogPathFolder string) error {
+func MainSTE(concurrency ConcurrencySettings, targetRateInMegaBitsPerSec int64, azcopyJobPlanFolder, azcopyLogPathFolder string) error {
 	// Initialize the JobsAdmin, resurrect Job plan files
-	initJobsAdmin(steCtx, concurrency, targetRateInMegaBitsPerSec, azcopyAppPathFolder, azcopyLogPathFolder)
+	initJobsAdmin(steCtx, concurrency, targetRateInMegaBitsPerSec, azcopyJobPlanFolder, azcopyLogPathFolder)
 	// No need to read the existing JobPartPlan files since Azcopy is running in process
 	//JobsAdmin.ResurrectJobParts()
 	// TODO: We may want to list listen first and terminate if there is already an instance listening
@@ -719,7 +719,8 @@ func ListJobs() common.ListJobsResponse {
 			continue
 		}
 		listJobResponse.JobIDDetails = append(listJobResponse.JobIDDetails,
-			common.JobIDDetails{JobId: jobId, CommandString: jpm.Plan().CommandString(), StartTime: jpm.Plan().StartTime})
+			common.JobIDDetails{JobId: jobId, CommandString: jpm.Plan().CommandString(),
+				StartTime: jpm.Plan().StartTime, JobStatus: jpm.Plan().JobStatus()})
 	}
 	return listJobResponse
 }


### PR DESCRIPTION
Summary of changes:

0. Allow user to specify where plan files are stored.
1. Allow user to see the job status when listing jobs
2. Added `jobs rm [jobID]` command to delete single job
3. Added `jobs clean --with-status=[Cancelled, Completed, Failed, InProgress, All]` to mass-clean job-related files.

Example:
```
./azcopy jobs clean --with-status=inprogress
INFO: Removing files for job 9f636ac6-783a-354a-4019-8e18ad8aee6c
INFO: Removing files for job be372649-87a8-9b43-7703-9c99712fb4fd
INFO: Removing files for job 1d39f399-8027-da45-464f-02e9a6040877
Successfully removed jobs with status: InProgress.
```

Note: the job status under `jobs` command are all non-enhanced (meaning simple Completed rather than CompletedWithErrors, CompletedWithSkipped, CompletedWithErrorsAndSkipped), this is because we do not read all the parts to calculate how many files got failed/skipped.