### PR TITLE
Fix credential override for S2S

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -852,6 +852,9 @@ func (cca *cookedCopyCmdArgs) processRedirectionUpload(blobUrl string, blockSize
 func (cca *cookedCopyCmdArgs) processCopyJobPartOrders() (err error) {
 	ctx := context.WithValue(context.TODO(), ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
 
+	// Note: credential info here is only used by remove at the moment.
+	// TODO: Get the entirety of remove into the new copyEnumeratorInit script so we can remove this
+	//       and stop having two places in copy that we get credential info
 	// verifies credential type and initializes credential info.
 	// Note: Currently, only one credential type is necessary for source and destination.
 	// For upload&download, only one side need credential.

--- a/cmd/credentialUtil.go
+++ b/cmd/credentialUtil.go
@@ -258,7 +258,9 @@ type rawFromToInfo struct {
 }
 
 func getCredentialInfoForLocation(ctx context.Context, location common.Location, resource, resourceSAS string, isSource bool) (credInfo common.CredentialInfo, isPublic bool, err error) {
-	if credInfo.CredentialType = GetCredTypeFromEnvVar(); credInfo.CredentialType == common.ECredentialType.Unknown() {
+	if resourceSAS != "" {
+		credInfo.CredentialType = common.ECredentialType.Anonymous()
+	} else if credInfo.CredentialType = GetCredTypeFromEnvVar(); credInfo.CredentialType == common.ECredentialType.Unknown() {
 		switch location {
 		case common.ELocation.Local(), common.ELocation.Benchmark():
 			credInfo.CredentialType = common.ECredentialType.Anonymous()


### PR DESCRIPTION
Addresses #719, where the new getCredentialTypeForLocation treated the override env var as the end-all-be-all of auth types. This caused the source in S2S transfers to be treated as OAuth when the user tried to override to use OAuth.

This never caused a bug in the old code because we were only considering credentials for one location, not two.