### PR TITLE
Fix/files enumeration perf

### DIFF
--- a/cmd/copyEnumeratorHelper.go
+++ b/cmd/copyEnumeratorHelper.go
@@ -15,6 +15,8 @@ import (
 	minio "github.com/minio/minio-go"
 )
 
+var enumerationParallelism = 1
+
 // addTransfer accepts a new transfer, if the threshold is reached, dispatch a job part order.
 func addTransfer(e *common.CopyJobPartOrderRequest, transfer common.CopyTransfer, cca *cookedCopyCmdArgs) error {
 	// Remove the source and destination roots from the path to save space in the plan files

--- a/cmd/removeEnumerator.go
+++ b/cmd/removeEnumerator.go
@@ -32,8 +32,6 @@ import (
 	"github.com/Azure/azure-storage-azcopy/azbfs"
 	"github.com/Azure/azure-storage-azcopy/common"
 	"github.com/Azure/azure-storage-azcopy/ste"
-
-	"github.com/Azure/azure-storage-file-go/azfile"
 )
 
 var NothingToRemoveError = errors.New("nothing found to remove")
@@ -97,24 +95,6 @@ func newRemoveEnumerator(cca *cookedCopyCmdArgs) (enumerator *copyEnumerator, er
 	}
 
 	return newCopyEnumerator(sourceTraverser, filters, transferScheduler.scheduleCopyTransfer, finalize), nil
-}
-
-type directoryStack []azfile.DirectoryURL
-
-func (s *directoryStack) Push(d azfile.DirectoryURL) {
-	*s = append(*s, d)
-}
-
-func (s *directoryStack) Pop() (*azfile.DirectoryURL, bool) {
-	l := len(*s)
-
-	if l == 0 {
-		return nil, false
-	} else {
-		e := (*s)[l-1]
-		*s = (*s)[:l-1]
-		return &e, true
-	}
 }
 
 // TODO move after ADLS/Blob interop goes public

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -90,6 +90,7 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		enumerationParallelism = concurrencySettings.EnumerationPoolSize.Value
 
 		// spawn a routine to fetch and compare the local application's version against the latest version available
 		// if there's a newer version that can be used, then write the suggestion to stderr

--- a/common/environment.go
+++ b/common/environment.go
@@ -100,6 +100,14 @@ func (EnvironmentVariable) TransferInitiationPoolSize() EnvironmentVariable {
 	}
 }
 
+func (EnvironmentVariable) EnumerationPoolSize() EnvironmentVariable {
+	return EnvironmentVariable{
+		Name:        "AZCOPY_CONCURRENT_SCAN",
+		Description: "Controls the (max) degree of parallelism used during enumeration. Only affects parallelized enumerators",
+		Hidden:      true, // hidden for now. We might not need to make it public? E.g. if we just cap it to the concurrency value or something?
+	}
+}
+
 func (EnvironmentVariable) OptimizeSparsePageBlobTransfers() EnvironmentVariable {
 	return EnvironmentVariable{
 		Name:         "AZCOPY_OPTIMIZE_SPARSE_PAGE_BLOB",

--- a/common/parallel/Transformer.go
+++ b/common/parallel/Transformer.go
@@ -1,0 +1,100 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package parallel
+
+import (
+	"context"
+	"sync"
+)
+
+type InputObject interface{}
+type OutputObject interface{}
+
+type transformer struct {
+	input       <-chan ErrorableItem // TODO: would have liked this to be of InputObject, but it made our usage messy.  Not sure of right solution to that yet
+	output      chan TransformResult
+	workerBody  TransformFunc
+	parallelism int
+}
+
+type ErrorableItem interface {
+	Item() (interface{}, error)
+}
+
+type TransformResult struct {
+	item OutputObject
+	err  error
+}
+
+func (r TransformResult) Item() (interface{}, error) {
+	return r.item, r.err
+}
+
+// must be safe to be simultaneously called by multiple go-routines
+type TransformFunc func(input InputObject) (OutputObject, error)
+
+// transformation will stop when input is closed
+func Transform(ctx context.Context, input <-chan ErrorableItem, worker TransformFunc, parallelism int) <-chan TransformResult {
+	t := &transformer{
+		input:       input,
+		output:      make(chan TransformResult, 1000),
+		workerBody:  worker,
+		parallelism: parallelism,
+	}
+	go t.runWorkersToCompletion(ctx)
+	return t.output
+}
+
+func (t *transformer) runWorkersToCompletion(ctx context.Context) {
+	wg := &sync.WaitGroup{}
+	for i := 0; i < t.parallelism; i++ {
+		wg.Add(1)
+		go t.workerLoop(ctx, wg)
+	}
+	wg.Wait()
+	close(t.output)
+}
+
+func (t *transformer) workerLoop(ctx context.Context, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	for t.processOneObject(ctx) {
+	}
+}
+
+func (t *transformer) processOneObject(ctx context.Context) bool {
+
+	select {
+	case rawObject, ok := <-t.input:
+		if ok {
+			in, err := rawObject.Item() // unpack it
+			if err != nil {
+				t.output <- TransformResult{err: err} // propagate the error
+				return true
+			}
+			out, err := t.workerBody(in)
+			t.output <- TransformResult{item: out, err: err}
+		}
+		return ok // exit this worker loop when input is closed and empty
+	case <-ctx.Done():
+		return false
+	}
+}

--- a/common/parallel/TreeCrawler.go
+++ b/common/parallel/TreeCrawler.go
@@ -1,0 +1,166 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package parallel
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+type crawler struct {
+	output      chan CrawlResult
+	workerBody  EnumerateOneDirFunc
+	parallelism int
+	cond        *sync.Cond
+	// the following is protected by cond (and must only be accessed when cond.L is held)
+	unstartedDirs      chan Directory // protected by cond.L because we use len() on this, and need to hold lock while making len-based decisions
+	dirInProgressCount int64
+}
+
+type Directory interface{}
+type DirectoryEntry interface{}
+
+type CrawlResult struct {
+	item DirectoryEntry
+	err  error
+}
+
+func (r *CrawlResult) Item() (Directory, error) {
+	return r.item, r.err
+}
+
+// must be safe to be simultaneously called by multiple go-routines, each with a different dir
+type EnumerateOneDirFunc func(dir Directory, enqueueDir func(Directory), enqueueOutput func(DirectoryEntry)) error
+
+func Crawl(ctx context.Context, root Directory, worker EnumerateOneDirFunc, parallelism int) <-chan CrawlResult {
+	c := &crawler{
+		unstartedDirs: make(chan Directory, 1000),
+		output:        make(chan CrawlResult, 1000),
+		workerBody:    worker,
+		parallelism:   parallelism,
+		cond:          sync.NewCond(&sync.Mutex{}),
+	}
+	go c.start(ctx, root)
+	return c.output
+}
+
+func (c *crawler) start(ctx context.Context, root Directory) {
+	done := make(chan struct{})
+	heartbeat := func() {
+		for {
+			select {
+			case <-done:
+				return
+			case <-time.After(10 * time.Second):
+				c.cond.Broadcast() // prevent things waiting for ever, even after cancellation has happened
+			}
+		}
+	}
+	go heartbeat()
+
+	c.unstartedDirs <- root
+	c.runWorkersToCompletion(ctx)
+	close(c.output)
+	close(done)
+}
+
+func (c *crawler) runWorkersToCompletion(ctx context.Context) {
+	wg := &sync.WaitGroup{}
+	for i := 0; i < c.parallelism; i++ {
+		wg.Add(1)
+		go c.workerLoop(ctx, wg)
+	}
+	wg.Wait()
+}
+
+func (c *crawler) workerLoop(ctx context.Context, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	var err error
+	mayHaveMore := true
+	for mayHaveMore && ctx.Err() == nil {
+		mayHaveMore, err = c.processOneDirectory(ctx)
+		if err != nil {
+			c.output <- CrawlResult{err: err}
+			// output the error, but we don't necessarily stop the enumeration (e.g. it might be one unreadable dir)
+		}
+	}
+}
+
+func (c *crawler) processOneDirectory(ctx context.Context) (bool, error) {
+	var toExamine Directory
+	stop := false
+
+	// Acquire a directory to work on
+	// Note that we need explicit locking because there are two
+	// mutable things involved in our decision making, not one (the two being c.dirs and c.dirInProgressCount)
+	// and because we use len(c.unstartedDirs) which is not accurate unless len and channel manipulation are protected
+	// by the same lock.
+	c.cond.L.Lock()
+	{
+		// wait while there's nothing to do, and another thread might be going to add something
+		for len(c.unstartedDirs) == 0 && c.dirInProgressCount > 0 && ctx.Err() == nil {
+			c.cond.Wait() // temporarily relinquish the lock (just on this line only) while we wait for a Signal/Broadcast
+		}
+
+		// if we have something to do now, grab it. Else we must be all finished with nothing more to do (ever)
+		stop = ctx.Err() != nil
+		if !stop {
+			select {
+			case toExamine = <-c.unstartedDirs:
+				c.dirInProgressCount++ // record that we are working on something
+				c.cond.Broadcast()     // and let other threads know of that fact
+			default:
+				if c.dirInProgressCount > 0 {
+					// something has gone wrong in the design of this algorithm, because we should only get here if all done now
+					panic("assertion failure: should be no more dirs in progress here")
+				}
+				stop = true
+			}
+		}
+	}
+	c.cond.L.Unlock()
+	if stop {
+		return false, nil
+	}
+
+	// find dir's immediate children (outside the lock, because this could be slow)
+	var foundDirectories = make([]Directory, 0, 16)
+	addDir := func(d Directory) {
+		foundDirectories = append(foundDirectories, d)
+	}
+	addOutput := func(e DirectoryEntry) {
+		c.output <- CrawlResult{item: e}
+	}
+	bodyErr := c.workerBody(toExamine, addDir, addOutput) // this is the worker body supplied by our caller
+
+	// finally, update shared state (inside the lock)
+	c.cond.L.Lock()
+	defer c.cond.L.Unlock()
+	for _, d := range foundDirectories {
+		c.unstartedDirs <- d
+	}
+	c.dirInProgressCount-- // we were doing something, and now we have finished it
+	c.cond.Broadcast()     // let other workers know that the state has changed
+
+	return true, bodyErr // true because, as far as we know, the work is not finished. And err because it was the err (if any) from THIS dir
+}

--- a/ste/concurrency.go
+++ b/ste/concurrency.go
@@ -103,6 +103,9 @@ type ConcurrencySettings struct {
 	// (i.e. creates chunkfuncs)
 	TransferInitiationPoolSize *ConfiguredInt
 
+	// EnumerationPoolSize is size of auxiliary goroutine pool used in enumerators (only some of which are in fact parallelized)
+	EnumerationPoolSize *ConfiguredInt
+
 	// MaxIdleConnections is the max number of idle TCP connections to keep open
 	MaxIdleConnections int
 
@@ -125,6 +128,7 @@ func (c ConcurrencySettings) AutoTuneMainPool() bool {
 }
 
 const defaultTransferInitiationPoolSize = 64
+const defaultEnumerationPoolSize = 64
 const concurrentFilesFloor = 32
 
 // NewConcurrencySettings gets concurrency settings by referring to the
@@ -138,9 +142,12 @@ func NewConcurrencySettings(maxFileAndSocketHandles int, requestAutoTuneGRs bool
 		InitialMainPoolSize:        initialMainPoolSize,
 		MaxMainPoolSize:            maxMainPoolSize,
 		TransferInitiationPoolSize: getTransferInitiationPoolSize(),
-		MaxOpenDownloadFiles:       getMaxOpenPayloadFiles(maxFileAndSocketHandles, maxMainPoolSize.Value),
-		CheckCpuWhenTuning:          getCheckCpuUsageWhenTuning(),
+		EnumerationPoolSize:        getEnumerationPoolSize(),
+		CheckCpuWhenTuning:         getCheckCpuUsageWhenTuning(),
 	}
+
+	s.MaxOpenDownloadFiles = getMaxOpenPayloadFiles(maxFileAndSocketHandles,
+		maxMainPoolSize.Value+s.TransferInitiationPoolSize.Value+s.EnumerationPoolSize.Value)
 
 	// Set the max idle connections that we allow. If there are any more idle connections
 	// than this, they will be closed, and then will result in creation of new connections
@@ -218,6 +225,17 @@ func getTransferInitiationPoolSize() *ConfiguredInt {
 	return &ConfiguredInt{defaultTransferInitiationPoolSize, false, envVar.Name, "hard-coded default"}
 }
 
+func getEnumerationPoolSize() *ConfiguredInt {
+	envVar := common.EEnvironmentVariable.EnumerationPoolSize()
+
+	if c := tryNewConfiguredInt(envVar); c != nil {
+		return c
+	}
+
+	return &ConfiguredInt{defaultEnumerationPoolSize, false, envVar.Name, "hard-coded default"}
+
+}
+
 func getCheckCpuUsageWhenTuning() *ConfiguredBool {
 	envVar := common.EEnvironmentVariable.AutoTuneToCpu()
 	if c := tryNewConfiguredBool(envVar); c != nil {
@@ -237,12 +255,8 @@ func getMaxOpenPayloadFiles(maxFileAndSocketHandles int, concurrentConnections i
 	// how many of those may be opened
 	const fileHandleAllowanceForPlanFiles = 300 // 300 plan files = 300 * common.NumOfFilesPerDispatchJobPart = 3million in total
 
-	const httpHandleAllowanceForOnGoingEnumeration = 1 // might still be scanning while we are transferring. Make this bigger if we ever do parallel scanning
-
 	// make a conservative estimate of total network and file handles known so far
-	estimateOfKnownHandles := int(float32(concurrentConnections)*1.1) +
-		fileHandleAllowanceForPlanFiles +
-		httpHandleAllowanceForOnGoingEnumeration
+	estimateOfKnownHandles := int(float32(concurrentConnections)*1.1) + fileHandleAllowanceForPlanFiles
 
 	// see what we've got left over for open files
 	concurrentFilesLimit := maxFileAndSocketHandles - estimateOfKnownHandles

--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -145,6 +145,11 @@ func (jm *jobMgr) logConcurrencyParameters() {
 	jm.logger.Log(pipeline.LogInfo, fmt.Sprintf("Max concurrent transfer initiation routines: %d (%s)",
 		jm.concurrency.TransferInitiationPoolSize.Value,
 		jm.concurrency.TransferInitiationPoolSize.GetDescription()))
+
+	jm.logger.Log(pipeline.LogInfo, fmt.Sprintf("Max enumeration routines: %d (%s)",
+		jm.concurrency.EnumerationPoolSize.Value,
+		jm.concurrency.EnumerationPoolSize.GetDescription()))
+
 	jm.logger.Log(pipeline.LogInfo, fmt.Sprintf("Max open files when downloading: %d (auto-computed)",
 		jm.concurrency.MaxOpenDownloadFiles))
 }


### PR DESCRIPTION
This fixes the Azure Files enumeration perf issue.

The idea is to isolate the parallelism into just a tiny part of the traverser, so we don't have the think about multi-threading anything else (e.g. don't want multi-threaded additions to the plan file(s).)

There's actually two parts to it. One allows directory crawls to be parallelized, and the other parallelizes the extra network roundtrip where we get the LMT and MD5.  Testing indicates both are necessary to get a significant speedup. 