### PR TITLE
Fix/symlink processsing

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -72,7 +72,6 @@ contained directly in a container or virtual directory include `/*` at the end o
 include/exclude patterns were disallowed, but exclude-path was not. That was incorrect. All should have been
 disallowed because none (other than include-path) are respected. 
    
-
 ## Version 10.3.4
 
 ### New features

--- a/cmd/zc_traverser_local.go
+++ b/cmd/zc_traverser_local.go
@@ -193,16 +193,19 @@ func WalkWithSymlinks(fullPath string, walkFunc filepath.WalkFunc, followSymlink
 					// TODO: remove the above info call and enable the below, with suitable multi-OS testing
 					//    including enable the test: TestWalkWithSymlinks_ToFile
 					/*
-						// It's a symlink to a file. Just process the file because there's no danger of cycles with links to individual files.
-						// (this does create the inconsistency that if there are two symlinks to the same file we will process it twice,
-						// but if there are two symlinks to the same directory we will process it only once. Beceause only directories are
-						// deduped to break cycles.  For now, we are living with the inconsistency. The alternative would be to "burn" more
-						// RAM by putting filepaths into seenDirs too, but that could be a non-trivial amount of RAM in big directories trees).
+							// It's a symlink to a file. Just process the file because there's no danger of cycles with links to individual files.
+							// (this does create the inconsistency that if there are two symlinks to the same file we will process it twice,
+							// but if there are two symlinks to the same directory we will process it only once. Because only directories are
+							// deduped to break cycles.  For now, we are living with the inconsistency. The alternative would be to "burn" more
+							// RAM by putting filepaths into seenDirs too, but that could be a non-trivial amount of RAM in big directories trees).
 
-						// Make file info that has name of source, and stats of dest (to mirror what os.Stat calls on source will give us later)
-						// TODO: do we really need this, or can we just use fileInfo directly?
-						targetFi := symlinkTargetFileInfo{rStat, fileInfo.Name()}
-						return walkFunc(common.GenerateFullPath(fullPath, computedRelativePath), targetFi, fileError)
+							// TODO: this code here won't handle the case of (file-type symlink) -> (another file-type symlink) -> file
+						    //    But do we WANT to handle that?  (since it opens us to risk of file->file cycles, and we are deliberately NOT
+						    //    putting files in our map, to reduce RAM usage).  Maybe just detect if the target of a file symlink its itself a symlink
+						    //    and skip those cases with an error message?
+							// Make file info that has name of source, and stats of dest (to mirror what os.Stat calls on source will give us later)
+							targetFi := symlinkTargetFileInfo{rStat, fileInfo.Name()}
+							return walkFunc(common.GenerateFullPath(fullPath, computedRelativePath), targetFi, fileError)
 					*/
 				}
 				return nil

--- a/cmd/zc_traverser_local.go
+++ b/cmd/zc_traverser_local.go
@@ -220,8 +220,9 @@ func WalkWithSymlinks(fullPath string, walkFunc filepath.WalkFunc, followSymlink
 						seenDirs.Record(result)
 						return walkFunc(common.GenerateFullPath(fullPath, computedRelativePath), fileInfo, fileError)
 					} else {
-						// Output resulting path of symlink and symlink source
-						glcm.Info(fmt.Sprintf("Ignored already seen directory located at %s (found at %s)", filePath, common.GenerateFullPath(fullPath, computedRelativePath)))
+						// We can't output a warning here (and versions 10.3.x never did)
+						// because we'll hit this for the directory that is the direct (root) target of any symlink, so any warning here would be a red herring.
+						// In theory there might be cases when a warning here would be correct - but they are rare and too hard to identify in our code
 						return nil
 					}
 				} else {

--- a/cmd/zc_traverser_local.go
+++ b/cmd/zc_traverser_local.go
@@ -146,7 +146,10 @@ func WalkWithSymlinks(fullPath string, walkFunc filepath.WalkFunc, followSymlink
 			computedRelativePath = cleanLocalPath(common.GenerateFullPath(queueItem.relativeBase, computedRelativePath))
 			computedRelativePath = strings.TrimPrefix(computedRelativePath, common.AZCOPY_PATH_SEPARATOR_STRING)
 
-			if followSymlinks && fileInfo.Mode()&os.ModeSymlink != 0 {
+			if fileInfo.Mode()&os.ModeSymlink != 0 {
+				if !followSymlinks {
+					return nil // skip it
+				}
 				result, err := filepath.EvalSymlinks(filePath)
 
 				if err != nil {

--- a/cmd/zc_traverser_local.go
+++ b/cmd/zc_traverser_local.go
@@ -166,7 +166,7 @@ func WalkWithSymlinks(fullPath string, walkFunc filepath.WalkFunc, followSymlink
 					return nil
 				}
 
-				rStat, err := os.Stat(result) // TODO: do we really need this, or can we just use fileInfo?
+				rStat, err := os.Stat(result)
 				if err != nil {
 					glcm.Info(fmt.Sprintf("Failed to get properties of symlink target at %s: %s", result, err))
 					return nil
@@ -180,6 +180,8 @@ func WalkWithSymlinks(fullPath string, walkFunc filepath.WalkFunc, followSymlink
 							fullPath:     result,
 							relativeBase: computedRelativePath,
 						})
+						// enumerate the FOLDER now (since its presence in seenDirs will prevent its properties getting enumerated later)
+						return walkFunc(common.GenerateFullPath(fullPath, computedRelativePath), symlinkTargetFileInfo{rStat, fileInfo.Name()}, fileError)
 					} else {
 						glcm.Info(fmt.Sprintf("Ignored already linked directory pointed at %s (link at %s)", result, common.GenerateFullPath(fullPath, computedRelativePath)))
 					}

--- a/cmd/zt_generic_traverser_test.go
+++ b/cmd/zt_generic_traverser_test.go
@@ -171,7 +171,7 @@ func (s *genericTraverserSuite) TestS3GetProperties(c *chk.C) {
 }
 
 // Test follow symlink functionality
-func (s *genericTraverserSuite) TestWalkWithSymlinks(c *chk.C) {
+func (s *genericTraverserSuite) TestWalkWithSymlinks_ToFolder(c *chk.C) {
 	fileNames := []string{"March 20th is international happiness day.txt", "wonderwall but it goes on and on and on.mp3", "bonzi buddy.exe"}
 	tmpDir := scenarioHelper{}.generateLocalDirectory(c)
 	defer os.RemoveAll(tmpDir)
@@ -198,6 +198,44 @@ func (s *genericTraverserSuite) TestWalkWithSymlinks(c *chk.C) {
 
 	// 3 files live in base, 3 files live in symlink
 	c.Assert(fileCount, chk.Equals, 6)
+}
+
+// symlinks are not just to folders. They may be to individual files
+func (s *genericTraverserSuite) TestWalkWithSymlinks_ToFile(c *chk.C) {
+	mainDirFilenames := []string{"iAmANormalFile.txt"}
+	symlinkTargetFilenames := []string{"iAmASymlinkTargetFile.txt"}
+	tmpDir := scenarioHelper{}.generateLocalDirectory(c)
+	defer os.RemoveAll(tmpDir)
+	symlinkTmpDir := scenarioHelper{}.generateLocalDirectory(c)
+	defer os.RemoveAll(symlinkTmpDir)
+	c.Assert(tmpDir, chk.Not(chk.Equals), symlinkTmpDir)
+
+	scenarioHelper{}.generateLocalFilesFromList(c, tmpDir, mainDirFilenames)
+	scenarioHelper{}.generateLocalFilesFromList(c, symlinkTmpDir, symlinkTargetFilenames)
+	trySymlink(filepath.Join(symlinkTmpDir, symlinkTargetFilenames[0]), filepath.Join(tmpDir, "iPointToTheSymlink"), c)
+	trySymlink(filepath.Join(symlinkTmpDir, symlinkTargetFilenames[0]), filepath.Join(tmpDir, "iPointToTheSameSymlink"), c)
+
+	fileCount := 0
+	c.Assert(WalkWithSymlinks(tmpDir, func(path string, fi os.FileInfo, err error) error {
+		c.Assert(err, chk.IsNil)
+
+		if fi.IsDir() {
+			return nil
+		}
+
+		fileCount++
+		if fi.Name() != "iAmANormalFile.txt" {
+			c.Assert(strings.HasPrefix(path, tmpDir), chk.Equals, true)                  // the file appears to have the location of the symlink source (not the dest)
+			c.Assert(strings.HasPrefix(filepath.Base(path), "iPoint"), chk.Equals, true) // the file appears to have the name of the symlink source (not the dest)
+			c.Assert(strings.HasPrefix(fi.Name(), "iPoint"), chk.Equals, true)           // and it still appears to have that name when we look it the fileInfo
+		}
+		return nil
+	},
+		true), chk.IsNil)
+
+	// 1 file is in base, 2 are pointed to by a symlink (the fact that both point to the same file is does NOT prevent us
+	// processing them both. For efficiency of dedupe algorithm, we only dedupe directories, not files).
+	c.Assert(fileCount, chk.Equals, 3)
 }
 
 // Test cancel symlink loop functionality

--- a/cmd/zt_generic_traverser_test.go
+++ b/cmd/zt_generic_traverser_test.go
@@ -200,6 +200,8 @@ func (s *genericTraverserSuite) TestWalkWithSymlinks_ToFolder(c *chk.C) {
 	c.Assert(fileCount, chk.Equals, 6)
 }
 
+// Next test is temporarily disabled, to avoid changing functionality near 10.4 release date
+/*
 // symlinks are not just to folders. They may be to individual files
 func (s *genericTraverserSuite) TestWalkWithSymlinks_ToFile(c *chk.C) {
 	mainDirFilenames := []string{"iAmANormalFile.txt"}
@@ -237,6 +239,7 @@ func (s *genericTraverserSuite) TestWalkWithSymlinks_ToFile(c *chk.C) {
 	// processing them both. For efficiency of dedupe algorithm, we only dedupe directories, not files).
 	c.Assert(fileCount, chk.Equals, 3)
 }
+*/
 
 // Test cancel symlink loop functionality
 func (s *genericTraverserSuite) TestWalkWithSymlinksBreakLoop(c *chk.C) {


### PR DESCRIPTION
In 10.4, we have already switched all our directory tree crawling to use the symlink-aware code, to reduce code duplication. It respects the followSymlinks flag that is passed into it.

But, this meant that any memory usage issues in that code would always have an effect. So this PR fixes two memory usage issues:
   1. previously the code ran the dedupe map even when followSymlinks was false AND
   1. previously it put files into the dedupe map as well as directories.

It also fixes a minor bug where we did not pick up directory properties for the directory that is the target of a symlink; and another minor bug where the Folders as First Class Citizens work had caused it to output a "duplicate skipped" message _every_ time.

This PR does not fix the other existing bug that was found, which is that: The existing code would not process a symlink to a file. (It would always treat it as a duplicate).  That can wait, and be tested properly, in 10.5.