### PR TITLE
Infer strip-top-dir by trailing wildcard

### DIFF
--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -127,7 +127,6 @@ func (raw rawBenchmarkCmdArgs) cook() (cookedCopyCmdArgs, error) {
 	if err != nil {
 		return dummyCooked, err
 	}
-	c.stripTopDir = true // prevent processor from trying to append part of our source URL to the destination (since our source isn't a real URL in benchmarking)
 
 	c.recursive = true                                     // because source is directory-like, in which case recursive is required
 	c.forceWrite = common.EOverwriteOption.True().String() // don't want the extra round trip (for overwrite check) when benchmarking
@@ -171,7 +170,7 @@ func (raw rawBenchmarkCmdArgs) appendVirtualDir(target, virtualDir string) (stri
 		if p.ContainerName == "" || p.BlobName != "" {
 			return "", errors.New("the blob target must be a container")
 		}
-		p.BlobName = virtualDir + "/"
+		p.BlobName = virtualDir + "/*" // Append /* to imply strip-top-dir
 		result = p.URL()
 
 	case common.ELocation.File():
@@ -181,7 +180,7 @@ func (raw rawBenchmarkCmdArgs) appendVirtualDir(target, virtualDir string) (stri
 		if p.ShareName == "" || p.DirectoryOrFilePath != "" {
 			return "", errors.New("the Azure Files target must be a file share root")
 		}
-		p.DirectoryOrFilePath = virtualDir + "/"
+		p.DirectoryOrFilePath = virtualDir + "/*" // Append /* to imply strip-top-dir
 		result = p.URL() */
 
 	case common.ELocation.BlobFS():
@@ -191,7 +190,7 @@ func (raw rawBenchmarkCmdArgs) appendVirtualDir(target, virtualDir string) (stri
 		if p.FileSystemName == "" || p.DirectoryOrFilePath != "" {
 			return "", errors.New("the blobFS target must be a file system")
 		}
-		p.DirectoryOrFilePath = virtualDir + "/"
+		p.DirectoryOrFilePath = virtualDir + "/*" // Append /* to imply strip-top-dir
 		result = p.URL()*/
 	default:
 		return "", errors.New("benchmarking only supports https connections to Blob, Azure Files, and ADLSGen2")

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -80,7 +80,6 @@ type rawCopyCmdArgs struct {
 	// filters from flags
 	listOfFilesToCopy string
 	recursive         bool
-	stripTopDir       bool
 	followSymlinks    bool
 	autoDecompress    bool
 	// forceWrite flag is used to define the User behavior
@@ -183,8 +182,6 @@ func (raw rawCopyCmdArgs) cookWithId(jobId common.JobID) (cookedCopyCmdArgs, err
 	cooked.destination = raw.dst
 
 	cooked.fromTo = fromTo
-
-	cooked.stripTopDir = raw.stripTopDir
 
 	// Check if source has a trailing wildcard on a URL
 	if fromTo.From().IsRemote() {
@@ -1400,7 +1397,6 @@ func init() {
 	rootCmd.AddCommand(cpCmd)
 
 	// filters change which files get transferred
-	cpCmd.PersistentFlags().BoolVar(&raw.stripTopDir, "strip-top-dir", false, "strip the source's root folder from the destination path, akin to \"cp dir/*\". E.g. sourcedir/subdir1/file1 copies to subdir1/file1 on destination; whereas without --strip-top-dir, it copies to sourcedir/subdir1/file1. May be used with and without --recursive. Without --recursive, just copies files under the folder but does not recurse into sub-directories")
 	cpCmd.PersistentFlags().BoolVar(&raw.followSymlinks, "follow-symlinks", false, "follow symbolic links when uploading from local file system.")
 	cpCmd.PersistentFlags().StringVar(&raw.include, "include-pattern", "", "only include these files when copying. "+
 		"Support use of *. Files should be separated with ';'.")

--- a/cmd/helpMessages.go
+++ b/cmd/helpMessages.go
@@ -76,11 +76,16 @@ Download a single file with a SAS using piping (block blobs only):
 Download an entire directory with a SAS:
   - azcopy cp "https://[account].blob.core.windows.net/[container]/[path/to/directory]?[SAS]" "/path/to/dir" --recursive=true
 
+A note about wildcards in URLs:
+
+The only usage of a wildcard in a URL that is supported is the final, trailing /*, and in the container name when not specifying a blob name.
+If you happen to use the character * in the name of a blob, please manually encode it to %2A to avoid it being treated as a wildcard character.
+
 Download a set of files with a SAS using wildcards:
-  - azcopy cp "https://[account].blob.core.windows.net/[container]/foo*?[SAS]" "/path/to/dir"
+  - azcopy cp "https://[account].blob.core.windows.net/[container]/*?[SAS]" "/path/to/dir"
 
 Download files and directories with a SAS using wildcards:
-  - azcopy cp "https://[account].blob.core.windows.net/[container]/foo*?[SAS]" "/path/to/dir" --recursive=true
+  - azcopy cp "https://[account].blob.core.windows.net/[container]/*?[SAS]" "/path/to/dir" --recursive=true
 
 Copy a single blob with SAS to another blob with SAS:
   - azcopy cp "https://[srcaccount].blob.core.windows.net/[container]/[path/to/blob]?[SAS]" "https://[destaccount].blob.core.windows.net/[container]/[path/to/blob]?[SAS]"

--- a/cmd/helpMessages.go
+++ b/cmd/helpMessages.go
@@ -81,11 +81,14 @@ A note about wildcards in URLs:
 The only usage of a wildcard in a URL that is supported is the final, trailing /*, and in the container name when not specifying a blob name.
 If you happen to use the character * in the name of a blob, please manually encode it to %2A to avoid it being treated as a wildcard character.
 
-Download a set of files with a SAS using wildcards:
-  - azcopy cp "https://[account].blob.core.windows.net/[container]/*?[SAS]" "/path/to/dir"
+Download the contents of a folder directly to the destination (rather than under a sub-directory):
+ - azcopy cp "https://[srcaccount].blob.core.windows.net/[container]/[path/to/folder]/*?[SAS]" "/path/to/dir"
 
-Download files and directories with a SAS using wildcards:
-  - azcopy cp "https://[account].blob.core.windows.net/[container]/*?[SAS]" "/path/to/dir" --recursive=true
+Download an entire storage account at once
+ - azcopy cp "https://[srcaccount].blob.core.windows.net/" "/path/to/dir" --recursive
+
+Download an entire storage account at once with a wildcarded container name
+ - azcopy cp "https://[srcaccount].blob.core.windows.net/[container*name]" "/path/to/dir" --recursive
 
 Copy a single blob with SAS to another blob with SAS:
   - azcopy cp "https://[srcaccount].blob.core.windows.net/[container]/[path/to/blob]?[SAS]" "https://[destaccount].blob.core.windows.net/[container]/[path/to/blob]?[SAS]"

--- a/cmd/zt_copy_blob_download_test.go
+++ b/cmd/zt_copy_blob_download_test.go
@@ -422,9 +422,9 @@ func (s *cmdIntegrationSuite) TestDownloadBlobContainerWithPattern(c *chk.C) {
 
 	// construct the raw input to simulate user input
 	rawContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, containerName)
+	rawContainerURLWithSAS.Path += "/*" // imply strip-top-dir
 	raw := getDefaultCopyRawInput(rawContainerURLWithSAS.String(), dstDirName)
 	raw.recursive = true
-	raw.stripTopDir = true
 	raw.include = "*.pdf"
 
 	runCopyAndVerify(c, raw, func(err error) {

--- a/common/genericResourceURLParts.go
+++ b/common/genericResourceURLParts.go
@@ -1,0 +1,116 @@
+package common
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/Azure/azure-storage-blob-go/azblob"
+	"github.com/Azure/azure-storage-file-go/azfile"
+
+	"github.com/Azure/azure-storage-azcopy/azbfs"
+)
+
+// GenericResourceURLParts is intended to be a generic solution to code duplication when using *URLParts
+// TODO: Consider returning to a "common" package structure for our SDKs
+//       (or, if we don't want to rely on a common package, create one that unifies URLParts and such into interfaces)
+//       The experience of trying to avoid code dupe is frankly quite poor and tends to result in more code dupe.
+// TODO #2: Use this to reduce code dupe in the cca.Source and jobPartOrder.Source setups
+// Currently this just contains generic functions for what we *need*. This isn't an overarching, perfect implementation.
+// The above suggestion would be preferable to continuing to expand this (due to 4x code dupe for every function)-- it's just a bridge over a LARGE gap for now.
+type GenericResourceURLParts struct {
+	location     Location // underlying location selects which URLParts we're using
+	blobURLParts azblob.BlobURLParts
+	fileURLParts azfile.FileURLParts
+	bfsURLParts  azbfs.BfsURLParts
+	s3URLParts   S3URLParts
+}
+
+func NewGenericResourceURLParts(resourceURL url.URL, location Location) GenericResourceURLParts {
+	g := GenericResourceURLParts{location: location}
+
+	switch location {
+	case ELocation.Blob():
+		g.blobURLParts = azblob.NewBlobURLParts(resourceURL)
+	case ELocation.File():
+		g.fileURLParts = azfile.NewFileURLParts(resourceURL)
+	case ELocation.BlobFS():
+		g.bfsURLParts = azbfs.NewBfsURLParts(resourceURL)
+	case ELocation.S3():
+		var err error
+		g.s3URLParts, err = NewS3URLParts(resourceURL)
+		PanicIfErr(err)
+
+	default:
+		panic(fmt.Sprintf("%s is an invalid location for GenericResourceURLParts", g.location))
+	}
+
+	return g
+}
+
+func (g GenericResourceURLParts) GetObjectName() string {
+	switch g.location {
+	case ELocation.Blob():
+		return g.blobURLParts.BlobName
+	case ELocation.File():
+		return g.fileURLParts.DirectoryOrFilePath
+	case ELocation.BlobFS():
+		return g.bfsURLParts.DirectoryOrFilePath
+	case ELocation.S3():
+		return g.s3URLParts.ObjectKey
+
+	default:
+		panic(fmt.Sprintf("%s is an invalid location for GenericResourceURLParts", g.location))
+	}
+}
+
+func (g *GenericResourceURLParts) SetObjectName(objectName string) {
+	switch g.location {
+	case ELocation.Blob():
+		g.blobURLParts.BlobName = objectName
+	case ELocation.File():
+		g.fileURLParts.DirectoryOrFilePath = objectName
+	case ELocation.BlobFS():
+		g.bfsURLParts.DirectoryOrFilePath = objectName
+	case ELocation.S3():
+		g.s3URLParts.ObjectKey = objectName
+
+	default:
+		panic(fmt.Sprintf("%s is an invalid location for GenericResourceURLParts", g.location))
+	}
+}
+
+func (g GenericResourceURLParts) String() string {
+	var URLOut url.URL
+
+	switch g.location {
+	case ELocation.S3():
+		return g.s3URLParts.String()
+
+	case ELocation.Blob():
+		URLOut = g.blobURLParts.URL()
+	case ELocation.File():
+		URLOut = g.fileURLParts.URL()
+	case ELocation.BlobFS():
+		URLOut = g.bfsURLParts.URL()
+
+	default:
+		panic(fmt.Sprintf("%s is an invalid location for GenericResourceURLParts", g.location))
+	}
+
+	return URLOut.String()
+}
+
+func (g GenericResourceURLParts) URL() url.URL {
+	switch g.location {
+	case ELocation.Blob():
+		return g.blobURLParts.URL()
+	case ELocation.File():
+		return g.fileURLParts.URL()
+	case ELocation.BlobFS():
+		return g.bfsURLParts.URL()
+	case ELocation.S3():
+		return g.s3URLParts.URL()
+	default:
+		panic(fmt.Sprintf("%s is an invalid location for GenericResourceURLParts", g.location))
+	}
+}

--- a/common/genericResourceURLParts.go
+++ b/common/genericResourceURLParts.go
@@ -47,6 +47,22 @@ func NewGenericResourceURLParts(resourceURL url.URL, location Location) GenericR
 	return g
 }
 
+func (g GenericResourceURLParts) GetContainerName() string {
+	switch g.location {
+	case ELocation.Blob():
+		return g.blobURLParts.ContainerName
+	case ELocation.File():
+		return g.fileURLParts.ShareName
+	case ELocation.BlobFS():
+		return g.bfsURLParts.FileSystemName
+	case ELocation.S3():
+		return g.s3URLParts.BucketName
+
+	default:
+		panic(fmt.Sprintf("%s is an invalid location for GenericResourceURLParts", g.location))
+	}
+}
+
 func (g GenericResourceURLParts) GetObjectName() string {
 	switch g.location {
 	case ELocation.Blob():

--- a/common/genericResourceURLParts.go
+++ b/common/genericResourceURLParts.go
@@ -11,10 +11,7 @@ import (
 )
 
 // GenericResourceURLParts is intended to be a generic solution to code duplication when using *URLParts
-// TODO: Consider returning to a "common" package structure for our SDKs
-//       (or, if we don't want to rely on a common package, create one that unifies URLParts and such into interfaces)
-//       The experience of trying to avoid code dupe is frankly quite poor and tends to result in more code dupe.
-// TODO #2: Use this to reduce code dupe in the cca.Source and jobPartOrder.Source setups
+// TODO: Use this to reduce code dupe in the cca.Source and jobPartOrder.Source setups
 // Currently this just contains generic functions for what we *need*. This isn't an overarching, perfect implementation.
 // The above suggestion would be preferable to continuing to expand this (due to 4x code dupe for every function)-- it's just a bridge over a LARGE gap for now.
 type GenericResourceURLParts struct {

--- a/testSuite/scripts/test_blob_download.py
+++ b/testSuite/scripts/test_blob_download.py
@@ -133,7 +133,8 @@ class Blob_Download_User_Scenario(unittest.TestCase):
 
     def test_blob_download_with_special_characters(self):
         filename_special_characters = "abc|>rd*"
-        resource_url = util.get_resource_sas(filename_special_characters)
+        # encode filename beforehand to avoid erroring out
+        resource_url = util.get_resource_sas(filename_special_characters.replace("*", "%2A"))
         # creating the file with random characters and with file name having special characters.
         result = util.Command("create").add_arguments(resource_url).add_flags("serviceType", "Blob").add_flags(
             "resourceType", "SingleFile").add_flags("blob-size", "1024").execute_azcopy_verify()

--- a/testSuite/scripts/test_blob_download.py
+++ b/testSuite/scripts/test_blob_download.py
@@ -269,10 +269,10 @@ class Blob_Download_User_Scenario(unittest.TestCase):
         self.assertEquals(result, False)
 
         # create the resource sas
-        dir_sas = util.get_resource_sas(dir_name)
+        dir_sas = util.get_resource_sas(dir_name + "/*")
         #download the directory
-        result = util.Command("copy").add_arguments(dir_sas).add_arguments(dir_path).\
-            add_flags("strip-top-dir", "true").add_flags("log-level", "Info").add_flags("output-type","json").\
+        result = util.Command("copy").add_arguments(dir_sas).add_arguments(dir_path). \
+            add_flags("log-level", "Info").add_flags("output-type","json").\
             execute_azcopy_copy_command_get_output()
         # parse the result to get the last job progress summary
         result = util.parseAzcopyOutput(result)
@@ -289,10 +289,10 @@ class Blob_Download_User_Scenario(unittest.TestCase):
         self.assertEquals(x.TransfersFailed, 0)
 
         # create the resource sas
-        dir_sas = util.get_resource_sas(dir_name + "/sub_dir_download_wildcard_recursive_false_1")
+        dir_sas = util.get_resource_sas(dir_name + "/sub_dir_download_wildcard_recursive_false_1/*")
         result = util.Command("copy").add_arguments(dir_sas).add_arguments(dir_path).\
-            add_flags("strip-top-dir", "true").add_flags("log-level", "Info").add_flags("output-type","json").\
-            add_flags("include-pattern", "*.txt").execute_azcopy_copy_command_get_output()
+            add_flags("log-level", "Info").add_flags("output-type","json").add_flags("include-pattern", "*.txt").\
+            execute_azcopy_copy_command_get_output()
         #download the directory
         # parse the result to get the last job progress summary
         result = util.parseAzcopyOutput(result)
@@ -337,11 +337,10 @@ class Blob_Download_User_Scenario(unittest.TestCase):
         self.assertTrue(result)
 
         # create the resource sas
-        dir_sas_with_wildcard = util.get_resource_sas(dir_name)
+        dir_sas_with_wildcard = util.get_resource_sas(dir_name + "/*")
         #download the directory
         result = util.Command("copy").add_arguments(dir_sas_with_wildcard).add_arguments(dir_path). \
-            add_flags("log-level", "Info").add_flags("strip-top-dir", "true").\
-            add_flags("output-type","json").add_flags("recursive","true").\
+            add_flags("log-level", "Info").add_flags("output-type", "json").add_flags("recursive", "true").\
             execute_azcopy_copy_command_get_output()
         # parse the result to get the last job progress summary
         result = util.parseAzcopyOutput(result)
@@ -358,12 +357,11 @@ class Blob_Download_User_Scenario(unittest.TestCase):
         self.assertEquals(x.TransfersFailed, 0)
 
         # create the resource sas
-        dir_sas_with_wildcard = util.get_resource_sas(dir_name)
+        dir_sas_with_wildcard = util.get_resource_sas(dir_name + "/*")
         # download the directory
         result = util.Command("copy").add_arguments(dir_sas_with_wildcard).add_arguments(dir_path). \
-            add_flags("log-level", "Info").add_flags("output-type","json").add_flags("strip-top-dir", "true").\
-            add_flags("recursive", "true").add_flags("include-path", "logs/;abc/").\
-            execute_azcopy_copy_command_get_output()
+            add_flags("log-level", "Info").add_flags("output-type", "json").add_flags("recursive", "true").\
+            add_flags("include-path", "logs/;abc/").execute_azcopy_copy_command_get_output()
         # parse the result to get the last job progress summary
         result = util.parseAzcopyOutput(result)
         try:

--- a/testSuite/scripts/test_file_download.py
+++ b/testSuite/scripts/test_file_download.py
@@ -59,6 +59,7 @@ class FileShare_Download_User_Scenario(unittest.TestCase):
 
         # downloading the uploaded file
         src = util.get_resource_sas_from_share(filename)
+        src_wildcard = util.get_resource_sas_from_share("*")
         dest = util.test_directory_path + "/test_upload_download_1kb_file_wildcard_all_files_dir"
         try:
             if os.path.exists(dest) and os.path.isdir(dest):
@@ -68,8 +69,8 @@ class FileShare_Download_User_Scenario(unittest.TestCase):
         finally:
             os.makedirs(dest)
 
-        result = util.Command("copy").add_arguments(src).add_arguments(dest). \
-            add_flags("log-level", "info").add_flags("recursive", "true").add_flags("strip-top-dir", "true"). \
+        result = util.Command("copy").add_arguments(src_wildcard).add_arguments(dest). \
+            add_flags("log-level", "info").add_flags("include-pattern", filename.replace("wildcard", "*")). \
             execute_azcopy_copy_command()
         self.assertTrue(result)
 

--- a/testSuite/scripts/test_service_to_service_copy.py
+++ b/testSuite/scripts/test_service_to_service_copy.py
@@ -731,7 +731,7 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
             srcFileURL = util.get_object_without_sas(srcBucketURL, filename)
         else:
             srcFileURL = util.get_object_sas(srcBucketURL, filename)
-        src_dir_url = srcFileURL.replace(filename, "")
+        src_dir_url = srcFileURL.replace(filename, "*")
 
         # Upload file.
         self.util_upload_to_src(file_path, srcType, srcFileURL, False)
@@ -739,11 +739,11 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
         # Copy file using azcopy from srcURL to destURL
         if recursive:
             result = util.Command("copy").add_arguments(src_dir_url).add_arguments(dstBucketURL). \
-                add_flags("log-level", "info").add_flags("recursive", "true").add_flags("strip-top-dir", "true"). \
+                add_flags("log-level", "info").add_flags("recursive", "true"). \
                 execute_azcopy_copy_command()
         else:
             result = util.Command("copy").add_arguments(src_dir_url).add_arguments(dstBucketURL). \
-                add_flags("log-level", "info").add_flags("strip-top-dir", "true").execute_azcopy_copy_command()
+                add_flags("log-level", "info").execute_azcopy_copy_command()
         self.assertTrue(result)
 
         # Downloading the copied files for validation
@@ -842,21 +842,21 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
         self.util_upload_to_src(src_dir_path, srcType, srcBucketURL, True)
         
         if srcType == "S3":
-            src_dir_url = util.get_object_without_sas(srcBucketURL, src_dir_name)
+            src_dir_url = util.get_object_without_sas(srcBucketURL, src_dir_name + "/*")
         else:
-            src_dir_url = util.get_object_sas(srcBucketURL, src_dir_name)
+            src_dir_url = util.get_object_sas(srcBucketURL, src_dir_name + "/*")
 
         dstDirURL = util.get_object_sas(dstBucketURL, src_dir_name)
         if recursive:
             # Copy files using azcopy from srcURL to destURL
             result = util.Command("copy").add_arguments(src_dir_url).add_arguments(dstDirURL). \
-                add_flags("log-level", "info").add_flags("recursive", "true").add_flags("strip-top-dir", "true"). \
+                add_flags("log-level", "info").add_flags("recursive", "true"). \
                 execute_azcopy_copy_command()
             self.assertTrue(result)
         else:
             # Copy files using azcopy from srcURL to destURL
             result = util.Command("copy").add_arguments(src_dir_url).add_arguments(dstDirURL). \
-                add_flags("log-level", "info").add_flags("strip-top-dir", "true").execute_azcopy_copy_command()
+                add_flags("log-level", "info").execute_azcopy_copy_command()
             self.assertTrue(result) 
 
         # Downloading the copied files for validation


### PR DESCRIPTION
Introduces a generic URLParts for all resources. It's intended to give us just what we need to reduce code duplication for now, and includes a general SDK suggestion for the go devex.