### PR TITLE
Use actual chunk size for progress calculations

### DIFF
--- a/common/chunkStatusLogger.go
+++ b/common/chunkStatusLogger.go
@@ -34,6 +34,7 @@ import (
 type ChunkID struct {
 	Name         string
 	offsetInFile int64
+	length       int64
 
 	// What is this chunk's progress currently waiting on?
 	// Must be a pointer, because the ChunkID itself is a struct.
@@ -55,12 +56,13 @@ type ChunkID struct {
 	//   And maybe at that point, we would also put Length into chunkID, and use that in jptm.ReportChunkDone
 }
 
-func NewChunkID(name string, offsetInFile int64) ChunkID {
+func NewChunkID(name string, offsetInFile int64, length int64) ChunkID {
 	dummyWaitReasonIndex := int32(0)
 	zeroNotificationState := int32(0)
 	return ChunkID{
 		Name:                     name,
 		offsetInFile:             offsetInFile,
+		length:                   length,
 		waitReasonIndex:          &dummyWaitReasonIndex, // must initialize, so don't get nil pointer on usage
 		completionNotifiedToJptm: &zeroNotificationState,
 	}
@@ -92,6 +94,10 @@ func (id ChunkID) OffsetInFile() int64 {
 
 func (id ChunkID) IsPseudoChunk() bool {
 	return id.offsetInFile < 0
+}
+
+func (id ChunkID) Length() int64 {
+	return id.length
 }
 
 var EWaitReason = WaitReason{0, ""}

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -42,7 +42,6 @@ type IJobPartTransferMgr interface {
 	ShouldDecompress() bool
 	GetSourceCompressionType() (common.CompressionType, error)
 	ReportChunkDone(id common.ChunkID) (lastChunk bool, chunksDone uint32)
-	UnsafeReportChunkDone() (lastChunk bool, chunksDone uint32)
 	TransferStatusIgnoringCancellation() common.TransferStatus
 	SetStatus(status common.TransferStatus)
 	SetErrorCode(errorCode int32)
@@ -135,7 +134,6 @@ type jobPartTransferMgr struct {
 
 	// used to show whether THIS jptm holds the destination lock
 	atomicDestLockHeldIndicator uint32
-
 
 	jobPartMgr          IJobPartMgr // Refers to the "owning" Job Part
 	jobPartPlanTransfer *JobPartPlanTransfer
@@ -425,17 +423,8 @@ func (jptm *jobPartTransferMgr) ReportChunkDone(id common.ChunkID) (lastChunk bo
 
 	// track progress
 	if jptm.IsLive() {
-		info := jptm.Info()
-		successBytesDelta := common.AtomicMorphInt64(&jptm.atomicSuccessfulBytes, func(old int64) (new int64, delta interface{}) {
-			new = old + int64(info.BlockSize) // assume we just completed a full block
-			if new > info.SourceSize {        // but if that assumption gives over-counts total bytes in blob, make a correction
-				new = info.SourceSize // (we do it this way because we don't have the actual chunk size available to us here)
-			}
-			delta = new - old
-			return
-		}).(int64)
-
-		JobsAdmin.AddSuccessfulBytesInActiveFiles(successBytesDelta)
+		atomic.AddInt64(&jptm.atomicSuccessfulBytes, id.Length())
+		JobsAdmin.AddSuccessfulBytesInActiveFiles(id.Length())
 	}
 
 	// Do our actual processing
@@ -446,11 +435,6 @@ func (jptm *jobPartTransferMgr) ReportChunkDone(id common.ChunkID) (lastChunk bo
 		JobsAdmin.AddSuccessfulBytesInActiveFiles(-atomic.LoadInt64(&jptm.atomicSuccessfulBytes)) // subtract our bytes from the active files bytes, because we are done now
 	}
 	return lastChunk, chunksDone
-}
-
-// TODO: phase this method out.  It's just here to support parts of the codebase that don't yet have chunk IDs
-func (jptm *jobPartTransferMgr) UnsafeReportChunkDone() (lastChunk bool, chunksDone uint32) {
-	return jptm.ReportChunkDone(common.NewChunkID("", 0))
 }
 
 // If an automatic action has been specified for after the last chunk, run it now

--- a/ste/xfer-anyToRemote.go
+++ b/ste/xfer-anyToRemote.go
@@ -210,13 +210,14 @@ func scheduleSendChunks(jptm IJobPartTransferMgr, srcPath string, srcFile common
 	chunkIDCount := int32(0)
 	for startIndex := int64(0); startIndex < srcSize || isDummyChunkInEmptyFile(startIndex, srcSize); startIndex += int64(chunkSize) {
 
-		id := common.NewChunkID(srcPath, startIndex)
 		adjustedChunkSize := int64(chunkSize)
 
 		// compute actual size of the chunk
 		if startIndex+int64(chunkSize) > srcSize {
 			adjustedChunkSize = srcSize - startIndex
 		}
+
+		id := common.NewChunkID(srcPath, startIndex, adjustedChunkSize) // TODO: stop using adjustedChunkSize, below, and use the size that's in the ID
 
 		if srcInfoProvider.IsLocal() {
 			if jptm.WasCanceled() {

--- a/ste/xfer-remoteToLocal.go
+++ b/ste/xfer-remoteToLocal.go
@@ -189,13 +189,14 @@ func remoteToLocal(jptm IJobPartTransferMgr, p pipeline.Pipeline, pacer pacer, d
 
 	chunkCount := uint32(0)
 	for startIndex := int64(0); startIndex < fileSize; startIndex += downloadChunkSize {
-		id := common.NewChunkID(info.Destination, startIndex)
 		adjustedChunkSize := downloadChunkSize
 
 		// compute exact size of the chunk
 		if startIndex+downloadChunkSize > fileSize {
 			adjustedChunkSize = fileSize - startIndex
 		}
+
+		id := common.NewChunkID(info.Destination, startIndex, adjustedChunkSize) // TODO: stop using adjustedChunkSize, below, and use the size that's in the ID
 
 		// Wait until its OK to schedule it
 		// To prevent excessive RAM consumption, we have a limit on the amount of scheduled-but-not-yet-saved data


### PR DESCRIPTION
Because for PageBlobs and AzureFiles, the size is capped below what the user may request in jptm.Info().BlockSize, so just using the "requested" size gave wrong results in % complete.

(This PR changes it to the way I should have done it all along!)

Fixes #683 

