### PR TITLE
Prototyped new end-to-end testing

### DIFF
--- a/common/output.go
+++ b/common/output.go
@@ -74,15 +74,15 @@ func GetJsonStringFromTemplate(template interface{}) string {
 }
 
 // defines the general output template when the format is set to json
-type jsonOutputTemplate struct {
+type JsonOutputTemplate struct {
 	TimeStamp      time.Time
 	MessageType    string
 	MessageContent string // a simple string for INFO and ERROR, a serialized JSON for INIT, PROGRESS, EXIT
 	PromptDetails  PromptDetails
 }
 
-func newJsonOutputTemplate(messageType outputMessageType, messageContent string, promptDetails PromptDetails) *jsonOutputTemplate {
-	return &jsonOutputTemplate{TimeStamp: time.Now(), MessageType: messageType.String(),
+func newJsonOutputTemplate(messageType outputMessageType, messageContent string, promptDetails PromptDetails) *JsonOutputTemplate {
+	return &JsonOutputTemplate{TimeStamp: time.Now(), MessageType: messageType.String(),
 		MessageContent: messageContent, PromptDetails: promptDetails}
 }
 

--- a/common/rpc-models.go
+++ b/common/rpc-models.go
@@ -143,7 +143,7 @@ type ListContainerResponse struct {
 type ListJobSummaryResponse struct {
 	ErrorMsg  string
 	Timestamp time.Time `json:"-"`
-	JobID     JobID     `json:"-"`
+	JobID     JobID
 	// TODO: added for debugging purpose. remove later
 	ActiveConnections int64 `json:",string"`
 	// CompleteJobOrdered determines whether the Job has been completely ordered or not

--- a/e2etest/config.go
+++ b/e2etest/config.go
@@ -1,0 +1,73 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package e2etest
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+
+	"github.com/JeffreyRichter/enum/enum"
+)
+
+// clearly define all the inputs to the end-to-end tests
+// it's ok to panic if the inputs are absolutely required
+// the general guidance is to take in as few parameters as possible
+type GlobalInputManager struct{}
+
+func (GlobalInputManager) GetAccountAndKey(accountType AccountType) (string, string) {
+	var name, key string
+
+	switch accountType {
+	case EAccountType.Standard():
+		name = os.Getenv("AZCOPY_E2E_ACCOUNT_NAME")
+		key = os.Getenv("AZCOPY_E2E_ACCOUNT_KEY")
+	default:
+		panic("Only the standard account type is supported for the moment.")
+	}
+
+	if name == "" || key == "" {
+		panic(fmt.Sprintf("Name and key for %s account must be set before running tests", accountType))
+	}
+
+	return name, key
+}
+
+func (GlobalInputManager) GetExecutablePath() string {
+	path := os.Getenv("AZCOPY_E2E_EXECUTABLE_PATH")
+	if path == "" {
+		panic("Cannot test AzCopy if AZCOPY_E2E_EXECUTABLE_PATH is not provided")
+	}
+
+	return path
+}
+
+var EAccountType = AccountType(0)
+
+type AccountType uint8
+
+func (AccountType) Standard() AccountType                     { return AccountType(0) }
+func (AccountType) Premium() AccountType                      { return AccountType(1) }
+func (AccountType) HierarchicalNamespaceEnabled() AccountType { return AccountType(2) }
+
+func (o AccountType) String() string {
+	return enum.StringInt(o, reflect.TypeOf(o))
+}

--- a/e2etest/factory.go
+++ b/e2etest/factory.go
@@ -1,0 +1,202 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package e2etest
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"runtime"
+	"strings"
+	"time"
+
+	chk "gopkg.in/check.v1"
+
+	"github.com/Azure/azure-storage-azcopy/azbfs"
+	"github.com/Azure/azure-storage-blob-go/azblob"
+	"github.com/Azure/azure-storage-file-go/azfile"
+)
+
+// provide convenient methods to get access to test resources such as accounts, containers/shares, directories
+type TestResourceFactory struct{}
+
+func (TestResourceFactory) GetBlobServiceURL(accountType AccountType) azblob.ServiceURL {
+	accountName, accountKey := GlobalInputManager{}.GetAccountAndKey(accountType)
+	u, _ := url.Parse(fmt.Sprintf("https://%s.blob.core.windows.net/", accountName))
+
+	credential, err := azblob.NewSharedKeyCredential(accountName, accountKey)
+	if err != nil {
+		panic(err)
+	}
+	pipeline := azblob.NewPipeline(credential, azblob.PipelineOptions{})
+	return azblob.NewServiceURL(*u, pipeline)
+}
+
+func (TestResourceFactory) GetFileServiceURL(accountType AccountType) azfile.ServiceURL {
+	accountName, accountKey := GlobalInputManager{}.GetAccountAndKey(accountType)
+	u, _ := url.Parse(fmt.Sprintf("https://%s.file.core.windows.net/", accountName))
+
+	credential, err := azfile.NewSharedKeyCredential(accountName, accountKey)
+	if err != nil {
+		panic(err)
+	}
+	pipeline := azfile.NewPipeline(credential, azfile.PipelineOptions{})
+	return azfile.NewServiceURL(*u, pipeline)
+}
+
+func (TestResourceFactory) GetDatalakeServiceURL(accountType AccountType) azbfs.ServiceURL {
+	accountName, accountKey := GlobalInputManager{}.GetAccountAndKey(accountType)
+	u, _ := url.Parse(fmt.Sprintf("https://%s.dfs.core.windows.net/", accountName))
+
+	cred := azbfs.NewSharedKeyCredential(accountName, accountKey)
+	pipeline := azbfs.NewPipeline(cred, azbfs.PipelineOptions{})
+	return azbfs.NewServiceURL(*u, pipeline)
+}
+
+func (TestResourceFactory) GetBlobServiceURLWithSAS(c *chk.C, accountType AccountType) azblob.ServiceURL {
+	accountName, accountKey := GlobalInputManager{}.GetAccountAndKey(accountType)
+	credential, err := azblob.NewSharedKeyCredential(accountName, accountKey)
+	c.Assert(err, chk.IsNil)
+
+	sasQueryParams, err := azblob.AccountSASSignatureValues{
+		Protocol:      azblob.SASProtocolHTTPS,
+		ExpiryTime:    time.Now().Add(48 * time.Hour),
+		Permissions:   azfile.AccountSASPermissions{Read: true, List: true, Write: true, Delete: true, Add: true, Create: true, Update: true, Process: true}.String(),
+		Services:      azfile.AccountSASServices{File: true, Blob: true, Queue: true}.String(),
+		ResourceTypes: azfile.AccountSASResourceTypes{Service: true, Container: true, Object: true}.String(),
+	}.NewSASQueryParameters(credential)
+	c.Assert(err, chk.IsNil)
+
+	// construct the url from scratch
+	qp := sasQueryParams.Encode()
+	rawURL := fmt.Sprintf("https://%s.blob.core.windows.net/?%s",
+		credential.AccountName(), qp)
+
+	// convert the raw url and validate it was parsed successfully
+	fullURL, err := url.Parse(rawURL)
+	c.Assert(err, chk.IsNil)
+
+	return azblob.NewServiceURL(*fullURL, azblob.NewPipeline(azblob.NewAnonymousCredential(), azblob.PipelineOptions{}))
+}
+
+func (TestResourceFactory) GetContainerURLWithSAS(c *chk.C, accountType AccountType, containerName string) azblob.ContainerURL {
+	accountName, accountKey := GlobalInputManager{}.GetAccountAndKey(accountType)
+	credential, err := azblob.NewSharedKeyCredential(accountName, accountKey)
+	c.Assert(err, chk.IsNil)
+
+	sasQueryParams, err := azblob.BlobSASSignatureValues{
+		Protocol:      azblob.SASProtocolHTTPS,
+		ExpiryTime:    time.Now().UTC().Add(48 * time.Hour),
+		ContainerName: containerName,
+		Permissions:   azblob.ContainerSASPermissions{Read: true, Add: true, Write: true, Create: true, Delete: true, List: true}.String(),
+	}.NewSASQueryParameters(credential)
+	c.Assert(err, chk.IsNil)
+
+	// construct the url from scratch
+	qp := sasQueryParams.Encode()
+	rawURL := fmt.Sprintf("https://%s.blob.core.windows.net/%s?%s",
+		credential.AccountName(), containerName, qp)
+
+	// convert the raw url and validate it was parsed successfully
+	fullURL, err := url.Parse(rawURL)
+	c.Assert(err, chk.IsNil)
+
+	return azblob.NewContainerURL(*fullURL, azblob.NewPipeline(azblob.NewAnonymousCredential(), azblob.PipelineOptions{}))
+}
+
+func (TestResourceFactory) GetBlobURLWithSAS(c *chk.C, accountType AccountType, containerName string, blobName string) azblob.BlobURL {
+	containerURLWithSAS := TestResourceFactory{}.GetContainerURLWithSAS(c, accountType, containerName)
+	blobURLWithSAS := containerURLWithSAS.NewBlobURL(blobName)
+	return blobURLWithSAS
+}
+
+func (TestResourceFactory) CreateNewContainer(c *chk.C, accountType AccountType) (container azblob.ContainerURL, name string, rawURL url.URL) {
+	name = TestResourceNameGenerator{}.GenerateContainerName()
+	container = TestResourceFactory{}.GetBlobServiceURL(accountType).NewContainerURL(name)
+
+	cResp, err := container.Create(context.Background(), nil, azblob.PublicAccessNone)
+	c.Assert(err, chk.IsNil)
+	c.Assert(cResp.StatusCode(), chk.Equals, 201)
+	return container, name, TestResourceFactory{}.GetContainerURLWithSAS(c, accountType, name).URL()
+}
+
+func (TestResourceFactory) CreateLocalDirectory(c *chk.C) (dstDirName string) {
+	dstDirName, err := ioutil.TempDir("", "AzCopyLocalTest")
+	c.Assert(err, chk.IsNil)
+	return
+}
+
+type TestResourceNameGenerator struct{}
+
+const (
+	containerPrefix = "e2etest"
+	blobPrefix      = "blob"
+)
+
+// This function generates an entity name by concatenating the passed prefix,
+// the name of the test requesting the entity name, and the minute, second, and nanoseconds of the call.
+// This should make it easy to associate the entities with their test, uniquely identify
+// them, and determine the order in which they were created.
+// Will truncate the end of the test name, if there is not enough room for it, followed by the time-based suffix,
+// with a non-zero maxLen.
+func generateName(prefix string, maxLen int) string {
+	// The following lines step up the stack find the name of the test method
+	// Note: the way to do this changed in go 1.12, refer to release notes for more info
+	var pcs [10]uintptr
+	n := runtime.Callers(1, pcs[:])
+	frames := runtime.CallersFrames(pcs[:n])
+	name := "TestFoo" // default stub "Foo" is used if anything goes wrong with this procedure
+	for {
+		frame, more := frames.Next()
+		if strings.Contains(frame.Func.Name(), "Suite") {
+			name = frame.Func.Name()
+			break
+		} else if !more {
+			break
+		}
+	}
+	funcNameStart := strings.Index(name, "Test")
+	name = name[funcNameStart+len("Test"):] // Just get the name of the test and not any of the garbage at the beginning
+	name = strings.ToLower(name)            // Ensure it is a valid resource name
+	textualPortion := fmt.Sprintf("%s%s", prefix, strings.ToLower(name))
+	currentTime := time.Now()
+	numericSuffix := fmt.Sprintf("%02d%02d%d", currentTime.Minute(), currentTime.Second(), currentTime.Nanosecond())
+	if maxLen > 0 {
+		maxTextLen := maxLen - len(numericSuffix)
+		if maxTextLen < 1 {
+			panic("max len too short")
+		}
+		if len(textualPortion) > maxTextLen {
+			textualPortion = textualPortion[:maxTextLen]
+		}
+	}
+	name = textualPortion + numericSuffix
+	return name
+}
+
+func (TestResourceNameGenerator) GenerateContainerName() string {
+	return generateName(containerPrefix, 63)
+}
+
+func (TestResourceNameGenerator) generateBlobName() string {
+	return generateName(blobPrefix, 0)
+}

--- a/e2etest/runner.go
+++ b/e2etest/runner.go
@@ -1,0 +1,154 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package e2etest
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/Azure/azure-storage-azcopy/common"
+)
+
+// encapsulates the interaction with the AzCopy instance that is being tested
+// the flag names should be captured here so that in case they change, only 1 place needs to be updated
+type TestRunner struct {
+	flags map[string]string
+}
+
+func newTestRunner() TestRunner {
+	return TestRunner{flags: make(map[string]string)}
+}
+
+func (t *TestRunner) SetOverwriteFlag(value string) {
+	t.flags["overwrite"] = value
+}
+
+func (t *TestRunner) SetRecursiveFlag(value bool) {
+	if value {
+		t.flags["recursive"] = "true"
+	} else {
+		t.flags["recursive"] = "false"
+	}
+}
+
+func (t *TestRunner) SetIncludePathFlag(value string) {
+	t.flags["include-path"] = value
+}
+
+func (t *TestRunner) computeArgs() []string {
+	args := make([]string, 0)
+	for key, value := range t.flags {
+		args = append(args, fmt.Sprintf("--%s=%s", key, value))
+	}
+
+	return append(args, "--output-type=json")
+}
+
+func (t *TestRunner) ExecuteCopyCommand(src, dst string) (CopyCommandResult, error) {
+	args := append([]string{"copy", src, dst}, t.computeArgs()...)
+	out, err := exec.Command(GlobalInputManager{}.GetExecutablePath(), args...).Output()
+	if err != nil {
+		return CopyCommandResult{}, err
+	}
+
+	return newCopyCommandResult(string(out)), nil
+}
+
+func (t *TestRunner) SetTransferStatusFlag(value string) {
+	t.flags["with-status"] = value
+}
+
+func (t *TestRunner) ExecuteJobsShowCommand(jobID common.JobID) (JobsShowCommandResult, error) {
+	args := append([]string{"jobs", "show", jobID.String()}, t.computeArgs()...)
+	out, err := exec.Command(GlobalInputManager{}.GetExecutablePath(), args...).Output()
+	if err != nil {
+		return JobsShowCommandResult{}, err
+	}
+
+	return newJobsShowCommandResult(string(out)), nil
+}
+
+type CopyCommandResult struct {
+	jobID       common.JobID
+	finalStatus common.ListJobSummaryResponse
+}
+
+func newCopyCommandResult(rawOutput string) CopyCommandResult {
+	lines := strings.Split(rawOutput, "\n")
+
+	// parse out the final status
+	// -2 because the last line is empty
+	finalLine := lines[len(lines)-2]
+	finalMsg := common.JsonOutputTemplate{}
+	err := json.Unmarshal([]byte(finalLine), &finalMsg)
+	if err != nil {
+		panic(err)
+	}
+
+	jobSummary := common.ListJobSummaryResponse{}
+	err = json.Unmarshal([]byte(finalMsg.MessageContent), &jobSummary)
+	if err != nil {
+		panic(err)
+	}
+
+	return CopyCommandResult{jobID: jobSummary.JobID, finalStatus: jobSummary}
+}
+
+func (c *CopyCommandResult) GetTransferList(status common.TransferStatus) []common.TransferDetail {
+	runner := newTestRunner()
+	runner.SetTransferStatusFlag(status.String())
+
+	// invoke AzCopy to get the status from the plan files
+	result, err := runner.ExecuteJobsShowCommand(c.jobID)
+	if err != nil {
+		panic(err)
+	}
+
+	return result.transfers
+}
+
+type JobsShowCommandResult struct {
+	jobID     common.JobID
+	transfers []common.TransferDetail
+}
+
+func newJobsShowCommandResult(rawOutput string) JobsShowCommandResult {
+	lines := strings.Split(rawOutput, "\n")
+
+	// parse out the final status
+	// -2 because the last line is empty
+	finalLine := lines[len(lines)-2]
+	finalMsg := common.JsonOutputTemplate{}
+	err := json.Unmarshal([]byte(finalLine), &finalMsg)
+	if err != nil {
+		panic(err)
+	}
+
+	listTransfersResponse := common.ListJobTransfersResponse{}
+	err = json.Unmarshal([]byte(finalMsg.MessageContent), &listTransfersResponse)
+	if err != nil {
+		panic(err)
+	}
+
+	return JobsShowCommandResult{jobID: listTransfersResponse.JobID, transfers: listTransfersResponse.Details}
+}

--- a/e2etest/validator.go
+++ b/e2etest/validator.go
@@ -1,0 +1,76 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package e2etest
+
+import (
+	"net/url"
+	"runtime"
+	"strings"
+
+	"github.com/Azure/azure-storage-azcopy/common"
+
+	chk "gopkg.in/check.v1"
+)
+
+type Validator struct{}
+
+func (Validator) ValidateCopyTransfersAreScheduled(c *chk.C, isSrcEncoded bool, isDstEncoded bool,
+	sourcePrefix string, destinationPrefix string, expectedTransfers []string, actualTransfers []common.TransferDetail) {
+
+	// validate that the right number of transfers were scheduled
+	c.Assert(len(actualTransfers), chk.Equals, len(expectedTransfers))
+
+	// validate that the right transfers were sent
+	lookupMap := scenarioHelper{}.convertListToMap(expectedTransfers)
+	for _, transfer := range actualTransfers {
+		srcRelativeFilePath := strings.TrimPrefix(strings.TrimPrefix(transfer.Src, sourcePrefix), "/")
+		dstRelativeFilePath := strings.TrimPrefix(strings.TrimPrefix(transfer.Dst, destinationPrefix), "/")
+
+		if isSrcEncoded {
+			srcRelativeFilePath, _ = url.PathUnescape(srcRelativeFilePath)
+
+			if runtime.GOOS == "windows" {
+				// Decode unsafe dst characters on windows
+				pathParts := strings.Split(dstRelativeFilePath, "/")
+				invalidChars := `<>\/:"|?*` + string(0x00)
+
+				for _, c := range strings.Split(invalidChars, "") {
+					for k, p := range pathParts {
+						pathParts[k] = strings.ReplaceAll(p, url.PathEscape(c), c)
+					}
+				}
+
+				dstRelativeFilePath = strings.Join(pathParts, "/")
+			}
+		}
+
+		if isDstEncoded {
+			dstRelativeFilePath, _ = url.PathUnescape(dstRelativeFilePath)
+		}
+
+		// the relative paths should be equal
+		c.Assert(srcRelativeFilePath, chk.Equals, dstRelativeFilePath)
+
+		// look up the path from the expected transfers, make sure it exists
+		_, transferExist := lookupMap[srcRelativeFilePath]
+		c.Assert(transferExist, chk.Equals, true)
+	}
+}

--- a/e2etest/zt_copy_blob_upload_test.go
+++ b/e2etest/zt_copy_blob_upload_test.go
@@ -1,0 +1,75 @@
+// Copyright © 2017 Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package e2etest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Azure/azure-storage-azcopy/common"
+
+	chk "gopkg.in/check.v1"
+)
+
+func (s *cmdIntegrationSuite) TestIncludeDir(c *chk.C) {
+	// set up the source
+	files := []string{
+		"filea",
+		"fileb",
+		"filec",
+		"sub/filea",
+		"sub/fileb",
+		"sub/filec",
+		"sub/somethingelse/subsub/filex", // should not be included because sub/subsub is not contiguous here
+		"othersub/sub/subsub/filey",      // should not be included because sub/subsub is not at root here
+	}
+
+	filesToInclude := []string{
+		"sub/subsub/filea",
+		"sub/subsub/fileb",
+		"sub/subsub/filec",
+	}
+
+	dirPath := TestResourceFactory{}.CreateLocalDirectory(c)
+	defer os.RemoveAll(dirPath)
+	scenarioHelper{}.generateLocalFilesFromList(c, dirPath, files)
+	scenarioHelper{}.generateLocalFilesFromList(c, dirPath, filesToInclude)
+
+	// set up the destination
+	containerURL, _, containerURLWithSAS := TestResourceFactory{}.CreateNewContainer(c, EAccountType.Standard())
+	defer deleteContainer(c, containerURL)
+
+	// invoke the executable and get results
+	runner := newTestRunner()
+	runner.SetRecursiveFlag(true)
+	runner.SetIncludePathFlag("sub/subsub")
+
+	result, err := runner.ExecuteCopyCommand(dirPath, containerURLWithSAS.String())
+	c.Assert(err, chk.IsNil)
+	c.Assert(int(result.finalStatus.TransfersCompleted), chk.Equals, len(filesToInclude))
+
+	transfers := result.GetTransferList(common.ETransferStatus.Success())
+	srcRoot := dirPath
+	dstRoot := fmt.Sprintf("%s/%s", containerURL.String(), filepath.Base(dirPath))
+	Validator{}.ValidateCopyTransfersAreScheduled(c, false, true, srcRoot, dstRoot,
+		filesToInclude, transfers)
+}

--- a/e2etest/zt_scenario_helpers.go
+++ b/e2etest/zt_scenario_helpers.go
@@ -1,0 +1,568 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// TODO this file was forked from the cmd package, it needs to cleaned to keep only the necessary part
+
+package e2etest
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-storage-azcopy/azbfs"
+	minio "github.com/minio/minio-go"
+
+	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-blob-go/azblob"
+	"github.com/Azure/azure-storage-file-go/azfile"
+	chk "gopkg.in/check.v1"
+)
+
+const defaultFileSize = 1024
+
+type scenarioHelper struct{}
+
+var specialNames = []string{
+	"打麻将.txt",
+	"wow such space so much space",
+	"打%%#%@#%麻将.txt",
+	//"saywut.pdf?yo=bla&WUWUWU=foo&sig=yyy", // TODO this breaks on windows, figure out a way to add it only for tests on Unix
+	"coração",
+	"আপনার নাম কি",
+	"%4509%4254$85140&",
+	"Donaudampfschifffahrtselektrizitätenhauptbetriebswerkbauunterbeamtengesellschaft",
+	"お名前は何ですか",
+	"Adın ne",
+	"як вас звати",
+}
+
+// note: this is to emulate the list-of-files flag
+func (scenarioHelper) generateListOfFiles(c *chk.C, fileList []string) (path string) {
+	parentDirName, err := ioutil.TempDir("", "AzCopyLocalTest")
+	c.Assert(err, chk.IsNil)
+
+	// create the file
+	path = common.GenerateFullPath(parentDirName, generateName("listy", 0))
+	err = os.MkdirAll(filepath.Dir(path), os.ModePerm)
+	c.Assert(err, chk.IsNil)
+
+	// pipe content into it
+	content := strings.Join(fileList, "\n")
+	err = ioutil.WriteFile(path, []byte(content), common.DEFAULT_FILE_PERM)
+	c.Assert(err, chk.IsNil)
+	return
+}
+
+func (scenarioHelper) generateLocalDirectory(c *chk.C) (dstDirName string) {
+	dstDirName, err := ioutil.TempDir("", "AzCopyLocalTest")
+	c.Assert(err, chk.IsNil)
+	return
+}
+
+// create a test file
+func (scenarioHelper) generateLocalFile(filePath string, fileSize int) ([]byte, error) {
+	// generate random data
+	_, bigBuff := getRandomDataAndReader(fileSize)
+
+	// create all parent directories
+	err := os.MkdirAll(filepath.Dir(filePath), os.ModePerm)
+	if err != nil {
+		return nil, err
+	}
+
+	// write to file and return the data
+	err = ioutil.WriteFile(filePath, bigBuff, common.DEFAULT_FILE_PERM)
+	return bigBuff, err
+}
+
+func (s scenarioHelper) generateLocalFilesFromList(c *chk.C, dirPath string, fileList []string) {
+	for _, fileName := range fileList {
+		_, err := s.generateLocalFile(filepath.Join(dirPath, fileName), defaultFileSize)
+		c.Assert(err, chk.IsNil)
+	}
+
+	// sleep a bit so that the files' lmts are guaranteed to be in the past
+	time.Sleep(time.Millisecond * 1050)
+}
+
+func (s scenarioHelper) generateCommonRemoteScenarioForLocal(c *chk.C, dirPath string, prefix string) (fileList []string) {
+	fileList = make([]string, 50)
+	for i := 0; i < 10; i++ {
+		batch := []string{
+			generateName(prefix+"top", 0),
+			generateName(prefix+"sub1/", 0),
+			generateName(prefix+"sub2/", 0),
+			generateName(prefix+"sub1/sub3/sub5/", 0),
+			generateName(prefix+specialNames[i], 0),
+		}
+
+		for j, name := range batch {
+			fileList[5*i+j] = name
+			_, err := s.generateLocalFile(filepath.Join(dirPath, name), defaultFileSize)
+			c.Assert(err, chk.IsNil)
+		}
+	}
+
+	// sleep a bit so that the files' lmts are guaranteed to be in the past
+	time.Sleep(time.Millisecond * 1050)
+	return
+}
+
+// make 50 blobs with random names
+// 10 of them at the top level
+// 10 of them in sub dir "sub1"
+// 10 of them in sub dir "sub2"
+// 10 of them in deeper sub dir "sub1/sub3/sub5"
+// 10 of them with special characters
+func (scenarioHelper) generateCommonRemoteScenarioForBlob(c *chk.C, containerURL azblob.ContainerURL, prefix string) (blobList []string) {
+	blobList = make([]string, 50)
+
+	for i := 0; i < 10; i++ {
+		_, blobName1 := createNewBlockBlob(c, containerURL, prefix+"top")
+		_, blobName2 := createNewBlockBlob(c, containerURL, prefix+"sub1/")
+		_, blobName3 := createNewBlockBlob(c, containerURL, prefix+"sub2/")
+		_, blobName4 := createNewBlockBlob(c, containerURL, prefix+"sub1/sub3/sub5/")
+		_, blobName5 := createNewBlockBlob(c, containerURL, prefix+specialNames[i])
+
+		blobList[5*i] = blobName1
+		blobList[5*i+1] = blobName2
+		blobList[5*i+2] = blobName3
+		blobList[5*i+3] = blobName4
+		blobList[5*i+4] = blobName5
+	}
+
+	// sleep a bit so that the blobs' lmts are guaranteed to be in the past
+	time.Sleep(time.Millisecond * 1050)
+	return
+}
+
+func (scenarioHelper) generateCommonRemoteScenarioForBlobFS(c *chk.C, filesystemURL azbfs.FileSystemURL, prefix string) (pathList []string) {
+	pathList = make([]string, 50)
+
+	for i := 0; i < 10; i++ {
+		_, pathName1 := createNewBfsFile(c, filesystemURL, prefix+"top")
+		_, pathName2 := createNewBfsFile(c, filesystemURL, prefix+"sub1/")
+		_, pathName3 := createNewBfsFile(c, filesystemURL, prefix+"sub2/")
+		_, pathName4 := createNewBfsFile(c, filesystemURL, prefix+"sub1/sub3/sub5")
+		_, pathName5 := createNewBfsFile(c, filesystemURL, prefix+specialNames[i])
+
+		pathList[5*i] = pathName1
+		pathList[5*i+1] = pathName2
+		pathList[5*i+2] = pathName3
+		pathList[5*i+3] = pathName4
+		pathList[5*i+4] = pathName5
+	}
+
+	// sleep a bit so that the paths' lmts are guaranteed to be in the past
+	time.Sleep(time.Millisecond * 1500)
+	return
+}
+
+func (scenarioHelper) generateCommonRemoteScenarioForAzureFile(c *chk.C, shareURL azfile.ShareURL, prefix string) (fileList []string) {
+	fileList = make([]string, 50)
+
+	for i := 0; i < 10; i++ {
+		_, fileName1 := createNewAzureFile(c, shareURL, prefix+"top")
+		_, fileName2 := createNewAzureFile(c, shareURL, prefix+"sub1/")
+		_, fileName3 := createNewAzureFile(c, shareURL, prefix+"sub2/")
+		_, fileName4 := createNewAzureFile(c, shareURL, prefix+"sub1/sub3/sub5/")
+		_, fileName5 := createNewAzureFile(c, shareURL, prefix+specialNames[i])
+
+		fileList[5*i] = fileName1
+		fileList[5*i+1] = fileName2
+		fileList[5*i+2] = fileName3
+		fileList[5*i+3] = fileName4
+		fileList[5*i+4] = fileName5
+	}
+
+	// sleep a bit so that the blobs' lmts are guaranteed to be in the past
+	time.Sleep(time.Millisecond * 1050)
+	return
+}
+
+func (s scenarioHelper) generateBlobContainersAndBlobsFromLists(c *chk.C, serviceURL azblob.ServiceURL, containerList []string, blobList []string, data string) {
+	for _, containerName := range containerList {
+		curl := serviceURL.NewContainerURL(containerName)
+		_, err := curl.Create(ctx, azblob.Metadata{}, azblob.PublicAccessNone)
+		c.Assert(err, chk.IsNil)
+
+		s.generateBlobsFromList(c, curl, blobList, data)
+	}
+}
+
+func (s scenarioHelper) generateFileSharesAndFilesFromLists(c *chk.C, serviceURL azfile.ServiceURL, shareList []string, fileList []string, data string) {
+	for _, shareName := range shareList {
+		surl := serviceURL.NewShareURL(shareName)
+		_, err := surl.Create(ctx, azfile.Metadata{}, 0)
+		c.Assert(err, chk.IsNil)
+
+		s.generateAzureFilesFromList(c, surl, fileList)
+	}
+}
+
+func (s scenarioHelper) generateFilesystemsAndFilesFromLists(c *chk.C, serviceURL azbfs.ServiceURL, fsList []string, fileList []string, data string) {
+	for _, filesystemName := range fsList {
+		fsURL := serviceURL.NewFileSystemURL(filesystemName)
+		_, err := fsURL.Create(ctx)
+		c.Assert(err, chk.IsNil)
+
+		s.generateBFSPathsFromList(c, fsURL, fileList)
+	}
+}
+
+func (s scenarioHelper) generateS3BucketsAndObjectsFromLists(c *chk.C, s3Client *minio.Client, bucketList []string, objectList []string, data string) {
+	for _, bucketName := range bucketList {
+		err := s3Client.MakeBucket(bucketName, "")
+		c.Assert(err, chk.IsNil)
+
+		s.generateObjects(c, s3Client, bucketName, objectList)
+	}
+}
+
+// create the demanded blobs
+func (scenarioHelper) generateBlobsFromList(c *chk.C, containerURL azblob.ContainerURL, blobList []string, data string) {
+	for _, blobName := range blobList {
+		blob := containerURL.NewBlockBlobURL(blobName)
+		cResp, err := blob.Upload(ctx, strings.NewReader(data), azblob.BlobHTTPHeaders{},
+			nil, azblob.BlobAccessConditions{})
+		c.Assert(err, chk.IsNil)
+		c.Assert(cResp.StatusCode(), chk.Equals, 201)
+	}
+
+	// sleep a bit so that the blobs' lmts are guaranteed to be in the past
+	time.Sleep(time.Millisecond * 1050)
+}
+
+func (scenarioHelper) generatePageBlobsFromList(c *chk.C, containerURL azblob.ContainerURL, blobList []string, data string) {
+	for _, blobName := range blobList {
+		//Create the blob (PUT blob)
+		blob := containerURL.NewPageBlobURL(blobName)
+		cResp, err := blob.Create(ctx,
+			int64(len(data)),
+			0,
+			azblob.BlobHTTPHeaders{
+				ContentType: "text/random",
+			},
+			azblob.Metadata{},
+			azblob.BlobAccessConditions{},
+		)
+		c.Assert(err, chk.IsNil)
+		c.Assert(cResp.StatusCode(), chk.Equals, 201)
+
+		//Create the page (PUT page)
+		uResp, err := blob.UploadPages(ctx,
+			0,
+			strings.NewReader(data),
+			azblob.PageBlobAccessConditions{},
+			nil,
+		)
+		c.Assert(err, chk.IsNil)
+		c.Assert(uResp.StatusCode(), chk.Equals, 201)
+	}
+
+	// sleep a bit so that the blobs' lmts are guaranteed to be in the past
+	time.Sleep(time.Millisecond * 1050)
+}
+
+func (scenarioHelper) generateAppendBlobsFromList(c *chk.C, containerURL azblob.ContainerURL, blobList []string, data string) {
+	for _, blobName := range blobList {
+		//Create the blob (PUT blob)
+		blob := containerURL.NewAppendBlobURL(blobName)
+		cResp, err := blob.Create(ctx,
+			azblob.BlobHTTPHeaders{
+				ContentType: "text/random",
+			},
+			azblob.Metadata{},
+			azblob.BlobAccessConditions{},
+		)
+		c.Assert(err, chk.IsNil)
+		c.Assert(cResp.StatusCode(), chk.Equals, 201)
+
+		//Append a block (PUT block)
+		uResp, err := blob.AppendBlock(ctx,
+			strings.NewReader(data),
+			azblob.AppendBlobAccessConditions{},
+			nil)
+		c.Assert(err, chk.IsNil)
+		c.Assert(uResp.StatusCode(), chk.Equals, 201)
+	}
+
+	// sleep a bit so that the blobs' lmts are guaranteed to be in the past
+	time.Sleep(time.Millisecond * 1050)
+}
+
+func (scenarioHelper) generateBlockBlobWithAccessTier(c *chk.C, containerURL azblob.ContainerURL, blobName string, accessTier azblob.AccessTierType) {
+	blob := containerURL.NewBlockBlobURL(blobName)
+	cResp, err := blob.Upload(ctx, strings.NewReader(blockBlobDefaultData), azblob.BlobHTTPHeaders{},
+		nil, azblob.BlobAccessConditions{})
+	c.Assert(err, chk.IsNil)
+	c.Assert(cResp.StatusCode(), chk.Equals, 201)
+
+	_, err = blob.SetTier(ctx, accessTier, azblob.LeaseAccessConditions{})
+	c.Assert(err, chk.IsNil)
+}
+
+// create the demanded objects
+func (scenarioHelper) generateObjects(c *chk.C, client *minio.Client, bucketName string, objectList []string) {
+	size := int64(len(objectDefaultData))
+	for _, objectName := range objectList {
+		n, err := client.PutObjectWithContext(ctx, bucketName, objectName, strings.NewReader(objectDefaultData), size, minio.PutObjectOptions{})
+		c.Assert(err, chk.IsNil)
+		c.Assert(n, chk.Equals, size)
+	}
+}
+
+// create the demanded files
+func (scenarioHelper) generateFlatFiles(c *chk.C, shareURL azfile.ShareURL, fileList []string) {
+	for _, fileName := range fileList {
+		file := shareURL.NewRootDirectoryURL().NewFileURL(fileName)
+		err := azfile.UploadBufferToAzureFile(ctx, []byte(fileDefaultData), file, azfile.UploadToAzureFileOptions{})
+		c.Assert(err, chk.IsNil)
+	}
+
+	// sleep a bit so that the blobs' lmts are guaranteed to be in the past
+	time.Sleep(time.Millisecond * 1050)
+}
+
+// make 50 objects with random names
+// 10 of them at the top level
+// 10 of them in sub dir "sub1"
+// 10 of them in sub dir "sub2"
+// 10 of them in deeper sub dir "sub1/sub3/sub5"
+// 10 of them with special characters
+func (scenarioHelper) generateCommonRemoteScenarioForS3(c *chk.C, client *minio.Client, bucketName string, prefix string, returnObjectListWithBucketName bool) (objectList []string) {
+	objectList = make([]string, 50)
+
+	for i := 0; i < 10; i++ {
+		objectName1 := createNewObject(c, client, bucketName, prefix+"top")
+		objectName2 := createNewObject(c, client, bucketName, prefix+"sub1/")
+		objectName3 := createNewObject(c, client, bucketName, prefix+"sub2/")
+		objectName4 := createNewObject(c, client, bucketName, prefix+"sub1/sub3/sub5/")
+		objectName5 := createNewObject(c, client, bucketName, prefix+specialNames[i])
+
+		// Note: common.AZCOPY_PATH_SEPARATOR_STRING is added before bucket or objectName, as in the change minimize JobPartPlan file size,
+		// transfer.Source & transfer.Destination(after trimed the SourceRoot and DestinationRoot) are with AZCOPY_PATH_SEPARATOR_STRING suffix,
+		// when user provided source & destination are without / suffix, which is the case for scenarioHelper generated URL.
+
+		bucketPath := ""
+		if returnObjectListWithBucketName {
+			bucketPath = common.AZCOPY_PATH_SEPARATOR_STRING + bucketName
+		}
+
+		objectList[5*i] = bucketPath + common.AZCOPY_PATH_SEPARATOR_STRING + objectName1
+		objectList[5*i+1] = bucketPath + common.AZCOPY_PATH_SEPARATOR_STRING + objectName2
+		objectList[5*i+2] = bucketPath + common.AZCOPY_PATH_SEPARATOR_STRING + objectName3
+		objectList[5*i+3] = bucketPath + common.AZCOPY_PATH_SEPARATOR_STRING + objectName4
+		objectList[5*i+4] = bucketPath + common.AZCOPY_PATH_SEPARATOR_STRING + objectName5
+	}
+
+	// sleep a bit so that the blobs' lmts are guaranteed to be in the past
+	time.Sleep(time.Millisecond * 1050)
+	return
+}
+
+// create the demanded azure files
+func (scenarioHelper) generateAzureFilesFromList(c *chk.C, shareURL azfile.ShareURL, fileList []string) {
+	for _, filePath := range fileList {
+		file := shareURL.NewRootDirectoryURL().NewFileURL(filePath)
+
+		// create parents first
+		generateParentsForAzureFile(c, file)
+
+		// create the file itself
+		cResp, err := file.Create(ctx, defaultAzureFileSizeInBytes, azfile.FileHTTPHeaders{}, azfile.Metadata{})
+		c.Assert(err, chk.IsNil)
+		c.Assert(cResp.StatusCode(), chk.Equals, 201)
+	}
+
+	// sleep a bit so that the files' lmts are guaranteed to be in the past
+	time.Sleep(time.Millisecond * 1050)
+}
+
+func (scenarioHelper) generateBFSPathsFromList(c *chk.C, filesystemURL azbfs.FileSystemURL, fileList []string) {
+	for _, path := range fileList {
+		file := filesystemURL.NewRootDirectoryURL().NewFileURL(path)
+
+		// Create the file
+		cResp, err := file.Create(ctx, azbfs.BlobFSHTTPHeaders{})
+		c.Assert(err, chk.IsNil)
+		c.Assert(cResp.StatusCode(), chk.Equals, 201)
+
+		aResp, err := file.AppendData(ctx, 0, strings.NewReader(string(make([]byte, defaultBlobFSFileSizeInBytes))))
+		c.Assert(err, chk.IsNil)
+		c.Assert(aResp.StatusCode(), chk.Equals, 202)
+
+		fResp, err := file.FlushData(ctx, defaultBlobFSFileSizeInBytes, nil, azbfs.BlobFSHTTPHeaders{}, false, true)
+		c.Assert(err, chk.IsNil)
+		c.Assert(fResp.StatusCode(), chk.Equals, 200)
+	}
+}
+
+// Golang does not have sets, so we have to use a map to fulfill the same functionality
+func (scenarioHelper) convertListToMap(list []string) map[string]int {
+	lookupMap := make(map[string]int)
+	for _, entryName := range list {
+		lookupMap[entryName] = 0
+	}
+
+	return lookupMap
+}
+
+func (scenarioHelper) shaveOffPrefix(list []string, prefix string) []string {
+	cleanList := make([]string, len(list))
+	for i, item := range list {
+		cleanList[i] = strings.TrimPrefix(item, prefix)
+	}
+	return cleanList
+}
+
+func (scenarioHelper) addPrefix(list []string, prefix string) []string {
+	modifiedList := make([]string, len(list))
+	for i, item := range list {
+		modifiedList[i] = prefix + item
+	}
+	return modifiedList
+}
+
+func (scenarioHelper) getRawContainerURLWithSAS(c *chk.C, containerName string) url.URL {
+	accountName, accountKey := GlobalInputManager{}.GetAccountAndKey(EAccountType.Standard())
+	credential, err := azblob.NewSharedKeyCredential(accountName, accountKey)
+	c.Assert(err, chk.IsNil)
+	containerURLWithSAS := getContainerURLWithSAS(c, *credential, containerName)
+	return containerURLWithSAS.URL()
+}
+
+func (scenarioHelper) getRawBlobURLWithSAS(c *chk.C, containerName string, blobName string) url.URL {
+	accountName, accountKey := GlobalInputManager{}.GetAccountAndKey(EAccountType.Standard())
+	credential, err := azblob.NewSharedKeyCredential(accountName, accountKey)
+	c.Assert(err, chk.IsNil)
+	containerURLWithSAS := getContainerURLWithSAS(c, *credential, containerName)
+	blobURLWithSAS := containerURLWithSAS.NewBlockBlobURL(blobName)
+	return blobURLWithSAS.URL()
+}
+
+func (scenarioHelper) getRawBlobServiceURLWithSAS(c *chk.C) url.URL {
+	accountName, accountKey := GlobalInputManager{}.GetAccountAndKey(EAccountType.Standard())
+	credential, err := azblob.NewSharedKeyCredential(accountName, accountKey)
+	c.Assert(err, chk.IsNil)
+
+	return getBlobServiceURLWithSAS(c, *credential).URL()
+}
+
+func (scenarioHelper) getRawFileServiceURLWithSAS(c *chk.C) url.URL {
+	accountName, accountKey := GlobalInputManager{}.GetAccountAndKey(EAccountType.Standard())
+	credential, err := azfile.NewSharedKeyCredential(accountName, accountKey)
+	c.Assert(err, chk.IsNil)
+
+	return getFileServiceURLWithSAS(c, *credential).URL()
+}
+
+func (scenarioHelper) getRawAdlsServiceURLWithSAS(c *chk.C) azbfs.ServiceURL {
+	accountName, accountKey := GlobalInputManager{}.GetAccountAndKey(EAccountType.Standard())
+	credential := azbfs.NewSharedKeyCredential(accountName, accountKey)
+
+	return getAdlsServiceURLWithSAS(c, *credential)
+}
+
+func (scenarioHelper) getBlobServiceURL(c *chk.C) azblob.ServiceURL {
+	accountName, accountKey := GlobalInputManager{}.GetAccountAndKey(EAccountType.Standard())
+	credential, err := azblob.NewSharedKeyCredential(accountName, accountKey)
+	c.Assert(err, chk.IsNil)
+	rawURL := fmt.Sprintf("https://%s.blob.core.windows.net", credential.AccountName())
+
+	// convert the raw url and validate it was parsed successfully
+	fullURL, err := url.Parse(rawURL)
+	c.Assert(err, chk.IsNil)
+
+	return azblob.NewServiceURL(*fullURL, azblob.NewPipeline(credential, azblob.PipelineOptions{}))
+}
+
+func (s scenarioHelper) getContainerURL(c *chk.C, containerName string) azblob.ContainerURL {
+	serviceURL := s.getBlobServiceURL(c)
+	containerURL := serviceURL.NewContainerURL(containerName)
+
+	return containerURL
+}
+
+func (scenarioHelper) getRawS3AccountURL(c *chk.C, region string) url.URL {
+	rawURL := fmt.Sprintf("https://s3%s.amazonaws.com", common.IffString(region == "", "", "-"+region))
+
+	fullURL, err := url.Parse(rawURL)
+	c.Assert(err, chk.IsNil)
+
+	return *fullURL
+}
+
+// TODO: Possibly add virtual-hosted-style and dual stack support. Currently use path style for testing.
+func (scenarioHelper) getRawS3BucketURL(c *chk.C, region string, bucketName string) url.URL {
+	rawURL := fmt.Sprintf("https://s3%s.amazonaws.com/%s", common.IffString(region == "", "", "-"+region), bucketName)
+
+	fullURL, err := url.Parse(rawURL)
+	c.Assert(err, chk.IsNil)
+
+	return *fullURL
+}
+
+func (scenarioHelper) getRawS3ObjectURL(c *chk.C, region string, bucketName string, objectName string) url.URL {
+	rawURL := fmt.Sprintf("https://s3%s.amazonaws.com/%s/%s", common.IffString(region == "", "", "-"+region), bucketName, objectName)
+
+	fullURL, err := url.Parse(rawURL)
+	c.Assert(err, chk.IsNil)
+
+	return *fullURL
+}
+
+func (scenarioHelper) getRawFileURLWithSAS(c *chk.C, shareName string, fileName string) url.URL {
+	credential, err := getGenericCredentialForFile("")
+	c.Assert(err, chk.IsNil)
+	shareURLWithSAS := getShareURLWithSAS(c, *credential, shareName)
+	fileURLWithSAS := shareURLWithSAS.NewRootDirectoryURL().NewFileURL(fileName)
+	return fileURLWithSAS.URL()
+}
+
+func (scenarioHelper) getRawShareURLWithSAS(c *chk.C, shareName string) url.URL {
+	accountName, accountKey := GlobalInputManager{}.GetAccountAndKey(EAccountType.Standard())
+	credential, err := azfile.NewSharedKeyCredential(accountName, accountKey)
+	c.Assert(err, chk.IsNil)
+	shareURLWithSAS := getShareURLWithSAS(c, *credential, shareName)
+	return shareURLWithSAS.URL()
+}
+
+func (scenarioHelper) blobExists(blobURL azblob.BlobURL) bool {
+	_, err := blobURL.GetProperties(context.Background(), azblob.BlobAccessConditions{})
+	if err == nil {
+		return true
+	}
+	return false
+}
+
+func (scenarioHelper) containerExists(containerURL azblob.ContainerURL) bool {
+	_, err := containerURL.GetProperties(context.Background(), azblob.LeaseAccessConditions{})
+	if err == nil {
+		return true
+	}
+	return false
+}

--- a/e2etest/zt_scenario_helpers_for_windows.go
+++ b/e2etest/zt_scenario_helpers_for_windows.go
@@ -1,0 +1,65 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// TODO this file was forked from the cmd package, it needs to cleaned to keep only the necessary part
+
+package e2etest
+
+import (
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	chk "gopkg.in/check.v1"
+)
+
+// set file attributes to test file
+func (scenarioHelper) setAttributesForLocalFile(filePath string, attrList []string) error {
+	lpFilePath, err := syscall.UTF16PtrFromString(filePath)
+	if err != nil {
+		return err
+	}
+
+	fileAttributeMap := map[string]uint32{
+		"R": 1,
+		"A": 32,
+		"S": 4,
+		"H": 2,
+		"C": 2048,
+		"N": 128,
+		"E": 16384,
+		"T": 256,
+		"O": 4096,
+		"I": 8192,
+	}
+	var attrs uint32
+	for _, attribute := range attrList {
+		attrs |= fileAttributeMap[strings.ToUpper(attribute)]
+	}
+	err = syscall.SetFileAttributes(lpFilePath, attrs)
+	return err
+}
+
+func (s scenarioHelper) setAttributesForLocalFiles(c *chk.C, dirPath string, fileList []string, attrList []string) {
+	for _, fileName := range fileList {
+		err := s.setAttributesForLocalFile(filepath.Join(dirPath, fileName), attrList)
+		c.Assert(err, chk.IsNil)
+	}
+}

--- a/e2etest/zt_test.go
+++ b/e2etest/zt_test.go
@@ -1,0 +1,660 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// TODO this file was forked from the cmd package, it needs to cleaned to keep only the necessary part
+
+package e2etest
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-storage-azcopy/azbfs"
+	"github.com/Azure/azure-storage-azcopy/ste"
+	minio "github.com/minio/minio-go"
+
+	chk "gopkg.in/check.v1"
+
+	"github.com/Azure/azure-storage-blob-go/azblob"
+	"github.com/Azure/azure-storage-file-go/azfile"
+)
+
+// Hookup to the testing framework
+func Test(t *testing.T) { chk.TestingT(t) }
+
+type cmdIntegrationSuite struct{}
+
+var _ = chk.Suite(&cmdIntegrationSuite{})
+var ctx = context.Background()
+
+const (
+	blockBlobDefaultData = "AzCopy Random Test Data"
+	//512 bytes of alphanumeric random data
+	pageBlobDefaultData   = "lEYvPHhS2c9T7DDNtM7f0gccgbqe7DMYByLj7d1XS6jV5Y0Cuiz5i86e5llkBwzCahnR4n1MUvfpniNBxgRgJ4oNk8oaIlCevtsPaCZgOMpKdPohp7yYTfawiz8MtHlTwM8OmfgngbH2BNiqtSFEx9GArvkwkVF0dPoG6RRBug0BqHiWyMd0mZifrBTneG13bqKg7A8EjRmBHIqCMGoxOYo1ufojJjYKiv8dfBYGib4pNpfrcxlEWrMKEPcgs3YG3AGg2lIKrMVs7yWnSzwqeEnl9oMFjdwc7XB2e7y2IH1JLt8CzaYgW6qvaPzhFXWbUkIJ6KznQAaKExJt9my625REjn8G4WT5tfo82J2gpdJNAveaF1O09Irjb93Yg07CfeSOrUBo4WwORrfJ60O4nc3MWWvHT2CsJ4b3MtjtVR0nb084SQpRycXPSF9rMympZrwmP0mutBYCVOEWDjsaLOQJoHo2UOiBD2sM5rm4N5mqt0mEInyGO8pKnV7NKn0N"
+	appendBlobDefaultData = "AzCopy Random Append Test Data"
+
+	bucketPrefix      = "s3bucket"
+	objectPrefix      = "s3object"
+	objectDefaultData = "AzCopy default data for S3 object"
+
+	fileDefaultData             = "AzCopy Random Test Data"
+	sharePrefix                 = "share"
+	azureFilePrefix             = "azfile"
+	defaultAzureFileSizeInBytes = 1000
+
+	blobfsPrefix                 = "blobfs"
+	defaultBlobFSFileSizeInBytes = 1000
+)
+
+// if S3_TESTS_OFF is set at all, S3 tests are disabled.
+func isS3Disabled() bool {
+	return strings.ToLower(os.Getenv("S3_TESTS_OFF")) != ""
+}
+
+func skipIfS3Disabled(c *chk.C) {
+	if isS3Disabled() {
+		c.Skip("S3 testing is disabled for this unit test suite run.")
+	}
+}
+
+func generateContainerName() string {
+	return generateName(containerPrefix, 63)
+}
+
+func generateBlobName() string {
+	return generateName(blobPrefix, 0)
+}
+
+func generateBucketName() string {
+	return generateName(bucketPrefix, 63)
+}
+
+func generateBucketNameWithCustomizedPrefix(customizedPrefix string) string {
+	return generateName(customizedPrefix, 63)
+}
+
+func generateObjectName() string {
+	return generateName(objectPrefix, 0)
+}
+
+func generateShareName() string {
+	return generateName(sharePrefix, 63)
+}
+
+func generateFilesystemName() string {
+	return generateName(blobfsPrefix, 63)
+}
+
+func getShareURL(c *chk.C, fsu azfile.ServiceURL) (share azfile.ShareURL, name string) {
+	name = generateShareName()
+	share = fsu.NewShareURL(name)
+
+	return share, name
+}
+
+func generateAzureFileName() string {
+	return generateName(azureFilePrefix, 0)
+}
+
+func generateBfsFileName() string {
+	return generateName(blobfsPrefix, 0)
+}
+
+func getContainerURL(c *chk.C, bsu azblob.ServiceURL) (container azblob.ContainerURL, name string) {
+	name = generateContainerName()
+	container = bsu.NewContainerURL(name)
+
+	return container, name
+}
+
+func getFilesystemURL(c *chk.C, bfssu azbfs.ServiceURL) (filesystem azbfs.FileSystemURL, name string) {
+	name = generateFilesystemName()
+	filesystem = bfssu.NewFileSystemURL(name)
+
+	return
+}
+
+func getBlockBlobURL(c *chk.C, container azblob.ContainerURL, prefix string) (blob azblob.BlockBlobURL, name string) {
+	name = prefix + generateBlobName()
+	blob = container.NewBlockBlobURL(name)
+
+	return blob, name
+}
+
+func getBfsFileURL(c *chk.C, filesystemURL azbfs.FileSystemURL, prefix string) (file azbfs.FileURL, name string) {
+	name = prefix + generateBfsFileName()
+	file = filesystemURL.NewRootDirectoryURL().NewFileURL(name)
+
+	return
+}
+
+func getAppendBlobURL(c *chk.C, container azblob.ContainerURL, prefix string) (blob azblob.AppendBlobURL, name string) {
+	name = generateBlobName()
+	blob = container.NewAppendBlobURL(prefix + name)
+
+	return blob, name
+}
+
+func getPageBlobURL(c *chk.C, container azblob.ContainerURL, prefix string) (blob azblob.PageBlobURL, name string) {
+	name = generateBlobName()
+	blob = container.NewPageBlobURL(prefix + name)
+
+	return
+}
+
+func getAzureFileURL(c *chk.C, shareURL azfile.ShareURL, prefix string) (fileURL azfile.FileURL, name string) {
+	name = prefix + generateAzureFileName()
+	fileURL = shareURL.NewRootDirectoryURL().NewFileURL(name)
+
+	return
+}
+
+func getReaderToRandomBytes(n int) *bytes.Reader {
+	r, _ := getRandomDataAndReader(n)
+	return r
+}
+
+func getRandomDataAndReader(n int) (*bytes.Reader, []byte) {
+	data := make([]byte, n, n)
+	rand.Read(data)
+	return bytes.NewReader(data), data
+}
+
+func createNewContainer(c *chk.C, bsu azblob.ServiceURL) (container azblob.ContainerURL, name string) {
+	container, name = getContainerURL(c, bsu)
+
+	cResp, err := container.Create(ctx, nil, azblob.PublicAccessNone)
+	c.Assert(err, chk.IsNil)
+	c.Assert(cResp.StatusCode(), chk.Equals, 201)
+	return container, name
+}
+
+func createNewFilesystem(c *chk.C, bfssu azbfs.ServiceURL) (filesystem azbfs.FileSystemURL, name string) {
+	filesystem, name = getFilesystemURL(c, bfssu)
+
+	cResp, err := filesystem.Create(ctx)
+	c.Assert(err, chk.IsNil)
+	c.Assert(cResp.StatusCode(), chk.Equals, 201)
+	return
+}
+
+func createNewBfsFile(c *chk.C, filesystem azbfs.FileSystemURL, prefix string) (file azbfs.FileURL, name string) {
+	file, name = getBfsFileURL(c, filesystem, prefix)
+
+	// Create the file
+	cResp, err := file.Create(ctx, azbfs.BlobFSHTTPHeaders{})
+	c.Assert(err, chk.IsNil)
+	c.Assert(cResp.StatusCode(), chk.Equals, 201)
+
+	aResp, err := file.AppendData(ctx, 0, strings.NewReader(string(make([]byte, defaultBlobFSFileSizeInBytes))))
+	c.Assert(err, chk.IsNil)
+	c.Assert(aResp.StatusCode(), chk.Equals, 202)
+
+	fResp, err := file.FlushData(ctx, defaultBlobFSFileSizeInBytes, nil, azbfs.BlobFSHTTPHeaders{}, false, true)
+	c.Assert(err, chk.IsNil)
+	c.Assert(fResp.StatusCode(), chk.Equals, 200)
+	return
+}
+
+func createNewBlockBlob(c *chk.C, container azblob.ContainerURL, prefix string) (blob azblob.BlockBlobURL, name string) {
+	blob, name = getBlockBlobURL(c, container, prefix)
+
+	cResp, err := blob.Upload(ctx, strings.NewReader(blockBlobDefaultData), azblob.BlobHTTPHeaders{},
+		nil, azblob.BlobAccessConditions{})
+
+	c.Assert(err, chk.IsNil)
+	c.Assert(cResp.StatusCode(), chk.Equals, 201)
+
+	return
+}
+
+func createNewAzureShare(c *chk.C, fsu azfile.ServiceURL) (share azfile.ShareURL, name string) {
+	share, name = getShareURL(c, fsu)
+
+	cResp, err := share.Create(ctx, nil, 0)
+	c.Assert(err, chk.IsNil)
+	c.Assert(cResp.StatusCode(), chk.Equals, 201)
+	return share, name
+}
+
+func createNewAzureFile(c *chk.C, share azfile.ShareURL, prefix string) (file azfile.FileURL, name string) {
+	file, name = getAzureFileURL(c, share, prefix)
+
+	// generate parents first
+	generateParentsForAzureFile(c, file)
+
+	cResp, err := file.Create(ctx, defaultAzureFileSizeInBytes, azfile.FileHTTPHeaders{}, azfile.Metadata{})
+	c.Assert(err, chk.IsNil)
+	c.Assert(cResp.StatusCode(), chk.Equals, 201)
+
+	return
+}
+
+func generateParentsForAzureFile(c *chk.C, fileURL azfile.FileURL) {
+	accountName, accountKey := GlobalInputManager{}.GetAccountAndKey(EAccountType.Standard())
+	credential, _ := azfile.NewSharedKeyCredential(accountName, accountKey)
+	err := ste.AzureFileParentDirCreator{}.CreateParentDirToRoot(ctx, fileURL, azfile.NewPipeline(credential, azfile.PipelineOptions{}))
+	c.Assert(err, chk.IsNil)
+}
+
+func createNewAppendBlob(c *chk.C, container azblob.ContainerURL, prefix string) (blob azblob.AppendBlobURL, name string) {
+	blob, name = getAppendBlobURL(c, container, prefix)
+
+	resp, err := blob.Create(ctx, azblob.BlobHTTPHeaders{}, nil, azblob.BlobAccessConditions{})
+
+	c.Assert(err, chk.IsNil)
+	c.Assert(resp.StatusCode(), chk.Equals, 201)
+	return
+}
+
+func createNewPageBlob(c *chk.C, container azblob.ContainerURL, prefix string) (blob azblob.PageBlobURL, name string) {
+	blob, name = getPageBlobURL(c, container, prefix)
+
+	resp, err := blob.Create(ctx, azblob.PageBlobPageBytes*10, 0, azblob.BlobHTTPHeaders{}, nil, azblob.BlobAccessConditions{})
+
+	c.Assert(err, chk.IsNil)
+	c.Assert(resp.StatusCode(), chk.Equals, 201)
+	return
+}
+
+func deleteContainer(c *chk.C, container azblob.ContainerURL) {
+	resp, err := container.Delete(ctx, azblob.ContainerAccessConditions{})
+	c.Assert(err, chk.IsNil)
+	c.Assert(resp.StatusCode(), chk.Equals, 202)
+}
+
+func deleteFilesystem(c *chk.C, filesystem azbfs.FileSystemURL) {
+	resp, err := filesystem.Delete(ctx)
+	c.Assert(err, chk.IsNil)
+	c.Assert(resp.StatusCode(), chk.Equals, 202)
+}
+
+func validateStorageError(c *chk.C, err error, code azblob.ServiceCodeType) {
+	serr, _ := err.(azblob.StorageError)
+	c.Assert(serr.ServiceCode(), chk.Equals, code)
+}
+
+func getRelativeTimeGMT(amount time.Duration) time.Time {
+	currentTime := time.Now().In(time.FixedZone("GMT", 0))
+	currentTime = currentTime.Add(amount * time.Second)
+	return currentTime
+}
+
+func generateCurrentTimeWithModerateResolution() time.Time {
+	highResolutionTime := time.Now().UTC()
+	return time.Date(highResolutionTime.Year(), highResolutionTime.Month(), highResolutionTime.Day(), highResolutionTime.Hour(), highResolutionTime.Minute(),
+		highResolutionTime.Second(), 0, highResolutionTime.Location())
+}
+
+type createS3ResOptions struct {
+	Location string
+}
+
+func createS3ClientWithMinio(o createS3ResOptions) (*minio.Client, error) {
+	if isS3Disabled() {
+		return nil, errors.New("s3 testing is disabled")
+	}
+
+	accessKeyID := os.Getenv("AWS_ACCESS_KEY_ID")
+	secretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
+
+	if accessKeyID == "" || secretAccessKey == "" {
+		return nil, fmt.Errorf("AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY should be set before creating the S3 client")
+	}
+
+	s3Client, err := minio.NewWithRegion("s3.amazonaws.com", accessKeyID, secretAccessKey, true, o.Location)
+	if err != nil {
+		return nil, err
+	}
+	return s3Client, nil
+}
+
+func createNewBucket(c *chk.C, client *minio.Client, o createS3ResOptions) string {
+	bucketName := generateBucketName()
+	err := client.MakeBucket(bucketName, o.Location)
+	c.Assert(err, chk.IsNil)
+
+	return bucketName
+}
+
+func createNewBucketWithName(c *chk.C, client *minio.Client, bucketName string, o createS3ResOptions) {
+	err := client.MakeBucket(bucketName, o.Location)
+	c.Assert(err, chk.IsNil)
+}
+
+func createNewObject(c *chk.C, client *minio.Client, bucketName string, prefix string) (objectKey string) {
+	objectKey = prefix + generateObjectName()
+
+	size := int64(len(objectDefaultData))
+	n, err := client.PutObject(bucketName, objectKey, strings.NewReader(objectDefaultData), size, minio.PutObjectOptions{})
+	c.Assert(err, chk.IsNil)
+
+	c.Assert(n, chk.Equals, size)
+
+	return
+}
+
+func deleteBucket(c *chk.C, client *minio.Client, bucketName string, waitQuarterMinute bool) {
+	// If we error out in this function, simply just skip over deleting the bucket.
+	// Some of our buckets have become "ghost" buckets in the past.
+	// Ghost buckets show up in list calls but can't actually be interacted with.
+	// Some ghost buckets are temporary, others are permanent.
+	// As such, we need a way to deal with them when they show up.
+	// By doing this, they'll just be cleaned up the next test run instead of failing all tests.
+	objectsCh := make(chan string)
+
+	go func() {
+		defer close(objectsCh)
+
+		// List all objects from a bucket-name with a matching prefix.
+		for object := range client.ListObjectsV2(bucketName, "", true, context.Background().Done()) {
+			if object.Err != nil {
+				return
+			}
+
+			objectsCh <- object.Key
+		}
+	}()
+
+	// List bucket, and delete all the objects in the bucket
+	errChn := client.RemoveObjects(bucketName, objectsCh)
+	var err error
+
+	for rmObjErr := range errChn {
+		if rmObjErr.Err != nil {
+			return
+		}
+	}
+
+	// Remove the bucket.
+	err = client.RemoveBucket(bucketName)
+
+	if err != nil {
+		return
+	}
+
+	if waitQuarterMinute {
+		time.Sleep(time.Second * 15)
+	}
+}
+
+func cleanS3Account(c *chk.C, client *minio.Client) {
+	buckets, err := client.ListBuckets()
+	if err != nil {
+		return
+	}
+
+	for _, bucket := range buckets {
+		if strings.Contains(bucket.Name, "elastic") {
+			continue
+		}
+		deleteBucket(c, client, bucket.Name, false)
+	}
+
+	time.Sleep(time.Minute)
+}
+
+func cleanBlobAccount(c *chk.C, serviceURL azblob.ServiceURL) {
+	marker := azblob.Marker{}
+	for marker.NotDone() {
+		resp, err := serviceURL.ListContainersSegment(ctx, marker, azblob.ListContainersSegmentOptions{})
+		c.Assert(err, chk.IsNil)
+
+		for _, v := range resp.ContainerItems {
+			_, err = serviceURL.NewContainerURL(v.Name).Delete(ctx, azblob.ContainerAccessConditions{})
+			c.Assert(err, chk.IsNil)
+		}
+
+		marker = resp.NextMarker
+	}
+}
+
+func cleanFileAccount(c *chk.C, serviceURL azfile.ServiceURL) {
+	marker := azfile.Marker{}
+	for marker.NotDone() {
+		resp, err := serviceURL.ListSharesSegment(ctx, marker, azfile.ListSharesOptions{})
+		c.Assert(err, chk.IsNil)
+
+		for _, v := range resp.ShareItems {
+			_, err = serviceURL.NewShareURL(v.Name).Delete(ctx, azfile.DeleteSnapshotsOptionNone)
+			c.Assert(err, chk.IsNil)
+		}
+
+		marker = resp.NextMarker
+	}
+
+	time.Sleep(time.Minute)
+}
+
+func getGenericCredentialForFile(accountType string) (*azfile.SharedKeyCredential, error) {
+	accountNameEnvVar := accountType + "ACCOUNT_NAME"
+	accountKeyEnvVar := accountType + "ACCOUNT_KEY"
+	accountName, accountKey := os.Getenv(accountNameEnvVar), os.Getenv(accountKeyEnvVar)
+	if accountName == "" || accountKey == "" {
+		return nil, errors.New(accountNameEnvVar + " and/or " + accountKeyEnvVar + " environment variables not specified.")
+	}
+	return azfile.NewSharedKeyCredential(accountName, accountKey)
+}
+
+func getAlternateFSU() (azfile.ServiceURL, error) {
+	secondaryAccountName, secondaryAccountKey := os.Getenv("SECONDARY_ACCOUNT_NAME"), os.Getenv("SECONDARY_ACCOUNT_KEY")
+	if secondaryAccountName == "" || secondaryAccountKey == "" {
+		return azfile.ServiceURL{}, errors.New("SECONDARY_ACCOUNT_NAME and/or SECONDARY_ACCOUNT_KEY environment variables not specified.")
+	}
+	fsURL, _ := url.Parse("https://" + secondaryAccountName + ".file.core.windows.net/")
+
+	credential, err := azfile.NewSharedKeyCredential(secondaryAccountName, secondaryAccountKey)
+	if err != nil {
+		return azfile.ServiceURL{}, err
+	}
+	pipeline := azfile.NewPipeline(credential, azfile.PipelineOptions{ /*Log: pipeline.NewLogWrapper(pipeline.LogInfo, log.New(os.Stderr, "", log.LstdFlags))*/ })
+
+	return azfile.NewServiceURL(*fsURL, pipeline), nil
+}
+
+func deleteShare(c *chk.C, share azfile.ShareURL) {
+	_, err := share.Delete(ctx, azfile.DeleteSnapshotsOptionInclude)
+	c.Assert(err, chk.IsNil)
+}
+
+// Some tests require setting service properties. It can take up to 30 seconds for the new properties to be reflected across all FEs.
+// We will enable the necessary property and try to run the test implementation. If it fails with an error that should be due to
+// those changes not being reflected yet, we will wait 30 seconds and try the test again. If it fails this time for any reason,
+// we fail the test. It is the responsibility of the the testImplFunc to determine which error string indicates the test should be retried.
+// There can only be one such string. All errors that cannot be due to this detail should be asserted and not returned as an error string.
+func runTestRequiringServiceProperties(c *chk.C, bsu azblob.ServiceURL, code string,
+	enableServicePropertyFunc func(*chk.C, azblob.ServiceURL),
+	testImplFunc func(*chk.C, azblob.ServiceURL) error,
+	disableServicePropertyFunc func(*chk.C, azblob.ServiceURL)) {
+	enableServicePropertyFunc(c, bsu)
+	defer disableServicePropertyFunc(c, bsu)
+	err := testImplFunc(c, bsu)
+	// We cannot assume that the error indicative of slow update will necessarily be a StorageError. As in ListBlobs.
+	if err != nil && err.Error() == code {
+		time.Sleep(time.Second * 30)
+		err = testImplFunc(c, bsu)
+		c.Assert(err, chk.IsNil)
+	}
+}
+
+func enableSoftDelete(c *chk.C, bsu azblob.ServiceURL) {
+	days := int32(1)
+	_, err := bsu.SetProperties(ctx, azblob.StorageServiceProperties{DeleteRetentionPolicy: &azblob.RetentionPolicy{Enabled: true, Days: &days}})
+	c.Assert(err, chk.IsNil)
+}
+
+func disableSoftDelete(c *chk.C, bsu azblob.ServiceURL) {
+	_, err := bsu.SetProperties(ctx, azblob.StorageServiceProperties{DeleteRetentionPolicy: &azblob.RetentionPolicy{Enabled: false}})
+	c.Assert(err, chk.IsNil)
+}
+
+func validateUpload(c *chk.C, blobURL azblob.BlockBlobURL) {
+	resp, err := blobURL.Download(ctx, 0, 0, azblob.BlobAccessConditions{}, false)
+	c.Assert(err, chk.IsNil)
+	data, _ := ioutil.ReadAll(resp.Response().Body)
+	c.Assert(data, chk.HasLen, 0)
+}
+
+func getContainerURLWithSAS(c *chk.C, credential azblob.SharedKeyCredential, containerName string) azblob.ContainerURL {
+	sasQueryParams, err := azblob.BlobSASSignatureValues{
+		Protocol:      azblob.SASProtocolHTTPS,
+		ExpiryTime:    time.Now().UTC().Add(48 * time.Hour),
+		ContainerName: containerName,
+		Permissions:   azblob.ContainerSASPermissions{Read: true, Add: true, Write: true, Create: true, Delete: true, List: true}.String(),
+	}.NewSASQueryParameters(&credential)
+	c.Assert(err, chk.IsNil)
+
+	// construct the url from scratch
+	qp := sasQueryParams.Encode()
+	rawURL := fmt.Sprintf("https://%s.blob.core.windows.net/%s?%s",
+		credential.AccountName(), containerName, qp)
+
+	// convert the raw url and validate it was parsed successfully
+	fullURL, err := url.Parse(rawURL)
+	c.Assert(err, chk.IsNil)
+
+	// TODO perhaps we need a global default pipeline
+	return azblob.NewContainerURL(*fullURL, azblob.NewPipeline(azblob.NewAnonymousCredential(), azblob.PipelineOptions{}))
+}
+
+func getBlobServiceURLWithSAS(c *chk.C, credential azblob.SharedKeyCredential) azblob.ServiceURL {
+	sasQueryParams, err := azblob.AccountSASSignatureValues{
+		Protocol:      azblob.SASProtocolHTTPS,
+		ExpiryTime:    time.Now().Add(48 * time.Hour),
+		Permissions:   azfile.AccountSASPermissions{Read: true, List: true, Write: true, Delete: true, Add: true, Create: true, Update: true, Process: true}.String(),
+		Services:      azfile.AccountSASServices{File: true, Blob: true, Queue: true}.String(),
+		ResourceTypes: azfile.AccountSASResourceTypes{Service: true, Container: true, Object: true}.String(),
+	}.NewSASQueryParameters(&credential)
+	c.Assert(err, chk.IsNil)
+
+	// construct the url from scratch
+	qp := sasQueryParams.Encode()
+	rawURL := fmt.Sprintf("https://%s.blob.core.windows.net/?%s",
+		credential.AccountName(), qp)
+
+	// convert the raw url and validate it was parsed successfully
+	fullURL, err := url.Parse(rawURL)
+	c.Assert(err, chk.IsNil)
+
+	return azblob.NewServiceURL(*fullURL, azblob.NewPipeline(azblob.NewAnonymousCredential(), azblob.PipelineOptions{}))
+}
+
+func getFileServiceURLWithSAS(c *chk.C, credential azfile.SharedKeyCredential) azfile.ServiceURL {
+	sasQueryParams, err := azfile.AccountSASSignatureValues{
+		Protocol:      azfile.SASProtocolHTTPS,
+		ExpiryTime:    time.Now().Add(48 * time.Hour),
+		Permissions:   azfile.AccountSASPermissions{Read: true, List: true, Write: true, Delete: true, Add: true, Create: true, Update: true, Process: true}.String(),
+		Services:      azfile.AccountSASServices{File: true, Blob: true, Queue: true}.String(),
+		ResourceTypes: azfile.AccountSASResourceTypes{Service: true, Container: true, Object: true}.String(),
+	}.NewSASQueryParameters(&credential)
+	c.Assert(err, chk.IsNil)
+
+	qp := sasQueryParams.Encode()
+	rawURL := fmt.Sprintf("https://%s.file.core.windows.net/?%s", credential.AccountName(), qp)
+
+	fullURL, err := url.Parse(rawURL)
+	c.Assert(err, chk.IsNil)
+
+	return azfile.NewServiceURL(*fullURL, azfile.NewPipeline(azfile.NewAnonymousCredential(), azfile.PipelineOptions{}))
+}
+
+func getShareURLWithSAS(c *chk.C, credential azfile.SharedKeyCredential, shareName string) azfile.ShareURL {
+	sasQueryParams, err := azfile.FileSASSignatureValues{
+		Protocol:    azfile.SASProtocolHTTPS,
+		ExpiryTime:  time.Now().UTC().Add(48 * time.Hour),
+		ShareName:   shareName,
+		Permissions: azfile.ShareSASPermissions{Read: true, Write: true, Create: true, Delete: true, List: true}.String(),
+	}.NewSASQueryParameters(&credential)
+	c.Assert(err, chk.IsNil)
+
+	// construct the url from scratch
+	qp := sasQueryParams.Encode()
+	rawURL := fmt.Sprintf("https://%s.file.core.windows.net/%s?%s",
+		credential.AccountName(), shareName, qp)
+
+	// convert the raw url and validate it was parsed successfully
+	fullURL, err := url.Parse(rawURL)
+	c.Assert(err, chk.IsNil)
+
+	// TODO perhaps we need a global default pipeline
+	return azfile.NewShareURL(*fullURL, azfile.NewPipeline(azfile.NewAnonymousCredential(), azfile.PipelineOptions{}))
+}
+
+func getAdlsServiceURLWithSAS(c *chk.C, credential azbfs.SharedKeyCredential) azbfs.ServiceURL {
+	sasQueryParams, err := azbfs.AccountSASSignatureValues{
+		Protocol:      azbfs.SASProtocolHTTPS,
+		ExpiryTime:    time.Now().Add(48 * time.Hour),
+		Permissions:   azfile.AccountSASPermissions{Read: true, List: true, Write: true, Delete: true, Add: true, Create: true, Update: true, Process: true}.String(),
+		Services:      azfile.AccountSASServices{File: true, Blob: true, Queue: true}.String(),
+		ResourceTypes: azfile.AccountSASResourceTypes{Service: true, Container: true, Object: true}.String(),
+	}.NewSASQueryParameters(&credential)
+	c.Assert(err, chk.IsNil)
+
+	// construct the url from scratch
+	qp := sasQueryParams.Encode()
+	rawURL := fmt.Sprintf("https://%s.dfs.core.windows.net/?%s",
+		credential.AccountName(), qp)
+
+	// convert the raw url and validate it was parsed successfully
+	fullURL, err := url.Parse(rawURL)
+	c.Assert(err, chk.IsNil)
+
+	return azbfs.NewServiceURL(*fullURL, azbfs.NewPipeline(azbfs.NewAnonymousCredential(), azbfs.PipelineOptions{}))
+}
+
+// check.v1 style "StringContains" checker
+
+type stringContainsChecker struct {
+	*chk.CheckerInfo
+}
+
+var StringContains = &stringContainsChecker{
+	&chk.CheckerInfo{Name: "StringContains", Params: []string{"obtained", "expected to find"}},
+}
+
+func (checker *stringContainsChecker) Check(params []interface{}, names []string) (result bool, error string) {
+	if len(params) < 2 {
+		return false, "StringContains requires two parameters"
+	} // Ignore extra parameters
+
+	// Assert that params[0] and params[1] are strings
+	aStr, aOK := params[0].(string)
+	bStr, bOK := params[1].(string)
+	if !aOK || !bOK {
+		return false, "All parameters must be strings"
+	}
+
+	if strings.Contains(aStr, bStr) {
+		return true, ""
+	}
+
+	return false, fmt.Sprintf("Failed to find substring in source string:\n\n"+
+		"SOURCE: %s\n"+
+		"EXPECTED: %s\n", aStr, bStr)
+}


### PR DESCRIPTION
The goals of the prototype is to propose a new approach to:

1. allow us to run tests in parallel (on multiple OSs at the same time, using the same account)
2. avoid the need to update credentials periodically on the CI config
3. understand why tests are failing (no "False is not True" LOL)
4. easily allow devs to run tests locally, no need to configure 20 environment variables
5. have faster tests so that it's easier to add coverage for our scenarios
6. have more concise tests (avoid repetitive setups)

😃 Don't be alarmed, there aren't that many new lines. Only 4 short files matter here:

1. config.go: defines all the inputs to the end-to-end testing. We should take in credentials that don't expire (goal 2 and 4), to lower the number of inputs.
2. factory.go: generate test resources on the fly. Each test should create its own randomly named resource, so that tests can run in parallel (goal 1 and 5). We need to think about how account -> account scenarios fit in (idea: use a SPN identity to create new accounts on the fly)
3. runner.go: takes care of invoking the AzCopy binary, and parse the outputs to tell us about the results (goal 3). More improvements are due here.
4. validator.go: helper methods that validate results. 

zt_copy_blob_upload_test.go shows a basic working test.

The rest of the files are ported from the cmd package. Their contents will be extracted out into the appropriate places ultimately. 