### PR TITLE
Remove all usages of legacy getCredType code

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -856,13 +856,14 @@ func (cca *cookedCopyCmdArgs) processCopyJobPartOrders() (err error) {
 	// We ignore the isPublic flag because it cannot be returned when we indicate this is not a source credential.
 	// Note that we also no longer need to obtain the OAuth token ourselves because getCredentialInfoForLocation does this for us in a safe manner.
 	// Note that this is not re-used for any operations against the source.
-	toTrash := cca.fromTo.To() == common.ELocation.Unknown()
+	useSrc := cca.fromTo.To() == common.ELocation.Unknown() || cca.fromTo.IsDownload()
 	if cca.dstCredentialInfo, _, err = getCredentialInfoForLocation(
 		ctx,
-		// We want to provide source information when doing a trash transfer, since remove puts all of our information in cca.source.
-		common.IffLocation(toTrash, cca.fromTo.From(), cca.fromTo.To()),
-		common.IffString(toTrash, cca.source, cca.destination),
-		common.IffString(toTrash, cca.sourceSAS, cca.destinationSAS),
+		// Sometimes we do need to use the source credentials.
+		// For instance, when downloading, or attempting to delete files.
+		common.IffLocation(useSrc, cca.fromTo.From(), cca.fromTo.To()),
+		common.IffString(useSrc, cca.source, cca.destination),
+		common.IffString(useSrc, cca.sourceSAS, cca.destinationSAS),
 		false,
 	); err != nil {
 		return err

--- a/cmd/credentialUtil.go
+++ b/cmd/credentialUtil.go
@@ -260,7 +260,7 @@ type rawFromToInfo struct {
 func getCredentialInfoForLocation(ctx context.Context, location common.Location, resource, resourceSAS string, isSource bool) (credInfo common.CredentialInfo, isPublic bool, err error) {
 	if resourceSAS != "" {
 		credInfo.CredentialType = common.ECredentialType.Anonymous()
-	} else if credInfo.CredentialType = GetCredTypeFromEnvVar(); credInfo.CredentialType == common.ECredentialType.Unknown() {
+	} else if credInfo.CredentialType = GetCredTypeFromEnvVar(); credInfo.CredentialType == common.ECredentialType.Unknown() || location == common.ELocation.S3() {
 		switch location {
 		case common.ELocation.Local(), common.ELocation.Benchmark():
 			credInfo.CredentialType = common.ECredentialType.Anonymous()

--- a/cmd/jobsResume.go
+++ b/cmd/jobsResume.go
@@ -273,13 +273,13 @@ func (rca resumeCmdArgs) process() error {
 
 	// Determine the destination credential info to pass to STE and remove.
 	// We ignore the isPublic flag because it cannot be returned when we indicate this is not a source credential.
-	toTrash := getJobFromToResponse.FromTo.To() == common.ELocation.Unknown()
+	useSrc := getJobFromToResponse.FromTo.To() == common.ELocation.Unknown() || getJobFromToResponse.FromTo.IsDownload()
 	if credentialInfo, _, err = getCredentialInfoForLocation(
 		ctx,
-		// Because delete blob and delete file are handled by STE, we'll do much the same thing as copy, and supply the "source" information instead.
-		common.IffLocation(toTrash, getJobFromToResponse.FromTo.From(), getJobFromToResponse.FromTo.To()),
-		common.IffString(toTrash, getJobFromToResponse.Source, getJobFromToResponse.Destination),
-		common.IffString(toTrash, rca.SourceSAS, rca.DestinationSAS),
+		// Since downloads and deletes require source credentials, we need to be able to get either when needbe.
+		common.IffLocation(useSrc, getJobFromToResponse.FromTo.From(), getJobFromToResponse.FromTo.To()),
+		common.IffString(useSrc, getJobFromToResponse.Source, getJobFromToResponse.Destination),
+		common.IffString(useSrc, rca.SourceSAS, rca.DestinationSAS),
 		false,
 	); err != nil {
 		return err

--- a/cmd/removeEnumerator.go
+++ b/cmd/removeEnumerator.go
@@ -57,7 +57,7 @@ func newRemoveEnumerator(cca *cookedCopyCmdArgs) (enumerator *copyEnumerator, er
 	}
 
 	// Include-path is handled by ListOfFilesChannel.
-	sourceTraverser, err = initResourceTraverser(rawURL.String(), cca.fromTo.From(), &ctx, &cca.credentialInfo, nil, cca.listOfFilesChannel, cca.recursive, false, func() {})
+	sourceTraverser, err = initResourceTraverser(rawURL.String(), cca.fromTo.From(), &ctx, &cca.dstCredentialInfo, nil, cca.listOfFilesChannel, cca.recursive, false, func() {})
 
 	// report failure to create traverser
 	if err != nil {
@@ -134,7 +134,7 @@ func removeBfsResources(cca *cookedCopyCmdArgs) (err error) {
 	}
 
 	// create bfs pipeline
-	p, err := createBlobFSPipeline(ctx, cca.credentialInfo)
+	p, err := createBlobFSPipeline(ctx, cca.dstCredentialInfo)
 	if err != nil {
 		return err
 	}

--- a/cmd/removeProcessor.go
+++ b/cmd/removeProcessor.go
@@ -33,7 +33,7 @@ func newRemoveTransferProcessor(cca *cookedCopyCmdArgs, numOfTransfersPerPart in
 		SourceRoot:    consolidatePathSeparators(cca.source),
 
 		// authentication related
-		CredentialInfo: cca.credentialInfo,
+		CredentialInfo: cca.dstCredentialInfo,
 		SourceSAS:      cca.sourceSAS,
 
 		// flags

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -478,11 +478,13 @@ func (cca *cookedSyncCmdArgs) process() (err error) {
 	ctx := context.WithValue(context.TODO(), ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
 
 	// Initializes credential info and oauth token for the destination. This should not be re-used on the source.
+	useSrc := cca.fromTo.To().IsLocal()
 	cca.dstCredentialInfo, _, err = getCredentialInfoForLocation(
 		ctx,
-		cca.fromTo.To(),
-		cca.destination,
-		cca.destinationSAS,
+		// On downloads, we'll still need to use the source credentials.
+		common.IffLocation(useSrc, cca.fromTo.From(), cca.fromTo.To()),
+		common.IffString(useSrc, cca.source, cca.destination),
+		common.IffString(useSrc, cca.sourceSAS, cca.destinationSAS),
 		false,
 	)
 

--- a/cmd/syncProcessor.go
+++ b/cmd/syncProcessor.go
@@ -45,7 +45,7 @@ func newSyncTransferProcessor(cca *cookedSyncCmdArgs, numOfTransfersPerPart int)
 		DestinationRoot: consolidatePathSeparators(cca.destination),
 
 		// authentication related
-		CredentialInfo: cca.credentialInfo,
+		CredentialInfo: cca.dstCredentialInfo,
 		SourceSAS:      cca.sourceSAS,
 		DestinationSAS: cca.destinationSAS,
 
@@ -189,7 +189,7 @@ func newSyncDeleteProcessor(cca *cookedSyncCmdArgs) (*interactiveDeleteProcessor
 
 	ctx := context.WithValue(context.TODO(), ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
 
-	p, err := initPipeline(ctx, cca.fromTo.To(), cca.credentialInfo)
+	p, err := initPipeline(ctx, cca.fromTo.To(), cca.dstCredentialInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/syncTraverser.go
+++ b/cmd/syncTraverser.go
@@ -93,7 +93,7 @@ func newBlobTraverserForSync(cca *cookedSyncCmdArgs, isSource bool) (t *blobTrav
 		return nil, errors.New("illegal URL, no pattern matching allowed for sync command")
 	}
 
-	p, err := createBlobPipeline(ctx, cca.credentialInfo)
+	p, err := createBlobPipeline(ctx, cca.dstCredentialInfo)
 	if err != nil {
 		return
 	}

--- a/cmd/zt_sync_processor_test.go
+++ b/cmd/zt_sync_processor_test.go
@@ -85,7 +85,7 @@ func (s *syncProcessorSuite) TestBlobDeleter(c *chk.C) {
 	cca := &cookedSyncCmdArgs{
 		destination:       containerURL.String(),
 		destinationSAS:    parts.SAS.Encode(),
-		credentialInfo:    common.CredentialInfo{CredentialType: common.ECredentialType.Anonymous()},
+		dstCredentialInfo: common.CredentialInfo{CredentialType: common.ECredentialType.Anonymous()},
 		deleteDestination: common.EDeleteDestination.True(),
 		fromTo:            common.EFromTo.LocalBlob(),
 	}
@@ -123,7 +123,7 @@ func (s *syncProcessorSuite) TestFileDeleter(c *chk.C) {
 	cca := &cookedSyncCmdArgs{
 		destination:       shareURL.String(),
 		destinationSAS:    parts.SAS.Encode(),
-		credentialInfo:    common.CredentialInfo{CredentialType: common.ECredentialType.Anonymous()},
+		dstCredentialInfo: common.CredentialInfo{CredentialType: common.ECredentialType.Anonymous()},
 		deleteDestination: common.EDeleteDestination.True(),
 		fromTo:            common.EFromTo.FileFile(),
 	}

--- a/common/iff.go
+++ b/common/iff.go
@@ -35,6 +35,13 @@ func IffError(test bool, trueVal, falseVal error) error {
 	return falseVal
 }
 
+func IffLocation(test bool, trueVal, falseVal Location) Location {
+	if test {
+		return trueVal
+	}
+	return falseVal
+}
+
 func IffString(test bool, trueVal, falseVal string) string {
 	if test {
 		return trueVal

--- a/testSuite/scripts/utility.py
+++ b/testSuite/scripts/utility.py
@@ -1,6 +1,7 @@
 import ctypes
 import os
 import platform
+import re
 import shutil
 import subprocess
 import shlex
@@ -540,6 +541,7 @@ def execute_azcopy_command(command):
             universal_newlines=True)
     except subprocess.CalledProcessError as exec:
         # todo kill azcopy command in case of timeout
+        print(re.sub("(?i)(?P<key>sig[ \t]*[:=][ \t]*)(?P<value>[^& ,;\t\n\r]+)", "sig=REDACTED", cmnd))
         print("command failed with error code " , exec.returncode , " and message " + exec.output)
         return False
     else:


### PR DESCRIPTION
When re-using the credential info given by the old code to enumerate the source, we'd accidentally send an OAuth token to public sources. This wasn't problematic prior to the fromto fix, but now it is because it can go to non-azure locations when enumerating.

This PR is a draft until we determine which of the three solutions to take to this still being caused when overriding the credential type.