### PR TITLE
Change osOpen to just do opening, and use standard os.Stat for Stat

### DIFF
--- a/common/osOpen_fallback.go
+++ b/common/osOpen_fallback.go
@@ -8,6 +8,7 @@ import (
 	"os"
 )
 
+// NOTE: OSOpenFile not safe to use on directories on Windows. See comment on the Windows version of this routine
 func OSOpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
 	return os.OpenFile(name, flag, perm)
 }

--- a/common/osOpen_windows.go
+++ b/common/osOpen_windows.go
@@ -6,6 +6,9 @@ import (
 	"os"
 )
 
+// NOTE: this is not safe to use on directories.  It returns an os.File that points at a directory, but thinks it points to a file.
+// There is no way around that in the Go SDK as at Go 1.13, because the only way to make a valid windows.File that points to a directory
+// is private inside the Go SDK's Windows package.
 func OSOpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
 	// use openwithwritethroughsetting with false writethrough, since it makes a windows syscall containing an ask
 	//     for backup privileges. This allows all of our file opening to go down one route of code.
@@ -24,13 +27,5 @@ func OSOpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
 }
 
 func OSStat(name string) (os.FileInfo, error) {
-	f, err := OSOpenFile(name, 0, 0)
-
-	if err != nil {
-		return nil, err
-	}
-
-	defer f.Close()
-
-	return f.Stat()
+	return os.Stat(name) // this is safe even with our --backup mode, because it uses FILE_FLAG_BACKUP_SEMANTICS (whereas os.File.Stat() does not)
 }


### PR DESCRIPTION
Since implementing our own Stat on top of our own OSOpen was relying on some "lucky" behavior for directories. Specifically, the os.File returned by our OSOpen on a directory is not actually initialized properly for a directory. (Since there is no public method that create a correctly-constructructed Windows.File - the only methods are private to the windows package).  AND, os.Stat() actually already sets the flag that we need.