### PR TITLE
Don't attempt to close the logs if the log level is none

### DIFF
--- a/common/logger.go
+++ b/common/logger.go
@@ -163,6 +163,10 @@ func (jl *jobLogger) ShouldLog(level pipeline.LogLevel) bool {
 }
 
 func (jl *jobLogger) CloseLog() {
+	if jl.minimumLevelToLog == pipeline.LogNone {
+		return
+	}
+
 	jl.logger.Println("Closing Log")
 	err := jl.file.Close()
 	PanicIfErr(err)


### PR DESCRIPTION
They were never opened in the first place.