### PR TITLE
Make rand seeding clearer and predictable

### DIFF
--- a/cmd/copyEnumeratorHelper.go
+++ b/cmd/copyEnumeratorHelper.go
@@ -52,7 +52,6 @@ func addTransfer(e *common.CopyJobPartOrderRequest, transfer common.CopyTransfer
 // this is done to avoid hitting the same partition continuously in an append only pattern
 // TODO this should probably be removed after the high throughput block blob feature is implemented on the service side
 func shuffleTransfers(transfers []common.CopyTransfer) {
-	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(transfers), func(i, j int) { transfers[i], transfers[j] = transfers[j], transfers[i] })
 }
 

--- a/common/randomDataGenerator.go
+++ b/common/randomDataGenerator.go
@@ -36,7 +36,7 @@ var randomDataBytePool = NewMultiSizeSlicePool(randomSliceLength)
 func NewRandomDataGenerator(length int64) CloseableReaderAt {
 	r := &randomDataGenerator{
 		length:    length,
-		randGen:   rand.New(rand.NewSource(rand.Int63())),
+		randGen:   rand.New(rand.NewSource(rand.Int63())), // create new rand source, seeded from global one, so that after seeding we never lock the global one
 		randBytes: randomDataBytePool.RentSlice(randomSliceLength),
 		randMu:    &sync.Mutex{}}
 

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ package main
 
 import (
 	"log"
+	"math/rand"
 	"os"
 	"path"
 	"runtime"
@@ -38,6 +39,8 @@ var glcm = common.GetLifecycleMgr()
 
 func main() {
 	pipeline.SetLogSanitizer(common.NewAzCopyLogSanitizer()) // make sure ForceLog logs get secrets redacted
+
+	rand.Seed(time.Now().UnixNano()) // make sure our random numbers actually are random (but remember, use crypto/rand for anything where strong/reliable randomness is required
 
 	// note: azcopyAppPathFolder is the default location for all AzCopy data (logs, job plans, oauth token on Windows)
 	// but both logs and job plans can be put elsewhere as they can become very large


### PR DESCRIPTION
By moving out of shuffleTransfers and into startup code.  

Previously, the randomness of our random numbers was relying on a side-effect of the shuffling of transfers, which seemed wrong.