### PR TITLE
Better error message for unrecognized source/dest

### DIFF
--- a/common/fe-ste-models.go
+++ b/common/fe-ste-models.go
@@ -409,7 +409,7 @@ func (Location) S3() Location        { return Location(6) }
 func (Location) Benchmark() Location { return Location(7) }
 
 func (l Location) String() string {
-	return enum.StringInt(uint32(l), reflect.TypeOf(l))
+	return enum.StringInt(l, reflect.TypeOf(l))
 }
 
 // fromToValue returns the fromTo enum value for given


### PR DESCRIPTION
To improve on the existing message of

> failed to parse user input due to error: the inferred source/destination combination is currently not supported. Please post an issue on Git hub if support for this scenario is desired