### PR TITLE
Force all property setting for storedObject to go through the constructor

### DIFF
--- a/cmd/zc_newobjectadapters.go
+++ b/cmd/zc_newobjectadapters.go
@@ -1,0 +1,124 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cmd
+
+import (
+	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-blob-go/azblob"
+)
+
+var noContentProps = emptyPropertiesAdapter{}
+var noBlobProps = emptyPropertiesAdapter{}
+var noMetdata common.Metadata = nil
+
+// emptyPropertiesAdapter supplies empty (zero-like) values
+// for all methods in contentPropsProvider and blobPropsProvider
+type emptyPropertiesAdapter struct{}
+
+func (e emptyPropertiesAdapter) CacheControl() string {
+	return ""
+}
+
+func (e emptyPropertiesAdapter) ContentDisposition() string {
+	return ""
+}
+
+func (e emptyPropertiesAdapter) ContentEncoding() string {
+	return ""
+}
+
+func (e emptyPropertiesAdapter) ContentLanguage() string {
+	return ""
+}
+
+func (e emptyPropertiesAdapter) ContentType() string {
+	return ""
+}
+
+func (e emptyPropertiesAdapter) ContentMD5() []byte {
+	return make([]byte, 0)
+}
+
+func (e emptyPropertiesAdapter) BlobType() azblob.BlobType {
+	return azblob.BlobNone
+}
+
+func (e emptyPropertiesAdapter) AccessTier() azblob.AccessTierType {
+	return azblob.AccessTierNone
+}
+
+// md5OnlyAdapter is like emptyProperties adapter, except for the ContentMD5
+// method, for which it returns a real value
+type md5OnlyAdapter struct {
+	emptyPropertiesAdapter
+	md5 []byte
+}
+
+func (m md5OnlyAdapter) ContentMD5() []byte {
+	return m.md5
+}
+
+// blobPropertiesResponseAdapter adapts a BlobGetPropertiesResponse to the blobPropsProvider interface
+type blobPropertiesResponseAdapter struct {
+	*azblob.BlobGetPropertiesResponse
+}
+
+func (a blobPropertiesResponseAdapter) AccessTier() azblob.AccessTierType {
+	return azblob.AccessTierType(a.BlobGetPropertiesResponse.AccessTier())
+}
+
+// blobPropertiesAdapter adapts a BlobProperties object to both the
+// contentPropsProvider and blobPropsProvider interfaces
+type blobPropertiesAdapter struct {
+	azblob.BlobProperties
+}
+
+func (a blobPropertiesAdapter) CacheControl() string {
+	return common.IffStringNotNil(a.BlobProperties.CacheControl, "")
+}
+
+func (a blobPropertiesAdapter) ContentDisposition() string {
+	return common.IffStringNotNil(a.BlobProperties.ContentDisposition, "")
+}
+
+func (a blobPropertiesAdapter) ContentEncoding() string {
+	return common.IffStringNotNil(a.BlobProperties.ContentEncoding, "")
+}
+
+func (a blobPropertiesAdapter) ContentLanguage() string {
+	return common.IffStringNotNil(a.BlobProperties.ContentLanguage, "")
+}
+
+func (a blobPropertiesAdapter) ContentType() string {
+	return common.IffStringNotNil(a.BlobProperties.ContentType, "")
+}
+
+func (a blobPropertiesAdapter) ContentMD5() []byte {
+	return a.BlobProperties.ContentMD5
+}
+
+func (a blobPropertiesAdapter) BlobType() azblob.BlobType {
+	return a.BlobProperties.BlobType
+}
+
+func (a blobPropertiesAdapter) AccessTier() azblob.AccessTierType {
+	return a.BlobProperties.AccessTier
+}

--- a/cmd/zc_traverser_benchmark.go
+++ b/cmd/zc_traverser_benchmark.go
@@ -67,8 +67,9 @@ func (t *benchmarkTraverser) traverse(preprocessor objectMorpher, processor obje
 			relativePath,
 			common.BenchmarkLmt,
 			t.bytesPerFile,
-			nil,
-			blobTypeNA,
+			noContentProps,
+			noBlobProps,
+			noMetdata,
 			""), processor)
 		if err != nil {
 			return err

--- a/cmd/zc_traverser_blob.go
+++ b/cmd/zc_traverser_blob.go
@@ -105,20 +105,11 @@ func (t *blobTraverser) traverse(preprocessor objectMorpher, processor objectPro
 			"",
 			blobProperties.LastModified(),
 			blobProperties.ContentLength(),
-			blobProperties.ContentMD5(),
-			blobProperties.BlobType(),
+			blobProperties,
+			blobPropertiesResponseAdapter{blobProperties},
+			common.FromAzBlobMetadataToCommonMetadata(blobProperties.NewMetadata()), // .NewMetadata() seems odd to call, but it does actually retrieve the metadata from the blob properties.
 			blobUrlParts.ContainerName,
 		)
-
-		storedObject.contentDisposition = blobProperties.ContentDisposition()
-		storedObject.cacheControl = blobProperties.CacheControl()
-		storedObject.contentLanguage = blobProperties.ContentLanguage()
-		storedObject.contentEncoding = blobProperties.ContentEncoding()
-		storedObject.contentType = blobProperties.ContentType()
-
-		// .NewMetadata() seems odd to call, but it does actually retrieve the metadata from the blob properties.
-		storedObject.Metadata = common.FromAzBlobMetadataToCommonMetadata(blobProperties.NewMetadata())
-		storedObject.blobAccessTier = azblob.AccessTierType(blobProperties.AccessTier())
 
 		if t.incrementEnumerationCounter != nil {
 			t.incrementEnumerationCounter()
@@ -165,26 +156,18 @@ func (t *blobTraverser) traverse(preprocessor objectMorpher, processor objectPro
 				continue
 			}
 
+			adapter := blobPropertiesAdapter{blobInfo.Properties}
 			storedObject := newStoredObject(
 				preprocessor,
 				getObjectNameOnly(blobInfo.Name),
 				relativePath,
 				blobInfo.Properties.LastModified,
 				*blobInfo.Properties.ContentLength,
-				blobInfo.Properties.ContentMD5,
-				blobInfo.Properties.BlobType,
+				adapter,
+				adapter, // adapter satisfies both interfaces
+				common.FromAzBlobMetadataToCommonMetadata(blobInfo.Metadata),
 				blobUrlParts.ContainerName,
 			)
-
-			storedObject.contentDisposition = common.IffStringNotNil(blobInfo.Properties.ContentDisposition, "")
-			storedObject.cacheControl = common.IffStringNotNil(blobInfo.Properties.CacheControl, "")
-			storedObject.contentLanguage = common.IffStringNotNil(blobInfo.Properties.ContentLanguage, "")
-			storedObject.contentEncoding = common.IffStringNotNil(blobInfo.Properties.ContentEncoding, "")
-			storedObject.contentType = common.IffStringNotNil(blobInfo.Properties.ContentType, "")
-
-			storedObject.Metadata = common.FromAzBlobMetadataToCommonMetadata(blobInfo.Metadata)
-
-			storedObject.blobAccessTier = blobInfo.Properties.AccessTier
 
 			if t.incrementEnumerationCounter != nil {
 				t.incrementEnumerationCounter()

--- a/cmd/zc_traverser_file.go
+++ b/cmd/zc_traverser_file.go
@@ -112,21 +112,20 @@ func (t *fileTraverser) traverse(preprocessor objectMorpher, processor objectPro
 				relativePath = strings.TrimPrefix(relativePath, common.AZCOPY_PATH_SEPARATOR_STRING)
 
 				// We need to omit some properties if we don't get properties
-				fullProperties := &azfile.FileGetPropertiesResponse{}
 				lmt := time.Time{}
+				var props contentPropsProvider = noContentProps
 				var meta common.Metadata = nil
 
 				// Only get the properties if we're told to
 				if t.getProperties {
-					fullProperties, err = f.GetProperties(t.ctx)
+					fullProperties, err := f.GetProperties(t.ctx)
 					if err != nil {
 						return err
 					}
 
 					lmt = fullProperties.LastModified()
-
+					props = fullProperties
 					meta = common.FromAzFileMetadataToCommonMetadata(fullProperties.NewMetadata())
-
 				}
 				storedObject := newStoredObject(
 					preprocessor,
@@ -134,7 +133,7 @@ func (t *fileTraverser) traverse(preprocessor objectMorpher, processor objectPro
 					relativePath,
 					lmt,
 					fileInfo.Properties.ContentLength,
-					fullProperties,
+					props,
 					noBlobProps,
 					meta,
 					targetURLParts.ShareName,

--- a/cmd/zc_traverser_file.go
+++ b/cmd/zc_traverser_file.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
 	"github.com/Azure/azure-storage-file-go/azfile"
@@ -74,19 +75,11 @@ func (t *fileTraverser) traverse(preprocessor objectMorpher, processor objectPro
 				"",
 				fileProperties.LastModified(),
 				fileProperties.ContentLength(),
-				fileProperties.ContentMD5(),
-				blobTypeNA,
+				fileProperties,
+				noBlobProps,
+				common.FromAzFileMetadataToCommonMetadata(fileProperties.NewMetadata()), // .NewMetadata() seems odd to call here, but it does actually obtain the metadata.
 				targetURLParts.ShareName,
 			)
-
-			storedObject.contentDisposition = fileProperties.ContentDisposition()
-			storedObject.cacheControl = fileProperties.CacheControl()
-			storedObject.contentLanguage = fileProperties.ContentLanguage()
-			storedObject.contentEncoding = fileProperties.ContentEncoding()
-			storedObject.contentType = fileProperties.ContentType()
-
-			// .NewMetadata() seems odd to call here, but it does actually obtain the metadata.
-			storedObject.Metadata = common.FromAzFileMetadataToCommonMetadata(fileProperties.NewMetadata())
 
 			if t.incrementEnumerationCounter != nil {
 				t.incrementEnumerationCounter()
@@ -119,37 +112,33 @@ func (t *fileTraverser) traverse(preprocessor objectMorpher, processor objectPro
 				relativePath = strings.TrimPrefix(relativePath, common.AZCOPY_PATH_SEPARATOR_STRING)
 
 				// We need to omit some properties if we don't get properties
-				// TODO: make it so we can (and must) call newStoredOBject here.
-				storedObject := storedObject{
-					name:          getObjectNameOnly(fileInfo.Name),
-					relativePath:  relativePath,
-					size:          fileInfo.Properties.ContentLength,
-					containerName: targetURLParts.ShareName,
-				}
-				if preprocessor != nil { // TODO ******** REMOVE THIS ONCE USE newStoredOBject, above *******
-					preprocessor(&storedObject)
-				}
+				fullProperties := &azfile.FileGetPropertiesResponse{}
+				lmt := time.Time{}
+				var meta common.Metadata = nil
 
 				// Only get the properties if we're told to
 				if t.getProperties {
-					fileProperties, err := f.GetProperties(t.ctx)
+					fullProperties, err = f.GetProperties(t.ctx)
 					if err != nil {
 						return err
 					}
 
-					// Leaving this on because it's free IO wise, and file->* is in the works
-					storedObject.contentDisposition = fileProperties.ContentDisposition()
-					storedObject.cacheControl = fileProperties.CacheControl()
-					storedObject.contentLanguage = fileProperties.ContentLanguage()
-					storedObject.contentEncoding = fileProperties.ContentEncoding()
-					storedObject.contentType = fileProperties.ContentType()
-					storedObject.md5 = fileProperties.ContentMD5()
+					lmt = fullProperties.LastModified()
 
-					// .NewMetadata() seems odd to call here, but it does actually obtain the metadata.
-					storedObject.Metadata = common.FromAzFileMetadataToCommonMetadata(fileProperties.NewMetadata())
+					meta = common.FromAzFileMetadataToCommonMetadata(fullProperties.NewMetadata())
 
-					storedObject.lastModifiedTime = fileProperties.LastModified()
 				}
+				storedObject := newStoredObject(
+					preprocessor,
+					getObjectNameOnly(fileInfo.Name),
+					relativePath,
+					lmt,
+					fileInfo.Properties.ContentLength,
+					fullProperties,
+					noBlobProps,
+					meta,
+					targetURLParts.ShareName,
+				)
 
 				if t.incrementEnumerationCounter != nil {
 					t.incrementEnumerationCounter()

--- a/cmd/zc_traverser_local.go
+++ b/cmd/zc_traverser_local.go
@@ -183,8 +183,9 @@ func (t *localTraverser) traverse(preprocessor objectMorpher, processor objectPr
 				"",
 				singleFileInfo.ModTime(),
 				singleFileInfo.Size(),
-				nil, // Local MD5s are taken in the STE
-				blobTypeNA,
+				noContentProps, // Local MD5s are computed in the STE, and other props don't apply to local files
+				noBlobProps,
+				noMetdata,
 				"", // Local has no such thing as containers
 			),
 			processor,
@@ -218,8 +219,9 @@ func (t *localTraverser) traverse(preprocessor objectMorpher, processor objectPr
 						strings.ReplaceAll(relPath, common.DeterminePathSeparator(t.fullPath), common.AZCOPY_PATH_SEPARATOR_STRING), // Consolidate relative paths to the azcopy path separator for sync
 						fileInfo.ModTime(),
 						fileInfo.Size(),
-						nil, // Local MD5s are taken in the STE
-						blobTypeNA,
+						noContentProps, // Local MD5s are computed in the STE, and other props don't apply to local files
+						noBlobProps,
+						noMetdata,
 						"", // Local has no such thing as containers
 					),
 					processor)
@@ -285,8 +287,9 @@ func (t *localTraverser) traverse(preprocessor objectMorpher, processor objectPr
 						strings.ReplaceAll(relativePath, common.DeterminePathSeparator(t.fullPath), common.AZCOPY_PATH_SEPARATOR_STRING), // Consolidate relative paths to the azcopy path separator for sync
 						singleFile.ModTime(),
 						singleFile.Size(),
-						nil, // Local MD5s are taken in the STE
-						blobTypeNA,
+						noContentProps, // Local MD5s are computed in the STE, and other props don't apply to local files
+						noBlobProps,
+						noMetdata,
 						"", // Local has no such thing as containers
 					),
 					processor)

--- a/cmd/zc_traverser_s3.go
+++ b/cmd/zc_traverser_s3.go
@@ -75,26 +75,18 @@ func (t *s3Traverser) traverse(preprocessor objectMorpher, processor objectProce
 		// Otherwise, treat it as a directory.
 		// According to IsDirectorySyntactically, objects and folders can share names
 		if err == nil {
+			// We had to statObject anyway, get ALL the info.
+			oie := common.ObjectInfoExtension{ObjectInfo: oi}
 			storedObject := newStoredObject(
 				preprocessor,
 				objectName,
 				"",
 				oi.LastModified,
 				oi.Size,
-				nil,
-				blobTypeNA,
+				&oie,
+				noBlobProps,
+				oie.NewCommonMetadata(),
 				t.s3URLParts.BucketName)
-
-			// We had to statObject anyway, get ALL the info.
-			oie := common.ObjectInfoExtension{ObjectInfo: oi}
-
-			storedObject.contentType = oi.ContentType
-			storedObject.md5 = oie.ContentMD5()
-			storedObject.cacheControl = oie.CacheControl()
-			storedObject.contentLanguage = oie.ContentLanguage()
-			storedObject.contentDisposition = oie.ContentDisposition()
-			storedObject.contentEncoding = oie.ContentEncoding()
-			storedObject.Metadata = oie.NewCommonMetadata()
 
 			err = processIfPassedFilters(
 				filters,
@@ -141,33 +133,25 @@ func (t *s3Traverser) traverse(preprocessor objectMorpher, processor objectProce
 			continue
 		}
 
+		// default to empty props, but retrieve real ones if required
+		oie := common.ObjectInfoExtension{ObjectInfo: minio.ObjectInfo{}}
+		if t.getProperties {
+			oi, err := t.s3Client.StatObject(t.s3URLParts.BucketName, objectInfo.Key, minio.StatObjectOptions{})
+			if err != nil {
+				return err
+			}
+			oie = common.ObjectInfoExtension{ObjectInfo: oi}
+		}
 		storedObject := newStoredObject(
 			preprocessor,
 			objectName,
 			relativePath,
 			objectInfo.LastModified,
 			objectInfo.Size,
-			nil,
-			blobTypeNA,
+			&oie,
+			noBlobProps,
+			oie.NewCommonMetadata(),
 			t.s3URLParts.BucketName)
-
-		if t.getProperties {
-			oi, err := t.s3Client.StatObject(t.s3URLParts.BucketName, objectInfo.Key, minio.StatObjectOptions{})
-
-			if err != nil {
-				return err
-			}
-
-			oie := common.ObjectInfoExtension{ObjectInfo: oi}
-
-			storedObject.contentType = oi.ContentType
-			storedObject.md5 = oie.ContentMD5()
-			storedObject.cacheControl = oie.CacheControl()
-			storedObject.contentLanguage = oie.ContentLanguage()
-			storedObject.contentDisposition = oie.ContentDisposition()
-			storedObject.contentEncoding = oie.ContentEncoding()
-			storedObject.Metadata = oie.NewCommonMetadata()
-		}
 
 		err = processIfPassedFilters(filters,
 			storedObject,

--- a/cmd/zt_generic_processor_test.go
+++ b/cmd/zt_generic_processor_test.go
@@ -128,7 +128,7 @@ func (s *genericProcessorSuite) TestCopyTransferProcessorSingleFile(c *chk.C) {
 		blobURL, filepath.Join(dstDirName, dstFileName), false, false, nil, nil)
 
 	// exercise the copy transfer processor
-	storedObject := newStoredObject(noPreProccessor, blobList[0], "", time.Now(), 0, nil, blobTypeNA, "")
+	storedObject := newStoredObject(noPreProccessor, blobList[0], "", time.Now(), 0, noContentProps, noBlobProps, noMetdata, "")
 	err := copyProcessor.scheduleCopyTransfer(storedObject)
 	c.Assert(err, chk.IsNil)
 

--- a/common/s3Models.go
+++ b/common/s3Models.go
@@ -31,6 +31,9 @@ type ObjectInfoExtension struct {
 	ObjectInfo minio.ObjectInfo
 }
 
+func (oie *ObjectInfoExtension) ContentType() string {
+	return oie.ObjectInfo.ContentType
+}
 // CacheControl returns the value for header Cache-Control.
 func (oie *ObjectInfoExtension) CacheControl() string {
 	return oie.ObjectInfo.Metadata.Get("Cache-Control")


### PR DESCRIPTION
So we can't forget any necessary properties, and to make the call sites more concise