### PR TITLE
Support Azure files snapshots

### DIFF
--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -199,15 +199,16 @@ func (raw rawBenchmarkCmdArgs) appendVirtualDir(target, virtualDir string) (stri
 }
 
 // define a cleanup job
-func (raw rawBenchmarkCmdArgs) createCleanupJobArgs(benchmarkDest, logVerbosity string) (*cookedCopyCmdArgs, error) {
+func (raw rawBenchmarkCmdArgs) createCleanupJobArgs(benchmarkDest common.ResourceString, logVerbosity string) (*cookedCopyCmdArgs, error) {
 
 	rc := rawCopyCmdArgs{}
 
-	rc.src = benchmarkDest // the SOURCE for the deletion is the the dest from the benchmark
+	u, _ := benchmarkDest.FullURL() // don't check error, because it was parsed already in main job
+	rc.src = u.String()             // the SOURCE for the deletion is the the dest from the benchmark
 	rc.recursive = true
 	rc.logVerbosity = logVerbosity
 
-	switch inferArgumentLocation(benchmarkDest) {
+	switch inferArgumentLocation(rc.src) {
 	case common.ELocation.Blob():
 		rc.fromTo = common.EFromTo.BlobTrash().String()
 	case common.ELocation.File():

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -225,28 +225,42 @@ func (raw rawCopyCmdArgs) cookWithId(jobId common.JobID) (cookedCopyCmdArgs, err
 	if err != nil {
 		return cooked, err
 	}
-	cooked.unparsedSource = raw.src
-	cooked.unparsedDest = raw.dst
 
-	if strings.EqualFold(cooked.unparsedDest, common.Dev_Null) && runtime.GOOS == "windows" {
-		cooked.unparsedDest = common.Dev_Null // map all capitalizations of "NUL"/"nul" to one because (on Windows) they all mean the same thing
+	var tempSrc string
+	tempDest := raw.dst
+
+	if strings.EqualFold(tempDest, common.Dev_Null) && runtime.GOOS == "windows" {
+		tempDest = common.Dev_Null // map all capitalizations of "NUL"/"nul" to one because (on Windows) they all mean the same thing
 	}
-
-	cooked.fromTo = fromTo
 
 	// Check if source has a trailing wildcard on a URL
 	if fromTo.From().IsRemote() {
-		cooked.unparsedSource, cooked.stripTopDir, err = raw.stripTrailingWildcardOnRemoteSource(fromTo.From())
+		tempSrc, cooked.stripTopDir, err = raw.stripTrailingWildcardOnRemoteSource(fromTo.From())
 
 		if err != nil {
 			return cooked, err
 		}
+	} else {
+		tempSrc = raw.src
 	}
-
 	if raw.internalOverrideStripTopDir {
 		cooked.stripTopDir = true
 	}
 
+	// Strip the SAS from the source and destination whenever there is SAS exists in URL.
+	// Note: SAS could exists in source of S2S copy, even if the credential type is OAuth for destination.
+
+	cooked.source, err = SplitResourceString(tempSrc, fromTo.From())
+	if err != nil {
+		return cooked, err
+	}
+
+	cooked.destination, err = SplitResourceString(tempDest, fromTo.To())
+	if err != nil {
+		return cooked, err
+	}
+
+	cooked.fromTo = fromTo
 	cooked.recursive = raw.recursive
 	cooked.followSymlinks = raw.followSymlinks
 
@@ -264,7 +278,7 @@ func (raw rawCopyCmdArgs) cookWithId(jobId common.JobID) (cookedCopyCmdArgs, err
 	// cooked.stripTopDir is effectively a workaround for the lack of wildcards in remote sources.
 	// Local, however, still supports wildcards, and thus needs its top directory stripped whenever a wildcard is used.
 	// Thus, we check for wildcards and instruct the processor to strip the top dir later instead of repeatedly checking cca.source for wildcards.
-	if fromTo.From() == common.ELocation.Local() && strings.Contains(cooked.source.Value, "*") {
+	if fromTo.From() == common.ELocation.Local() && strings.Contains(cooked.source.ValueLocal(), "*") {
 		cooked.stripTopDir = true
 	}
 
@@ -666,13 +680,9 @@ func validateMd5Option(option common.HashValidationOption, fromTo common.FromTo)
 // represents the processed copy command input from the user
 type cookedCopyCmdArgs struct {
 	// from arguments
-	unparsedSource string
-	unparsedDest   string
-	fromTo         common.FromTo
-
-	// produced from their unparsed variants
 	source      common.ResourceString
 	destination common.ResourceString
+	fromTo      common.FromTo
 
 	// new include/exclude only apply to file names
 	// implemented for remove (and sync) only
@@ -790,15 +800,16 @@ func (cca *cookedCopyCmdArgs) process() error {
 // TODO discuss with Jeff what features should be supported by redirection, such as metadata, content-type, etc.
 func (cca *cookedCopyCmdArgs) processRedirectionCopy() error {
 	if cca.fromTo == common.EFromTo.PipeBlob() {
-		return cca.processRedirectionUpload(cca.unparsedDest, cca.blockSize)
+		return cca.processRedirectionUpload(cca.destination, cca.blockSize)
 	} else if cca.fromTo == common.EFromTo.BlobPipe() {
-		return cca.processRedirectionDownload(cca.unparsedSource)
+		return cca.processRedirectionDownload(cca.source)
 	}
 
 	return fmt.Errorf("unsupported redirection type: %s", cca.fromTo)
 }
 
-func (cca *cookedCopyCmdArgs) processRedirectionDownload(blobUrl string) error {
+func (cca *cookedCopyCmdArgs) processRedirectionDownload(blobResource common.ResourceString) error {
+
 	ctx := context.WithValue(context.TODO(), ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
 
 	// step 0: check the Stdout before uploading
@@ -814,7 +825,7 @@ func (cca *cookedCopyCmdArgs) processRedirectionDownload(blobUrl string) error {
 	}
 
 	// step 2: parse source url
-	u, err := url.Parse(blobUrl)
+	u, err := blobResource.FullURL()
 	if err != nil {
 		return fmt.Errorf("fatal: cannot parse source blob URL due to error: %s", err.Error())
 	}
@@ -838,7 +849,7 @@ func (cca *cookedCopyCmdArgs) processRedirectionDownload(blobUrl string) error {
 	return nil
 }
 
-func (cca *cookedCopyCmdArgs) processRedirectionUpload(blobUrl string, blockSize uint32) error {
+func (cca *cookedCopyCmdArgs) processRedirectionUpload(blobResource common.ResourceString, blockSize uint32) error {
 	ctx := context.WithValue(context.TODO(), ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
 
 	// if no block size is set, then use default value
@@ -853,7 +864,7 @@ func (cca *cookedCopyCmdArgs) processRedirectionUpload(blobUrl string, blockSize
 	}
 
 	// step 1: parse destination url
-	u, err := url.Parse(blobUrl)
+	u, err := blobResource.FullURL()
 	if err != nil {
 		return fmt.Errorf("fatal: cannot parse destination blob URL due to error: %s", err.Error())
 	}
@@ -938,18 +949,9 @@ func (cca *cookedCopyCmdArgs) processCopyJobPartOrders() (err error) {
 	}
 
 	from := cca.fromTo.From()
-	to := cca.fromTo.To()
 
-	// TODO: it's not pretty that we replace unparsed source/dest with the parsed versions here.
-	//   Should really be done in cookWithId. But historically it's always been done here.
+	jobPartOrder.DestinationRoot = cca.destination
 
-	// Strip the SAS from the source and destination whenever there is SAS exists in URL.
-	// Note: SAS could exists in source of S2S copy, even if the credential type is OAuth for destination.
-	cca.source, err = SplitResourceString(cca.unparsedSource, from)
-	if err != nil {
-		return err
-	}
-	cca.unparsedSource = "" // prevent any accidental use, now that it's been parsed
 	jobPartOrder.SourceRoot = cca.source
 	jobPartOrder.SourceRoot.Value, err = GetResourceRoot(cca.source.Value, from)
 	if err != nil {
@@ -965,13 +967,6 @@ func (cca *cookedCopyCmdArgs) processCopyJobPartOrders() (err error) {
 		// set stripTopDir to true so that --list-of-files/--include-path play nice
 		cca.stripTopDir = true
 	}
-
-	cca.destination, err = SplitResourceString(cca.unparsedDest, to)
-	if err != nil {
-		return err
-	}
-	cca.unparsedDest = "" // prevent accidental use, now that we've parsed it
-	jobPartOrder.DestinationRoot = cca.destination
 
 	// depending on the source and destination type, we process the cp command differently
 	// Create enumerator and do enumerating

--- a/cmd/copyEnumeratorHelper.go
+++ b/cmd/copyEnumeratorHelper.go
@@ -18,8 +18,8 @@ import (
 // addTransfer accepts a new transfer, if the threshold is reached, dispatch a job part order.
 func addTransfer(e *common.CopyJobPartOrderRequest, transfer common.CopyTransfer, cca *cookedCopyCmdArgs) error {
 	// Remove the source and destination roots from the path to save space in the plan files
-	transfer.Source = strings.TrimPrefix(transfer.Source, e.SourceRoot)
-	transfer.Destination = strings.TrimPrefix(transfer.Destination, e.DestinationRoot)
+	transfer.Source = strings.TrimPrefix(transfer.Source, e.SourceRoot.Value)
+	transfer.Destination = strings.TrimPrefix(transfer.Destination, e.DestinationRoot.Value)
 
 	// dispatch the transfers once the number reaches NumOfFilesPerDispatchJobPart
 	// we do this so that in the case of large transfer, the transfer engine can get started

--- a/cmd/copyEnumeratorHelper_test.go
+++ b/cmd/copyEnumeratorHelper_test.go
@@ -30,15 +30,11 @@ type copyEnumeratorHelperTestSuite struct{}
 var _ = chk.Suite(&copyEnumeratorHelperTestSuite{})
 
 func newLocalRes(path string) common.ResourceString {
-	r, err := SplitResourceString(path, common.ELocation.Local())
-	if err != nil {
-		panic("can't parse resource string")
-	}
-	return r
+	return common.ResourceString{Value: path}
 }
 
-func newRemoteRes(path string) common.ResourceString {
-	r, err := SplitResourceString(path, common.ELocation.Blob())
+func newRemoteRes(url string) common.ResourceString {
+	r, err := SplitResourceString(url, common.ELocation.Blob())
 	if err != nil {
 		panic("can't parse resource string")
 	}

--- a/cmd/copyEnumeratorHelper_test.go
+++ b/cmd/copyEnumeratorHelper_test.go
@@ -29,11 +29,27 @@ type copyEnumeratorHelperTestSuite struct{}
 
 var _ = chk.Suite(&copyEnumeratorHelperTestSuite{})
 
+func newLocalRes(path string) common.ResourceString {
+	r, err := SplitResourceString(path, common.ELocation.Local())
+	if err != nil {
+		panic("can't parse resource string")
+	}
+	return r
+}
+
+func newRemoteRes(path string) common.ResourceString {
+	r, err := SplitResourceString(path, common.ELocation.Blob())
+	if err != nil {
+		panic("can't parse resource string")
+	}
+	return r
+}
+
 func (s *copyEnumeratorHelperTestSuite) TestAddTransferPathRootsTrimmed(c *chk.C) {
 	// setup
 	request := common.CopyJobPartOrderRequest{
-		SourceRoot:      "a/b/",
-		DestinationRoot: "y/z/",
+		SourceRoot:      newLocalRes("a/b/"),
+		DestinationRoot: newLocalRes("y/z/"),
 	}
 
 	transfer := common.CopyTransfer{

--- a/cmd/copyUtil.go
+++ b/cmd/copyUtil.go
@@ -68,15 +68,6 @@ func (util copyHandlerUtil) urlIsContainerOrVirtualDirectory(url *url.URL) bool 
 	}
 }
 
-func (util copyHandlerUtil) appendQueryParamToUrl(url *url.URL, queryParam string) *url.URL {
-	if len(url.RawQuery) > 0 {
-		url.RawQuery += "&" + queryParam
-	} else {
-		url.RawQuery = queryParam
-	}
-	return url
-}
-
 // redactSigQueryParam checks for the signature in the given rawquery part of the url
 // If the signature exists, it replaces the value of the signature with "REDACTED"
 // This api is used when SAS is written to log file to avoid exposing the user given SAS

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -88,27 +88,27 @@ type ListParameters struct {
 var parameters = ListParameters{}
 
 // HandleListContainerCommand handles the list container command
-func HandleListContainerCommand(source string, location common.Location) (err error) {
+func HandleListContainerCommand(unparsedSource string, location common.Location) (err error) {
 	// TODO: Temporarily use context.TODO(), this should be replaced with a root context from main.
 	ctx := context.WithValue(context.TODO(), ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
 
 	credentialInfo := common.CredentialInfo{}
 
-	base, token, err := SplitAuthTokenFromResource(source, location)
+	source, err := SplitResourceString(unparsedSource, location)
 	if err != nil {
 		return err
 	}
 
-	level, err := determineLocationLevel(source, location, true)
+	level, err := determineLocationLevel(source.Value, location, true)
 
 	if err != nil {
 		return err
 	}
 
 	// Treat our check as a destination because the isSource flag was designed for S2S transfers.
-	if credentialInfo, _, err = getCredentialInfoForLocation(ctx, location, base, token, false); err != nil {
+	if credentialInfo, _, err = getCredentialInfoForLocation(ctx, location, source.Value, source.SAS, false); err != nil {
 		return fmt.Errorf("failed to obtain credential info: %s", err.Error())
-	} else if location == location.File() && token == "" {
+	} else if location == location.File() && source.SAS == "" {
 		return errors.New("azure files requires a SAS token for authentication")
 	} else if credentialInfo.CredentialType == common.ECredentialType.OAuthToken() {
 		glcm.Info("List is using OAuth token for authentication.")

--- a/cmd/pathUtils.go
+++ b/cmd/pathUtils.go
@@ -192,6 +192,8 @@ func splitAuthTokenFromResource(resource string, location common.Location) (reso
 			return resource, "", nil // don't mess with the special dev-null path, at all
 		}
 		return cleanLocalPath(common.ToExtendedPath(resource)), "", nil
+	case common.ELocation.Pipe():
+		return resource, "", nil
 	case common.ELocation.S3():
 		// Encoding +s as %20 (space) is important in S3 URLs as this is unsupported in Azure (but %20 can still be used as a space in S3 URLs)
 		var baseURL *url.URL

--- a/cmd/removeProcessor.go
+++ b/cmd/removeProcessor.go
@@ -27,15 +27,12 @@ import (
 // extract the right info from cooked arguments and instantiate a generic copy transfer processor from it
 func newRemoveTransferProcessor(cca *cookedCopyCmdArgs, numOfTransfersPerPart int, fpo common.FolderPropertyOption) *copyTransferProcessor {
 	copyJobTemplate := &common.CopyJobPartOrderRequest{
-		JobID:         cca.jobID,
-		CommandString: cca.commandString,
-		FromTo:        cca.fromTo,
+		JobID:          cca.jobID,
+		CommandString:  cca.commandString,
+		FromTo:         cca.fromTo,
 		Fpo:           fpo,
-		SourceRoot:    consolidatePathSeparators(cca.source),
-
-		// authentication related
+		SourceRoot:     cca.source.CloneWithConsolidatedSeparators(), // TODO: why do we consolidate here, but not in "copy"? Is it needed in both places or neither? Or is copy just covering the same need differently?
 		CredentialInfo: cca.credentialInfo,
-		SourceSAS:      cca.sourceSAS,
 
 		// flags
 		LogLevel:       cca.logVerbosity,

--- a/cmd/syncEnumerator.go
+++ b/cmd/syncEnumerator.go
@@ -33,20 +33,11 @@ import (
 // -------------------------------------- Implemented Enumerators -------------------------------------- \\
 
 func (cca *cookedSyncCmdArgs) initEnumerator(ctx context.Context) (enumerator *syncEnumerator, err error) {
-	src, err := appendSASIfNecessary(cca.source, cca.sourceSAS)
-	if err != nil {
-		return nil, err
-	}
-
-	dst, err := appendSASIfNecessary(cca.destination, cca.destinationSAS)
-	if err != nil {
-		return nil, err
-	}
 
 	// TODO: enable symlink support in a future release after evaluating the implications
 	// GetProperties is enabled by default as sync supports both upload and download.
 	// This property only supports Files and S3 at the moment, but provided that Files sync is coming soon, enable to avoid stepping on Files sync work
-	sourceTraverser, err := initResourceTraverser(src, cca.fromTo.From(), &ctx, &cca.credentialInfo,
+	sourceTraverser, err := initResourceTraverser(cca.source, cca.fromTo.From(), &ctx, &cca.credentialInfo,
 		nil, nil, cca.recursive, true, func(entityType common.EntityType) {
 			if entityType == common.EEntityType.File() {
 				atomic.AddUint64(&cca.atomicSourceFilesScanned, 1)
@@ -60,7 +51,7 @@ func (cca *cookedSyncCmdArgs) initEnumerator(ctx context.Context) (enumerator *s
 	// TODO: enable symlink support in a future release after evaluating the implications
 	// GetProperties is enabled by default as sync supports both upload and download.
 	// This property only supports Files and S3 at the moment, but provided that Files sync is coming soon, enable to avoid stepping on Files sync work
-	destinationTraverser, err := initResourceTraverser(dst, cca.fromTo.To(), &ctx, &cca.credentialInfo,
+	destinationTraverser, err := initResourceTraverser(cca.destination, cca.fromTo.To(), &ctx, &cca.credentialInfo,
 		nil, nil, cca.recursive, true, func(entityType common.EntityType) {
 			if entityType == common.EEntityType.File() {
 				atomic.AddUint64(&cca.atomicDestinationFilesScanned, 1)
@@ -81,14 +72,14 @@ func (cca *cookedSyncCmdArgs) initEnumerator(ctx context.Context) (enumerator *s
 	// Same rule applies to excludeFilters and excludeAttrFilters
 	filters := buildIncludeFilters(cca.includePatterns)
 	if cca.fromTo.From() == common.ELocation.Local() {
-		includeAttrFilters := buildAttrFilters(cca.includeFileAttributes, src, true)
+		includeAttrFilters := buildAttrFilters(cca.includeFileAttributes, cca.source.ValueLocal(), true)
 		filters = append(filters, includeAttrFilters...)
 	}
 
 	filters = append(filters, buildExcludeFilters(cca.excludePatterns, false)...)
 	filters = append(filters, buildExcludeFilters(cca.excludePaths, true)...)
 	if cca.fromTo.From() == common.ELocation.Local() {
-		excludeAttrFilters := buildAttrFilters(cca.excludeFileAttributes, src, false)
+		excludeAttrFilters := buildAttrFilters(cca.excludeFileAttributes, cca.source.ValueLocal(), false)
 		filters = append(filters, excludeAttrFilters...)
 	}
 

--- a/cmd/syncTraverser.go
+++ b/cmd/syncTraverser.go
@@ -39,9 +39,9 @@ func newLocalTraverserForSync(cca *cookedSyncCmdArgs, isSource bool) (*localTrav
 	var fullPath string
 
 	if isSource {
-		fullPath = cca.source
+		fullPath = cca.source.ValueLocal()
 	} else {
-		fullPath = cca.destination
+		fullPath = cca.destination.ValueLocal()
 	}
 
 	if strings.ContainsAny(strings.TrimPrefix(fullPath, common.EXTENDED_PATH_PREFIX), "*?") {
@@ -76,15 +76,9 @@ func newBlobTraverserForSync(cca *cookedSyncCmdArgs, isSource bool) (t *blobTrav
 	// figure out the right URL
 	var rawURL *url.URL
 	if isSource {
-		rawURL, err = url.Parse(cca.source)
-		if err == nil && cca.sourceSAS != "" {
-			copyHandlerUtil{}.appendQueryParamToUrl(rawURL, cca.sourceSAS)
-		}
+		rawURL, err = cca.source.FullURL()
 	} else {
-		rawURL, err = url.Parse(cca.destination)
-		if err == nil && cca.destinationSAS != "" {
-			copyHandlerUtil{}.appendQueryParamToUrl(rawURL, cca.destinationSAS)
-		}
+		rawURL, err = cca.destination.FullURL()
 	}
 
 	if err != nil {

--- a/cmd/zc_processor.go
+++ b/cmd/zc_processor.go
@@ -33,8 +33,8 @@ import (
 type copyTransferProcessor struct {
 	numOfTransfersPerPart int
 	copyJobTemplate       *common.CopyJobPartOrderRequest
-	source                string
-	destination           string
+	source                common.ResourceString
+	destination           common.ResourceString
 
 	// handles for progress tracking
 	reportFirstPartDispatched func(jobStarted bool)
@@ -45,7 +45,7 @@ type copyTransferProcessor struct {
 }
 
 func newCopyTransferProcessor(copyJobTemplate *common.CopyJobPartOrderRequest, numOfTransfersPerPart int,
-	source string, destination string,
+	source string, destination common.ResourceString,
 	reportFirstPartDispatched func(bool), reportFinalPartDispatched func(), preserveAccessTier bool) *copyTransferProcessor {
 	return &copyTransferProcessor{
 		numOfTransfersPerPart:     numOfTransfersPerPart,

--- a/cmd/zc_processor.go
+++ b/cmd/zc_processor.go
@@ -45,7 +45,7 @@ type copyTransferProcessor struct {
 }
 
 func newCopyTransferProcessor(copyJobTemplate *common.CopyJobPartOrderRequest, numOfTransfersPerPart int,
-	source string, destination common.ResourceString,
+	source, destination common.ResourceString,
 	reportFirstPartDispatched func(bool), reportFinalPartDispatched func(), preserveAccessTier bool) *copyTransferProcessor {
 	return &copyTransferProcessor{
 		numOfTransfersPerPart:     numOfTransfersPerPart,

--- a/cmd/zc_traverser_list.go
+++ b/cmd/zc_traverser_list.go
@@ -87,22 +87,19 @@ func (l *listTraverser) traverse(preprocessor objectMorpher, processor objectPro
 	return nil
 }
 
-func newListTraverser(parent string, parentSAS string, parentType common.Location, credential *common.CredentialInfo, ctx *context.Context,
+func newListTraverser(parent common.ResourceString, parentType common.Location, credential *common.CredentialInfo, ctx *context.Context,
 	recursive, followSymlinks, getProperties bool, listChan chan string, incrementEnumerationCounter enumerationCounterFunc) resourceTraverser {
 	var traverserGenerator childTraverserGenerator
 
 	traverserGenerator = func(relativeChildPath string) (resourceTraverser, error) {
-		source := ""
+		source := parent.Clone()
 		if parentType != common.ELocation.Local() {
 			// assume child path is not URL-encoded yet, this is consistent with the behavior of previous implementation
-			childURL, _ := url.Parse(parent)
-			childURL.Path = common.GenerateFullPath(childURL.Path, relativeChildPath)
-
-			// append query to URL
-			source = copyHandlerUtil{}.appendQueryParamToUrl(childURL, parentSAS).String()
+			childURL, _ := url.Parse(parent.Value)
+			source.Value = common.GenerateFullPath(childURL.Path, relativeChildPath)
 		} else {
 			// is local, only generate the full path
-			source = common.GenerateFullPath(parent, relativeChildPath)
+			source.Value = common.GenerateFullPath(parent.Value, relativeChildPath)
 		}
 
 		// Construct a traverser that goes through the child

--- a/cmd/zc_traverser_list.go
+++ b/cmd/zc_traverser_list.go
@@ -96,10 +96,11 @@ func newListTraverser(parent common.ResourceString, parentType common.Location, 
 		if parentType != common.ELocation.Local() {
 			// assume child path is not URL-encoded yet, this is consistent with the behavior of previous implementation
 			childURL, _ := url.Parse(parent.Value)
-			source.Value = common.GenerateFullPath(childURL.Path, relativeChildPath)
+			childURL.Path = common.GenerateFullPath(childURL.Path, relativeChildPath)
+			source.Value = childURL.String()
 		} else {
 			// is local, only generate the full path
-			source.Value = common.GenerateFullPath(parent.Value, relativeChildPath)
+			source.Value = common.GenerateFullPath(parent.ValueLocal(), relativeChildPath)
 		}
 
 		// Construct a traverser that goes through the child

--- a/cmd/zc_traverser_local.go
+++ b/cmd/zc_traverser_local.go
@@ -305,13 +305,6 @@ func (t *localTraverser) traverse(preprocessor objectMorpher, processor objectPr
 	return
 }
 
-// Replace azcopy path separators (/) with the OS path separator
-func consolidatePathSeparators(path string) string {
-	pathSep := common.DeterminePathSeparator(path)
-
-	return strings.ReplaceAll(path, common.AZCOPY_PATH_SEPARATOR_STRING, pathSep)
-}
-
 func newLocalTraverser(fullPath string, recursive bool, followSymlinks bool, incrementEnumerationCounter enumerationCounterFunc) *localTraverser {
 	traverser := localTraverser{
 		fullPath:                    cleanLocalPath(fullPath),

--- a/cmd/zt_generic_processor_test.go
+++ b/cmd/zt_generic_processor_test.go
@@ -78,7 +78,7 @@ func (s *genericProcessorSuite) TestCopyTransferProcessorMultipleFiles(c *chk.C)
 	for _, numOfParts := range []int{1, 3} {
 		numOfTransfersPerPart := len(sampleObjects) / numOfParts
 		copyProcessor := newCopyTransferProcessor(processorTestSuiteHelper{}.getCopyJobTemplate(), numOfTransfersPerPart,
-			containerURL.String(), dstDirName, false, false, nil, nil, false)
+			newRemoteRes(containerURL.String()), newLocalRes(dstDirName), nil, nil, false)
 
 		// go through the objects and make sure they are processed without error
 		for _, storedObject := range sampleObjects {

--- a/cmd/zt_generic_processor_test.go
+++ b/cmd/zt_generic_processor_test.go
@@ -78,7 +78,7 @@ func (s *genericProcessorSuite) TestCopyTransferProcessorMultipleFiles(c *chk.C)
 	for _, numOfParts := range []int{1, 3} {
 		numOfTransfersPerPart := len(sampleObjects) / numOfParts
 		copyProcessor := newCopyTransferProcessor(processorTestSuiteHelper{}.getCopyJobTemplate(), numOfTransfersPerPart,
-			containerURL.String(), dstDirName, nil, nil, false)
+			containerURL.String(), dstDirName, false, false, nil, nil, false)
 
 		// go through the objects and make sure they are processed without error
 		for _, storedObject := range sampleObjects {
@@ -125,7 +125,7 @@ func (s *genericProcessorSuite) TestCopyTransferProcessorSingleFile(c *chk.C) {
 	// set up the processor
 	blobURL := containerURL.NewBlockBlobURL(blobList[0]).String()
 	copyProcessor := newCopyTransferProcessor(processorTestSuiteHelper{}.getCopyJobTemplate(), 2,
-		blobURL, filepath.Join(dstDirName, dstFileName), nil, nil, false)
+		newRemoteRes(blobURL), newLocalRes(filepath.Join(dstDirName, dstFileName)), nil, nil, false)
 
 	// exercise the copy transfer processor
 	storedObject := newStoredObject(noPreProccessor, blobList[0], "", common.EEntityType.File(), time.Now(), 0, noContentProps, noBlobProps, noMetdata, "")

--- a/cmd/zt_pathUtils_test.go
+++ b/cmd/zt_pathUtils_test.go
@@ -1,0 +1,59 @@
+// Copyright © 2017 Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cmd
+
+import (
+	"github.com/Azure/azure-storage-azcopy/common"
+	chk "gopkg.in/check.v1"
+)
+
+type pathUtilsSuite struct{}
+
+var _ = chk.Suite(&pathUtilsSuite{})
+
+func (s *pathUtilsSuite) TestStripQueryFromSaslessUrl(c *chk.C) {
+	tests := []struct {
+		full          string
+		isRemote      bool
+		expectedMain  string
+		expectedQuery string
+	}{
+		// remote urls
+		{"http://example.com/abc?foo=bar", true, "http://example.com/abc", "foo=bar"},
+		{"http://example.com/abc", true, "http://example.com/abc", ""},
+		{"http://example.com/abc?", true, "http://example.com/abc", ""}, // no query string if ? is at very end
+
+		// things that are not URLs, or not to be interpreted as such
+		{"http://foo/bar?eee", false, "http://foo/bar?eee", ""}, // note isRemote == false
+		{`c:\notUrl`, false, `c:\notUrl`, ""},
+		{`\\?\D:\longStyle\Windows\path`, false, `\\?\D:\longStyle\Windows\path`, ""},
+	}
+
+	for _, t := range tests {
+		loc := common.ELocation.Local()
+		if t.isRemote {
+			loc = common.ELocation.File()
+		}
+		m, q := SplitQueryFromSaslessResource(t.full, loc)
+		c.Assert(m, chk.Equals, t.expectedMain)
+		c.Assert(q, chk.Equals, t.expectedQuery)
+	}
+}

--- a/cmd/zt_pathUtils_test.go
+++ b/cmd/zt_pathUtils_test.go
@@ -52,7 +52,7 @@ func (s *pathUtilsSuite) TestStripQueryFromSaslessUrl(c *chk.C) {
 		if t.isRemote {
 			loc = common.ELocation.File()
 		}
-		m, q := SplitQueryFromSaslessResource(t.full, loc)
+		m, q := splitQueryFromSaslessResource(t.full, loc)
 		c.Assert(m, chk.Equals, t.expectedMain)
 		c.Assert(q, chk.Equals, t.expectedQuery)
 	}

--- a/cmd/zt_sync_processor_test.go
+++ b/cmd/zt_sync_processor_test.go
@@ -25,8 +25,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/Azure/azure-storage-file-go/azfile"
-
 	"github.com/Azure/azure-storage-azcopy/common"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	chk "gopkg.in/check.v1"
@@ -45,7 +43,7 @@ func (s *syncProcessorSuite) TestLocalDeleter(c *chk.C) {
 
 	// construct the cooked input to simulate user input
 	cca := &cookedSyncCmdArgs{
-		destination:       dstDirName,
+		destination:       newLocalRes(dstDirName),
 		deleteDestination: common.EDeleteDestination.True(),
 	}
 
@@ -81,10 +79,8 @@ func (s *syncProcessorSuite) TestBlobDeleter(c *chk.C) {
 
 	// construct the cooked input to simulate user input
 	rawContainerURL := scenarioHelper{}.getRawContainerURLWithSAS(c, containerName)
-	parts := azblob.NewBlobURLParts(rawContainerURL)
 	cca := &cookedSyncCmdArgs{
-		destination:       containerURL.String(),
-		destinationSAS:    parts.SAS.Encode(),
+		destination:       newRemoteRes(rawContainerURL.String()),
 		credentialInfo:    common.CredentialInfo{CredentialType: common.ECredentialType.Anonymous()},
 		deleteDestination: common.EDeleteDestination.True(),
 		fromTo:            common.EFromTo.LocalBlob(),
@@ -119,10 +115,8 @@ func (s *syncProcessorSuite) TestFileDeleter(c *chk.C) {
 
 	// construct the cooked input to simulate user input
 	rawShareSAS := scenarioHelper{}.getRawShareURLWithSAS(c, shareName)
-	parts := azfile.NewFileURLParts(rawShareSAS)
 	cca := &cookedSyncCmdArgs{
-		destination:       shareURL.String(),
-		destinationSAS:    parts.SAS.Encode(),
+		destination:       newRemoteRes(rawShareSAS.String()),
 		credentialInfo:    common.CredentialInfo{CredentialType: common.ECredentialType.Anonymous()},
 		deleteDestination: common.EDeleteDestination.True(),
 		fromTo:            common.EFromTo.FileFile(),

--- a/common/extensions.go
+++ b/common/extensions.go
@@ -158,3 +158,14 @@ func GenerateFullPath(rootPath, childPath string) string {
 	// otherwise, make sure a path separator is inserted between the rootPath if necessary
 	return rootPath + rootSeparator + childPath
 }
+
+func GenerateFullPathWithQuery(rootPath, childPath, extraQuery string) string {
+	p := GenerateFullPath(rootPath, childPath)
+
+	extraQuery = strings.TrimLeft(extraQuery, "?")
+	if extraQuery == "" {
+		return p
+	} else {
+		return p + "?" + extraQuery
+	}
+}

--- a/common/rpc-models.go
+++ b/common/rpc-models.go
@@ -52,13 +52,17 @@ type CopyJobPartOrderRequest struct {
 	Fpo            FolderPropertyOption // passed in from front-end to ensure that front-end and STE agree on the desired behaviour for the job
 	// list of blobTypes to exclude.
 	ExcludeBlobType []azblob.BlobType
-	SourceRoot      string
-	DestinationRoot string
-	Transfers       []CopyTransfer
-	LogLevel        LogLevel
-	BlobAttributes  BlobTransferAttributes
-	SourceSAS       string
-	DestinationSAS  string
+
+	SourceRoot       string
+	SourceExtraQuery string // extra query params (that are not part of SAS) that should be included in the source URLs
+	DestinationRoot  string
+	DestExtraQuery   string // not sure this is needed by any real-world scenarios, but included for symmetry with SourceExtraQuery
+
+	Transfers      []CopyTransfer
+	LogLevel       LogLevel
+	BlobAttributes BlobTransferAttributes
+	SourceSAS      string
+	DestinationSAS string
 	// commandString hold the user given command which is logged to the Job log file
 	CommandString  string
 	CredentialInfo CredentialInfo

--- a/ste/JobPartPlanFileName.go
+++ b/ste/JobPartPlanFileName.go
@@ -74,8 +74,14 @@ func (jpfn JobPartPlanFileName) Create(order common.CopyJobPartOrderRequest) {
 	if len(order.SourceRoot) > len(JobPartPlanHeader{}.SourceRoot) {
 		panic(fmt.Errorf("source root string is too large: %q", order.SourceRoot))
 	}
+	if len(order.SourceExtraQuery) > len(JobPartPlanHeader{}.SourceExtraQuery) {
+		panic(fmt.Errorf("source extra query strings too large: %q", order.SourceExtraQuery))
+	}
 	if len(order.DestinationRoot) > len(JobPartPlanHeader{}.DestinationRoot) {
 		panic(fmt.Errorf("destination root string is too large: %q", order.DestinationRoot))
+	}
+	if len(order.DestExtraQuery) > len(JobPartPlanHeader{}.DestExtraQuery) {
+		panic(fmt.Errorf("destination extra query strings too large: %q", order.DestExtraQuery))
 	}
 	if len(order.BlobAttributes.ContentType) > len(JobPartPlanDstBlob{}.ContentType) {
 		panic(fmt.Errorf("content type string is too large: %q", order.BlobAttributes.ContentType))
@@ -147,22 +153,24 @@ func (jpfn JobPartPlanFileName) Create(order common.CopyJobPartOrderRequest) {
 	//}
 	// Initialize the Job Part's Plan header
 	jpph := JobPartPlanHeader{
-		Version:               DataSchemaVersion,
-		StartTime:             time.Now().UnixNano(),
-		JobID:                 order.JobID,
-		PartNum:               order.PartNum,
-		SourceRootLength:      uint16(len(order.SourceRoot)),
-		DestinationRootLength: uint16(len(order.DestinationRoot)),
-		IsFinalPart:           order.IsFinalPart,
-		ForceWrite:            order.ForceWrite,
-		AutoDecompress:        order.AutoDecompress,
-		Priority:              order.Priority,
-		TTLAfterCompletion:    uint32(time.Time{}.Nanosecond()),
-		FromTo:                order.FromTo,
-		Fpo:                   order.Fpo,
-		CommandStringLength:   uint32(len(order.CommandString)),
-		NumTransfers:          uint32(len(order.Transfers)),
-		LogLevel:              order.LogLevel,
+		Version:                DataSchemaVersion,
+		StartTime:              time.Now().UnixNano(),
+		JobID:                  order.JobID,
+		PartNum:                order.PartNum,
+		SourceRootLength:       uint16(len(order.SourceRoot)),
+		SourceExtraQueryLength: uint16(len(order.SourceExtraQuery)),
+		DestinationRootLength:  uint16(len(order.DestinationRoot)),
+		DestExtraQueryLength:   uint16(len(order.DestExtraQuery)),
+		IsFinalPart:            order.IsFinalPart,
+		ForceWrite:             order.ForceWrite,
+		AutoDecompress:         order.AutoDecompress,
+		Priority:               order.Priority,
+		TTLAfterCompletion:     uint32(time.Time{}.Nanosecond()),
+		FromTo:                 order.FromTo,
+		Fpo:                    order.Fpo,
+		CommandStringLength:    uint32(len(order.CommandString)),
+		NumTransfers:           uint32(len(order.Transfers)),
+		LogLevel:               order.LogLevel,
 		DstBlobData: JobPartPlanDstBlob{
 			BlobType:                 order.BlobAttributes.BlobType,
 			NoGuessMimeType:          order.BlobAttributes.NoGuessMimeType,
@@ -193,7 +201,9 @@ func (jpfn JobPartPlanFileName) Create(order common.CopyJobPartOrderRequest) {
 
 	// Copy any strings into their respective fields
 	copy(jpph.SourceRoot[:], order.SourceRoot)
+	copy(jpph.SourceExtraQuery[:], order.SourceExtraQuery)
 	copy(jpph.DestinationRoot[:], order.DestinationRoot)
+	copy(jpph.DestExtraQuery[:], order.DestExtraQuery)
 	copy(jpph.DstBlobData.ContentType[:], order.BlobAttributes.ContentType)
 	copy(jpph.DstBlobData.ContentEncoding[:], order.BlobAttributes.ContentEncoding)
 	copy(jpph.DstBlobData.ContentLanguage[:], order.BlobAttributes.ContentLanguage)

--- a/ste/JobPartPlanFileName.go
+++ b/ste/JobPartPlanFileName.go
@@ -71,17 +71,17 @@ func (jpfn JobPartPlanFileName) Map() *JobPartPlanMMF {
 // createJobPartPlanFile creates the memory map JobPartPlanHeader using the given JobPartOrder and JobPartPlanBlobData
 func (jpfn JobPartPlanFileName) Create(order common.CopyJobPartOrderRequest) {
 	// Validate that the passed-in strings can fit in their respective fields
-	if len(order.SourceRoot) > len(JobPartPlanHeader{}.SourceRoot) {
+	if len(order.SourceRoot.Value) > len(JobPartPlanHeader{}.SourceRoot) {
 		panic(fmt.Errorf("source root string is too large: %q", order.SourceRoot))
 	}
-	if len(order.SourceExtraQuery) > len(JobPartPlanHeader{}.SourceExtraQuery) {
-		panic(fmt.Errorf("source extra query strings too large: %q", order.SourceExtraQuery))
+	if len(order.SourceRoot.ExtraQuery) > len(JobPartPlanHeader{}.SourceExtraQuery) {
+		panic(fmt.Errorf("source extra query strings too large: %q", order.SourceRoot.ExtraQuery))
 	}
-	if len(order.DestinationRoot) > len(JobPartPlanHeader{}.DestinationRoot) {
+	if len(order.DestinationRoot.Value) > len(JobPartPlanHeader{}.DestinationRoot) {
 		panic(fmt.Errorf("destination root string is too large: %q", order.DestinationRoot))
 	}
-	if len(order.DestExtraQuery) > len(JobPartPlanHeader{}.DestExtraQuery) {
-		panic(fmt.Errorf("destination extra query strings too large: %q", order.DestExtraQuery))
+	if len(order.DestinationRoot.ExtraQuery) > len(JobPartPlanHeader{}.DestExtraQuery) {
+		panic(fmt.Errorf("destination extra query strings too large: %q", order.DestinationRoot.ExtraQuery))
 	}
 	if len(order.BlobAttributes.ContentType) > len(JobPartPlanDstBlob{}.ContentType) {
 		panic(fmt.Errorf("content type string is too large: %q", order.BlobAttributes.ContentType))
@@ -157,10 +157,10 @@ func (jpfn JobPartPlanFileName) Create(order common.CopyJobPartOrderRequest) {
 		StartTime:              time.Now().UnixNano(),
 		JobID:                  order.JobID,
 		PartNum:                order.PartNum,
-		SourceRootLength:       uint16(len(order.SourceRoot)),
-		SourceExtraQueryLength: uint16(len(order.SourceExtraQuery)),
-		DestinationRootLength:  uint16(len(order.DestinationRoot)),
-		DestExtraQueryLength:   uint16(len(order.DestExtraQuery)),
+		SourceRootLength:       uint16(len(order.SourceRoot.Value)),
+		SourceExtraQueryLength: uint16(len(order.SourceRoot.ExtraQuery)),
+		DestinationRootLength:  uint16(len(order.DestinationRoot.Value)),
+		DestExtraQueryLength:   uint16(len(order.DestinationRoot.ExtraQuery)),
 		IsFinalPart:            order.IsFinalPart,
 		ForceWrite:             order.ForceWrite,
 		AutoDecompress:         order.AutoDecompress,
@@ -200,10 +200,11 @@ func (jpfn JobPartPlanFileName) Create(order common.CopyJobPartOrderRequest) {
 	}
 
 	// Copy any strings into their respective fields
-	copy(jpph.SourceRoot[:], order.SourceRoot)
-	copy(jpph.SourceExtraQuery[:], order.SourceExtraQuery)
-	copy(jpph.DestinationRoot[:], order.DestinationRoot)
-	copy(jpph.DestExtraQuery[:], order.DestExtraQuery)
+	// do NOT copy Source/DestinationRoot.SAS, since we do NOT persist SASs
+	copy(jpph.SourceRoot[:], order.SourceRoot.Value)
+	copy(jpph.SourceExtraQuery[:], order.SourceRoot.ExtraQuery)
+	copy(jpph.DestinationRoot[:], order.DestinationRoot.Value)
+	copy(jpph.DestExtraQuery[:], order.DestinationRoot.ExtraQuery)
 	copy(jpph.DstBlobData.ContentType[:], order.BlobAttributes.ContentType)
 	copy(jpph.DstBlobData.ContentEncoding[:], order.BlobAttributes.ContentEncoding)
 	copy(jpph.DstBlobData.ContentLanguage[:], order.BlobAttributes.ContentLanguage)

--- a/ste/init.go
+++ b/ste/init.go
@@ -153,7 +153,7 @@ func ExecuteNewCopyJobPartOrder(order common.CopyJobPartOrderRequest) common.Cop
 			credentialInfo: order.CredentialInfo,
 		})
 	// Supply no plan MMF because we don't have one, and AddJobPart will create one on its own.
-	jpm.AddJobPart(order.PartNum, jppfn, nil, order.SourceSAS, order.DestinationSAS, true) // Add this part to the Job and schedule its transfers
+	jpm.AddJobPart(order.PartNum, jppfn, nil, order.SourceRoot.SAS, order.DestinationRoot.SAS, true) // Add this part to the Job and schedule its transfers
 	return common.CopyJobPartOrderResponse{JobStarted: true}
 }
 

--- a/ste/xfer-remoteToLocal-folder.go
+++ b/ste/xfer-remoteToLocal-folder.go
@@ -43,7 +43,7 @@ func remoteToLocal_folder(jptm IJobPartTransferMgr, p pipeline.Pipeline, pacer p
 
 	err := common.CreateDirectoryIfNotExist(info.Destination, t) // we may create it here, or possible there's already a file transfer for the folder that has created it, or maybe it already existed before this job
 	if err != nil {
-		jptm.FailActiveSend("ensuring destination folder exists", err)
+		jptm.FailActiveDownload("ensuring destination folder exists", err)
 	} else {
 		shouldSetProps := t.ShouldSetProperties(info.Destination, jptm.GetOverwriteOption())
 		if !shouldSetProps {
@@ -58,7 +58,7 @@ func remoteToLocal_folder(jptm IJobPartTransferMgr, p pipeline.Pipeline, pacer p
 		//    and set them
 		//
 		//		if err != nil {
-		//			jptm.FailActiveSend("setting folder properties", err)
+		//			jptm.FailActiveDownload("setting folder properties", err)
 		//}
 	}
 	commonDownloaderCompletion(jptm, info, common.EEntityType.Folder()) // for consistency, always run the standard epilogue


### PR DESCRIPTION
There's a lot of code changed here, but there's only two key parts to it.

1. Add a field to the job part plan file, to hold extra query params (that are not part of the SAS). This is where something like `sharesnapshot=2020-03-03T20%3A24%3A13.0000000Z` ends up if it is included in the source URL.
2. Refactor the handing of URLs in the front end (enumeration) code. Instead of having two fields for source - source and sourceSAS - have one struct with *three* fields: the main value, the SAS, and extra query params. Ditto for the destination.  By using this struct, not only do we have somewhere to store the extra query params, but also it is explicit when we are dealing with just the "non-query" part of the URL, vs the full URL, including all query params.

Without the clear separation between the different elements, provided by item 2 above, we ended up with some confusion.  E.g. this line

```
	} else if !source && !cca.stripTopDir {
		// We ONLY need to do this adjustment to the destination.
		// The source SAS has already been removed. No need to convert it to a URL or whatever.
		// Save to a directory
		rootDir := filepath.Base(cca.source)  // <--- HERE
```

Was including the snapshot identifier as part of "rootDir", because the extra query params were in cca.source.