### PR TITLE
Fix broken flags & remove historically non-working flags

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -256,13 +256,25 @@ func (raw rawCopyCmdArgs) cookWithId(jobId common.JobID) (cookedCopyCmdArgs, err
 		}
 	}
 
+	// Prepare UTF-8 byte order marker
+	utf8BOM := string([]byte{0xEF, 0xBB, 0xBF})
+
 	go func() {
 		defer close(listChan)
 
 		if f != nil {
 			scanner := bufio.NewScanner(f)
+			checkBOM := false
 			for scanner.Scan() {
 				v := scanner.Text()
+
+				// Yes, the UTF-8 BOM has valid characters (butwhytho*10)
+				// Check it on the first line and remove it if necessary.
+				if !checkBOM {
+					v = strings.TrimPrefix(v, utf8BOM)
+					checkBOM = true
+				}
+
 				// empty strings should be ignored, otherwise the source root itself is selected
 				if len(v) > 0 {
 					listChan <- v

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -1393,7 +1393,7 @@ func init() {
 	// To achieve better performance and at same time have good control for overall go routine numbers, getting property in ste is introduced,
 	// so properties can be get in parallel, at same time no additional go routines are created for this specific job.
 	// The usage of this hidden flag is to provide fallback to traditional behavior, when service supports returning full properties during list.
-	cpCmd.PersistentFlags().BoolVar(&raw.s2sGetPropertiesInBackend, "s2s-get-properties-in-backend", true, "get S3 objects' or Azure files' properties in backend. ")
+	cpCmd.PersistentFlags().BoolVar(&raw.s2sGetPropertiesInBackend, "s2s-get-properties-in-backend", true, "get S3 objects' or Azure files' properties in backend, if properties need to be accessed. Properties need to be accessed if s2s-preserve-properties is true, and in certain other cases where we need the properties for modification time checks or MD5 checks")
 
 	// permanently hidden
 	// Hide the list-of-files flag since it is implemented only for Storage Explorer.

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -307,6 +307,25 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 		if cooked.blobType != common.EBlobType.Detect() {
 			return cooked, fmt.Errorf("blob-type is not supported on ADLS Gen 2")
 		}
+		if cooked.preserveLastModifiedTime {
+			return cooked, fmt.Errorf("preserve-last-modified-time is not supported while uploading")
+		}
+		if cooked.blockBlobTier != common.EBlockBlobTier.None() ||
+			cooked.pageBlobTier != common.EPageBlobTier.None() {
+			return cooked, fmt.Errorf("blob-tier is not supported while uploading to ADLS Gen 2")
+		}
+		if cooked.s2sPreserveProperties {
+			return cooked, fmt.Errorf("s2s-preserve-properties is not supported while uploading")
+		}
+		if cooked.s2sPreserveAccessTier {
+			return cooked, fmt.Errorf("s2s-preserve-access-tier is not supported while uploading")
+		}
+		if cooked.s2sInvalidMetadataHandleOption != common.DefaultInvalidMetadataHandleOption {
+			return cooked, fmt.Errorf("s2s-handle-invalid-metadata is not supported while uploading")
+		}
+		if cooked.s2sSourceChangeValidation {
+			return cooked, fmt.Errorf("s2s-detect-source-changed is not supported while uploading")
+		}
 	case common.EFromTo.LocalBlob():
 		if cooked.preserveLastModifiedTime {
 			return cooked, fmt.Errorf("preserve-last-modified-time is not supported while uploading")
@@ -347,7 +366,8 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 			return cooked, fmt.Errorf("blob-type is not supported on Azure File")
 		}
 	case common.EFromTo.BlobLocal(),
-		common.EFromTo.FileLocal():
+		common.EFromTo.FileLocal(),
+		common.EFromTo.BlobFSLocal():
 		if cooked.followSymlinks {
 			return cooked, fmt.Errorf("follow-symlinks flag is not supported while downloading")
 		}

--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -49,7 +49,7 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 	// If source change validation is enabled on files to remote, turn it on (consider a separate flag entirely?)
 	getRemoteProperties := (cca.fromTo.From() == common.ELocation.File() && !cca.fromTo.To().IsRemote()) || // If download, we still need LMT and MD5 from files.
 		(cca.fromTo.From() == common.ELocation.File() && cca.fromTo.To().IsRemote() && cca.s2sSourceChangeValidation) || // If S2S from File to *, and sourceChangeValidation is enabled, we get properties anyway (according to the old code)
-		(cca.fromTo.From().IsRemote() && cca.fromTo.To().IsRemote() && cca.s2sPreserveProperties && !cca.s2sGetPropertiesInBackend) // If S2S and
+		(cca.fromTo.From().IsRemote() && cca.fromTo.To().IsRemote() && cca.s2sPreserveProperties && !cca.s2sGetPropertiesInBackend) // If S2S and preserve properties AND get properties in backend is on, turn this off, as properties will be obtained in the backend.
 	jobPartOrder.S2SGetPropertiesInBackend = cca.s2sPreserveProperties && !getRemoteProperties && cca.s2sGetPropertiesInBackend // Infer GetProperties if GetPropertiesInBackend is enabled.
 	jobPartOrder.S2SSourceChangeValidation = cca.s2sSourceChangeValidation
 	jobPartOrder.S2SDestLengthValidation = cca.CheckLength

--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -50,7 +50,7 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 	getRemoteProperties := (cca.fromTo.From().IsRemote() && !cca.fromTo.To().IsRemote()) || // If download, we still need LMT and MD5 from files.
 		(cca.fromTo.From() == common.ELocation.File() && cca.fromTo.To().IsRemote() && cca.s2sSourceChangeValidation) || // If S2S from File to *, and sourceChangeValidation is enabled, we get properties anyway (according to the old code)
 		(cca.fromTo.From().IsRemote() && cca.fromTo.To().IsRemote() && cca.s2sPreserveProperties && !cca.s2sGetPropertiesInBackend) // If S2S and
-	jobPartOrder.S2SGetPropertiesInBackend = !getRemoteProperties && cca.s2sGetPropertiesInBackend // Infer GetProperties if GetPropertiesInBackend is enabled.
+	jobPartOrder.S2SGetPropertiesInBackend = cca.s2sPreserveProperties && !getRemoteProperties && cca.s2sGetPropertiesInBackend // Infer GetProperties if GetPropertiesInBackend is enabled.
 	jobPartOrder.S2SSourceChangeValidation = cca.s2sSourceChangeValidation
 	jobPartOrder.S2SDestLengthValidation = cca.CheckLength
 

--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -47,7 +47,7 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 	// On S2S transfers the following rules apply:
 	// If preserve properties is enabled, but get properties in backend is disabled, turn it on
 	// If source change validation is enabled on files to remote, turn it on (consider a separate flag entirely?)
-	getRemoteProperties := (cca.fromTo.From().IsRemote() && !cca.fromTo.To().IsRemote()) || // If download, we still need LMT and MD5 from files.
+	getRemoteProperties := (cca.fromTo.From() == common.ELocation.File() && !cca.fromTo.To().IsRemote()) || // If download, we still need LMT and MD5 from files.
 		(cca.fromTo.From() == common.ELocation.File() && cca.fromTo.To().IsRemote() && cca.s2sSourceChangeValidation) || // If S2S from File to *, and sourceChangeValidation is enabled, we get properties anyway (according to the old code)
 		(cca.fromTo.From().IsRemote() && cca.fromTo.To().IsRemote() && cca.s2sPreserveProperties && !cca.s2sGetPropertiesInBackend) // If S2S and
 	jobPartOrder.S2SGetPropertiesInBackend = cca.s2sPreserveProperties && !getRemoteProperties && cca.s2sGetPropertiesInBackend // Infer GetProperties if GetPropertiesInBackend is enabled.

--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -49,6 +49,7 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 	// If source change validation is enabled on files to remote, turn it on (consider a seperate flag entirely?)
 	getRemoteProperties := (cca.fromTo.From().IsRemote() && !cca.fromTo.To().IsRemote()) ||
 		(cca.fromTo.From().IsRemote() && cca.fromTo.To().IsRemote() && cca.s2sPreserveProperties && !cca.s2sGetPropertiesInBackend)
+	jobPartOrder.S2SGetPropertiesInBackend = !getRemoteProperties && cca.s2sGetPropertiesInBackend
 
 	traverser, err = initResourceTraverser(src, cca.fromTo.From(), &ctx, &srcCredInfo, &cca.followSymlinks, cca.listOfFilesChannel, cca.recursive, getRemoteProperties, func() {})
 

--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -53,6 +53,7 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 	jobPartOrder.S2SGetPropertiesInBackend = cca.s2sPreserveProperties && !getRemoteProperties && cca.s2sGetPropertiesInBackend // Infer GetProperties if GetPropertiesInBackend is enabled.
 	jobPartOrder.S2SSourceChangeValidation = cca.s2sSourceChangeValidation
 	jobPartOrder.S2SDestLengthValidation = cca.CheckLength
+	jobPartOrder.S2SInvalidMetadataHandleOption = cca.s2sInvalidMetadataHandleOption
 
 	traverser, err = initResourceTraverser(src, cca.fromTo.From(), &ctx, &srcCredInfo, &cca.followSymlinks, cca.listOfFilesChannel, cca.recursive, getRemoteProperties, func() {})
 

--- a/cmd/removeEnumerator.go
+++ b/cmd/removeEnumerator.go
@@ -54,7 +54,7 @@ func newRemoveEnumerator(cca *cookedCopyCmdArgs) (enumerator *copyEnumerator, er
 	}
 
 	// Include-path is handled by ListOfFilesChannel.
-	sourceTraverser, err = initResourceTraverser(rawURL.String(), cca.fromTo.From(), &ctx, &cca.credentialInfo, nil, cca.listOfFilesChannel, cca.recursive, func() {})
+	sourceTraverser, err = initResourceTraverser(rawURL.String(), cca.fromTo.From(), &ctx, &cca.credentialInfo, nil, cca.listOfFilesChannel, cca.recursive, false, func() {})
 
 	// report failure to create traverser
 	if err != nil {

--- a/cmd/syncEnumerator.go
+++ b/cmd/syncEnumerator.go
@@ -43,8 +43,10 @@ func (cca *cookedSyncCmdArgs) initEnumerator(ctx context.Context) (enumerator *s
 	}
 
 	// TODO: enable symlink support in a future release after evaluating the implications
+	// GetProperties is enabled by default as sync supports both upload and download.
+	// This property only supports Files and S3 at the moment, but provided that Files sync is coming soon, enable to avoid stepping on Files sync work
 	sourceTraverser, err := initResourceTraverser(src, cca.fromTo.From(), &ctx, &cca.credentialInfo,
-		nil, nil, cca.recursive, func() {
+		nil, nil, cca.recursive, true, func() {
 			atomic.AddUint64(&cca.atomicSourceFilesScanned, 1)
 		})
 
@@ -53,8 +55,10 @@ func (cca *cookedSyncCmdArgs) initEnumerator(ctx context.Context) (enumerator *s
 	}
 
 	// TODO: enable symlink support in a future release after evaluating the implications
+	// GetProperties is enabled by default as sync supports both upload and download.
+	// This property only supports Files and S3 at the moment, but provided that Files sync is coming soon, enable to avoid stepping on Files sync work
 	destinationTraverser, err := initResourceTraverser(dst, cca.fromTo.To(), &ctx, &cca.credentialInfo,
-		nil, nil, cca.recursive, func() {
+		nil, nil, cca.recursive, true, func() {
 			atomic.AddUint64(&cca.atomicDestinationFilesScanned, 1)
 		})
 	if err != nil {

--- a/cmd/zc_enumerator.go
+++ b/cmd/zc_enumerator.go
@@ -130,7 +130,7 @@ const accountTraversalInherentlyRecursiveError = "account copies are an inherent
 // ctx, pipeline are only required for remote resources.
 // followSymlinks is only required for local resources (defaults to false)
 // errorOnDirWOutRecursive is used by copy.
-func initResourceTraverser(source string, location common.Location, ctx *context.Context, credential *common.CredentialInfo, followSymlinks *bool, listofFilesChannel chan string, recursive bool, incrementEnumerationCounter func()) (resourceTraverser, error) {
+func initResourceTraverser(source string, location common.Location, ctx *context.Context, credential *common.CredentialInfo, followSymlinks *bool, listofFilesChannel chan string, recursive, getProperties bool, incrementEnumerationCounter func()) (resourceTraverser, error) {
 	var output resourceTraverser
 	var p *pipeline.Pipeline
 
@@ -164,7 +164,7 @@ func initResourceTraverser(source string, location common.Location, ctx *context
 			sas = splitsrc[1]
 		}
 
-		output = newListTraverser(splitsrc[0], sas, location, credential, ctx, recursive, toFollow, listofFilesChannel, incrementEnumerationCounter)
+		output = newListTraverser(splitsrc[0], sas, location, credential, ctx, recursive, toFollow, getProperties, listofFilesChannel, incrementEnumerationCounter)
 		return output, nil
 	}
 
@@ -190,7 +190,7 @@ func initResourceTraverser(source string, location common.Location, ctx *context
 				}
 			}()
 
-			output = newListTraverser(cleanLocalPath(basePath), "", location, nil, nil, recursive, toFollow, globChan, incrementEnumerationCounter)
+			output = newListTraverser(cleanLocalPath(basePath), "", location, nil, nil, recursive, toFollow, getProperties, globChan, incrementEnumerationCounter)
 		} else {
 			output = newLocalTraverser(source, recursive, toFollow, incrementEnumerationCounter)
 		}
@@ -233,9 +233,9 @@ func initResourceTraverser(source string, location common.Location, ctx *context
 				return nil, errors.New(accountTraversalInherentlyRecursiveError)
 			}
 
-			output = newFileAccountTraverser(sourceURL, *p, *ctx, incrementEnumerationCounter)
+			output = newFileAccountTraverser(sourceURL, *p, *ctx, getProperties, incrementEnumerationCounter)
 		} else {
-			output = newFileTraverser(sourceURL, *p, *ctx, recursive, incrementEnumerationCounter)
+			output = newFileTraverser(sourceURL, *p, *ctx, recursive, getProperties, incrementEnumerationCounter)
 		}
 	case common.ELocation.BlobFS():
 		sourceURL, err := url.Parse(source)

--- a/cmd/zc_enumerator.go
+++ b/cmd/zc_enumerator.go
@@ -282,13 +282,13 @@ func initResourceTraverser(source string, location common.Location, ctx *context
 				return nil, errors.New(accountTraversalInherentlyRecursiveError)
 			}
 
-			output, err = newS3ServiceTraverser(sourceURL, *ctx, incrementEnumerationCounter)
+			output, err = newS3ServiceTraverser(sourceURL, *ctx, getProperties, incrementEnumerationCounter)
 
 			if err != nil {
 				return nil, err
 			}
 		} else {
-			output, err = newS3Traverser(sourceURL, *ctx, recursive, incrementEnumerationCounter)
+			output, err = newS3Traverser(sourceURL, *ctx, recursive, getProperties, incrementEnumerationCounter)
 
 			if err != nil {
 				return nil, err

--- a/cmd/zc_traverser_file.go
+++ b/cmd/zc_traverser_file.go
@@ -117,16 +117,6 @@ func (t *fileTraverser) traverse(processor objectProcessor, filters []objectFilt
 				relativePath := strings.TrimPrefix(fileURLParts.DirectoryOrFilePath, targetURLParts.DirectoryOrFilePath)
 				relativePath = strings.TrimPrefix(relativePath, common.AZCOPY_PATH_SEPARATOR_STRING)
 
-				/*storedObject := newStoredObject(
-					getObjectNameOnly(fileInfo.Name),
-					relativePath,
-					time.Time{},
-					fileInfo.Properties.ContentLength,
-					fileProperties.ContentMD5(),
-					azblob.BlobNone,
-					targetURLParts.ShareName,
-				)*/
-
 				// We need to omit some properties if we don't get properties
 				storedObject := storedObject{
 					name:          getObjectNameOnly(fileInfo.Name),

--- a/cmd/zc_traverser_file_account.go
+++ b/cmd/zc_traverser_file_account.go
@@ -31,11 +31,12 @@ import (
 
 // Enumerates an entire files account, looking into each matching share as it goes
 type fileAccountTraverser struct {
-	accountURL   azfile.ServiceURL
-	p            pipeline.Pipeline
-	ctx          context.Context
-	sharePattern string
-	cachedShares []string
+	accountURL    azfile.ServiceURL
+	p             pipeline.Pipeline
+	ctx           context.Context
+	sharePattern  string
+	cachedShares  []string
+	getProperties bool
 
 	// a generic function to notify that a new stored object has been enumerated
 	incrementEnumerationCounter func()
@@ -92,7 +93,7 @@ func (t *fileAccountTraverser) traverse(processor objectProcessor, filters []obj
 
 	for _, v := range shareList {
 		shareURL := t.accountURL.NewShareURL(v).URL()
-		shareTraverser := newFileTraverser(&shareURL, t.p, t.ctx, true, t.incrementEnumerationCounter)
+		shareTraverser := newFileTraverser(&shareURL, t.p, t.ctx, true, t.getProperties, t.incrementEnumerationCounter)
 
 		middlemanProcessor := initContainerDecorator(v, processor)
 
@@ -107,7 +108,7 @@ func (t *fileAccountTraverser) traverse(processor objectProcessor, filters []obj
 	return nil
 }
 
-func newFileAccountTraverser(rawURL *url.URL, p pipeline.Pipeline, ctx context.Context, incrementEnumerationCounter func()) (t *fileAccountTraverser) {
+func newFileAccountTraverser(rawURL *url.URL, p pipeline.Pipeline, ctx context.Context, getProperties bool, incrementEnumerationCounter func()) (t *fileAccountTraverser) {
 	fURLparts := azfile.NewFileURLParts(*rawURL)
 	sPattern := fURLparts.ShareName
 
@@ -115,6 +116,6 @@ func newFileAccountTraverser(rawURL *url.URL, p pipeline.Pipeline, ctx context.C
 		fURLparts.ShareName = ""
 	}
 
-	t = &fileAccountTraverser{p: p, ctx: ctx, incrementEnumerationCounter: incrementEnumerationCounter, accountURL: azfile.NewServiceURL(fURLparts.URL(), p), sharePattern: sPattern}
+	t = &fileAccountTraverser{p: p, ctx: ctx, incrementEnumerationCounter: incrementEnumerationCounter, accountURL: azfile.NewServiceURL(fURLparts.URL(), p), sharePattern: sPattern, getProperties: getProperties}
 	return
 }

--- a/cmd/zc_traverser_list.go
+++ b/cmd/zc_traverser_list.go
@@ -88,7 +88,7 @@ func (l *listTraverser) traverse(processor objectProcessor, filters []objectFilt
 }
 
 func newListTraverser(parent string, parentSAS string, parentType common.Location, credential *common.CredentialInfo, ctx *context.Context,
-	recursive, followSymlinks bool, listChan chan string, incrementEnumerationCounter func()) resourceTraverser {
+	recursive, followSymlinks, getProperties bool, listChan chan string, incrementEnumerationCounter func()) resourceTraverser {
 	var traverserGenerator childTraverserGenerator
 
 	traverserGenerator = func(relativeChildPath string) (resourceTraverser, error) {
@@ -106,7 +106,7 @@ func newListTraverser(parent string, parentSAS string, parentType common.Locatio
 		}
 
 		// Construct a traverser that goes through the child
-		traverser, err := initResourceTraverser(source, parentType, ctx, credential, &followSymlinks, nil, recursive, incrementEnumerationCounter)
+		traverser, err := initResourceTraverser(source, parentType, ctx, credential, &followSymlinks, nil, recursive, getProperties, incrementEnumerationCounter)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/zc_traverser_s3_service.go
+++ b/cmd/zc_traverser_s3_service.go
@@ -39,6 +39,7 @@ type s3ServiceTraverser struct {
 	ctx           context.Context
 	bucketPattern string
 	cachedBuckets []string
+	getProperties bool
 
 	s3URL    s3URLPartsExtension
 	s3Client *minio.Client
@@ -92,7 +93,7 @@ func (t *s3ServiceTraverser) traverse(processor objectProcessor, filters []objec
 		tmpS3URL := t.s3URL
 		tmpS3URL.BucketName = v
 		urlResult := tmpS3URL.URL()
-		bucketTraverser, err := newS3Traverser(&urlResult, t.ctx, true, t.incrementEnumerationCounter)
+		bucketTraverser, err := newS3Traverser(&urlResult, t.ctx, true, t.getProperties, t.incrementEnumerationCounter)
 
 		if err != nil {
 			return err
@@ -121,8 +122,8 @@ func (t *s3ServiceTraverser) traverse(processor objectProcessor, filters []objec
 	return nil
 }
 
-func newS3ServiceTraverser(rawURL *url.URL, ctx context.Context, incrementEnumerationCounter func()) (t *s3ServiceTraverser, err error) {
-	t = &s3ServiceTraverser{ctx: ctx, incrementEnumerationCounter: incrementEnumerationCounter}
+func newS3ServiceTraverser(rawURL *url.URL, ctx context.Context, getProperties bool, incrementEnumerationCounter func()) (t *s3ServiceTraverser, err error) {
+	t = &s3ServiceTraverser{ctx: ctx, incrementEnumerationCounter: incrementEnumerationCounter, getProperties: getProperties}
 
 	var s3URLParts common.S3URLParts
 	s3URLParts, err = common.NewS3URLParts(*rawURL)

--- a/cmd/zt_copy_blob_download_test.go
+++ b/cmd/zt_copy_blob_download_test.go
@@ -299,7 +299,7 @@ func (s *cmdIntegrationSuite) TestDownloadBlobContainerWithPattern(c *chk.C) {
 	raw := getDefaultCopyRawInput(rawContainerURLWithSAS.String(), dstDirName)
 	raw.recursive = true
 	raw.stripTopDir = true
-	raw.legacyInclude = "*.pdf"
+	raw.include = "*.pdf"
 
 	runCopyAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)

--- a/cmd/zt_generic_service_traverser_test.go
+++ b/cmd/zt_generic_service_traverser_test.go
@@ -174,7 +174,7 @@ func (s *genericTraverserSuite) TestServiceTraverserWithManyObjects(c *chk.C) {
 	// construct a file account traverser
 	filePipeline := azfile.NewPipeline(azfile.NewAnonymousCredential(), azfile.PipelineOptions{})
 	rawFSU := scenarioHelper{}.getRawFileServiceURLWithSAS(c)
-	fileAccountTraverser := newFileAccountTraverser(&rawFSU, filePipeline, ctx, func() {})
+	fileAccountTraverser := newFileAccountTraverser(&rawFSU, filePipeline, ctx, false, func() {})
 
 	// invoke the file account traversal with a dummy processor
 	fileDummyProcessor := dummyProcessor{}
@@ -319,7 +319,7 @@ func (s *genericTraverserSuite) TestServiceTraverserWithWildcards(c *chk.C) {
 	filePipeline := azfile.NewPipeline(azfile.NewAnonymousCredential(), azfile.PipelineOptions{})
 	rawFSU := scenarioHelper{}.getRawFileServiceURLWithSAS(c)
 	rawFSU.Path = "/objectmatch*" // set the container name to contain a wildcard
-	fileAccountTraverser := newFileAccountTraverser(&rawFSU, filePipeline, ctx, func() {})
+	fileAccountTraverser := newFileAccountTraverser(&rawFSU, filePipeline, ctx, false, func() {})
 
 	// invoke the file account traversal with a dummy processor
 	fileDummyProcessor := dummyProcessor{}

--- a/cmd/zt_generic_service_traverser_test.go
+++ b/cmd/zt_generic_service_traverser_test.go
@@ -185,7 +185,7 @@ func (s *genericTraverserSuite) TestServiceTraverserWithManyObjects(c *chk.C) {
 	if testS3 {
 		// construct a s3 service traverser
 		accountURL := scenarioHelper{}.getRawS3AccountURL(c, "")
-		s3ServiceTraverser, err := newS3ServiceTraverser(&accountURL, ctx, func() {})
+		s3ServiceTraverser, err := newS3ServiceTraverser(&accountURL, ctx, false, func() {})
 		c.Assert(err, chk.IsNil)
 
 		// invoke the s3 service traversal with a dummy processor
@@ -344,7 +344,7 @@ func (s *genericTraverserSuite) TestServiceTraverserWithWildcards(c *chk.C) {
 		accountURL.BucketName = "objectmatch*" // set the container name to contain a wildcard
 
 		urlOut := accountURL.URL()
-		s3ServiceTraverser, err := newS3ServiceTraverser(&urlOut, ctx, func() {})
+		s3ServiceTraverser, err := newS3ServiceTraverser(&urlOut, ctx, false, func() {})
 		c.Assert(err, chk.IsNil)
 
 		// invoke the s3 service traversal with a dummy processor

--- a/cmd/zt_generic_traverser_test.go
+++ b/cmd/zt_generic_traverser_test.go
@@ -294,7 +294,7 @@ func (s *genericTraverserSuite) TestTraverserWithSingleObject(c *chk.C) {
 
 		// construct a s3 traverser
 		url := scenarioHelper{}.getRawS3ObjectURL(c, "", bucketName, storedObjectName)
-		S3Traverser, err := newS3Traverser(&url, ctx, false, func() {})
+		S3Traverser, err := newS3Traverser(&url, ctx, false, false, func() {})
 		c.Assert(err, chk.IsNil)
 
 		s3DummyProcessor := dummyProcessor{}
@@ -389,7 +389,7 @@ func (s *genericTraverserSuite) TestTraverserContainerAndLocalDirectory(c *chk.C
 
 		// construct and run a S3 traverser
 		rawS3URL := scenarioHelper{}.getRawS3BucketURL(c, "", bucketName)
-		S3Traverser, err := newS3Traverser(&rawS3URL, ctx, isRecursiveOn, func() {})
+		S3Traverser, err := newS3Traverser(&rawS3URL, ctx, isRecursiveOn, false, func() {})
 		c.Assert(err, chk.IsNil)
 		s3DummyProcessor := dummyProcessor{}
 		err = S3Traverser.traverse(s3DummyProcessor.process, nil)
@@ -498,7 +498,7 @@ func (s *genericTraverserSuite) TestTraverserWithVirtualAndLocalDirectory(c *chk
 		// construct and run a S3 traverser
 		// directory object keys always end with / in S3
 		rawS3URL := scenarioHelper{}.getRawS3ObjectURL(c, "", bucketName, virDirName+"/")
-		S3Traverser, err := newS3Traverser(&rawS3URL, ctx, isRecursiveOn, func() {})
+		S3Traverser, err := newS3Traverser(&rawS3URL, ctx, isRecursiveOn, false, func() {})
 		c.Assert(err, chk.IsNil)
 		s3DummyProcessor := dummyProcessor{}
 		err = S3Traverser.traverse(s3DummyProcessor.process, nil)

--- a/cmd/zt_generic_traverser_test.go
+++ b/cmd/zt_generic_traverser_test.go
@@ -246,6 +246,9 @@ func (s *genericTraverserSuite) TestTraverserWithSingleObject(c *chk.C) {
 		c.Assert(localDummyProcessor.record[0].relativePath, chk.Equals, blobDummyProcessor.record[0].relativePath)
 
 		// Azure File cannot handle names with '/' in them
+		// TODO: Construct a directory URL and then build a file URL atop it in order to solve this portion of the test.
+		//  We shouldn't be excluding things the traverser is actually capable of doing.
+		//  Fix within scenarioHelper.generateAzureFilesFromList, since that's what causes the fail.
 		if !strings.Contains(storedObjectName, "/") {
 			// set up the Azure Share with a single file
 			fileList := []string{storedObjectName}
@@ -254,7 +257,7 @@ func (s *genericTraverserSuite) TestTraverserWithSingleObject(c *chk.C) {
 			// construct an Azure file traverser
 			filePipeline := azfile.NewPipeline(azfile.NewAnonymousCredential(), azfile.PipelineOptions{})
 			rawFileURLWithSAS := scenarioHelper{}.getRawFileURLWithSAS(c, shareName, fileList[0])
-			azureFileTraverser := newFileTraverser(&rawFileURLWithSAS, filePipeline, ctx, false, func() {})
+			azureFileTraverser := newFileTraverser(&rawFileURLWithSAS, filePipeline, ctx, false, false, func() {})
 
 			// invoke the file traversal with a dummy processor
 			fileDummyProcessor := dummyProcessor{}
@@ -366,7 +369,7 @@ func (s *genericTraverserSuite) TestTraverserContainerAndLocalDirectory(c *chk.C
 		// construct an Azure File traverser
 		filePipeline := azfile.NewPipeline(azfile.NewAnonymousCredential(), azfile.PipelineOptions{})
 		rawFileURLWithSAS := scenarioHelper{}.getRawShareURLWithSAS(c, shareName)
-		azureFileTraverser := newFileTraverser(&rawFileURLWithSAS, filePipeline, ctx, isRecursiveOn, func() {})
+		azureFileTraverser := newFileTraverser(&rawFileURLWithSAS, filePipeline, ctx, isRecursiveOn, false, func() {})
 
 		// invoke the file traversal with a dummy processor
 		fileDummyProcessor := dummyProcessor{}
@@ -475,7 +478,7 @@ func (s *genericTraverserSuite) TestTraverserWithVirtualAndLocalDirectory(c *chk
 		// construct an Azure File traverser
 		filePipeline := azfile.NewPipeline(azfile.NewAnonymousCredential(), azfile.PipelineOptions{})
 		rawFileURLWithSAS := scenarioHelper{}.getRawFileURLWithSAS(c, shareName, virDirName)
-		azureFileTraverser := newFileTraverser(&rawFileURLWithSAS, filePipeline, ctx, isRecursiveOn, func() {})
+		azureFileTraverser := newFileTraverser(&rawFileURLWithSAS, filePipeline, ctx, isRecursiveOn, false, func() {})
 
 		// invoke the file traversal with a dummy processor
 		fileDummyProcessor := dummyProcessor{}

--- a/common/rpc-models.go
+++ b/common/rpc-models.go
@@ -48,8 +48,6 @@ type CopyJobPartOrderRequest struct {
 	ForceWrite  OverwriteOption // to determine if the existing needs to be overwritten or not. If set to true, existing blobs are overwritten
 	Priority    JobPriority     // priority of the task
 	FromTo      FromTo
-	Include     map[string]int
-	Exclude     map[string]int
 	// list of blobTypes to exclude.
 	ExcludeBlobType []azblob.BlobType
 	SourceRoot      string


### PR DESCRIPTION
//TODO: Write tests for attributes that were forgotten initially. (Seperate PBI-- We decided to do a double-custody lock on the failure injection options.)

Removed flags (all of this is in a single commit, could easily be cherry-picked out):
- with-snapshots (never worked in the first place)
- background-op (no longer works; remnant of STE being a daemon)
- acl (didn't work on master either)

Fixed flags:
- check-length
- s2s-preserve-properties
- s2s-get-properties-in-backend
- s2s-source-change-validation


