### PR TITLE
Replace lowercase drive characters

### DIFF
--- a/cmd/zc_enumerator.go
+++ b/cmd/zc_enumerator.go
@@ -179,8 +179,6 @@ func initResourceTraverser(resource string, location common.Location, ctx *conte
 	if listofFilesChannel != nil {
 		sas := ""
 		if location.IsRemote() {
-			// note to future self: this will cause a merge conflict.
-			// rename source to resource and delete this comment.
 			var err error
 			resource, sas, err = SplitAuthTokenFromResource(resource, location)
 

--- a/common/LongPathHandler.go
+++ b/common/LongPathHandler.go
@@ -36,6 +36,11 @@ import (
 
 // ToExtendedPath converts short paths to an extended path.
 func ToExtendedPath(short string) string {
+	// filepath.Abs has an issue where if the path is just the drive indicator of your CWD, it just returns the CWD. So, we append the / to show that yes, we really mean C: or whatever.
+	if runtime.GOOS == "windows" && len(short) == 2 && RootDriveRegex.MatchString(strings.ToUpper(short)) {
+		short += "/"
+	}
+
 	short, err := filepath.Abs(short)
 	PanicIfErr(err) //TODO: Handle errors better?
 
@@ -48,7 +53,7 @@ func ToExtendedPath(short string) string {
 			// Steal the first backslash, and then append the prefix. Enforce \.
 			return strings.Replace(EXTENDED_UNC_PATH_PREFIX+short[1:], `/`, `\`, -1) // convert to extended UNC path
 		} else { // this is coming from a drive-- capitalize the drive prefix. (C:/folder/file.txt)
-			if RootDriveRegex.MatchString(short[:2]) {
+			if len(short) >= 2 && RootDriveRegex.MatchString(strings.ToUpper(short[:2])) { // make the check case insensitive
 				short = strings.Replace(short, short[:2], strings.ToUpper(short[:2]), 1)
 			}
 			// Then append the prefix. Enforce \.

--- a/common/LongPathHandler.go
+++ b/common/LongPathHandler.go
@@ -42,13 +42,16 @@ func ToExtendedPath(short string) string {
 	// ex. C:/dir/file.txt -> \\?\C:\dir\file.txt
 	// ex. \\share\dir\file.txt -> \\?\UNC\share\dir\file.txt
 	if runtime.GOOS == "windows" { // Only do this on Windows
-		if strings.HasPrefix(short, EXTENDED_PATH_PREFIX) {
+		if strings.HasPrefix(short, EXTENDED_PATH_PREFIX) { // already an extended path \\?\C:\folder\file.txt or \\?\UNC\sharename\folder\file.txt
 			return strings.Replace(short, `/`, `\`, -1) // Just ensure it has all backslashes-- Windows can't handle forward-slash anymore in this format.
-		} else if strings.HasPrefix(short, `\\`) {
+		} else if strings.HasPrefix(short, `\\`) { // this is a file share (//sharename/folder/file.txt)
 			// Steal the first backslash, and then append the prefix. Enforce \.
 			return strings.Replace(EXTENDED_UNC_PATH_PREFIX+short[1:], `/`, `\`, -1) // convert to extended UNC path
-		} else {
-			// Just append the prefix. Enforce \.
+		} else { // this is coming from a drive-- capitalize the drive prefix. (C:/folder/file.txt)
+			if RootDriveRegex.MatchString(short[:2]) {
+				short = strings.Replace(short, short[:2], strings.ToUpper(short[:2]), 1)
+			}
+			// Then append the prefix. Enforce \.
 			return strings.Replace(EXTENDED_PATH_PREFIX+short, `/`, `\`, -1) // Just append the prefix
 		}
 	}

--- a/common/LongPathHandler_test.go
+++ b/common/LongPathHandler_test.go
@@ -10,6 +10,9 @@ var _ = chk.Suite(&pathHandlerSuite{})
 
 func (p *pathHandlerSuite) TestShortToLong(c *chk.C) {
 	if OS_PATH_SEPARATOR == `\` {
+		c.Assert(ToExtendedPath(`c:`), chk.Equals, `\\?\C:\`)
+		c.Assert(ToExtendedPath(`c:/`), chk.Equals, `\\?\C:\`)
+		c.Assert(ToExtendedPath(`c:/myPath`), chk.Equals, `\\?\C:\myPath`)
 		c.Assert(ToExtendedPath(`C:\myPath`), chk.Equals, `\\?\C:\myPath`)
 		c.Assert(ToExtendedPath(`\\myHost\myPath`), chk.Equals, `\\?\UNC\myHost\myPath`)
 		c.Assert(ToExtendedPath(`\\?\C:\myPath`), chk.Equals, `\\?\C:\myPath`)


### PR DESCRIPTION
This solves an issue where if a user tried to upload targeting a lowercase drive character, it would fail to scan because the lower-case drive character is no longer treated by windows before we use it with our special prefix.