### PR TITLE
Benchmark for downloads

### DIFF
--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -23,22 +23,22 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+
 	"github.com/Azure/azure-storage-azcopy/azbfs"
 	"github.com/Azure/azure-storage-azcopy/common"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/Azure/azure-storage-file-go/azfile"
 	"github.com/spf13/cobra"
-	"net/url"
-	"strconv"
-	"strings"
 )
 
 // represents the raw benchmark command input from the user
 type rawBenchmarkCmdArgs struct {
-	// no src, since it's implicitly the auto-data-generator used for benchmarking
-
-	// where are we uploading the benchmark data to ?
-	dst string
+	// The destination/src endpoint we are benchmarking.
+	target string
 
 	// parameters controlling the auto-generated data
 	sizePerFile    string
@@ -52,6 +52,7 @@ type rawBenchmarkCmdArgs struct {
 	blobType     string
 	output       string
 	logVerbosity string
+	download     bool
 }
 
 const (
@@ -123,12 +124,17 @@ func (raw rawBenchmarkCmdArgs) cook() (cookedCopyCmdArgs, error) {
 	c := rawCopyCmdArgs{}
 	c.setMandatoryDefaults()
 
-	// src must be string, but needs to indicate that its for benchmark and encode what we want
-	c.src = benchmarkSourceHelper{}.ToUrl(raw.fileCount, bytesPerFile)
-
-	c.dst, err = raw.appendVirtualDir(raw.dst, virtualDir)
-	if err != nil {
-		return dummyCooked, err
+	if raw.download {
+		//We to write to NULL device, so our measurements are not masked by disk perf
+		c.dst = os.DevNull
+		c.src = raw.target
+	} else {
+		// src must be string, but needs to indicate that its for benchmark and encode what we want
+		c.src = benchmarkSourceHelper{}.ToUrl(raw.fileCount, bytesPerFile)
+		c.dst, err = raw.appendVirtualDir(raw.target, virtualDir)
+		if err != nil {
+			return dummyCooked, err
+		}
 	}
 
 	c.recursive = true                                     // because source is directory-like, in which case recursive is required
@@ -147,7 +153,7 @@ func (raw rawBenchmarkCmdArgs) cook() (cookedCopyCmdArgs, error) {
 		return cooked, err
 	}
 
-	if raw.deleteTestData {
+	if !raw.download && raw.deleteTestData {
 		// set up automatic cleanup
 		cooked.followupJobArgs, err = raw.createCleanupJobArgs(cooked.destination, raw.logVerbosity)
 		if err != nil {
@@ -283,7 +289,7 @@ func init() {
 			// TODO: if/when we support benchmarking for S2S, note that the current code to set userAgent string in
 			//   jobPartMgr will need to be changed if we want it to still set the benchmarking suffix for S2S
 			if len(args) == 1 {
-				raw.dst = args[0]
+				raw.target = args[0]
 			} else {
 				return errors.New("wrong number of arguments, please refer to the help page on usage of this command")
 			}
@@ -317,6 +323,7 @@ func init() {
 	benchCmd.PersistentFlags().StringVar(&raw.blobType, "blob-type", "Detect", "defines the type of blob at the destination. Used to allow benchmarking different blob types. Identical to the same-named parameter in the copy command")
 	benchCmd.PersistentFlags().BoolVar(&raw.putMd5, "put-md5", false, "create an MD5 hash of each file, and save the hash as the Content-MD5 property of the destination blob/file. (By default the hash is NOT created.) Identical to the same-named parameter in the copy command")
 	benchCmd.PersistentFlags().BoolVar(&raw.checkLength, "check-length", true, "Check the length of a file on the destination after the transfer. If there is a mismatch between source and destination, the transfer is marked as failed.")
+	benchCmd.PersistentFlags().BoolVar(&raw.download, "download", false, "Measure download performance from this location.")
 
 	// TODO use constant for default value or, better, move loglevel param to root cmd?
 	benchCmd.PersistentFlags().StringVar(&raw.logVerbosity, "log-level", "INFO", "define the log verbosity for the log file, available levels: INFO(all requests/responses), WARNING(slow responses), ERROR(only failed requests), and NONE(no output logs).")

--- a/cmd/helpMessages.go
+++ b/cmd/helpMessages.go
@@ -399,35 +399,41 @@ const benchCmdShortDescription = "Performs a performance benchmark"
 // TODO: document whether we delete the uploaded data
 
 const benchCmdLongDescription = `
-Runs a performance benchmark by uploading test data to a specified destination. The test data is automatically generated.
+Runs a performance benchmark by uploading or downloading test data to or from a specified destination. 
+For uploads, the test data is automatically generated.
 
-The benchmark command runs the same upload process as 'copy', except that: 
+The benchmark command runs the same process as 'copy', except that: 
 
-  - The command requires a target URL. In the current release, target must refer to a blob container.
+  - Instead of requiring both source and destination parameters, benchmark takes just one. This is the 
+    blob container, Azure Files Share, or ADLS Gen 2 File System that you want to upload to or download from.
 
-  - The 'mode' parameter describes whether Azcopy should test uploads to or downloads from given target. Valid values are 'Upload'
+  - The 'mode' parameter describes whether AzCopy should test uploads to or downloads from given target. Valid values are 'Upload'
     and 'Download'. Default value is 'Upload'.
 
-  - The payload is described by command line parameters, which control how many files are auto-generated and 
+  - For upload benchmarks, the payload is described by command line parameters, which control how many files are auto-generated and 
     how big they are. The generation process takes place entirely in memory. Disk is not used.
+
+  - For downloads, the payload consists of whichever files already exist at the source. (See example below about how to generate
+    test files if needed).
   
   - Only a few of the optional parameters that are available to the copy command are supported.
   
   - Additional diagnostics are measured and reported.
   
-  - By default, the transferred data is deleted at the end of the test run.
+  - For uploads, the default behaviour is to delete the transferred data at the end of the test run.  For downloads, the data
+    is never actually saved locally.
 
 Benchmark mode will automatically tune itself to the number of parallel TCP connections that gives 
 the maximum throughput. It will display that number at the end. To prevent auto-tuning, set the 
 AZCOPY_CONCURRENCY_VALUE environment variable to a specific number of connections. 
 
 All the usual authentication types are supported. However, the most convenient approach for benchmarking upload is typically
-to create an empty container with a SAS token and use SAS authentication. Download mode requires a set of test data to be
-present in the target container.
+to create an empty container with a SAS token and use SAS authentication. (Download mode requires a set of test data to be
+present in the target container.)
   
 `
 
-const benchCmdExample = `Run a benchmark test with default parameters (suitable for benchmarking networks up to 1 Gbps):'
+const benchCmdExample = `Run an upload benchmark with default parameters (suitable for benchmarking networks up to 1 Gbps):'
 
    - azcopy bench "https://[account].blob.core.windows.net/[container]?<SAS>"
 
@@ -441,7 +447,11 @@ selected file count and size:
 
    - azcopy bench --mode='Upload' "https://[account].blob.core.windows.net/[container]?<SAS>" --file-count 50000 --size-per-file 8M --put-md5
 
-Run a benchmark test that downloads from a target
+Run a benchmark test that downloads existing files from a target
 
    - azcopy bench --mode='Download' "https://[account].blob.core.windows.net/[container]?<SAS?"
+
+Run an upload that does not delete the transferred files. (These files can then serve as the payload for a download test)
+
+   - azcopy bench "https://[account].blob.core.windows.net/[container]?<SAS>" --file-count 100 --delete-test-data=false
 `

--- a/cmd/helpMessages.go
+++ b/cmd/helpMessages.go
@@ -403,8 +403,11 @@ Runs a performance benchmark by uploading test data to a specified destination. 
 
 The benchmark command runs the same upload process as 'copy', except that: 
 
-  - There's no source parameter.  The command requires only a destination URL. In the current release, this destination URL must refer to a blob container.
-  
+  - The command requires a target URL. In the current release, target must refer to a blob container.
+
+  - The 'mode' parameter describes whether Azcopy should test uploads to or downloads from given target. Valid values are 'Upload'
+    and 'Download'. Default value is 'Upload'.
+
   - The payload is described by command line parameters, which control how many files are auto-generated and 
     how big they are. The generation process takes place entirely in memory. Disk is not used.
   
@@ -418,8 +421,10 @@ Benchmark mode will automatically tune itself to the number of parallel TCP conn
 the maximum throughput. It will display that number at the end. To prevent auto-tuning, set the 
 AZCOPY_CONCURRENCY_VALUE environment variable to a specific number of connections. 
 
-All the usual authentication types are supported. However, the most convenient approach for benchmarking is typically
-to create an empty container with a SAS token and use SAS authentication.
+All the usual authentication types are supported. However, the most convenient approach for benchmarking upload is typically
+to create an empty container with a SAS token and use SAS authentication. Download mode requires a set of test data to be
+present in the target container.
+  
 `
 
 const benchCmdExample = `Run a benchmark test with default parameters (suitable for benchmarking networks up to 1 Gbps):'
@@ -434,5 +439,9 @@ Same as above, but use 50,000 files, each 8 MiB in size and compute their MD5 ha
 in the copy command). The purpose of --put-md5 when benchmarking is to test whether MD5 computation affects throughput for the 
 selected file count and size:
 
-   - azcopy bench "https://[account].blob.core.windows.net/[container]?<SAS>" --file-count 50000 --size-per-file 8M --put-md5
+   - azcopy bench --mode='Upload' "https://[account].blob.core.windows.net/[container]?<SAS>" --file-count 50000 --size-per-file 8M --put-md5
+
+Run a benchmark test that downloads from a target
+
+   - azcopy bench --mode='Download' "https://[account].blob.core.windows.net/[container]?<SAS?"
 `

--- a/common/fe-ste-models.go
+++ b/common/fe-ste-models.go
@@ -23,13 +23,14 @@ package common
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/Azure/azure-storage-azcopy/azbfs"
 	"math"
 	"reflect"
 	"regexp"
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"github.com/Azure/azure-storage-azcopy/azbfs"
 
 	"fmt"
 
@@ -1179,6 +1180,27 @@ const SizePerFileParam = "size-per-file"
 const FileCountParam = "file-count"
 const FileCountDefault = 100
 
+//BenchMarkMode enumerates values for Azcopy bench command. Valid values Upload or Download
+type BenchMarkMode uint8
+
+var EBenchMarkMode = BenchMarkMode(0)
+
+func (BenchMarkMode) Upload() BenchMarkMode { return BenchMarkMode(0) }
+
+func (BenchMarkMode) Download() BenchMarkMode { return BenchMarkMode(1) }
+
+func (bm BenchMarkMode) String() string {
+	return enum.StringInt(bm, reflect.TypeOf(bm))
+}
+
+func (bm *BenchMarkMode) Parse(s string) error {
+	val, err := enum.ParseInt(reflect.TypeOf(bm), s, true, true)
+	if err == nil {
+		*bm = val.(BenchMarkMode)
+	}
+	return err
+}
+
 //////////////////////////////////////////////////////////////////////////////////////
 
 var ECompressionType = CompressionType(0)
@@ -1243,7 +1265,9 @@ var EPreservePermissionsOption = PreservePermissionsOption(0)
 
 type PreservePermissionsOption uint8
 
-func (PreservePermissionsOption) None() PreservePermissionsOption { return PreservePermissionsOption(0) }
+func (PreservePermissionsOption) None() PreservePermissionsOption {
+	return PreservePermissionsOption(0)
+}
 func (PreservePermissionsOption) ACLsOnly() PreservePermissionsOption {
 	return PreservePermissionsOption(1)
 }


### PR DESCRIPTION
The existing infra for workloads is used to test downloads as well.
The current usage is 'azcopy bench <target> --download'. The exact
usage will be decided.