### PR TITLE
Fault induction tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,7 @@ jobs:
         inputs:
           version: '1.13'
       - script: |
+          # Do not produce a debug artifact, as that's generated during Test_On_Ubuntu
           GOARCH=amd64 GOOS=linux go build -o "$(Build.ArtifactStagingDirectory)/azcopy_linux_amd64"
           GOARCH=amd64 GOOS=linux go build -tags "se_integration" -o "$(Build.ArtifactStagingDirectory)/azcopy_linux_se_amd64"
           GOARCH=amd64 GOOS=windows go build -o "$(Build.ArtifactStagingDirectory)/azcopy_windows_amd64.exe"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,7 +77,7 @@ jobs:
           # "-check.v" (must be after package list) outputs timings
           set -e
           go test -timeout 25m -race -short -cover ./cmd ./common ./ste ./azbfs "-check.v" 
-          GOARCH=amd64 GOOS=linux go build -o azcopy_linux_amd64
+          GOARCH=amd64 GOOS=linux go build -tags debug -o azcopy_linux_amd64
         name: 'Run_unit_tests'
         env:
           ACCOUNT_NAME: $(ACCOUNT_NAME)

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -237,11 +237,11 @@ func (raw rawCopyCmdArgs) cookWithId(jobId common.JobID) (cookedCopyCmdArgs, err
 
 	// set up CI flags if set and the prerequisite debug mode environment variable is set
 	if strings.ToLower(glcm.GetEnvironmentVariable(common.EEnvironmentVariable.AzcopyDebugMode())) == "on" {
-		ste.ADLSFlushThreshold = raw.adlsFlushThreshold
+		ste.ADLSFlushThreshold = common.Iffuint32(raw.adlsFlushThreshold <= 0, 7500, raw.adlsFlushThreshold)
 		ste.SupplyInvalidDstLength = raw.introduceLenFault
 		ste.SupplyInvalidMD5 = raw.introduceMD5Fault
 		ste.SupplyInvalidSrcTimeCheck = raw.introduceLMTFault
-	} else if raw.adlsFlushThreshold != 7500 || raw.introduceLenFault || raw.introduceMD5Fault || raw.introduceLMTFault {
+	} else if (raw.adlsFlushThreshold != 7500 && raw.adlsFlushThreshold != 0) || raw.introduceLenFault || raw.introduceMD5Fault || raw.introduceLMTFault {
 		return cooked, errors.New("cannot use debug flags without the AZCOPY_DEBUG_MODE flag set to \"on\"")
 	}
 

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -125,6 +125,10 @@ type rawCopyCmdArgs struct {
 	// specify how user wants to handle invalid metadata.
 	s2sInvalidMetadataHandleOption string
 
+	introduceMD5Fault bool
+	introduceLMTFault bool
+	introduceLenFault bool
+
 	// internal override to enforce strip-top-dir
 	internalOverrideStripTopDir bool
 }
@@ -227,6 +231,12 @@ func (raw rawCopyCmdArgs) cookWithId(jobId common.JobID) (cookedCopyCmdArgs, err
 
 	cooked := cookedCopyCmdArgs{
 		jobID: jobId,
+	}
+
+	if strings.ToLower(glcm.GetEnvironmentVariable(common.EEnvironmentVariable.AzcopyDebugMode())) == "on" {
+		ste.SupplyInvalidDstLength = raw.introduceLenFault
+		ste.SupplyInvalidMD5 = raw.introduceMD5Fault
+		ste.SupplyInvalidSrcTimeCheck = raw.introduceLMTFault
 	}
 
 	fromTo, err := validateFromTo(raw.src, raw.dst, raw.fromTo) // TODO: src/dst
@@ -1421,6 +1431,12 @@ func init() {
 	// Hide the flush-threshold flag since it is implemented only for CI.
 	cpCmd.PersistentFlags().Uint32Var(&ste.ADLSFlushThreshold, "flush-threshold", 7500, "Adjust the number of blocks to flush at once on accounts that have a hierarchical namespace.")
 	cpCmd.PersistentFlags().MarkHidden("flush-threshold")
-	cpCmd.PersistentFlags().BoolVar(&ste.SupplyInvalidSrcTimeCheck, "supply-invalid-lmt", false, "Have SIP hand off an invalid LMT to fail a transfer intentionally")
+
+	// Hide the fault induction flags as they are only implemented for CI purposes.
+	cpCmd.PersistentFlags().BoolVar(&raw.introduceLMTFault, "supply-invalid-lmt", false, "Have SIP hand off an invalid LMT to fail a transfer intentionally. In order to use this flag, please set AZCOPY_DEBUG_MODE to \"on\"")
 	cpCmd.PersistentFlags().MarkHidden("supply-invalid-lmt")
+	cpCmd.PersistentFlags().BoolVar(&raw.introduceMD5Fault, "supply-invalid-md5", false, "Intentionally damage the MD5 taken from the local file to fail a transfer. In order to use this flag, please set AZCOPY_DEBUG_MODE to \"on\"")
+	cpCmd.PersistentFlags().MarkHidden("supply-invalid-md5")
+	cpCmd.PersistentFlags().BoolVar(&raw.introduceLenFault, "supply-invalid-length", false, "Intentionally provide a false destination length to fail the transfer. In order to use this flag, please set AZCOPY_DEBUG_MODE to \"on\"")
+	cpCmd.PersistentFlags().MarkHidden("supply-invalid-length")
 }

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -241,6 +241,8 @@ func (raw rawCopyCmdArgs) cookWithId(jobId common.JobID) (cookedCopyCmdArgs, err
 		ste.SupplyInvalidDstLength = raw.introduceLenFault
 		ste.SupplyInvalidMD5 = raw.introduceMD5Fault
 		ste.SupplyInvalidSrcTimeCheck = raw.introduceLMTFault
+	} else if raw.adlsFlushThreshold != 7500 || raw.introduceLenFault || raw.introduceMD5Fault || raw.introduceLMTFault {
+		return cooked, errors.New("cannot use debug flags without the AZCOPY_DEBUG_MODE flag set to \"on\"")
 	}
 
 	fromTo, err := validateFromTo(raw.src, raw.dst, raw.fromTo) // TODO: src/dst

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -1421,4 +1421,6 @@ func init() {
 	// Hide the flush-threshold flag since it is implemented only for CI.
 	cpCmd.PersistentFlags().Uint32Var(&ste.ADLSFlushThreshold, "flush-threshold", 7500, "Adjust the number of blocks to flush at once on accounts that have a hierarchical namespace.")
 	cpCmd.PersistentFlags().MarkHidden("flush-threshold")
+	cpCmd.PersistentFlags().BoolVar(&ste.SupplyInvalidSrcTimeCheck, "supply-invalid-lmt", false, "Have SIP hand off an invalid LMT to fail a transfer intentionally")
+	cpCmd.PersistentFlags().MarkHidden("supply-invalid-lmt")
 }

--- a/cmd/copy_params_debug.go
+++ b/cmd/copy_params_debug.go
@@ -1,0 +1,14 @@
+// +build debug
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func setupDebugCpParams(cpCmd *cobra.Command, raw *rawCopyCmdArgs) {
+	cpCmd.PersistentFlags().Uint32Var(&raw.adlsFlushThreshold, "flush-threshold", 7500, "Adjust the number of blocks to flush at once on ADLS gen 2")
+	cpCmd.PersistentFlags().BoolVar(&raw.introduceLMTFault, "supply-invalid-lmt", false, "Have SIP hand off an invalid LMT to fail a transfer intentionally. In order to use this flag, please set AZCOPY_DEBUG_MODE to \"on\"")
+	cpCmd.PersistentFlags().BoolVar(&raw.introduceMD5Fault, "supply-invalid-md5", false, "Intentionally damage the MD5 taken from the local file to fail a transfer. In order to use this flag, please set AZCOPY_DEBUG_MODE to \"on\"")
+	cpCmd.PersistentFlags().BoolVar(&raw.introduceLenFault, "supply-invalid-length", false, "Intentionally provide a false destination length to fail the transfer. In order to use this flag, please set AZCOPY_DEBUG_MODE to \"on\"")
+}

--- a/cmd/copy_params_debug_fallback.go
+++ b/cmd/copy_params_debug_fallback.go
@@ -1,0 +1,6 @@
+// +build !debug
+
+package cmd
+
+// noop func; actual debug params enabled by compiling with -tags debug
+func setupDebugCpParams(CpCmd *cobra.Command, raw *rawCopyCmdArgs) {}

--- a/cmd/copy_params_debug_fallback.go
+++ b/cmd/copy_params_debug_fallback.go
@@ -2,5 +2,9 @@
 
 package cmd
 
+import (
+	"github.com/spf13/cobra"
+)
+
 // noop func; actual debug params enabled by compiling with -tags debug
 func setupDebugCpParams(CpCmd *cobra.Command, raw *rawCopyCmdArgs) {}

--- a/cmd/zt_scenario_helpers_for_test.go
+++ b/cmd/zt_scenario_helpers_for_test.go
@@ -690,6 +690,7 @@ func getDefaultCopyRawInput(src string, dst string) rawCopyCmdArgs {
 		md5ValidationOption:            common.DefaultHashValidationOption.String(),
 		s2sInvalidMetadataHandleOption: defaultS2SInvalideMetadataHandleOption.String(),
 		forceWrite:                     common.EOverwriteOption.True().String(),
+		adlsFlushThreshold:             7500,
 	}
 }
 

--- a/common/environment.go
+++ b/common/environment.go
@@ -22,6 +22,8 @@ package common
 
 import (
 	"runtime"
+
+	"github.com/Azure/azure-storage-file-go/azfile"
 )
 
 type EnvironmentVariable struct {
@@ -180,6 +182,7 @@ func (EnvironmentVariable) AwsSessionToken() EnvironmentVariable {
 // OAuthTokenInfo is only used for internal integration.
 func (EnvironmentVariable) OAuthTokenInfo() EnvironmentVariable {
 	return EnvironmentVariable{Name: "AZCOPY_OAUTH_TOKEN_INFO"}
+	azfile.NewShareURL()
 }
 
 // CredentialType is only used for internal integration.
@@ -192,5 +195,13 @@ func (EnvironmentVariable) DefaultServiceApiVersion() EnvironmentVariable {
 		Name:         "AZCOPY_DEFAULT_SERVICE_API_VERSION",
 		DefaultValue: "2018-03-28",
 		Description:  "Overrides the service API version so that AzCopy could accommodate custom environments such as Azure Stack.",
+	}
+}
+
+func (EnvironmentVariable) AzcopyDebugMode() EnvironmentVariable {
+	return EnvironmentVariable{
+		Name:         "AZCOPY_DEBUG_MODE",
+		DefaultValue: "off",
+		Description:  "Enables the use of flags that intentionally cause transfer failures. (\"on\" = enabled)",
 	}
 }

--- a/common/environment.go
+++ b/common/environment.go
@@ -22,8 +22,6 @@ package common
 
 import (
 	"runtime"
-
-	"github.com/Azure/azure-storage-file-go/azfile"
 )
 
 type EnvironmentVariable struct {

--- a/common/environment.go
+++ b/common/environment.go
@@ -182,7 +182,6 @@ func (EnvironmentVariable) AwsSessionToken() EnvironmentVariable {
 // OAuthTokenInfo is only used for internal integration.
 func (EnvironmentVariable) OAuthTokenInfo() EnvironmentVariable {
 	return EnvironmentVariable{Name: "AZCOPY_OAUTH_TOKEN_INFO"}
-	azfile.NewShareURL()
 }
 
 // CredentialType is only used for internal integration.

--- a/ste/sender-appendBlobFromLocal.go
+++ b/ste/sender-appendBlobFromLocal.go
@@ -85,5 +85,9 @@ func (u *appendBlobUploader) GetDestinationLength() (int64, error) {
 		return -1, err
 	}
 
+	if SupplyInvalidDstLength {
+		return prop.ContentLength() + 5, nil
+	}
+
 	return prop.ContentLength(), nil
 }

--- a/ste/sender-appendBlobFromURL.go
+++ b/ste/sender-appendBlobFromURL.go
@@ -82,5 +82,9 @@ func (c *urlToAppendBlobCopier) GetDestinationLength() (int64, error) {
 		return -1, err
 	}
 
+	if SupplyInvalidDstLength {
+		return properties.ContentLength() + 5, nil
+	}
+
 	return properties.ContentLength(), nil
 }

--- a/ste/sender-azureFile.go
+++ b/ste/sender-azureFile.go
@@ -161,6 +161,10 @@ func (u *azureFileSenderBase) GetDestinationLength() (int64, error) {
 		return -1, err
 	}
 
+	if SupplyInvalidDstLength {
+		return prop.ContentLength() + 5, nil
+	}
+
 	return prop.ContentLength(), nil
 }
 

--- a/ste/sender-blockBlobFromLocal.go
+++ b/ste/sender-blockBlobFromLocal.go
@@ -143,5 +143,9 @@ func (u *blockBlobUploader) GetDestinationLength() (int64, error) {
 		return -1, err
 	}
 
+	if SupplyInvalidDstLength {
+		return prop.ContentLength() + 5, nil
+	}
+
 	return prop.ContentLength(), nil
 }

--- a/ste/sender-blockBlobFromURL.go
+++ b/ste/sender-blockBlobFromURL.go
@@ -156,5 +156,9 @@ func (c *urlToBlockBlobCopier) GetDestinationLength() (int64, error) {
 		return -1, err
 	}
 
+	if SupplyInvalidDstLength {
+		return properties.ContentLength() + 5, nil
+	}
+
 	return properties.ContentLength(), nil
 }

--- a/ste/sender-pageBlobFromLocal.go
+++ b/ste/sender-pageBlobFromLocal.go
@@ -110,5 +110,9 @@ func (u *pageBlobUploader) GetDestinationLength() (int64, error) {
 		return -1, err
 	}
 
+	if SupplyInvalidDstLength {
+		return prop.ContentLength() + 5, nil
+	}
+
 	return prop.ContentLength(), nil
 }

--- a/ste/sender-pageBlobFromURL.go
+++ b/ste/sender-pageBlobFromURL.go
@@ -130,6 +130,10 @@ func (c *urlToPageBlobCopier) GetDestinationLength() (int64, error) {
 		return -1, err
 	}
 
+	if SupplyInvalidDstLength {
+		return properties.ContentLength() + 5, nil
+	}
+
 	return properties.ContentLength(), nil
 }
 

--- a/ste/sourceInfoProvider-Blob.go
+++ b/ste/sourceInfoProvider-Blob.go
@@ -62,5 +62,12 @@ func (p *blobSourceInfoProvider) GetLastModifiedTime() (time.Time, error) {
 		return time.Time{}, err
 	}
 
-	return properties.LastModified(), nil
+	lmt := properties.LastModified()
+
+	// Offset the LMT by an hour to create a invalid LMT for testing purposes.
+	if SupplyInvalidSrcTimeCheck {
+		lmt = lmt.Add(time.Hour)
+	}
+
+	return lmt, nil
 }

--- a/ste/sourceInfoProvider-File.go
+++ b/ste/sourceInfoProvider-File.go
@@ -96,5 +96,12 @@ func (p *fileSourceInfoProvider) GetLastModifiedTime() (time.Time, error) {
 		return time.Time{}, err
 	}
 
-	return properties.LastModified(), nil
+	lmt := properties.LastModified()
+
+	// Offset the LMT by an hour to create a invalid LMT for testing purposes.
+	if SupplyInvalidSrcTimeCheck {
+		lmt = lmt.Add(time.Hour)
+	}
+
+	return lmt, nil
 }

--- a/ste/sourceInfoProvider-Local.go
+++ b/ste/sourceInfoProvider-Local.go
@@ -68,5 +68,13 @@ func (f localFileSourceInfoProvider) GetLastModifiedTime() (time.Time, error) {
 	if err != nil {
 		return time.Time{}, err
 	}
-	return i.ModTime(), nil
+
+	lmt := i.ModTime()
+
+	// Offset the LMT by an hour to create a invalid LMT for testing purposes.
+	if SupplyInvalidSrcTimeCheck {
+		lmt = lmt.Add(time.Hour)
+	}
+
+	return lmt, nil
 }

--- a/ste/sourceInfoProvider-S3.go
+++ b/ste/sourceInfoProvider-S3.go
@@ -170,5 +170,13 @@ func (p *s3SourceInfoProvider) GetLastModifiedTime() (time.Time, error) {
 	if err != nil {
 		return time.Time{}, err
 	}
-	return objectInfo.LastModified, nil
+
+	lmt := objectInfo.LastModified
+
+	// Offset the LMT by an hour to create a invalid LMT for testing purposes.
+	if SupplyInvalidSrcTimeCheck {
+		lmt = lmt.Add(time.Hour)
+	}
+
+	return lmt, nil
 }

--- a/ste/uploader-blobFS.go
+++ b/ste/uploader-blobFS.go
@@ -227,5 +227,9 @@ func (u *blobFSUploader) GetDestinationLength() (int64, error) {
 		return -1, err
 	}
 
+	if SupplyInvalidDstLength {
+		return prop.ContentLength() + 5, nil
+	}
+
 	return prop.ContentLength(), nil
 }

--- a/ste/xfer-remoteToLocal.go
+++ b/ste/xfer-remoteToLocal.go
@@ -269,6 +269,12 @@ func epilogueWithCleanupDownload(jptm IJobPartTransferMgr, dl downloader, active
 
 		// wait until all received chunks are flushed out
 		md5OfFileAsWritten, flushError := cw.Flush(jptm.Context())
+
+		if SupplyInvalidMD5 && (jptm.MD5ValidationOption() == common.EHashValidationOption.FailIfDifferent() || jptm.MD5ValidationOption() == common.EHashValidationOption.FailIfDifferentOrMissing()) {
+			// Increment and shift first byte of MD5 to ensure damage has been done
+			md5OfFileAsWritten[0] = (md5OfFileAsWritten[0] + 1) >> 1
+		}
+
 		closeErr := activeDstFile.Close() // always try to close if, even if flush failed
 		if flushError != nil {
 			jptm.FailActiveDownload("Flushing file", flushError)

--- a/ste/xfer-remoteToLocal.go
+++ b/ste/xfer-remoteToLocal.go
@@ -308,7 +308,13 @@ func epilogueWithCleanupDownload(jptm IJobPartTransferMgr, dl downloader, active
 				jptm.FailActiveDownload("Download length check", err)
 			}
 
-			if fi.Size() != info.SourceSize {
+			fLength := fi.Size()
+
+			if SupplyInvalidDstLength {
+				fLength += 5
+			}
+
+			if fLength != info.SourceSize {
 				jptm.FailActiveDownload("Download length check", errors.New("destination length did not match source length"))
 			}
 		}

--- a/ste/xfer.go
+++ b/ste/xfer.go
@@ -38,7 +38,8 @@ const UploadTryTimeout = time.Minute * 15
 const UploadRetryDelay = time.Second * 1
 const UploadMaxRetryDelay = time.Second * 60
 
-var ADLSFlushThreshold uint32 = 7500 // The # of blocks to flush at a time-- Implemented only for CI.
+var ADLSFlushThreshold uint32 = 7500  // The # of blocks to flush at a time-- Implemented only for CI.
+var SupplyInvalidSrcTimeCheck = false // Intentionally return a false src LMT to fail a transfer-- Implemented only for CI.
 
 // download related
 const MaxRetryPerDownloadBody = 5

--- a/ste/xfer.go
+++ b/ste/xfer.go
@@ -40,6 +40,8 @@ const UploadMaxRetryDelay = time.Second * 60
 
 var ADLSFlushThreshold uint32 = 7500  // The # of blocks to flush at a time-- Implemented only for CI.
 var SupplyInvalidSrcTimeCheck = false // Intentionally return a false src LMT to fail a transfer-- Implemented only for CI.
+var SupplyInvalidMD5 = false          // Intentionally return a false local MD5 to fail a transfer-- Implemented only for CI.
+var SupplyInvalidDstLength = false    // Intentionally return a false destination length to fail a transfer-- implemented only for CI.
 
 // download related
 const MaxRetryPerDownloadBody = 5

--- a/testSuite/scripts/test_blob_download.py
+++ b/testSuite/scripts/test_blob_download.py
@@ -46,7 +46,7 @@ class Blob_Download_User_Scenario(unittest.TestCase):
         # upload 1kb using azcopy
         src = file_path
         dst = util.test_container_url
-        result = util.Command("copy").add_arguments(src).add_flags(dst). \
+        result = util.Command("copy").add_arguments(src).add_arguments(dst). \
             add_flags("log-level", "info").execute_azcopy_copy_command()
         self.assertTrue(result)
 
@@ -83,7 +83,7 @@ class Blob_Download_User_Scenario(unittest.TestCase):
         # upload 1kb using azcopy
         src = file_path
         dst = util.test_container_url
-        result = util.Command("copy").add_arguments(src).add_flags(dst). \
+        result = util.Command("copy").add_arguments(src).add_arguments(dst). \
             add_flags("log-level", "info").add_flags("put-md5", "true").execute_azcopy_copy_command()
         self.assertTrue(result)
 

--- a/testSuite/scripts/test_blobfs_upload_oauth.py
+++ b/testSuite/scripts/test_blobfs_upload_oauth.py
@@ -55,6 +55,8 @@ class BlobFs_Upload_OAuth_User_Scenarios(unittest.TestCase):
         # create test file of size 64MB
         filename = "test_uneven_multiflush_64MB_file.txt"
         file_path = util.create_test_file(filename, 64*1024*1024)
+        # enable debug mode
+        os.environ['AZCOPY_DEBUG_MODE'] = 'on'
         # Upload the file using AzCopy @ 1MB blocks, 15 block flushes (5 flushes, 4 15 blocks, 1 4 blocks)
         cmd = util.Command("copy").add_arguments(file_path).add_arguments(util.test_bfs_account_url). \
             add_flags("block-size-mb", "1").add_flags("flush-threshold", "15").add_flags("log-level", "Info")
@@ -63,6 +65,8 @@ class BlobFs_Upload_OAuth_User_Scenarios(unittest.TestCase):
             "LocalBlobFS" if explicitFromTo else "")
         result = cmd.execute_azcopy_copy_command()
         self.assertTrue(result)
+        # disable debug mode for future tests
+        os.environ['AZCOPY_DEBUG_MODE'] = 'off'
 
         # Validate the file uploaded
         fileUrl = util.test_bfs_account_url + filename
@@ -75,6 +79,8 @@ class BlobFs_Upload_OAuth_User_Scenarios(unittest.TestCase):
         # create test file of size 64MB
         filename = "test_even_multiflush_64MB_file.txt"
         file_path = util.create_test_file(filename, 64 * 1024 * 1024)
+        # enable debug mode
+        os.environ['AZCOPY_DEBUG_MODE'] = 'on'
         # Upload the file using AzCopy @ 1MB blocks, 16 block flushes (4 16 block flushes)
         cmd = util.Command("copy").add_arguments(file_path).add_arguments(util.test_bfs_account_url). \
             add_flags("block-size-mb", "1").add_flags("flush-threshold", "16").add_flags("log-level", "Info")
@@ -83,6 +89,8 @@ class BlobFs_Upload_OAuth_User_Scenarios(unittest.TestCase):
             "LocalBlobFS" if explicitFromTo else "")
         result = cmd.execute_azcopy_copy_command()
         self.assertTrue(result)
+        # disable debug mode for future tests
+        os.environ['AZCOPY_DEBUG_MODE'] = 'off'
 
         # Validate the file uploaded
         fileUrl = util.test_bfs_account_url + filename

--- a/testSuite/scripts/test_service_to_service_copy.py
+++ b/testSuite/scripts/test_service_to_service_copy.py
@@ -114,6 +114,16 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
             "Blob",
             self.bucket_name)
 
+    def test_copy_single_file_from_blob_to_blob_propertyandmetadata_in_frontend(self):
+        src_container_url = util.get_object_sas(util.test_s2s_src_blob_account_url, self.bucket_name)
+        dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
+        self.util_test_copy_single_file_from_x_to_x_propertyandmetadata(
+            src_container_url,
+            "Blob",
+            dst_container_url,
+            "Blob",
+            preservePropertiesInBackend=False)
+
     def test_copy_single_file_from_blob_to_blob_propertyandmetadata(self):
         src_container_url = util.get_object_sas(util.test_s2s_src_blob_account_url, self.bucket_name)
         dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
@@ -1027,7 +1037,8 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
         srcType,
         dstBucketURL,
         dstType,
-        preserveProperties=True):
+        preserveProperties=True,
+        preservePropertiesInBackend=False):
         # create bucket and create file with metadata and properties
         result = util.Command("create").add_arguments(srcBucketURL).add_flags("serviceType", srcType). \
             add_flags("resourceType", "Bucket").execute_azcopy_create()
@@ -1054,6 +1065,8 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
             add_flags("log-level", "info")
         if preserveProperties == False:
             cpCmd.add_flags("s2s-preserve-properties", "false")
+        if preservePropertiesInBackend == False:
+            cpCmd.add_flags("s2s-get-properties-in-backend", "false")
 
         result = cpCmd.execute_azcopy_copy_command()
         self.assertTrue(result)

--- a/testSuite/scripts/test_service_to_service_copy.py
+++ b/testSuite/scripts/test_service_to_service_copy.py
@@ -785,15 +785,13 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
         self.assertTrue(result)
 
         # Verifying the downloaded blob
-        result = filecmp.cmp(file_path, local_validate_dest, shallow=False)
         if not checkLMT == "fail":
+            result = filecmp.cmp(file_path, local_validate_dest, shallow=False)
             # Do not expect a failure
             self.assertTrue(result)
         else:
             # disable debug mode for future tests
             os.environ['AZCOPY_DEBUG_MODE'] = 'off'
-            # Expect a failure caused by supply-invalid-lmt
-            self.assertFalse(result)
 
         # clean up both source and destination bucket
         # util.Command("clean").add_arguments(srcBucketURL).add_flags("serviceType", srcType). \

--- a/testSuite/scripts/test_service_to_service_copy.py
+++ b/testSuite/scripts/test_service_to_service_copy.py
@@ -206,8 +206,7 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
             dst_container_url,
             "File",
             1,
-            checkLMT="pass"
-        )
+            checkLMT="pass")
 
     def test_copy_single_1kb_file_from_file_to_blob_fail_lmt(self):
         src_share_url = util.get_object_sas(util.test_s2s_src_file_account_url, self.bucket_name)
@@ -218,8 +217,7 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
             dst_container_url,
             "File",
             1,
-            checkLMT="fail"
-        )
+            checkLMT="fail")
 
     def test_copy_single_file_from_file_to_blob_propertyandmetadata_in_frontend(self):
         src_share_url = util.get_object_sas(util.test_s2s_src_file_account_url, self.bucket_name)

--- a/testSuite/scripts/test_service_to_service_copy.py
+++ b/testSuite/scripts/test_service_to_service_copy.py
@@ -775,9 +775,9 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
         if checkLMT == "pass":
             result.add_flags("s2s-detect-source-changed", "True")
         elif checkLMT == "fail":
+            result.add_flags("s2s-detect-source-changed", "True")
             # enable debug mode
             os.environ['AZCOPY_DEBUG_MODE'] = 'on'
-            result.add_flags("s2s-detect-source-changed", "True")
             # introduce a fault in the LMT to fail the transfer
             result.add_flags("supply-invalid-lmt", "True")
 
@@ -790,6 +790,7 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
             # Do not expect a failure
             self.assertTrue(result)
         else:
+            self.assertFalse(result)
             # disable debug mode for future tests
             os.environ['AZCOPY_DEBUG_MODE'] = 'off'
 

--- a/testSuite/scripts/test_service_to_service_copy.py
+++ b/testSuite/scripts/test_service_to_service_copy.py
@@ -114,16 +114,6 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
             "Blob",
             self.bucket_name)
 
-    def test_copy_single_file_from_blob_to_blob_propertyandmetadata_in_frontend(self):
-        src_container_url = util.get_object_sas(util.test_s2s_src_blob_account_url, self.bucket_name)
-        dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
-        self.util_test_copy_single_file_from_x_to_x_propertyandmetadata(
-            src_container_url,
-            "Blob",
-            dst_container_url,
-            "Blob",
-            preservePropertiesInBackend=False)
-
     def test_copy_single_file_from_blob_to_blob_propertyandmetadata(self):
         src_container_url = util.get_object_sas(util.test_s2s_src_blob_account_url, self.bucket_name)
         dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
@@ -230,6 +220,16 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
             1,
             checkLMT="fail"
         )
+
+    def test_copy_single_file_from_file_to_blob_propertyandmetadata_in_frontend(self):
+        src_share_url = util.get_object_sas(util.test_s2s_src_file_account_url, self.bucket_name)
+        dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name)
+        self.util_test_copy_single_file_from_x_to_x_propertyandmetadata(
+            src_share_url,
+            "File",
+            dst_container_url,
+            "Blob",
+            preservePropertiesInBackend=False)
 
     def test_copy_single_63mb_file_from_file_to_blob(self):
         src_share_url = util.get_object_sas(util.test_s2s_src_file_account_url, self.bucket_name_file_blob)

--- a/testSuite/scripts/test_service_to_service_copy.py
+++ b/testSuite/scripts/test_service_to_service_copy.py
@@ -782,7 +782,6 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
             result.add_flags("supply-invalid-lmt", "True")
 
         result = result.execute_azcopy_copy_command()
-        self.assertTrue(result)
 
         # Verifying the downloaded blob
         if not checkLMT == "fail":

--- a/testSuite/scripts/test_upload_block_blob.py
+++ b/testSuite/scripts/test_upload_block_blob.py
@@ -38,13 +38,17 @@ class Block_Upload_User_Scenarios(unittest.TestCase):
             result.add_flags("check-length", "true").add_flags("supply-invalid-length", "true")
 
         result = result.execute_azcopy_copy_command()
-        self.assertTrue(result)
+        if checkLength == "fail":
+            self.assertFalse(result)
+        else:
+            self.assertTrue(result)
 
-        # Verifying the uploaded blob.
-        # the resource local path should be the first argument for the azcopy validator.
-        # the resource sas should be the second argument for azcopy validator.
-        result = util.Command("testBlob").add_arguments(file_path).add_arguments(dest_validate).execute_azcopy_verify()
-        self.assertTrue(result)
+        if not checkLength == "fail":
+            # Verifying the uploaded blob.
+            # the resource local path should be the first argument for the azcopy validator.
+            # the resource sas should be the second argument for azcopy validator.
+            result = util.Command("testBlob").add_arguments(file_path).add_arguments(dest_validate).execute_azcopy_verify()
+            self.assertTrue(result)
 
     # test_1kb_blob_upload verifies the 1KB blob upload by azcopy.
     def test_1kb_blob_upload_with_sas(self):

--- a/testSuite/scripts/utility.py
+++ b/testSuite/scripts/utility.py
@@ -582,7 +582,7 @@ def verify_operation(command):
             command, stderr=subprocess.STDOUT, shell=True, timeout=240,
             universal_newlines=True)
     except subprocess.CalledProcessError as exec:
-        # print("command failed with error code ", exec.returncode, " and message " + exec.output)
+        print("command failed with error code ", exec.returncode, " and message " + exec.output)
         return False
     else:
         return True


### PR DESCRIPTION
Added flags (, a environment variable, and a build flag to enable them) to force a failure for things like md5 checks, LMT checks, and length checks. In order to induce the failure, we modify the property internally before handing it off to the actual check.