### PR TITLE
Fix storage explorer's credential location issue when downloading

### DIFF
--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -263,7 +263,7 @@ func (cca *cookedCopyCmdArgs) isDestDirectory(dst common.ResourceString, ctx *co
 		return false
 	}
 
-	if dstCredInfo, _, err = getCredentialInfoForLocation(*ctx, cca.fromTo.To(), cca.destination.Value, cca.destination.SAS, true); err != nil {
+	if dstCredInfo, _, err = getCredentialInfoForLocation(*ctx, cca.fromTo.To(), cca.destination.Value, cca.destination.SAS, false); err != nil {
 		return false
 	}
 

--- a/cmd/credentialUtil.go
+++ b/cmd/credentialUtil.go
@@ -298,14 +298,10 @@ func checkAuthSafeForTarget(ct common.CredentialType, resource, extraSuffixesAAD
 		return nil
 	case common.ECredentialType.OAuthToken(),
 		common.ECredentialType.SharedKey():
-		// Files doesn't currently support OAuth.
-		// TODO: When adding files OAuth support to AzCopy eventually, fix this if statement.
-		if resourceType != common.ELocation.Blob() && resourceType != common.ELocation.BlobFS() {
+		// Files doesn't currently support OAuth, but it's a valid azure endpoint anyway, so it'll pass the check.
+		if resourceType != common.ELocation.Blob() && resourceType != common.ELocation.BlobFS() && resourceType != common.ELocation.File() {
 			// There may be a reason for files->blob to specify this.
-			// Files doesn't take OAuth currently, anyway.
-			// And for storage explorer, they just always supply it.
-			// We however, disinclude S3 from this list because S3 is a remote non-azure resource.
-			if resourceType == common.ELocation.Local() || resourceType == common.ELocation.File() {
+			if resourceType == common.ELocation.Local() {
 				return nil
 			}
 
@@ -389,10 +385,10 @@ func getCredentialTypeForLocation(ctx context.Context, location common.Location,
 	return doGetCredentialTypeForLocation(ctx, location, resource, resourceSAS, isSource, GetCredTypeFromEnvVar)
 }
 
-func doGetCredentialTypeForLocation(ctx context.Context, location common.Location, resource, resourceSAS string, isSource bool, getForcedCredType func(isSource bool) common.CredentialType) (credType common.CredentialType, isPublic bool, err error) {
+func doGetCredentialTypeForLocation(ctx context.Context, location common.Location, resource, resourceSAS string, isSource bool, getForcedCredType func() common.CredentialType) (credType common.CredentialType, isPublic bool, err error) {
 	if resourceSAS != "" {
 		credType = common.ECredentialType.Anonymous()
-	} else if credType = getForcedCredType(isSource); credType == common.ECredentialType.Unknown() || location == common.ELocation.S3() {
+	} else if credType = getForcedCredType(); credType == common.ECredentialType.Unknown() || location == common.ELocation.S3() {
 		switch location {
 		case common.ELocation.Local(), common.ELocation.Benchmark():
 			credType = common.ECredentialType.Anonymous()

--- a/cmd/zt_credentialUtil_test.go
+++ b/cmd/zt_credentialUtil_test.go
@@ -61,13 +61,13 @@ func (s *credentialUtilSuite) TestCheckAuthSafeForTarget(c *chk.C) {
 		{common.ECredentialType.S3AccessKey(), common.ELocation.S3(), "http://somethingelseinaws.amazonaws.com", "", false},
 
 		// As should these (they are nothing to do with the expected URLs)
-		{common.ECredentialType.OAuthToken(), common.ELocation.Blob(), "http://example.com", "", false},
-		{common.ECredentialType.S3AccessKey(), common.ELocation.S3(), "http://example.com", "", false},
+		{common.ECredentialType.OAuthToken(), common.ELocation.Blob(), "http://abc.example.com", "", false},
+		{common.ECredentialType.S3AccessKey(), common.ELocation.S3(), "http://abc.example.com", "", false},
 		// Test that we don't want to send an S3 access key to a blob resource type.
-		{common.ECredentialType.S3AccessKey(), common.ELocation.Blob(), "http://example.com", "", false},
+		{common.ECredentialType.S3AccessKey(), common.ELocation.Blob(), "http://abc.example.com", "", false},
 
 		// But the same Azure one should pass if the user opts in to them (we don't support any similar override for S3)
-		{common.ECredentialType.OAuthToken(), common.ELocation.Blob(), "http://example.com", "*.foo.com;*.example.com", false},
+		{common.ECredentialType.OAuthToken(), common.ELocation.Blob(), "http://abc.example.com", "*.foo.com;*.example.com", true},
 	}
 
 	for i, t := range tests {
@@ -77,7 +77,7 @@ func (s *credentialUtilSuite) TestCheckAuthSafeForTarget(c *chk.C) {
 }
 
 func (s *credentialUtilSuite) TestCheckAuthSafeForTargetIsCalledWhenGettingAuthType(c *chk.C) {
-	mockGetCredTypeFromEnvVar := func(isSource bool) common.CredentialType {
+	mockGetCredTypeFromEnvVar := func() common.CredentialType {
 		return common.ECredentialType.OAuthToken() // force it to OAuth, which is the case we want to test
 	}
 

--- a/cmd/zt_credentialUtil_test.go
+++ b/cmd/zt_credentialUtil_test.go
@@ -34,46 +34,50 @@ var _ = chk.Suite(&credentialUtilSuite{})
 func (s *credentialUtilSuite) TestCheckAuthSafeForTarget(c *chk.C) {
 	tests := []struct {
 		ct               common.CredentialType
+		resourceType     common.Location
 		resource         string
 		extraSuffixesAAD string
 		expectedOK       bool
 	}{
 		// these auth types deliberately don't get checked, i.e. always should be considered safe
-		{common.ECredentialType.Unknown(), "http://nowhere.com", "", true},
-		{common.ECredentialType.Anonymous(), "http://nowhere.com", "", true},
+		// invalid URLs are supposedly overridden as the resource type specified via --fromTo in this scenario
+		{common.ECredentialType.Unknown(), common.ELocation.Blob(), "http://nowhere.com", "", true},
+		{common.ECredentialType.Anonymous(), common.ELocation.Blob(), "http://nowhere.com", "", true},
 
 		// these ones get checked, so these should pass:
-		{common.ECredentialType.OAuthToken(), "http://myaccount.blob.core.windows.net", "", true},
-		{common.ECredentialType.OAuthToken(), "http://myaccount.blob.core.chinacloudapi.cn", "", true},
-		{common.ECredentialType.OAuthToken(), "http://myaccount.blob.core.cloudapi.de", "", true},
-		{common.ECredentialType.OAuthToken(), "http://myaccount.blob.core.core.usgovcloudapi.net", "", true},
-		{common.ECredentialType.SharedKey(), "http://myaccount.dfs.core.windows.net", "", true},
-		{common.ECredentialType.S3AccessKey(), "http://something.s3.eu-central-1.amazonaws.com", "", true},
-		{common.ECredentialType.S3AccessKey(), "http://something.s3.cn-north-1.amazonaws.com.cn", "", true},
-		{common.ECredentialType.S3AccessKey(), "http://s3.eu-central-1.amazonaws.com", "", true},
-		{common.ECredentialType.S3AccessKey(), "http://s3.cn-north-1.amazonaws.com.cn", "", true},
-		{common.ECredentialType.S3AccessKey(), "http://s3.amazonaws.com", "", true},
+		{common.ECredentialType.OAuthToken(), common.ELocation.Blob(), "http://myaccount.blob.core.windows.net", "", true},
+		{common.ECredentialType.OAuthToken(), common.ELocation.Blob(), "http://myaccount.blob.core.chinacloudapi.cn", "", true},
+		{common.ECredentialType.OAuthToken(), common.ELocation.Blob(), "http://myaccount.blob.core.cloudapi.de", "", true},
+		{common.ECredentialType.OAuthToken(), common.ELocation.Blob(), "http://myaccount.blob.core.core.usgovcloudapi.net", "", true},
+		{common.ECredentialType.SharedKey(), common.ELocation.BlobFS(), "http://myaccount.dfs.core.windows.net", "", true},
+		{common.ECredentialType.S3AccessKey(), common.ELocation.S3(), "http://something.s3.eu-central-1.amazonaws.com", "", true},
+		{common.ECredentialType.S3AccessKey(), common.ELocation.S3(), "http://something.s3.cn-north-1.amazonaws.com.cn", "", true},
+		{common.ECredentialType.S3AccessKey(), common.ELocation.S3(), "http://s3.eu-central-1.amazonaws.com", "", true},
+		{common.ECredentialType.S3AccessKey(), common.ELocation.S3(), "http://s3.cn-north-1.amazonaws.com.cn", "", true},
+		{common.ECredentialType.S3AccessKey(), common.ELocation.S3(), "http://s3.amazonaws.com", "", true},
 
 		// These should fail (they are not storage)
-		{common.ECredentialType.OAuthToken(), "http://somethingelseinazure.windows.net", "", false},
-		{common.ECredentialType.S3AccessKey(), "http://somethingelseinaws.amazonaws.com", "", false},
+		{common.ECredentialType.OAuthToken(), common.ELocation.Blob(), "http://somethingelseinazure.windows.net", "", false},
+		{common.ECredentialType.S3AccessKey(), common.ELocation.S3(), "http://somethingelseinaws.amazonaws.com", "", false},
 
 		// As should these (they are nothing to do with the expected URLs)
-		{common.ECredentialType.OAuthToken(), "http://example.com", "", false},
-		{common.ECredentialType.S3AccessKey(), "http://example.com", "", false},
+		{common.ECredentialType.OAuthToken(), common.ELocation.Blob(), "http://example.com", "", false},
+		{common.ECredentialType.S3AccessKey(), common.ELocation.S3(), "http://example.com", "", false},
+		// Test that we don't want to send an S3 access key to a blob resource type.
+		{common.ECredentialType.S3AccessKey(), common.ELocation.Blob(), "http://example.com", "", false},
 
 		// But the same Azure one should pass if the user opts in to them (we don't support any similar override for S3)
-		{common.ECredentialType.OAuthToken(), "http://example.com", "*.foo.com;*.example.com", false},
+		{common.ECredentialType.OAuthToken(), common.ELocation.Blob(), "http://example.com", "*.foo.com;*.example.com", false},
 	}
 
 	for i, t := range tests {
-		err := checkAuthSafeForTarget(t.ct, t.resource, t.extraSuffixesAAD)
+		err := checkAuthSafeForTarget(t.ct, t.resource, t.extraSuffixesAAD, t.resourceType)
 		c.Assert(err == nil, chk.Equals, t.expectedOK, chk.Commentf("Failed on test %d for resource %s", i, t.resource))
 	}
 }
 
 func (s *credentialUtilSuite) TestCheckAuthSafeForTargetIsCalledWhenGettingAuthType(c *chk.C) {
-	mockGetCredTypeFromEnvVar := func() common.CredentialType {
+	mockGetCredTypeFromEnvVar := func(isSource bool) common.CredentialType {
 		return common.ECredentialType.OAuthToken() // force it to OAuth, which is the case we want to test
 	}
 

--- a/common/environment.go
+++ b/common/environment.go
@@ -208,6 +208,10 @@ func (EnvironmentVariable) CredentialType() EnvironmentVariable {
 	return EnvironmentVariable{Name: "AZCOPY_CRED_TYPE"}
 }
 
+func (EnvironmentVariable) SourceCredentialType() EnvironmentVariable {
+	return EnvironmentVariable{Name: "AZCOPY_SRC_CRED_TYPE"}
+}
+
 func (EnvironmentVariable) DefaultServiceApiVersion() EnvironmentVariable {
 	return EnvironmentVariable{
 		Name:         "AZCOPY_DEFAULT_SERVICE_API_VERSION",

--- a/common/environment.go
+++ b/common/environment.go
@@ -208,10 +208,6 @@ func (EnvironmentVariable) CredentialType() EnvironmentVariable {
 	return EnvironmentVariable{Name: "AZCOPY_CRED_TYPE"}
 }
 
-func (EnvironmentVariable) SourceCredentialType() EnvironmentVariable {
-	return EnvironmentVariable{Name: "AZCOPY_SRC_CRED_TYPE"}
-}
-
 func (EnvironmentVariable) DefaultServiceApiVersion() EnvironmentVariable {
 	return EnvironmentVariable{
 		Name:         "AZCOPY_DEFAULT_SERVICE_API_VERSION",


### PR DESCRIPTION
This introduces a breaking change, in that it splits off the credential type overrides into source and destination credential type overrides. This is more consistent with our newer, internal usage of credential types (and with the introduction of User Delegation SAS Token generation, will be beneficial).

This furthermore, ensures we're no longer confused when a user overrides the credential type without both sides being of that credential type.