### PR TITLE
Ignore AuthFailed errror while listing properties of parent directory

### DIFF
--- a/ste/sender-azureFile.go
+++ b/ste/sender-azureFile.go
@@ -428,9 +428,10 @@ func (d AzureFileParentDirCreator) CreateDirToRoot(ctx context.Context, dirURL a
 	dirURLExtension := common.FileURLPartsExtension{FileURLParts: azfile.NewFileURLParts(dirURL.URL())}
 	if _, err := dirURL.GetProperties(ctx); err != nil {
 		if stgErr, stgErrOk := err.(azfile.StorageError); stgErrOk && stgErr.Response() != nil &&
-			stgErr.Response().StatusCode == http.StatusNotFound { // At least need read and write permisson for destination
-			// File's parent directory doesn't exist, try to create the parent directories.
-			// Split directories as segments.
+			(stgErr.Response().StatusCode == http.StatusNotFound ||
+				stgErr.Response().StatusCode == http.StatusForbidden) {
+			// Either the parent directory does not exist, or we may not have read permissions.
+			// Try to create the parent directories. Split directories as segments.
 			segments := d.splitWithoutToken(dirURLExtension.DirectoryOrFilePath, '/')
 
 			shareURL := azfile.NewShareURL(dirURLExtension.GetShareURL(), p)

--- a/ste/sender-azureFile.go
+++ b/ste/sender-azureFile.go
@@ -427,9 +427,9 @@ func (d AzureFileParentDirCreator) CreateParentDirToRoot(ctx context.Context, fi
 func (d AzureFileParentDirCreator) CreateDirToRoot(ctx context.Context, dirURL azfile.DirectoryURL, p pipeline.Pipeline, t common.FolderCreationTracker) error {
 	dirURLExtension := common.FileURLPartsExtension{FileURLParts: azfile.NewFileURLParts(dirURL.URL())}
 	if _, err := dirURL.GetProperties(ctx); err != nil {
-		if stgErr, stgErrOk := err.(azfile.StorageError); stgErrOk && stgErr.Response() != nil &&
-			(stgErr.Response().StatusCode == http.StatusNotFound ||
-				stgErr.Response().StatusCode == http.StatusForbidden) {
+		if resp, respOk := err.(pipeline.Response); respOk && resp.Response() != nil &&
+			(resp.Response().StatusCode == http.StatusNotFound ||
+				resp.Response().StatusCode == http.StatusForbidden) {
 			// Either the parent directory does not exist, or we may not have read permissions.
 			// Try to create the parent directories. Split directories as segments.
 			segments := d.splitWithoutToken(dirURLExtension.DirectoryOrFilePath, '/')

--- a/ste/xfer-anyToRemote-file.go
+++ b/ste/xfer-anyToRemote-file.go
@@ -371,9 +371,8 @@ func epilogueWithCleanupSendToRemote(jptm IJobPartTransferMgr, s sender, sip ISo
 			// The destination is write-only. Cannot verify length
 			shouldCheckLength = false
 			checkLengthFailureOnReadOnlyDst.Do( func() {
-				if jptm.ShouldLog(pipeline.LogError) {
-					jptm.Log(pipeline.LogError, fmt.Sprintf("Could not read destination length. If destination is write-only use --check-length=false on the AzCopy command line. %s", err))
-				}
+				var glcm = common.GetLifecycleMgr()
+				glcm.Info(fmt.Sprintf("Could not read destination length. If destination is write-only use --check-length=false on the AzCopy command line."))
 			})
 		}
 
@@ -381,9 +380,7 @@ func epilogueWithCleanupSendToRemote(jptm IJobPartTransferMgr, s sender, sip ISo
 			if err != nil {
 				wrapped := fmt.Errorf("Could not read destination length. %w", err)
 				jptm.FailActiveSend(common.IffString(isS2SCopier, "S2S ", "Upload ")+"Length check: Get destination length", wrapped)
-			}
-
-			if destLength != jptm.Info().SourceSize {
+			} else if destLength != jptm.Info().SourceSize {
 				jptm.FailActiveSend(common.IffString(isS2SCopier, "S2S ", "Upload ")+"Length check", errors.New("destination length does not match source length"))
 			}
 		}

--- a/ste/xfer-anyToRemote-file.go
+++ b/ste/xfer-anyToRemote-file.go
@@ -372,7 +372,11 @@ func epilogueWithCleanupSendToRemote(jptm IJobPartTransferMgr, s sender, sip ISo
 			shouldCheckLength = false
 			checkLengthFailureOnReadOnlyDst.Do( func() {
 				var glcm = common.GetLifecycleMgr()
-				glcm.Info(fmt.Sprintf("Could not read destination length. If destination is write-only use --check-length=false on the AzCopy command line."))
+				msg :=fmt.Sprintf("Could not read destination length. If the destination is write-only, use --check-length=false on the command line.")
+				glcm.Info(msg)
+				if jptm.ShouldLog(pipeline.LogError) {
+					jptm.Log(pipeline.LogError, msg)
+				}
 			})
 		}
 


### PR DESCRIPTION
Transfer to a filestore with a read-only SAS fails because we try
listing properties for parent directory, and fail with permission mismatch.
With this change, we ignore the error and try creating parent directories.
Also, we try matching the source and destination file lengths in
epilogue. The error here will be selectively ignored as well.