### PR TITLE
Fix crash for 32 bit when a 64 bit atomic variable isn't aligned

### DIFF
--- a/ste/JobsAdmin.go
+++ b/ste/JobsAdmin.go
@@ -472,9 +472,9 @@ func (ja *jobsAdmin) transferProcessor(workerID int) {
 // The coordinator uses this to manage all the running jobs and their job parts.
 type jobsAdmin struct {
 	atomicSuccessfulBytesInActiveFiles int64
-	atomicCurrentMainPoolSize          int32
 	atomicBytesTransferredWhileTuning  int64
 	atomicTuningEndSeconds             int64
+	atomicCurrentMainPoolSize          int32 // align 64 bit integers for 32 bit arch
 	concurrency                        ConcurrencySettings
 	logger                             common.ILoggerCloser
 	jobIDToJobMgr                      jobIDToJobMgr // Thread-safe map from each JobID to its JobInfo

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -115,6 +115,9 @@ type chunkFunc func(int)
 
 // jobPartTransferMgr represents the runtime information for a Job Part's transfer
 type jobPartTransferMgr struct {
+	// how many bytes have been successfully transferred
+	// (hard to infer from atomicChunksDone because that counts both successes and failures)
+	atomicSuccessfulBytes int64
 
 	// NumberOfChunksDone represents the number of chunks of a transfer
 	// which are either completed or failed.
@@ -126,10 +129,6 @@ type jobPartTransferMgr struct {
 
 	// used to show whether we have started doing things that may affect the destination
 	atomicDestModifiedIndicator uint32
-
-	// how many bytes have been successfully transferred
-	// (hard to infer from atomicChunksDone because that counts both successes and failures)
-	atomicSuccessfulBytes int64
 
 	jobPartMgr          IJobPartMgr // Refers to the "owning" Job Part
 	jobPartPlanTransfer *JobPartPlanTransfer


### PR DESCRIPTION
In the future we should be more careful about where we place int64s-- taking pointers of them on a 32 bit system is somewhat dangerous.