### PR TITLE
Disallow uploads directly to the service level

### DIFF
--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -99,7 +99,7 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 		return nil, errors.New("cannot combine list-of-files or include-path with account traversal")
 	}
 
-	if srcLevel == ELocationLevel.Object() && dstLevel == ELocationLevel.Service() {
+	if (srcLevel == ELocationLevel.Object() || cca.fromTo.From().IsLocal()) && dstLevel == ELocationLevel.Service() {
 		return nil, errors.New("cannot transfer individual files/folders to the root of a service. Add a container or directory to the destination URL")
 	}
 


### PR DESCRIPTION
Local had some funkiness where a folder could be registered as a container-level tx.

This is fully intended, just not the side-effect of this odd case where you could try (and fail) a upload directly to the service level.