### PR TITLE
Fix/make tier processing consistent between copy and sync

### DIFF
--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -230,16 +230,9 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 		srcRelPath := cca.makeEscapedRelativePath(true, isDestDir, object)
 		dstRelPath := cca.makeEscapedRelativePath(false, isDestDir, object)
 
-		transfer := common.NewCopyTransfer(
+		transfer := object.ToNewCopyTransfer(
 			cca.autoDecompress && cca.fromTo.IsDownload(),
 			srcRelPath, dstRelPath,
-			object.lastModifiedTime,
-			object.size,
-			object.contentType, object.contentEncoding, object.contentDisposition, object.contentLanguage, object.cacheControl,
-			object.md5,
-			object.Metadata,
-			object.blobType,
-			object.blobAccessTier,
 			cca.s2sPreserveAccessTier,
 		)
 

--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -239,11 +239,9 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 			object.md5,
 			object.Metadata,
 			object.blobType,
-			azblob.AccessTierNone) // access tier is assigned conditionally
-
-		if cca.s2sPreserveAccessTier {
-			transfer.BlobTier = object.blobAccessTier
-		}
+			object.blobAccessTier,
+			cca.s2sPreserveAccessTier,
+		)
 
 		return addTransfer(&jobPartOrder, transfer, cca)
 	}

--- a/cmd/removeProcessor.go
+++ b/cmd/removeProcessor.go
@@ -53,5 +53,5 @@ func newRemoveTransferProcessor(cca *cookedCopyCmdArgs, numOfTransfersPerPart in
 	// note that the source and destination, along with the template are given to the generic processor's constructor
 	// this means that given an object with a relative path, this processor already knows how to schedule the right kind of transfers
 	return newCopyTransferProcessor(copyJobTemplate, numOfTransfersPerPart, cca.source, cca.destination,
-		shouldEncodeSource, false, reportFirstPart, reportFinalPart)
+		shouldEncodeSource, false, reportFirstPart, reportFinalPart, false)
 }

--- a/cmd/syncProcessor.go
+++ b/cmd/syncProcessor.go
@@ -72,7 +72,7 @@ func newSyncTransferProcessor(cca *cookedSyncCmdArgs, numOfTransfersPerPart int)
 	// note that the source and destination, along with the template are given to the generic processor's constructor
 	// this means that given an object with a relative path, this processor already knows how to schedule the right kind of transfers
 	return newCopyTransferProcessor(copyJobTemplate, numOfTransfersPerPart, cca.source, cca.destination,
-		shouldEncodeSource, shouldEncodeDestination, reportFirstPart, reportFinalPart)
+		shouldEncodeSource, shouldEncodeDestination, reportFirstPart, reportFinalPart, cca.preserveAccessTier)
 }
 
 // base for delete processors targeting different resources

--- a/cmd/zc_processor.go
+++ b/cmd/zc_processor.go
@@ -42,11 +42,13 @@ type copyTransferProcessor struct {
 	// handles for progress tracking
 	reportFirstPartDispatched func(jobStarted bool)
 	reportFinalPartDispatched func()
+
+	preserveAccessTier bool
 }
 
 func newCopyTransferProcessor(copyJobTemplate *common.CopyJobPartOrderRequest, numOfTransfersPerPart int,
 	source string, destination string, shouldEscapeSourceObjectName bool, shouldEscapeDestinationObjectName bool,
-	reportFirstPartDispatched func(bool), reportFinalPartDispatched func()) *copyTransferProcessor {
+	reportFirstPartDispatched func(bool), reportFinalPartDispatched func(), preserveAccessTier bool) *copyTransferProcessor {
 	return &copyTransferProcessor{
 		numOfTransfersPerPart:             numOfTransfersPerPart,
 		copyJobTemplate:                   copyJobTemplate,
@@ -56,6 +58,7 @@ func newCopyTransferProcessor(copyJobTemplate *common.CopyJobPartOrderRequest, n
 		shouldEscapeDestinationObjectName: shouldEscapeDestinationObjectName,
 		reportFirstPartDispatched:         reportFirstPartDispatched,
 		reportFinalPartDispatched:         reportFinalPartDispatched,
+		preserveAccessTier:                preserveAccessTier,
 	}
 }
 
@@ -90,6 +93,7 @@ func (s *copyTransferProcessor) scheduleCopyTransfer(storedObject storedObject) 
 		storedObject.Metadata,
 		storedObject.blobType,
 		storedObject.blobAccessTier,
+		s.preserveAccessTier,
 	))
 
 	return nil

--- a/cmd/zc_processor.go
+++ b/cmd/zc_processor.go
@@ -78,21 +78,10 @@ func (s *copyTransferProcessor) scheduleCopyTransfer(storedObject storedObject) 
 
 	// only append the transfer after we've checked and dispatched a part
 	// so that there is at least one transfer for the final part
-	s.copyJobTemplate.Transfers = append(s.copyJobTemplate.Transfers, common.NewCopyTransfer(
-		false,
+	s.copyJobTemplate.Transfers = append(s.copyJobTemplate.Transfers, storedObject.ToNewCopyTransfer(
+		false, // sync has no --decompress option
 		s.escapeIfNecessary(storedObject.relativePath, s.shouldEscapeSourceObjectName),
 		s.escapeIfNecessary(storedObject.relativePath, s.shouldEscapeDestinationObjectName),
-		storedObject.lastModifiedTime,
-		storedObject.size,
-		storedObject.contentType,
-		storedObject.contentEncoding,
-		storedObject.contentDisposition,
-		storedObject.contentLanguage,
-		storedObject.cacheControl,
-		storedObject.md5,
-		storedObject.Metadata,
-		storedObject.blobType,
-		storedObject.blobAccessTier,
 		s.preserveAccessTier,
 	))
 

--- a/cmd/zt_generic_processor_test.go
+++ b/cmd/zt_generic_processor_test.go
@@ -78,7 +78,7 @@ func (s *genericProcessorSuite) TestCopyTransferProcessorMultipleFiles(c *chk.C)
 	for _, numOfParts := range []int{1, 3} {
 		numOfTransfersPerPart := len(sampleObjects) / numOfParts
 		copyProcessor := newCopyTransferProcessor(processorTestSuiteHelper{}.getCopyJobTemplate(), numOfTransfersPerPart,
-			containerURL.String(), dstDirName, false, false, nil, nil)
+			containerURL.String(), dstDirName, false, false, nil, nil, false)
 
 		// go through the objects and make sure they are processed without error
 		for _, storedObject := range sampleObjects {
@@ -125,7 +125,7 @@ func (s *genericProcessorSuite) TestCopyTransferProcessorSingleFile(c *chk.C) {
 	// set up the processor
 	blobURL := containerURL.NewBlockBlobURL(blobList[0]).String()
 	copyProcessor := newCopyTransferProcessor(processorTestSuiteHelper{}.getCopyJobTemplate(), 2,
-		blobURL, filepath.Join(dstDirName, dstFileName), false, false, nil, nil)
+		blobURL, filepath.Join(dstDirName, dstFileName), false, false, nil, nil, false)
 
 	// exercise the copy transfer processor
 	storedObject := newStoredObject(noPreProccessor, blobList[0], "", time.Now(), 0, nil, blobTypeNA, "")

--- a/common/fe-ste-models.go
+++ b/common/fe-ste-models.go
@@ -24,7 +24,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"math"
-	"path/filepath"
 	"reflect"
 	"regexp"
 	"strings"
@@ -851,6 +850,7 @@ const (
 )
 
 // This struct represent a single transfer entry with source and destination details
+// ** DO NOT construct directly. Use cmd.storedObject.ToNewCopyTransfer **
 type CopyTransfer struct {
 	Source           string
 	Destination      string
@@ -869,64 +869,6 @@ type CopyTransfer struct {
 	// Properties for S2S blob copy
 	BlobType azblob.BlobType
 	BlobTier azblob.AccessTierType
-}
-
-// TODO: after merging PR#760, and before adding any more properties to CopyTransfer, refactor signature of this method
-//     to take interfaces that group properties together, probably by reusing some interfaces from PR 760
-func NewCopyTransfer(
-	steWillAutoDecompress bool,
-	Source, Destination string,
-	LMT time.Time,
-	ContentSize int64,
-	ContentType, ContentEncoding, ContentDisposition, ContentLanguage, CacheControl string,
-	ContentMD5 []byte,
-	Metadata Metadata,
-	BlobType azblob.BlobType,
-	BlobTier azblob.AccessTierType,
-	preserveBlobTier bool) CopyTransfer {
-
-	if !preserveBlobTier {
-		BlobTier = azblob.AccessTierNone // don't preserve the blob tier
-	}
-
-	if steWillAutoDecompress {
-		Destination = stripCompressionExtension(Destination, ContentEncoding)
-	}
-
-	return CopyTransfer{
-		Source:             Source,
-		Destination:        Destination,
-		LastModifiedTime:   LMT,
-		SourceSize:         ContentSize,
-		ContentType:        ContentType,
-		ContentEncoding:    ContentEncoding,
-		ContentDisposition: ContentDisposition,
-		ContentLanguage:    ContentLanguage,
-		CacheControl:       CacheControl,
-		ContentMD5:         ContentMD5,
-		Metadata:           Metadata,
-		BlobType:           BlobType,
-		BlobTier:           BlobTier,
-	}
-}
-
-// stringCompressionExtension strips any file extension that corresponds to the
-// compression indicated by the encoding type.
-// Why remove this extension here, at enumeration time, instead of just doing it
-// in the STE when we are about to save the file?
-// Because by doing it here we get the accurate name in things that
-// directly read the Plan files, like the jobs show command
-func stripCompressionExtension(dest string, contentEncoding string) string {
-	// Ignore error getting compression type. We can't easily report it now, and we don't need to know about the error
-	// cases here when deciding renaming.  STE will log error on the error cases
-	ct, _ := GetCompressionType(contentEncoding)
-	ext := strings.ToLower(filepath.Ext(dest))
-	stripGzip := ct == ECompressionType.GZip() && (ext == ".gz" || ext == ".gzip")
-	stripZlib := ct == ECompressionType.ZLib() && ext == ".zz" // "standard" extension for zlib-wrapped files, according to pigz doc and Stack Overflow
-	if stripGzip || stripZlib {
-		return strings.TrimSuffix(dest, filepath.Ext(dest))
-	}
-	return dest
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/common/fe-ste-models.go
+++ b/common/fe-ste-models.go
@@ -871,6 +871,8 @@ type CopyTransfer struct {
 	BlobTier azblob.AccessTierType
 }
 
+// TODO: after merging PR#760, and before adding any more properties to CopyTransfer, refactor signature of this method
+//     to take interfaces that group properties together, probably by reusing some interfaces from PR 760
 func NewCopyTransfer(
 	steWillAutoDecompress bool,
 	Source, Destination string,
@@ -880,7 +882,12 @@ func NewCopyTransfer(
 	ContentMD5 []byte,
 	Metadata Metadata,
 	BlobType azblob.BlobType,
-	BlobTier azblob.AccessTierType) CopyTransfer {
+	BlobTier azblob.AccessTierType,
+	preserveBlobTier bool) CopyTransfer {
+
+	if !preserveBlobTier {
+		BlobTier = azblob.AccessTierNone // don't preserve the blob tier
+	}
 
 	if steWillAutoDecompress {
 		Destination = stripCompressionExtension(Destination, ContentEncoding)


### PR DESCRIPTION
Without this, there'll be a bug in that it will impossible to, for instance, sync between a standard blob storage account and a premium block blob account (because they don't have the same access tiers).

Note that there are two commits in this PR. Only the first is technically necessary to fix the bug. But the second reduces code duplication and should improve maintainability as we add more properties in future.  The second basically just takes `common.NewCopyTransfer` and makes it a method of `storedObject` so we don't have to pass heaps of parameters invididually