### PR TITLE
Fix/unit test failures

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,8 +73,9 @@ jobs:
           # -timeout 40m as our tests typically run between 10-15m and I'd rather have some headroom. (updated to 40 min 1 Oct 2019, was 25)
           # Race detection parameter, -race, removed, 1 Oct 2019, to bring down execution time
           # Also removed -cover, since we are not currently using the output of that from automated builds
+          # Check.v = verbose with gocheck
           set -e
-          go test -timeout 40m -short -v ./cmd ./common ./ste ./azbfs
+          go test -timeout 40m -short ./cmd ./common ./ste ./azbfs "-check.v" 
           GOARCH=amd64 GOOS=linux go build -o azcopy_linux_amd64
         name: 'Run_unit_tests'
         env:

--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -270,7 +270,7 @@ func (cca *cookedCopyCmdArgs) initModularFilters() []objectFilter {
 	filters := make([]objectFilter, 0) // same as []objectFilter{} under the hood
 
 	if len(cca.includePatterns) != 0 {
-		filters = append(filters, &includeFilter{patterns: cca.includePatterns})
+		filters = append(filters, &includeFilter{patterns: cca.includePatterns}) // TODO should this call buildIncludeFilters?
 	}
 
 	if len(cca.excludePatterns) != 0 {

--- a/cmd/zt_copy_blob_download_test.go
+++ b/cmd/zt_copy_blob_download_test.go
@@ -422,8 +422,10 @@ func (s *cmdIntegrationSuite) TestDownloadBlobContainerWithPattern(c *chk.C) {
 
 	// construct the raw input to simulate user input
 	rawContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, containerName)
-	rawContainerURLWithSAS.Path += "/*" // imply strip-top-dir
-	raw := getDefaultCopyRawInput(rawContainerURLWithSAS.String(), dstDirName)
+	urlString := rawContainerURLWithSAS.String()
+	// imply strip-top-dir (without the /* getting escaped by the line above)
+	urlString = strings.Replace(urlString, "?", "/*?", -1) // TODO: find a better way to do this in our tests
+	raw := getDefaultCopyRawInput(urlString, dstDirName)
 	raw.recursive = true
 	raw.include = "*.pdf"
 

--- a/cmd/zt_remove_blob_test.go
+++ b/cmd/zt_remove_blob_test.go
@@ -254,6 +254,8 @@ func (s *cmdIntegrationSuite) TestRemoveWithIncludeAndExcludeFlag(c *chk.C) {
 
 // note: list-of-files flag is used
 func (s *cmdIntegrationSuite) TestRemoveListOfBlobsAndVirtualDirs(c *chk.C) {
+	skipIfShort(c)
+
 	bsu := getBSU()
 	vdirName := "megadir"
 

--- a/cmd/zt_remove_file_test.go
+++ b/cmd/zt_remove_file_test.go
@@ -254,6 +254,8 @@ func (s *cmdIntegrationSuite) TestRemoveFilesWithIncludeAndExcludeFlag(c *chk.C)
 
 // note: list-of-files flag is used
 func (s *cmdIntegrationSuite) TestRemoveListOfFilesAndDirectories(c *chk.C) {
+	skipIfShort(c)
+
 	fsu := getFSU()
 	dirName := "megadir"
 

--- a/cmd/zt_sync_file_file_test.go
+++ b/cmd/zt_sync_file_file_test.go
@@ -31,6 +31,8 @@ import (
 
 // regular file->file sync
 func (s *cmdIntegrationSuite) TestFileSyncS2SWithSingleFile(c *chk.C) {
+	skipIfShort(c)
+
 	fsu := getFSU()
 	srcShareURL, srcShareName := createNewAzureShare(c, fsu)
 	dstShareURL, dstShareName := createNewAzureShare(c, fsu)
@@ -76,6 +78,8 @@ func (s *cmdIntegrationSuite) TestFileSyncS2SWithSingleFile(c *chk.C) {
 
 // regular share->share sync but destination is empty, so everything has to be transferred
 func (s *cmdIntegrationSuite) TestFileSyncS2SWithEmptyDestination(c *chk.C) {
+	skipIfShort(c)
+
 	fsu := getFSU()
 	srcShareURL, srcShareName := createNewAzureShare(c, fsu)
 	dstShareURL, dstShareName := createNewAzureShare(c, fsu)
@@ -122,6 +126,8 @@ func (s *cmdIntegrationSuite) TestFileSyncS2SWithEmptyDestination(c *chk.C) {
 
 // regular share->share sync but destination is identical to the source, transfers are scheduled based on lmt
 func (s *cmdIntegrationSuite) TestFileSyncS2SWithIdenticalDestination(c *chk.C) {
+	skipIfShort(c)
+
 	fsu := getFSU()
 	srcShareURL, srcShareName := createNewAzureShare(c, fsu)
 	dstShareURL, dstShareName := createNewAzureShare(c, fsu)
@@ -163,6 +169,7 @@ func (s *cmdIntegrationSuite) TestFileSyncS2SWithIdenticalDestination(c *chk.C) 
 }
 
 // regular share->share sync where destination is missing some files from source, and also has some extra files
+// include this test even if running short test suite, because it covers a lot
 func (s *cmdIntegrationSuite) TestFileSyncS2SWithMismatchedDestination(c *chk.C) {
 	fsu := getFSU()
 	srcShareURL, srcShareName := createNewAzureShare(c, fsu)
@@ -216,6 +223,8 @@ func (s *cmdIntegrationSuite) TestFileSyncS2SWithMismatchedDestination(c *chk.C)
 
 // include flag limits the scope of source/destination comparison
 func (s *cmdIntegrationSuite) TestFileSyncS2SWithIncludeFlag(c *chk.C) {
+	skipIfShort(c)
+
 	fsu := getFSU()
 	srcShareURL, srcShareName := createNewAzureShare(c, fsu)
 	dstShareURL, dstShareName := createNewAzureShare(c, fsu)
@@ -251,6 +260,8 @@ func (s *cmdIntegrationSuite) TestFileSyncS2SWithIncludeFlag(c *chk.C) {
 
 // exclude flag limits the scope of source/destination comparison
 func (s *cmdIntegrationSuite) TestFileSyncS2SWithExcludeFlag(c *chk.C) {
+	skipIfShort(c)
+
 	fsu := getFSU()
 	srcShareURL, srcShareName := createNewAzureShare(c, fsu)
 	dstShareURL, dstShareName := createNewAzureShare(c, fsu)
@@ -285,6 +296,7 @@ func (s *cmdIntegrationSuite) TestFileSyncS2SWithExcludeFlag(c *chk.C) {
 }
 
 // include and exclude flag can work together to limit the scope of source/destination comparison
+// Include this one even if running short test suite, since it covers a lot
 func (s *cmdIntegrationSuite) TestFileSyncS2SWithIncludeAndExcludeFlag(c *chk.C) {
 	fsu := getFSU()
 	srcShareURL, srcShareName := createNewAzureShare(c, fsu)
@@ -328,6 +340,8 @@ func (s *cmdIntegrationSuite) TestFileSyncS2SWithIncludeAndExcludeFlag(c *chk.C)
 
 // validate the bug fix for this scenario
 func (s *cmdIntegrationSuite) TestFileSyncS2SWithMissingDestination(c *chk.C) {
+	skipIfShort(c)
+
 	fsu := getFSU()
 	srcShareURL, srcShareName := createNewAzureShare(c, fsu)
 	dstShareURL, dstShareName := createNewAzureShare(c, fsu)
@@ -362,6 +376,8 @@ func (s *cmdIntegrationSuite) TestFileSyncS2SWithMissingDestination(c *chk.C) {
 
 // there is a type mismatch between the source and destination
 func (s *cmdIntegrationSuite) TestFileSyncS2SMismatchShareAndFile(c *chk.C) {
+	skipIfShort(c)
+
 	fsu := getFSU()
 	srcShareURL, srcShareName := createNewAzureShare(c, fsu)
 	dstShareURL, dstShareName := createNewAzureShare(c, fsu)
@@ -408,6 +424,8 @@ func (s *cmdIntegrationSuite) TestFileSyncS2SMismatchShareAndFile(c *chk.C) {
 
 // share <-> dir sync
 func (s *cmdIntegrationSuite) TestFileSyncS2SShareAndEmptyDir(c *chk.C) {
+	skipIfShort(c)
+
 	fsu := getFSU()
 	srcShareURL, srcShareName := createNewAzureShare(c, fsu)
 	dstShareURL, dstShareName := createNewAzureShare(c, fsu)
@@ -458,6 +476,8 @@ func (s *cmdIntegrationSuite) TestFileSyncS2SShareAndEmptyDir(c *chk.C) {
 
 // regular dir -> dir sync
 func (s *cmdIntegrationSuite) TestFileSyncS2SBetweenDirs(c *chk.C) {
+	skipIfShort(c)
+
 	fsu := getFSU()
 	srcShareURL, srcShareName := createNewAzureShare(c, fsu)
 	dstShareURL, dstShareName := createNewAzureShare(c, fsu)

--- a/cmd/zt_test.go
+++ b/cmd/zt_test.go
@@ -73,6 +73,12 @@ const (
 	defaultBlobFSFileSizeInBytes = 1000
 )
 
+func skipIfShort(c *chk.C) {
+	if testing.Short() { // reads the go test flag called: -short
+		c.Skip("Running -short suite")
+	}
+}
+
 // This function generates an entity name by concatenating the passed prefix,
 // the name of the test requesting the entity name, and the minute, second, and nanoseconds of the call.
 // This should make it easy to associate the entities with their test, uniquely identify


### PR DESCRIPTION
Fixes one test, and supports `go test -short` (which we use in our tests) by skipping a selection of the lengthier tests when the -short flag is used