### PR TITLE
Fix permission protection at download root, in case where downloading whole share

### DIFF
--- a/ste/downloader-azureFiles_windows.go
+++ b/ste/downloader-azureFiles_windows.go
@@ -4,6 +4,8 @@ package ste
 
 import (
 	"fmt"
+	"github.com/Azure/azure-storage-file-go/azfile"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -127,10 +129,15 @@ func (a *azureFilesDownloader) PutSDDL(sip ISMBPropertyBearingSourceInfoProvider
 	// To achieve robocopy like functionality, and maintain the ability to add new permissions in the middle of the copied file tree,
 	//     we choose to protect both already protected files at the source, and to protect the entire root folder of the transfer.
 	//     Protected files and folders experience no inheritance from their parents (but children do experience inheritance)
+	//     To protect the root folder of the transfer, it's not enough to just look at "isTransferRoot" because, in the
+	//     case of downloading a complete share, with strip-top-dir = false (i.e. no trailing /* on the URL), the thing at the transfer
+	//     root is the share, and currently (April 2019) we can't get permissions for the share itself.  So we have to "lock"/protect
+	//     the permissions one level down in that case (i.e. for its children).  But in the case of downloading from a directory (not the share root)
+	//     then we DO need the check on isAtTransferRoot.
 	isProtectedAtSource := (ctl & windows.SE_DACL_PROTECTED) != 0
 	isAtTransferRoot := len(splitPath) == 1
 
-	if isProtectedAtSource || isAtTransferRoot {
+	if isProtectedAtSource || isAtTransferRoot || a.parentIsShareRoot(txInfo.Source) {
 		securityInfoFlags |= windows.PROTECTED_DACL_SECURITY_INFORMATION
 	}
 
@@ -165,4 +172,17 @@ func (a *azureFilesDownloader) PutSDDL(sip ISMBPropertyBearingSourceInfoProvider
 	}
 
 	return err
+}
+
+// TODO: this method may become obsolete if/when we are able to get permissions from the share root
+func (a *azureFilesDownloader) parentIsShareRoot(source string) bool {
+	u, err := url.Parse(source)
+	if err != nil {
+		return false
+	}
+	f := azfile.NewFileURLParts(*u)
+	path := f.DirectoryOrFilePath
+	sep := common.DeterminePathSeparator(path)
+	splitPath := strings.Split(strings.Trim(path, sep), sep)
+	return path != "" && len(splitPath) == 1
 }

--- a/ste/zt_ste_misc_test.go
+++ b/ste/zt_ste_misc_test.go
@@ -1,0 +1,47 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ste
+
+import (
+	chk "gopkg.in/check.v1"
+)
+
+type steMiscSuite struct{}
+
+var _ = chk.Suite(&steMiscSuite{})
+
+func (s *concurrencyTunerSuite) Test_IsParentShareRoot(c *chk.C) {
+	d := azureFilesDownloader{}
+
+	c.Assert(d.parentIsShareRoot("https://a.file.core.windows.net/share"), chk.Equals, false) // THIS is the share root, not the parent of this
+	c.Assert(d.parentIsShareRoot("https://a.file.core.windows.net/share/"), chk.Equals, false)
+	c.Assert(d.parentIsShareRoot("https://a.file.core.windows.net/share?aaa/bbb"), chk.Equals, false)
+	c.Assert(d.parentIsShareRoot("https://a.file.core.windows.net/share/?aaa/bbb"), chk.Equals, false)
+
+	c.Assert(d.parentIsShareRoot("https://a.file.core.windows.net/share/foo"), chk.Equals, true)
+	c.Assert(d.parentIsShareRoot("https://a.file.core.windows.net/share/foo/"), chk.Equals, true)
+	c.Assert(d.parentIsShareRoot("https://a.file.core.windows.net/share/foo/?x/y"), chk.Equals, true)
+	c.Assert(d.parentIsShareRoot("https://a.file.core.windows.net/share/foo?x/y"), chk.Equals, true)
+
+	c.Assert(d.parentIsShareRoot("https://a.file.core.windows.net/share/foo/bar"), chk.Equals, false)
+	c.Assert(d.parentIsShareRoot("https://a.file.core.windows.net/share/foo/bar/"), chk.Equals, false)
+	c.Assert(d.parentIsShareRoot("https://a.file.core.windows.net/share/foo/bar?nethe"), chk.Equals, false)
+}


### PR DESCRIPTION
Our robocopy-like behavior, of protecting permissions at the download root, was failing when the downlaod root was the share itself - because share itself did not return any SDDL, so there was nothing for us to protect.