### PR TITLE
Tighten up block list access

### DIFF
--- a/ste/sender-blockBlob.go
+++ b/ste/sender-blockBlob.go
@@ -125,6 +125,7 @@ func (s *blockBlobSenderBase) Epilogue() {
 
 	s.muBlockIDs.Lock()
 	blockIDs := s.blockIDs
+	s.blockIDs = nil // so we know for sure that only this routine has access after we release the lock (nothing else should need it now, since we're in the epilogue. Nil-ing here is just being defensive)
 	s.muBlockIDs.Unlock()
 	shouldPutBlockList := getPutListNeed(&s.atomicPutListIndicator)
 	if shouldPutBlockList == putListNeedUnknown && !jptm.WasCanceled() {


### PR DESCRIPTION
Old code was only locking the reference to the slice, not the contents. In theory it doesn't matter, because the code is in the epilogue so nothing else will access it at that time anyway. But this change makes that assumption explicit by making sure we'll be notified if the assumption is ever violated. (with an error dereferenceing the now-nil slice field)