### PR TITLE
Make RootDriveRegex case insensitive at is definition, instead of at sites of usage

### DIFF
--- a/cmd/zc_traverser_local_test.go
+++ b/cmd/zc_traverser_local_test.go
@@ -42,6 +42,8 @@ func (s *localTraverserTestSuite) TestCleanLocalPathForWindows(c *chk.C) {
 		`\\foo\bar\`:  `\\foo\bar`,  // network share
 		`C:\`:         `C:\`,        // special case, the slash after colon is actually required
 		`D:`:          `D:\`,        // special case, the slash after colon is actually required
+		`c:\`:         `c:\`,        // special case, the slash after colon is actually required
+		`c:`:          `c:\`,        // special case, the slash after colon is actually required
 	}
 
 	for orig, expected := range testCases {

--- a/common/LongPathHandler.go
+++ b/common/LongPathHandler.go
@@ -37,7 +37,7 @@ import (
 // ToExtendedPath converts short paths to an extended path.
 func ToExtendedPath(short string) string {
 	// filepath.Abs has an issue where if the path is just the drive indicator of your CWD, it just returns the CWD. So, we append the / to show that yes, we really mean C: or whatever.
-	if runtime.GOOS == "windows" && len(short) == 2 && RootDriveRegex.MatchString(strings.ToUpper(short)) {
+	if runtime.GOOS == "windows" && len(short) == 2 && RootDriveRegex.MatchString(short) {
 		short += "/"
 	}
 
@@ -53,7 +53,7 @@ func ToExtendedPath(short string) string {
 			// Steal the first backslash, and then append the prefix. Enforce \.
 			return strings.Replace(EXTENDED_UNC_PATH_PREFIX+short[1:], `/`, `\`, -1) // convert to extended UNC path
 		} else { // this is coming from a drive-- capitalize the drive prefix. (C:/folder/file.txt)
-			if len(short) >= 2 && RootDriveRegex.MatchString(strings.ToUpper(short[:2])) { // make the check case insensitive
+			if len(short) >= 2 && RootDriveRegex.MatchString(short[:2]) {
 				short = strings.Replace(short, short[:2], strings.ToUpper(short[:2]), 1)
 			}
 			// Then append the prefix. Enforce \.

--- a/common/writeThoughFile.go
+++ b/common/writeThoughFile.go
@@ -32,7 +32,7 @@ import (
 // //myShare
 // //myShare/
 // demonstrated at: https://regexr.com/4mf6l
-var RootDriveRegex = regexp.MustCompile(`(^[A-Z]:\/?$)`)
+var RootDriveRegex = regexp.MustCompile(`(?i)(^[A-Z]:\/?$)`)
 var RootShareRegex = regexp.MustCompile(`(^\/\/[^\/]*\/?$)`)
 
 func CreateParentDirectoryIfNotExist(destinationPath string) error {


### PR DESCRIPTION
So we know for sure its always doing what we want, and we don't have to rely on code order to give us expected capitalization beforehand