### PR TITLE
Allow cancellation during enumeration

### DIFF
--- a/ste/init.go
+++ b/ste/init.go
@@ -318,7 +318,8 @@ func ResumeJobOrder(req common.ResumeJobRequest) common.CancelPauseResumeRespons
 	jpp0 := jpm.Plan()
 	switch jpp0.JobStatus() {
 	// Cannot resume a Job which is in Cancelling state
-	// Cancelling is an intermediary state
+	// Cancelling is an intermediary state. The reason we accept and process it here, rather than returning an error,
+	// is in case a process was terminated while its job was in cancelling state.
 	case common.EJobStatus.Cancelling():
 		jpp0.SetJobStatus(common.EJobStatus.Cancelled())
 		fallthrough


### PR DESCRIPTION
Works by allowing the transition to cancelled, in this case.  That will then cause application exit. So there is no change to the actual enumeration code, since it gets ended just by the application exit.