### PR TITLE
Refactor/move to single logging policy

### DIFF
--- a/azbfs/zc_pipeline.go
+++ b/azbfs/zc_pipeline.go
@@ -40,7 +40,7 @@ func NewPipeline(c Credential, o PipelineOptions) pipeline.Pipeline {
 	}
 	f = append(f,
 		pipeline.MethodFactoryMarker(), // indicates at what stage in the pipeline the method factory is invoked
-		NewRequestLogPolicyFactory(o.RequestLog))
+		NewRequestLogPolicyFactory_Deprecated(o.RequestLog))
 
 	return pipeline.NewPipeline(f, pipeline.Options{HTTPSender: nil, Log: o.Log})
 }

--- a/azbfs/zc_policy_request_log.go
+++ b/azbfs/zc_policy_request_log.go
@@ -33,8 +33,9 @@ func (o RequestLogOptions) defaults() RequestLogOptions {
 	return o
 }
 
-// NewRequestLogPolicyFactory creates a RequestLogPolicyFactory object configured using the specified options.
-func NewRequestLogPolicyFactory(o RequestLogOptions) pipeline.Factory {
+// NewRequestLogPolicyFactory_Deprecated creates a RequestLogPolicyFactory object configured using the specified options.
+// Deprecated because we are moving to centralize everything on the one logging policy in STE
+func NewRequestLogPolicyFactory_Deprecated(o RequestLogOptions) pipeline.Factory {
 	o = o.defaults() // Force defaults to be calculated
 	return pipeline.FactoryFunc(func(next pipeline.Policy, po *pipeline.PolicyOptions) pipeline.PolicyFunc {
 		// These variables are per-policy; shared by multiple calls to Do

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -204,7 +204,7 @@ func NewFilePipeline(c azfile.Credential, o azfile.PipelineOptions, r azfile.Ret
 		c,
 		pipeline.MethodFactoryMarker(), // indicates at what stage in the pipeline the method factory is invoked
 		NewVersionPolicyFactory(),
-		azfile.NewRequestLogPolicyFactory(o.RequestLog),
+		NewRequestLogPolicyFactory(RequestLogOptions{LogWarningIfTryOverThreshold: o.RequestLog.LogWarningIfTryOverThreshold}),
 		newXferStatsPolicyFactory(statsAcc),
 	}
 	return pipeline.NewPipeline(f, pipeline.Options{HTTPSender: newAzcopyHTTPClientFactory(client), Log: o.Log})

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -184,7 +184,7 @@ func NewBlobFSPipeline(c azbfs.Credential, o azbfs.PipelineOptions, r XferRetryO
 
 	f = append(f,
 		pipeline.MethodFactoryMarker(), // indicates at what stage in the pipeline the method factory is invoked
-		azbfs.NewRequestLogPolicyFactory(o.RequestLog),
+		NewRequestLogPolicyFactory(RequestLogOptions{LogWarningIfTryOverThreshold: o.RequestLog.LogWarningIfTryOverThreshold}),
 		newXferStatsPolicyFactory(statsAcc))
 
 	return pipeline.NewPipeline(f, pipeline.Options{HTTPSender: newAzcopyHTTPClientFactory(client), Log: o.Log})


### PR DESCRIPTION
Move the main data transfer pipelines to a common logging policy, so that they pick up all the improvements that we've done for 10.3

(The separate pipelines made by credentialUtil, which are for enumeration IIRC, are not affected.  Don't have time to change those just now.)