### PR TITLE
Check the destination length on upload/rename s2s related checklength variables to generic ones

### DIFF
--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -58,7 +58,7 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 		(cca.fromTo.From().IsRemote() && cca.fromTo.To().IsRemote() && cca.s2sPreserveProperties && !cca.s2sGetPropertiesInBackend) // If S2S and preserve properties AND get properties in backend is on, turn this off, as properties will be obtained in the backend.
 	jobPartOrder.S2SGetPropertiesInBackend = cca.s2sPreserveProperties && !getRemoteProperties && cca.s2sGetPropertiesInBackend // Infer GetProperties if GetPropertiesInBackend is enabled.
 	jobPartOrder.S2SSourceChangeValidation = cca.s2sSourceChangeValidation
-	jobPartOrder.S2SDestLengthValidation = cca.CheckLength
+	jobPartOrder.DestLengthValidation = cca.CheckLength
 	jobPartOrder.S2SInvalidMetadataHandleOption = cca.s2sInvalidMetadataHandleOption
 
 	traverser, err = initResourceTraverser(src, cca.fromTo.From(), &ctx, &srcCredInfo, &cca.followSymlinks, cca.listOfFilesChannel, cca.recursive, getRemoteProperties, func() {})

--- a/cmd/syncProcessor.go
+++ b/cmd/syncProcessor.go
@@ -58,7 +58,7 @@ func newSyncTransferProcessor(cca *cookedSyncCmdArgs, numOfTransfersPerPart int)
 		ForceWrite:                     common.EOverwriteOption.True(), // once we decide to transfer for a sync operation, we overwrite the destination regardless
 		LogLevel:                       cca.logVerbosity,
 		S2SSourceChangeValidation:      true,
-		S2SDestLengthValidation:        true,
+		DestLengthValidation:           true,
 		S2SGetPropertiesInBackend:      true,
 		S2SInvalidMetadataHandleOption: common.EInvalidMetadataHandleOption.RenameIfInvalid(),
 	}

--- a/common/rpc-models.go
+++ b/common/rpc-models.go
@@ -64,7 +64,7 @@ type CopyJobPartOrderRequest struct {
 
 	S2SGetPropertiesInBackend      bool
 	S2SSourceChangeValidation      bool
-	S2SDestLengthValidation        bool
+	DestLengthValidation           bool
 	S2SInvalidMetadataHandleOption InvalidMetadataHandleOption
 }
 

--- a/ste/JobPartPlan.go
+++ b/ste/JobPartPlan.go
@@ -63,7 +63,7 @@ type JobPartPlanHeader struct {
 	// S2SSourceChangeValidation represents whether user wants to check if source has changed after enumerating.
 	S2SSourceChangeValidation bool
 	// DestLengthValidation represents whether the user wants to check if the destination has a different content-length
-	S2SDestLengthValidation bool
+	DestLengthValidation bool
 	// S2SInvalidMetadataHandleOption represents how user wants to handle invalid metadata.
 	S2SInvalidMetadataHandleOption common.InvalidMetadataHandleOption
 
@@ -152,7 +152,7 @@ func (jpph *JobPartPlanHeader) TransferSrcPropertiesAndMetadata(transferIndex ui
 	s2sGetPropertiesInBackend = jpph.S2SGetPropertiesInBackend
 	s2sSourceChangeValidation = jpph.S2SSourceChangeValidation
 	s2sInvalidMetadataHandleOption = jpph.S2SInvalidMetadataHandleOption
-	DestLengthValidation = jpph.S2SDestLengthValidation
+	DestLengthValidation = jpph.DestLengthValidation
 
 	offset := t.SrcOffset + int64(t.SrcLength) + int64(t.DstLength)
 

--- a/ste/JobPartPlanFileName.go
+++ b/ste/JobPartPlanFileName.go
@@ -183,7 +183,7 @@ func (jpfn JobPartPlanFileName) Create(order common.CopyJobPartOrderRequest) {
 		S2SGetPropertiesInBackend:      order.S2SGetPropertiesInBackend,
 		S2SSourceChangeValidation:      order.S2SSourceChangeValidation,
 		S2SInvalidMetadataHandleOption: order.S2SInvalidMetadataHandleOption,
-		S2SDestLengthValidation:        order.S2SDestLengthValidation,
+		DestLengthValidation:           order.DestLengthValidation,
 		atomicJobStatus:                common.EJobStatus.InProgress(), // We default to InProgress
 	}
 

--- a/ste/xfer-anyToRemote.go
+++ b/ste/xfer-anyToRemote.go
@@ -318,11 +318,11 @@ func epilogueWithCleanupSendToRemote(jptm IJobPartTransferMgr, s ISenderBase, si
 		destLength, err := s.GetDestinationLength()
 
 		if err != nil {
-			jptm.FailActiveSend(common.IffString(isS2SCopier, "S2S ", "Download ")+"Length check: Get destination length", err)
+			jptm.FailActiveSend(common.IffString(isS2SCopier, "S2S ", "Upload ")+"Length check: Get destination length", err)
 		}
 
 		if destLength != jptm.Info().SourceSize {
-			jptm.FailActiveSend(common.IffString(isS2SCopier, "S2S ", "Download ")+"Length check", errors.New("destination length does not match source length"))
+			jptm.FailActiveSend(common.IffString(isS2SCopier, "S2S ", "Upload ")+"Length check", errors.New("destination length does not match source length"))
 		}
 	}
 

--- a/ste/xfer-anyToRemote.go
+++ b/ste/xfer-anyToRemote.go
@@ -314,16 +314,15 @@ func epilogueWithCleanupSendToRemote(jptm IJobPartTransferMgr, s ISenderBase, si
 	s.Epilogue() // Perform service-specific cleanup before jptm cleanup. Some services may actually require setup to make the file actually appear.
 
 	if jptm.IsLive() && info.DestLengthValidation {
-		if s2sc, isS2SCopier := s.(s2sCopier); isS2SCopier { // TODO: Implement this for upload and download?
-			destLength, err := s2sc.GetDestinationLength()
+		_, isS2SCopier := s.(s2sCopier)
+		destLength, err := s.GetDestinationLength()
 
-			if err != nil {
-				jptm.FailActiveSend("S2S Length check: Get destination length", err)
-			}
+		if err != nil {
+			jptm.FailActiveSend(common.IffString(isS2SCopier, "S2S ", "Download ")+"Length check: Get destination length", err)
+		}
 
-			if destLength != jptm.Info().SourceSize {
-				jptm.FailActiveSend("S2S Length check", errors.New("destination length does not match source length"))
-			}
+		if destLength != jptm.Info().SourceSize {
+			jptm.FailActiveSend(common.IffString(isS2SCopier, "S2S ", "Download ")+"Length check", errors.New("destination length does not match source length"))
 		}
 	}
 


### PR DESCRIPTION
This will have a merge conflict with fault induction in xfer-anyToRemote.