### PR TITLE
Skip S3 testing via env var

### DIFF
--- a/cmd/zt_copy_s2smigration_test.go
+++ b/cmd/zt_copy_s2smigration_test.go
@@ -49,6 +49,11 @@ const (
 var defaultS2SInvalideMetadataHandleOption = common.DefaultInvalidMetadataHandleOption
 
 func (s *cmdIntegrationSuite) SetUpSuite(c *chk.C) {
+	// skip cleaning up the S3 account when not necessary
+	if isS3Disabled() {
+		return
+	}
+
 	s3Client, err := createS3ClientWithMinio(createS3ResOptions{})
 
 	// If S3 credentials aren't supplied, we're probably only trying to run Azure tests.

--- a/cmd/zt_copy_s2smigration_test.go
+++ b/cmd/zt_copy_s2smigration_test.go
@@ -135,6 +135,7 @@ func printTransfers(ts []string) {
 }
 
 func (s *cmdIntegrationSuite) TestS2SCopyFromS3ToBlobWithBucketNameNeedBeResolved(c *chk.C) {
+	skipIfS3Disabled(c)
 	s3Client, err := createS3ClientWithMinio(createS3ResOptions{})
 	if err != nil {
 		c.Skip("S3 client credentials not supplied")
@@ -187,6 +188,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromS3ToBlobWithBucketNameNeedBeResolve
 }
 
 func (s *cmdIntegrationSuite) TestS2SCopyFromS3ToBlobWithWildcardInSrcAndBucketNameNeedBeResolved(c *chk.C) {
+	skipIfS3Disabled(c)
 	s3Client, err := createS3ClientWithMinio(createS3ResOptions{})
 	if err != nil {
 		c.Skip("S3 client credentials not supplied")
@@ -242,6 +244,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromS3ToBlobWithWildcardInSrcAndBucketN
 // This is negative because generateBucketNameWithCustomizedPrefix will return a bucket name with length 63,
 // and resolving logic will resolve -- to -2- which means the length to be 64. This exceeds valid container name, so error will be returned.
 func (s *cmdIntegrationSuite) TestS2SCopyFromS3ToBlobWithBucketNameNeedBeResolvedNegative(c *chk.C) {
+	skipIfS3Disabled(c)
 	s3Client, err := createS3ClientWithMinio(createS3ResOptions{})
 	if err != nil {
 		c.Skip("S3 client credentials not supplied")
@@ -281,6 +284,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromS3ToBlobWithBucketNameNeedBeResolve
 
 // Copy from virtual directory to container, with normal encoding ' ' as ' '.
 func (s *cmdIntegrationSuite) TestS2SCopyFromS3ToBlobWithSpaceInSrcNotEncoded(c *chk.C) {
+	skipIfS3Disabled(c)
 	s3Client, err := createS3ClientWithMinio(createS3ResOptions{})
 	if err != nil {
 		c.Skip("S3 client credentials not supplied")
@@ -323,6 +327,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromS3ToBlobWithSpaceInSrcNotEncoded(c 
 // '+' is handled in copy.go before extract the SourceRoot.
 // The scheduled transfer would be URL encoded no matter what's the raw source/destination provided by user.
 func (s *cmdIntegrationSuite) TestS2SCopyFromS3ToBlobWithSpaceInSrcEncodedAsPlus(c *chk.C) {
+	skipIfS3Disabled(c)
 	s3Client, err := createS3ClientWithMinio(createS3ResOptions{})
 	if err != nil {
 		c.Skip("S3 client credentials not supplied")
@@ -363,6 +368,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromS3ToBlobWithSpaceInSrcEncodedAsPlus
 
 // By design, when source directory contains objects with suffix ‘/’, objects with suffix ‘/’ should be ignored.
 func (s *cmdIntegrationSuite) TestS2SCopyFromS3ToBlobWithObjectUsingSlashAsSuffix(c *chk.C) {
+	skipIfS3Disabled(c)
 	s3Client, err := createS3ClientWithMinio(createS3ResOptions{})
 	if err != nil {
 		c.Skip("S3 client credentials not supplied")
@@ -402,6 +408,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromS3ToBlobWithObjectUsingSlashAsSuffi
 }
 
 func (s *cmdIntegrationSuite) TestS2SCopyFromS3AccountWithBucketInDifferentRegionsAndListUseDefaultEndpoint(c *chk.C) {
+	skipIfS3Disabled(c)
 	s3Client, err := createS3ClientWithMinio(createS3ResOptions{})
 	if err != nil {
 		c.Skip("S3 client credentials not supplied")
@@ -444,6 +451,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromS3AccountWithBucketInDifferentRegio
 }
 
 func (s *cmdIntegrationSuite) TestS2SCopyFromS3AccountWithBucketInDifferentRegionsAndListUseSpecificRegion(c *chk.C) {
+	skipIfS3Disabled(c)
 	specificRegion := "us-west-2"
 	s3Client, err := createS3ClientWithMinio(createS3ResOptions{})
 	if err != nil {
@@ -486,6 +494,7 @@ func (s *cmdIntegrationSuite) TestS2SCopyFromS3AccountWithBucketInDifferentRegio
 }
 
 func (s *cmdIntegrationSuite) TestS2SCopyFromS3ObjectToBlobContainer(c *chk.C) {
+	skipIfS3Disabled(c)
 	s3Client, err := createS3ClientWithMinio(createS3ResOptions{})
 	if err != nil {
 		c.Skip("S3 client credentials not supplied")

--- a/cmd/zt_generic_service_traverser_test.go
+++ b/cmd/zt_generic_service_traverser_test.go
@@ -90,7 +90,8 @@ func (s *genericTraverserSuite) TestServiceTraverserWithManyObjects(c *chk.C) {
 	fsu := getFSU()
 	testS3 := false // Only test S3 if credentials are present.
 	s3Client, err := createS3ClientWithMinio(createS3ResOptions{})
-	if err == nil {
+	// disable S3 testing
+	if err == nil && !isS3Disabled() {
 		testS3 = true
 	} else {
 		c.Log("WARNING: Service level traverser is NOT testing S3")
@@ -219,7 +220,7 @@ func (s *genericTraverserSuite) TestServiceTraverserWithWildcards(c *chk.C) {
 	bfssu := GetBFSSU()
 	testS3 := false // Only test S3 if credentials are present.
 	s3Client, err := createS3ClientWithMinio(createS3ResOptions{})
-	if err == nil {
+	if err == nil && !isS3Disabled() {
 		testS3 = true
 	} else {
 		c.Log("WARNING: Service level traverser is NOT testing S3")

--- a/cmd/zt_test.go
+++ b/cmd/zt_test.go
@@ -73,6 +73,17 @@ const (
 	defaultBlobFSFileSizeInBytes = 1000
 )
 
+// if S3_TESTS_OFF is set at all, S3 tests are disabled.
+func isS3Disabled() bool {
+	return strings.ToLower(os.Getenv("S3_TESTS_OFF")) != ""
+}
+
+func skipIfS3Disabled(c *chk.C) {
+	if isS3Disabled() {
+		c.Skip("S3 testing is disabled for this unit test suite run.")
+	}
+}
+
 // This function generates an entity name by concatenating the passed prefix,
 // the name of the test requesting the entity name, and the minute, second, and nanoseconds of the call.
 // This should make it easy to associate the entities with their test, uniquely identify
@@ -391,6 +402,10 @@ type createS3ResOptions struct {
 }
 
 func createS3ClientWithMinio(o createS3ResOptions) (*minio.Client, error) {
+	if isS3Disabled() {
+		return nil, errors.New("s3 testing is disabled")
+	}
+
 	accessKeyID := os.Getenv("AWS_ACCESS_KEY_ID")
 	secretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
 

--- a/testSuite/scripts/test_service_to_service_copy.py
+++ b/testSuite/scripts/test_service_to_service_copy.py
@@ -281,55 +281,77 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
     # Test from S3 to blob copy.
     ##################################
     def test_copy_single_1kb_file_from_s3_to_blob(self):
+        if os.environ['S3_TESTS_OFF'] != '':
+            self.skipTest('S3 testing is disabled for this smoke test run.')
         src_bucket_url = util.get_object_without_sas(util.test_s2s_src_s3_service_url, self.bucket_name_s3_blob)
         dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name_s3_blob)
         self.util_test_copy_single_file_from_x_to_x(src_bucket_url, "S3", dst_container_url, "Blob", 1)
 
     def test_copy_single_0kb_file_from_s3_to_blob(self):
+        if os.environ['S3_TESTS_OFF'] != '':
+            self.skipTest('S3 testing is disabled for this smoke test run.')
         src_bucket_url = util.get_object_without_sas(util.test_s2s_src_s3_service_url, self.bucket_name_s3_blob)
         dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name_s3_blob)
         self.util_test_copy_single_file_from_x_to_x(src_bucket_url, "S3", dst_container_url, "Blob", 0)
 
     def test_copy_single_63mb_file_from_s3_to_blob(self):
+        if os.environ['S3_TESTS_OFF'] != '':
+            self.skipTest('S3 testing is disabled for this smoke test run.')
         src_bucket_url = util.get_object_without_sas(util.test_s2s_src_s3_service_url, self.bucket_name_s3_blob)
         dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name_s3_blob)
         self.util_test_copy_single_file_from_x_to_x(src_bucket_url, "S3", dst_container_url, "Blob", 63 * 1024 * 1024)
 
     def test_copy_10_files_from_s3_bucket_to_blob_container(self):
+        if os.environ['S3_TESTS_OFF'] != '':
+            self.skipTest('S3 testing is disabled for this smoke test run.')
         src_bucket_url = util.get_object_without_sas(util.test_s2s_src_s3_service_url, self.bucket_name_s3_blob)
         dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name_s3_blob)
         self.util_test_copy_n_files_from_x_bucket_to_x_bucket(src_bucket_url, "S3", dst_container_url, "Blob")
 
     def test_copy_10_files_from_s3_bucket_to_blob_account(self):
+        if os.environ['S3_TESTS_OFF'] != '':
+            self.skipTest('S3 testing is disabled for this smoke test run.')
         src_bucket_url = util.get_object_without_sas(util.test_s2s_src_s3_service_url, self.bucket_name_s3_blob)
         self.util_test_copy_n_files_from_s3_bucket_to_blob_account(src_bucket_url, util.test_s2s_dst_blob_account_url)
 
     def test_copy_file_from_s3_bucket_to_blob_container_strip_top_dir_recursive(self):
+        if os.environ['S3_TESTS_OFF'] != '':
+            self.skipTest('S3 testing is disabled for this smoke test run.')
         src_bucket_url = util.get_object_without_sas(util.test_s2s_src_s3_service_url, self.bucket_name_s3_blob)
         dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name_s3_blob)
         self.util_test_copy_file_from_x_bucket_to_x_bucket_strip_top_dir(src_bucket_url, "S3", dst_container_url, "Blob", True)
 
     def test_copy_file_from_s3_bucket_to_blob_container_strip_top_dir_non_recursive(self):
+        if os.environ['S3_TESTS_OFF'] != '':
+            self.skipTest('S3 testing is disabled for this smoke test run.')
         src_bucket_url = util.get_object_without_sas(util.test_s2s_src_s3_service_url, self.bucket_name_s3_blob)
         dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name_s3_blob)
         self.util_test_copy_file_from_x_bucket_to_x_bucket_strip_top_dir(src_bucket_url, "S3", dst_container_url, "Blob", False)
     
     def test_copy_n_files_from_s3_dir_to_blob_dir(self):
+        if os.environ['S3_TESTS_OFF'] != '':
+            self.skipTest('S3 testing is disabled for this smoke test run.')
         src_bucket_url = util.get_object_without_sas(util.test_s2s_src_s3_service_url, self.bucket_name_s3_blob)
         dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name_s3_blob)
         self.util_test_copy_n_files_from_x_dir_to_x_dir(src_bucket_url, "S3", dst_container_url, "Blob")
 
     def test_copy_n_files_from_s3_dir_to_blob_dir_strip_top_dir_recursive(self):
+        if os.environ['S3_TESTS_OFF'] != '':
+            self.skipTest('S3 testing is disabled for this smoke test run.')
         src_bucket_url = util.get_object_without_sas(util.test_s2s_src_s3_service_url, self.bucket_name_s3_blob)
         dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name_s3_blob)
         self.util_test_copy_n_files_from_x_dir_to_x_dir_strip_top_dir(src_bucket_url, "S3", dst_container_url, "Blob", True)
 
     def test_copy_n_files_from_s3_dir_to_blob_dir_strip_top_dir_non_recursive(self):
+        if os.environ['S3_TESTS_OFF'] != '':
+            self.skipTest('S3 testing is disabled for this smoke test run.')
         src_bucket_url = util.get_object_without_sas(util.test_s2s_src_s3_service_url, self.bucket_name_s3_blob)
         dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name_s3_blob)
         self.util_test_copy_n_files_from_x_dir_to_x_dir_strip_top_dir(src_bucket_url, "S3", dst_container_url, "Blob", False)
 
     def test_copy_files_from_s3_service_to_blob_account(self):
+        if os.environ['S3_TESTS_OFF'] != '':
+            self.skipTest('S3 testing is disabled for this smoke test run.')
         self.util_test_copy_files_from_x_account_to_x_account(
             util.test_s2s_src_s3_service_url, 
             "S3", 
@@ -338,6 +360,8 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
             self.bucket_name_s3_blob)
 
     def test_copy_single_file_from_s3_to_blob_propertyandmetadata(self):
+        if os.environ['S3_TESTS_OFF'] != '':
+            self.skipTest('S3 testing is disabled for this smoke test run.')
         src_bucket_url = util.get_object_without_sas(util.test_s2s_src_s3_service_url, self.bucket_name_s3_blob)
         dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name_s3_blob)
         self.util_test_copy_single_file_from_x_to_x_propertyandmetadata(
@@ -347,6 +371,8 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
             "Blob")
 
     def test_copy_single_file_from_s3_to_blob_no_preserve_propertyandmetadata(self):
+        if os.environ['S3_TESTS_OFF'] != '':
+            self.skipTest('S3 testing is disabled for this smoke test run.')
         src_bucket_url = util.get_object_without_sas(util.test_s2s_src_s3_service_url, self.bucket_name_s3_blob)
         dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name_s3_blob)
         self.util_test_copy_single_file_from_x_to_x_propertyandmetadata(
@@ -357,6 +383,8 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
             False)
     
     def test_copy_file_from_s3_bucket_to_blob_container_propertyandmetadata(self):
+        if os.environ['S3_TESTS_OFF'] != '':
+            self.skipTest('S3 testing is disabled for this smoke test run.')
         src_bucket_url = util.get_object_without_sas(util.test_s2s_src_s3_service_url, self.bucket_name_s3_blob)
         dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name_s3_blob)
         self.util_test_copy_file_from_x_bucket_to_x_bucket_propertyandmetadata(
@@ -366,6 +394,8 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
             "Blob")
 
     def test_copy_file_from_s3_bucket_to_blob_container_no_preserve_propertyandmetadata(self):
+        if os.environ['S3_TESTS_OFF'] != '':
+            self.skipTest('S3 testing is disabled for this smoke test run.')
         src_bucket_url = util.get_object_without_sas(util.test_s2s_src_s3_service_url, self.bucket_name_s3_blob)
         dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name_s3_blob)
         self.util_test_copy_file_from_x_bucket_to_x_bucket_propertyandmetadata(
@@ -376,6 +406,8 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
             False)
 
     def test_overwrite_copy_single_file_from_s3_to_blob(self):
+        if os.environ['S3_TESTS_OFF'] != '':
+            self.skipTest('S3 testing is disabled for this smoke test run.')
         src_bucket_url = util.get_object_without_sas(util.test_s2s_src_s3_service_url, self.bucket_name_s3_blob)
         dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name_s3_blob)
         self.util_test_overwrite_copy_single_file_from_x_to_x(
@@ -387,6 +419,8 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
             True)
 
     def test_non_overwrite_copy_single_file_from_s3_to_blob(self):
+        if os.environ['S3_TESTS_OFF'] != '':
+            self.skipTest('S3 testing is disabled for this smoke test run.')
         src_bucket_url = util.get_object_without_sas(util.test_s2s_src_s3_service_url, self.bucket_name_s3_blob)
         dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name_s3_blob)
         self.util_test_overwrite_copy_single_file_from_x_to_x(
@@ -398,6 +432,8 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
             False)
 
     def test_copy_single_file_from_s3_to_blob_with_url_encoded_slash_as_filename(self):
+        if os.environ['S3_TESTS_OFF'] != '':
+            self.skipTest('S3 testing is disabled for this smoke test run.')
         src_bucket_url = util.get_object_without_sas(util.test_s2s_src_s3_service_url, self.bucket_name_s3_blob)
         dst_container_url = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name_s3_blob)
         self.util_test_copy_single_file_from_x_to_x(
@@ -410,6 +446,8 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
             "%252F") #encoded name for %2F, as path will be decoded
 
     def test_copy_single_file_from_s3_to_blob_excludeinvalidmetadata(self):
+        if os.environ['S3_TESTS_OFF'] != '':
+            self.skipTest('S3 testing is disabled for this smoke test run.')
         self.util_test_copy_single_file_from_s3_to_blob_handleinvalidmetadata(
             "", # By default it should be ExcludeIfInvalid
             "1abc=jiac;$%^=width;description=test file",
@@ -417,6 +455,8 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
         )
 
     def test_copy_single_file_from_s3_to_blob_renameinvalidmetadata(self):
+        if os.environ['S3_TESTS_OFF'] != '':
+            self.skipTest('S3 testing is disabled for this smoke test run.')
         self.util_test_copy_single_file_from_s3_to_blob_handleinvalidmetadata(
             "RenameIfInvalid", # By default it should be ExcludeIfInvalid
             "1abc=jiac;$%^=width;description=test file",
@@ -429,6 +469,8 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
         invalidMetadataHandleOption,
         srcS3Metadata, 
         expectResolvedMetadata):
+        if os.environ['S3_TESTS_OFF'] != '':
+            self.skipTest('S3 testing is disabled for this smoke test run.')
         srcBucketURL = util.get_object_without_sas(util.test_s2s_src_s3_service_url, self.bucket_name_s3_blob)
         dstBucketURL = util.get_object_sas(util.test_s2s_dst_blob_account_url, self.bucket_name_s3_blob)
         srcType = "S3"

--- a/testSuite/scripts/utility.py
+++ b/testSuite/scripts/utility.py
@@ -108,6 +108,8 @@ def clean_test_blob_account(account):
     return True
 
 def clean_test_s3_account(account):
+    if os.environ['S3_TESTS_OFF'] != '':
+        return True
     result = Command("clean").add_arguments(account).add_flags("serviceType", "S3").add_flags("resourceType", "Account").execute_azcopy_clean()
     if not result:
         print("error cleaning the S3 account.")


### PR DESCRIPTION
To disable S3 tests and cleanly skip them, set the environment variable S3_TESTS_OFF to anything at all, as long as it's not empty.