### PR TITLE
Check if the MD5 is missing before starting the transfer to save time

### DIFF
--- a/ste/md5Comparer.go
+++ b/ste/md5Comparer.go
@@ -61,8 +61,9 @@ func (c *md5Comparer) Check() error {
 	// missing (at the source)
 	if len(c.expected) == 0 {
 		switch c.validationOption {
+		// This code would never be triggered anymore due to the early check that now occurs in xfer-remoteToLocal.go
 		case common.EHashValidationOption.FailIfDifferentOrMissing():
-			return errExpectedMd5Missing
+			panic("Transfer should've pre-emptively failed with a missing MD5.")
 		case common.EHashValidationOption.FailIfDifferent(),
 			common.EHashValidationOption.LogOnly():
 			c.logAsMissing()

--- a/ste/xfer-remoteToLocal.go
+++ b/ste/xfer-remoteToLocal.go
@@ -73,6 +73,17 @@ func remoteToLocal(jptm IJobPartTransferMgr, p pipeline.Pipeline, pacer pacer, d
 		}
 	}
 
+	if jptm.MD5ValidationOption() == common.EHashValidationOption.FailIfDifferentOrMissing() {
+		// We can make a check early on MD5 existence and fail the transfer if it's not present.
+		// This will save hours in the event a user has say, a several hundred gigabyte file.
+		if len(info.SrcHTTPHeaders.ContentMD5) == 0 {
+			jptm.LogDownloadError(info.Source, info.Destination, errExpectedMd5Missing.Error(), 0)
+			jptm.SetStatus(common.ETransferStatus.Failed())
+			jptm.ReportTransferDone()
+			return
+		}
+	}
+
 	// step 4a: mark destination as modified before we take our first action there (which is to create the destination file)
 	jptm.SetDestinationIsModified()
 

--- a/testSuite/cmd/create.go
+++ b/testSuite/cmd/create.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"crypto/md5"
 	"fmt"
 	"net/url"
 	"os"
@@ -31,6 +32,8 @@ func createStringWithRandomChars(length int) string {
 	}
 	return string(b)
 }
+
+var genMD5 = false
 
 // initializes the create command, its aliases and description.
 func init() {
@@ -161,6 +164,7 @@ func init() {
 	createCmd.PersistentFlags().StringVar(&cacheControl, "cache-control", "", "cache control for blob.")
 	createCmd.PersistentFlags().StringVar(&contentMD5, "content-md5", "", "content MD5 for blob.")
 	createCmd.PersistentFlags().StringVar(&location, "location", "", "Location of the Azure account or S3 bucket to create")
+	createCmd.PersistentFlags().BoolVar(&genMD5, "generate-md5", false, "auto-generate MD5 for a new blob")
 
 }
 
@@ -238,6 +242,13 @@ func createBlob(blobURL string, blobSize uint32, metadata azblob.Metadata, blobH
 	if blobHTTPHeaders.ContentType == "" {
 		blobHTTPHeaders.ContentType = http.DetectContentType([]byte(randomString))
 	}
+
+	// Generate a content MD5 for the new blob if requested
+	if genMD5 {
+		md5hasher := md5.New()
+		blobHTTPHeaders.ContentMD5 = md5hasher.Sum([]byte(randomString))
+	}
+
 	putBlobResp, err := blobUrl.Upload(
 		context.Background(),
 		strings.NewReader(randomString),
@@ -309,6 +320,12 @@ func createFile(fileURLStr string, fileSize uint32, metadata azfile.Metadata, fi
 	randomString := createStringWithRandomChars(int(fileSize))
 	if fileHTTPHeaders.ContentType == "" {
 		fileHTTPHeaders.ContentType = http.DetectContentType([]byte(randomString))
+	}
+
+	// Generate a content MD5 for the new blob if requested
+	if genMD5 {
+		md5hasher := md5.New()
+		fileHTTPHeaders.ContentMD5 = md5hasher.Sum([]byte(randomString))
 	}
 
 	err = azfile.UploadBufferToAzureFile(context.Background(), []byte(randomString), fileURL, azfile.UploadToAzureFileOptions{

--- a/testSuite/cmd/create.go
+++ b/testSuite/cmd/create.go
@@ -246,7 +246,8 @@ func createBlob(blobURL string, blobSize uint32, metadata azblob.Metadata, blobH
 	// Generate a content MD5 for the new blob if requested
 	if genMD5 {
 		md5hasher := md5.New()
-		blobHTTPHeaders.ContentMD5 = md5hasher.Sum([]byte(randomString))
+		md5hasher.Write([]byte(randomString))
+		blobHTTPHeaders.ContentMD5 = md5hasher.Sum(nil)
 	}
 
 	putBlobResp, err := blobUrl.Upload(
@@ -325,7 +326,8 @@ func createFile(fileURLStr string, fileSize uint32, metadata azfile.Metadata, fi
 	// Generate a content MD5 for the new blob if requested
 	if genMD5 {
 		md5hasher := md5.New()
-		fileHTTPHeaders.ContentMD5 = md5hasher.Sum([]byte(randomString))
+		md5hasher.Write([]byte(randomString))
+		fileHTTPHeaders.ContentMD5 = md5hasher.Sum(nil)
 	}
 
 	err = azfile.UploadBufferToAzureFile(context.Background(), []byte(randomString), fileURL, azfile.UploadToAzureFileOptions{

--- a/testSuite/scripts/test_service_to_service_copy.py
+++ b/testSuite/scripts/test_service_to_service_copy.py
@@ -1147,12 +1147,17 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
         validate_dir_name = "validate_copy_file_from_%s_bucket_to_%s_bucket_propertyandmetadata_%s" % (srcType, dstType, preserveProperties)
         local_validate_dest_dir = util.create_test_dir(validate_dir_name)
         local_validate_dest = local_validate_dest_dir + fileName
+        # Because the MD5 is checked early, we need to clear the check-md5 flag.
         if srcType == "S3":
             result = util.Command("copy").add_arguments(dstFileURL).add_arguments(local_validate_dest). \
-                add_flags("log-level", "info").execute_azcopy_copy_command()
+                add_flags("log-level", "info")  # Temporarily set result to Command for the sake of modifying the md5 check
+            result.flags["check-md5"] = ""
+            result = result.execute_azcopy_copy_command()  # Wrangle result to a bool for checking
         else:
             result = util.Command("copy").add_arguments(srcFileURL).add_arguments(local_validate_dest). \
-                add_flags("log-level", "info").execute_azcopy_copy_command()
+                add_flags("log-level", "info")  # Temporarily set result to Command for the sake of modifying the md5 check
+            result.flags["check-md5"] = ""
+            result = result.execute_azcopy_copy_command()  # Wrangle result to a bool for checking
         self.assertTrue(result)
 
         # TODO: test different targets according to dstType

--- a/testSuite/scripts/test_service_to_service_copy.py
+++ b/testSuite/scripts/test_service_to_service_copy.py
@@ -1151,12 +1151,12 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
         if srcType == "S3":
             result = util.Command("copy").add_arguments(dstFileURL).add_arguments(local_validate_dest). \
                 add_flags("log-level", "info")  # Temporarily set result to Command for the sake of modifying the md5 check
-            result.flags["check-md5"] = ""
+            result.flags["check-md5"] = "NoCheck"
             result = result.execute_azcopy_copy_command()  # Wrangle result to a bool for checking
         else:
             result = util.Command("copy").add_arguments(srcFileURL).add_arguments(local_validate_dest). \
                 add_flags("log-level", "info")  # Temporarily set result to Command for the sake of modifying the md5 check
-            result.flags["check-md5"] = ""
+            result.flags["check-md5"] = "NoCheck"
             result = result.execute_azcopy_copy_command()  # Wrangle result to a bool for checking
         self.assertTrue(result)
 

--- a/testSuite/scripts/test_service_to_service_copy.py
+++ b/testSuite/scripts/test_service_to_service_copy.py
@@ -1137,7 +1137,7 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
         cpCmd = util.Command("copy").add_arguments(srcBucketURL).add_arguments(dstBucketURL). \
             add_flags("log-level", "info").add_flags("recursive", "true")
 
-        if preserveProperties == False:
+        if not preserveProperties:
             cpCmd.add_flags("s2s-preserve-properties", "false")
 
         result = cpCmd.execute_azcopy_copy_command()
@@ -1151,12 +1151,14 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
         if srcType == "S3":
             result = util.Command("copy").add_arguments(dstFileURL).add_arguments(local_validate_dest). \
                 add_flags("log-level", "info")  # Temporarily set result to Command for the sake of modifying the md5 check
-            result.flags["check-md5"] = "NoCheck"
+            if not preserveProperties:
+                result.flags["check-md5"] = "NoCheck"
             result = result.execute_azcopy_copy_command()  # Wrangle result to a bool for checking
         else:
             result = util.Command("copy").add_arguments(srcFileURL).add_arguments(local_validate_dest). \
                 add_flags("log-level", "info")  # Temporarily set result to Command for the sake of modifying the md5 check
-            result.flags["check-md5"] = "NoCheck"
+            if not preserveProperties:
+                result.flags["check-md5"] = "NoCheck"
             result = result.execute_azcopy_copy_command()  # Wrangle result to a bool for checking
         self.assertTrue(result)
 

--- a/testSuite/scripts/test_service_to_service_copy.py
+++ b/testSuite/scripts/test_service_to_service_copy.py
@@ -1141,6 +1141,7 @@ class Service_2_Service_Copy_User_Scenario(unittest.TestCase):
             cpCmd.add_flags("s2s-preserve-properties", "false")
 
         result = cpCmd.execute_azcopy_copy_command()
+        self.assertTrue(result)
 
         # Downloading the copied file for validation
         validate_dir_name = "validate_copy_file_from_%s_bucket_to_%s_bucket_propertyandmetadata_%s" % (srcType, dstType, preserveProperties)

--- a/testSuite/scripts/utility.py
+++ b/testSuite/scripts/utility.py
@@ -595,7 +595,7 @@ def verify_operation(command):
             command, stderr=subprocess.STDOUT, shell=True, timeout=240,
             universal_newlines=True)
     except subprocess.CalledProcessError as exec:
-        # print("command failed with error code ", exec.returncode, " and message " + exec.output)
+        print("command failed with error code ", exec.returncode, " and message " + exec.output)
         return False
     else:
         return True

--- a/testSuite/scripts/utility.py
+++ b/testSuite/scripts/utility.py
@@ -34,6 +34,9 @@ class Command(object):
                 self.add_flags("put-md5", "true")  # this is an upload
             else:
                 self.add_flags("check-md5", "FailIfDifferentOrMissing")
+        if ct == "create":
+            if len(self.args) == 1:
+                self.add_flags("generate-md5", "true") # We want to generate an MD5 on the way up.
 
         return self
 

--- a/testSuite/scripts/utility.py
+++ b/testSuite/scripts/utility.py
@@ -595,7 +595,7 @@ def verify_operation(command):
             command, stderr=subprocess.STDOUT, shell=True, timeout=240,
             universal_newlines=True)
     except subprocess.CalledProcessError as exec:
-        print("command failed with error code ", exec.returncode, " and message " + exec.output)
+        # print("command failed with error code ", exec.returncode, " and message " + exec.output)
         return False
     else:
         return True


### PR DESCRIPTION
Saves a lot of time in the case of extra-large files (#811)