### PR TITLE
Stop treating zero-item copy as failure

### DIFF
--- a/ste/init.go
+++ b/ste/init.go
@@ -144,8 +144,12 @@ func ExecuteNewCopyJobPartOrder(order common.CopyJobPartOrderRequest) common.Cop
 	jpm := JobsAdmin.JobMgrEnsureExists(order.JobID, order.LogLevel, order.CommandString) // Get a this job part's job manager (create it if it doesn't exist)
 
 	if len(order.Transfers) == 0 && order.IsFinalPart {
-		jpm.Log(pipeline.LogError, "ERROR: No transfers were scheduled.")
-		return common.CopyJobPartOrderResponse{JobStarted: false, ErrorMsg: common.ECopyJobPartOrderErrorType.NoTransfersScheduledErr()}
+		/*
+		 * We set the status of this jobPart to Completed()
+		 * immediately after it is scheduled, and wind down
+		 * the transfer
+		 */
+		jpm.Log(pipeline.LogError, "No transfers were scheduled.")
 	}
 	// Get credential info from RPC request order, and set in InMemoryTransitJobState.
 	jpm.setInMemoryTransitJobState(

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -295,6 +295,12 @@ func (jpm *jobPartMgr) ScheduleTransfers(jobCtx context.Context) {
 	// partplan file is opened and mapped when job part is added
 	//jpm.planMMF = jpm.filename.Map() // Open the job part plan file & memory-map it in
 	plan := jpm.planMMF.Plan()
+	if plan.PartNum == 0 && plan.NumTransfers == 0 {
+		/* This will wind down the transfer and report summary */
+		plan.SetJobStatus(common.EJobStatus.Completed())
+		return
+	}
+
 	// get the list of include / exclude transfers
 	includeTransfer, excludeTransfer := jpm.jobMgr.IncludeExclude()
 	// *** Open the job part: process any job part plan-setting used by all transfers ***


### PR DESCRIPTION
* Edit log entry to note we are transferring zero items

* Mark status of jobPartMgr to Completed() so that we wind down
  transfer and print the summary