### PR TITLE
White glove requested features

### DIFF
--- a/cmd/cancel.go
+++ b/cmd/cancel.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/telemetry"
 	"github.com/spf13/cobra"
 )
 
@@ -53,6 +54,8 @@ type cookedCancelCmdArgs struct {
 // dispatches the cancel Job order to the storage engine
 func (cca cookedCancelCmdArgs) process() error {
 	var cancelJobResponse common.CancelPauseResumeResponse
+	// White Glove: raise cancellation Telemetry event
+	telemetry.RaiseCancellationEvent(cca.jobID.String())
 	Rpc(common.ERpcCmd.CancelJob(), cca.jobID, &cancelJobResponse)
 	if !cancelJobResponse.CancelledPauseResumed {
 		return errors.New(cancelJobResponse.ErrorMsg)

--- a/common/logger.go
+++ b/common/logger.go
@@ -114,6 +114,7 @@ type jobLogger struct {
 	sanitizer         pipeline.LogSanitizer
 }
 
+// NewJobLogger creates an initialize jobLogger structure
 func NewJobLogger(jobID JobID, minimumLevelToLog LogLevel, appLogger ILogger, logFileFolder string) ILoggerResetable {
 	if appLogger == nil {
 		panic("You must pass a appLogger when creating a JobLogger")
@@ -149,6 +150,9 @@ func (jl *jobLogger) OpenLog() {
 	jl.logger.Println("OS-Environment ", runtime.GOOS)
 	jl.logger.Println("OS-Architecture ", runtime.GOARCH)
 	jl.logger.Println(utcMessage)
+	// White Glove - Report hostname
+	hostname, _ := os.Hostname()
+	jl.logger.Println("HostName ", hostname)
 }
 
 func (jl *jobLogger) MinimumLogLevel() pipeline.LogLevel {
@@ -181,6 +185,10 @@ func (jl jobLogger) Log(loglevel pipeline.LogLevel, msg string) {
 		msg = strings.Replace(msg, "\n", lineEnding, -1)
 	}
 	if jl.ShouldLog(loglevel) {
+		// Todo: White Glove - Tap into the full log output
+		// I'm still undecided as to whether this should be done while running or
+		// just copy the log file at the end of the process
+		//telemetry.RaiseLoginEvent(jobid, msg)
 		jl.logger.Println(msg)
 	}
 }

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -1,0 +1,111 @@
+// As part of the White Glove White Glove project,
+// this is a telemetry package to support posting summary and cancellation events
+// to a given webhook endpoint with a reference project id in the shape of an event grid
+// custom event.
+
+package telemetry
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/Azure/azure-storage-azcopy/common"
+)
+
+var (
+	// ReportingAPIURI the Webhook URI
+	ReportingAPIURI string
+	// ProjectReferenceID the project reference ID
+	ProjectReferenceID string
+)
+
+type telemetry struct {
+	JobID     string      `json:"jobID"`
+	ProjectID string      `json:"projectId"`
+	Telemetry interface{} `json:"telemetry"`
+}
+
+type reportEvent struct {
+	EventType  string      `json:"eventType"`
+	EventTopic string      `json:"eventTopic"`
+	Data       interface{} `json:"data"`
+	EventTime  time.Time   `json:"eventTime"`
+}
+
+func getJSON(t interface{}) string {
+	json, err := json.Marshal(t)
+	common.PanicIfErr(err)
+	return string(json)
+}
+
+func newReportEvent(eventType string, data interface{}) *reportEvent {
+	return &reportEvent{
+		EventType:  eventType,
+		EventTopic: "",
+		Data:       data,
+		EventTime:  time.Now(),
+	}
+}
+
+func postEvent(json string) {
+	var jsonStr = []byte(json)
+	_, err := http.Post(ReportingAPIURI, "application/json", bytes.NewBuffer(jsonStr))
+	common.PanicIfErr(err)
+}
+
+func appendToFile(content string) {
+	f, err := os.OpenFile("./telemetry.log",
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Println(err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(content); err != nil {
+		log.Println(err)
+	}
+}
+
+// RaiseCancellationEvent raises a cancellation event
+func RaiseCancellationEvent(jobID string) {
+	if ReportingAPIURI != "" {
+		telemetry := telemetry{
+			JobID:     jobID,
+			ProjectID: ProjectReferenceID,
+		}
+		evt := newReportEvent("job-cancellation-event", telemetry)
+		json := getJSON(evt)
+		postEvent(json)
+	}
+}
+
+// RaiseSummaryEvent raises a telemetry event
+func RaiseSummaryEvent(summary common.ListJobSummaryResponse) {
+	if ReportingAPIURI != "" && ProjectReferenceID != "" {
+		telemetry := telemetry{
+			JobID:     summary.JobID.String(),
+			ProjectID: ProjectReferenceID,
+			Telemetry: summary,
+		}
+		evt := newReportEvent("job-telemetry-event", telemetry)
+		json := getJSON(evt)
+		postEvent(json)
+	}
+}
+
+// RaiseLogingEvent raises a telemetry event
+func RaiseLogingEvent(jobID, msg string) {
+	if ReportingAPIURI != "" && ProjectReferenceID != "" {
+		telemetry := telemetry{
+			JobID:     jobID,
+			ProjectID: ProjectReferenceID,
+			Telemetry: msg,
+		}
+		evt := newReportEvent("job-telemetry-event", telemetry)
+		json := getJSON(evt)
+		postEvent(json)
+	}
+}


### PR DESCRIPTION
Hi AzCopy team, we recently had a meeting with Ashish Mishra and he asked me to submit a pull request with some of the changes we are proposing in support of the White Glove migration project. The goal of this project is to provide government customers with a dashboard and tool that can be used to track the progress of azcopy jobs and to start-stop jobs remotely. In other words, some of the main requested features are:

- Ability to post the summary structure to a WebHook with a given project reference id as the project is running or canceled. If the project is canceled, the system should capture the cancellation event and the last summary event.
- Ability to capture all the logs to a WebHook. I am not too decided on whether this should be done while the application is running or at the end of the job when the log file is finally closed. 
- Ability to start/stop jobs remotely.

This pull request includes some ideas as how to tap into the telemetry while az-copy is running, but by no means, it is finished. Furthermore, there's no code for starting/stopping jobs remotely.

Regards