### PR TITLE
Use a lower initial starting point for auto-tuning concurrency

### DIFF
--- a/ste/concurrency.go
+++ b/ste/concurrency.go
@@ -183,7 +183,7 @@ func getMainPoolSize(numOfCPUs int, requestAutoTune bool) (initial int, max *Con
 	var initialValue int
 
 	if requestAutoTune {
-		initialValue = 8 // deliberately start with a small initial value if we are auto-tuning.  If it's not small enough, then the auto tuning becomes
+		initialValue = 4 // deliberately start with a small initial value if we are auto-tuning.  If it's not small enough, then the auto tuning becomes
 		// sluggish since, every time it needs to tune downwards, it needs to let a lot of data (num connections * block size) get transmitted,
 		// and that is slow over very small links, e.g. 10 Mbps, and produces noticable time lag when downsizing the connection count.
 		// So we start small. (The alternatives, of using small chunk sizes or small file sizes just for the first 200 MB or so, were too hard to orchestrate within the existing app architecture)

--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -331,9 +331,11 @@ func (jm *jobMgr) setDirection(fromTo common.FromTo) {
 	}
 	if fromTo.IsDownload() {
 		jm.atomicTransferDirection.AtomicStore(common.ETransferDirection.Download())
+		JobsAdmin.RequestTuneSlowly()
 	}
 	if fromTo.IsS2S() {
 		jm.atomicTransferDirection.AtomicStore(common.ETransferDirection.S2SCopy())
+		JobsAdmin.RequestTuneSlowly()
 	}
 }
 

--- a/ste/zt_concurrencyTuner_test.go
+++ b/ste/zt_concurrencyTuner_test.go
@@ -40,9 +40,11 @@ func (s *concurrencyTunerSuite) noMax() int {
 	return math.MaxInt32
 }
 
-func (s *concurrencyTunerSuite) TestConcurrencyTuner_LowBandwidth(c *chk.C) {
+func (s *concurrencyTunerSuite) TestConcurrencyTuner_LowBW(c *chk.C) {
 	steps := []tunerStep{
-		{16, concurrencyReasonInitial, 100, false},
+		{4, concurrencyReasonInitial, 40, false},
+		{8, concurrencyReasonSeeking, 80, false},
+		{16, concurrencyReasonSeeking, 100, false},
 		{32, concurrencyReasonSeeking, 100, false},
 		{16, concurrencyReasonBackoff, 100, false},
 		{19, concurrencyReasonSeeking, 100, false},
@@ -53,9 +55,24 @@ func (s *concurrencyTunerSuite) TestConcurrencyTuner_LowBandwidth(c *chk.C) {
 
 }
 
+func (s *concurrencyTunerSuite) TestConcurrencyTuner_VeryLowBandwidth(c *chk.C) {
+	steps := []tunerStep{
+		{4, concurrencyReasonInitial, 10, false},
+		{8, concurrencyReasonSeeking, 11, false},
+		{4, concurrencyReasonBackoff, 10, false},
+		{5, concurrencyReasonSeeking, 10, false},
+		{4, concurrencyReasonAtOptimum, 10, false},
+		{4, concurrencyReasonFinished, 10, false}}
+
+	s.runTest(c, steps, s.noMax(), true, false)
+
+}
+
 func (s *concurrencyTunerSuite) TestConcurrencyTuner_HighBandwidth_PlentyOfCpu(c *chk.C) {
 	steps := []tunerStep{
-		{16, concurrencyReasonInitial, 1000, false},
+		{4, concurrencyReasonInitial, 400, false},
+		{8, concurrencyReasonSeeking, 800, false},
+		{16, concurrencyReasonSeeking, 1000, false},
 		{32, concurrencyReasonSeeking, 3000, false},
 		{64, concurrencyReasonSeeking, 6000, false},
 		{128, concurrencyReasonSeeking, 12000, false},
@@ -72,7 +89,9 @@ func (s *concurrencyTunerSuite) TestConcurrencyTuner_HighBandwidth_PlentyOfCpu(c
 
 func (s *concurrencyTunerSuite) TestConcurrencyTuner_HighBandwidth_ConstrainedCpu(c *chk.C) {
 	steps := []tunerStep{
-		{16, concurrencyReasonInitial, 1000, false},
+		{4, concurrencyReasonInitial, 400, false},
+		{8, concurrencyReasonSeeking, 800, false},
+		{16, concurrencyReasonSeeking, 1000, false},
 		{32, concurrencyReasonSeeking, 3000, false},
 		{64, concurrencyReasonSeeking, 6000, false},
 		{128, concurrencyReasonSeeking, 12000, true}, // high CPU doesn't stop it probing higher, but does change the final status
@@ -89,7 +108,9 @@ func (s *concurrencyTunerSuite) TestConcurrencyTuner_HighBandwidth_ConstrainedCp
 
 func (s *concurrencyTunerSuite) TestConcurrencyTuner_CapMaxConcurrency(c *chk.C) {
 	steps := []tunerStep{
-		{16, concurrencyReasonInitial, 1000, false},
+		{4, concurrencyReasonInitial, 400, false},
+		{8, concurrencyReasonSeeking, 800, false},
+		{16, concurrencyReasonSeeking, 1000, false},
 		{32, concurrencyReasonSeeking, 2000, false},
 		{64, concurrencyReasonSeeking, 4000, false},
 		{100, concurrencyReasonHitMax, 8000, false}, // NOT "at optimum"
@@ -101,7 +122,9 @@ func (s *concurrencyTunerSuite) TestConcurrencyTuner_CapMaxConcurrency(c *chk.C)
 
 func (s *concurrencyTunerSuite) TestConcurrencyTuner_OptimalValueNotNearStandardSteps(c *chk.C) {
 	steps := []tunerStep{
-		{16, concurrencyReasonInitial, 100, false},
+		{4, concurrencyReasonInitial, 200, false},
+		{8, concurrencyReasonSeeking, 400, false},
+		{16, concurrencyReasonSeeking, 800, false},
 		{32, concurrencyReasonSeeking, 1000, false},
 		{64, concurrencyReasonSeeking, 2000, false},
 		{128, concurrencyReasonSeeking, 5000, false},
@@ -122,7 +145,9 @@ func (s *concurrencyTunerSuite) TestConcurrencyTuner_OptimalValueNotNearStandard
 
 func (s *concurrencyTunerSuite) TestConcurrencyTuner_HighBandwidthWorkaround_AppliesWhenBenchmarking(c *chk.C) {
 	steps := []tunerStep{
-		{16, concurrencyReasonInitial, 4000, false},
+		{4, concurrencyReasonInitial, 1000, false},
+		{8, concurrencyReasonSeeking, 2000, false},
+		{16, concurrencyReasonSeeking, 4000, false},
 		{32, concurrencyReasonSeeking, 10900, false},
 		{64, concurrencyReasonSeeking, 11100, false},  // this would cause backoff if not for workaround
 		{128, concurrencyReasonSeeking, 11600, false}, // instead it tries higher...
@@ -134,7 +159,9 @@ func (s *concurrencyTunerSuite) TestConcurrencyTuner_HighBandwidthWorkaround_App
 
 func (s *concurrencyTunerSuite) TestConcurrencyTuner_HighBandwidthWorkaround_DoesntApplyWhenNotBenchmarking(c *chk.C) {
 	steps := []tunerStep{
-		{16, concurrencyReasonInitial, 4000, false},
+		{4, concurrencyReasonInitial, 1000, false},
+		{8, concurrencyReasonSeeking, 2000, false},
+		{16, concurrencyReasonSeeking, 4000, false},
 		{32, concurrencyReasonSeeking, 10900, false},
 		{64, concurrencyReasonSeeking, 11100, false},
 		{32, concurrencyReasonBackoff, 11600, false},
@@ -145,7 +172,9 @@ func (s *concurrencyTunerSuite) TestConcurrencyTuner_HighBandwidthWorkaround_Doe
 
 func (s *concurrencyTunerSuite) TestConcurrencyTuner__HighBandwidthWorkaround_StaysHighIfSeesRetries(c *chk.C) {
 	steps := []tunerStep{
-		{16, concurrencyReasonInitial, 4000, false},
+		{4, concurrencyReasonInitial, 1000, false},
+		{8, concurrencyReasonSeeking, 2000, false},
+		{16, concurrencyReasonSeeking, 4000, false},
 		{32, concurrencyReasonSeeking, 10900, false},
 		{64, concurrencyReasonSeeking, 11100, false},    // this would cause backoff if not for workaround
 		{128, concurrencyReasonSeeking, 11600, false},   // instead it tries higher...
@@ -156,7 +185,7 @@ func (s *concurrencyTunerSuite) TestConcurrencyTuner__HighBandwidthWorkaround_St
 }
 
 func (s *concurrencyTunerSuite) runTest(c *chk.C, steps []tunerStep, maxConcurrency int, isBenchmarking bool, simulateRetries bool) {
-	t := NewAutoConcurrencyTuner(16, maxConcurrency, isBenchmarking)
+	t := NewAutoConcurrencyTuner(4, maxConcurrency, isBenchmarking)
 	observedMbps := -1 // there's no observation at first
 	observedHighCpu := false
 


### PR DESCRIPTION
To better accomodate very low bandwidth networks.

We've had a few bug reports from folks with big machines (high CPU count) running of very small networks (or low-capacity proxies) and reporting problems.  This fix should help if they choose to use AUTO concurrency level, since now we'll start seeking optimum from 4 connections instead of 8 (where 8 might already be too many).

I did wonder about trying 2, but that adds one more step (and so even more time) to the tuning process for high speed cases, and 4 seems pretty low.  If you think I should make it 2, let me know.