### PR TITLE
Convert a hostname style S3 URL to path style

### DIFF
--- a/common/s3URLParts.go
+++ b/common/s3URLParts.go
@@ -153,6 +153,10 @@ func (p *S3URLParts) URL() url.URL {
 	if p.BucketName != "" {
 		if p.isPathStyle {
 			path += "/" + p.BucketName
+		} else { // Convert to path style
+			p.Host = p.Endpoint
+			p.isPathStyle = true
+			path += "/" + p.BucketName
 		}
 		if p.ObjectKey != "" {
 			path += "/" + p.ObjectKey


### PR DESCRIPTION
BucketName is used for path style, or explicitly set by the S3 account enumerator.

Therefore, allowing the URL to convert itself to the new form works just fine.