### PR TITLE
Fix file creation error on linux decompressingWriter

### DIFF
--- a/common/writeThoughFile_linux.go
+++ b/common/writeThoughFile_linux.go
@@ -22,7 +22,6 @@ package common
 
 import (
 	"os"
-	"syscall"
 )
 
 func CreateFileOfSizeWithWriteThroughOption(destinationPath string, fileSize int64, writeThrough bool, t FolderCreationTracker, forceIfReadOnly bool) (*os.File, error) {
@@ -43,18 +42,9 @@ func CreateFileOfSizeWithWriteThroughOption(destinationPath string, fileSize int
 		return nil, err
 	}
 
-	err = syscall.Fallocate(int(f.Fd()), 0, 0, fileSize)
-	if err != nil {
-		// To solve the case that Fallocate cannot work well with cifs/smb3.
-		if err == syscall.ENOTSUP {
-			if truncateError := f.Truncate(fileSize); truncateError != nil {
-				return nil, truncateError
-			}
-		} else {
-			return nil, err
-		}
-	}
-	return f, nil
+	err = f.Truncate(fileSize)
+
+	return f, err
 }
 
 func SetBackupMode(enable bool, fromTo FromTo) error {


### PR DESCRIPTION
This will fix the file creation error with a Decompressing Writer on linux and
avoid special handling of cifs/smb3 failures.