### PR TITLE
Added parallel blob enumeration

### DIFF
--- a/cmd/zc_traverser_benchmark.go
+++ b/cmd/zc_traverser_benchmark.go
@@ -28,17 +28,19 @@ import (
 type benchmarkTraverser struct {
 	fileCount                   uint
 	bytesPerFile                int64
+	numOfFolders                uint
 	incrementEnumerationCounter enumerationCounterFunc
 }
 
 func newBenchmarkTraverser(source string, incrementEnumerationCounter enumerationCounterFunc) (*benchmarkTraverser, error) {
-	fc, bpf, err := benchmarkSourceHelper{}.FromUrl(source)
+	fc, bpf, nf, err := benchmarkSourceHelper{}.FromUrl(source)
 	if err != nil {
 		return nil, err
 	}
 	return &benchmarkTraverser{
 			fileCount:                   fc,
 			bytesPerFile:                bpf,
+			numOfFolders:                nf,
 			incrementEnumerationCounter: incrementEnumerationCounter},
 		nil
 }
@@ -68,6 +70,11 @@ func (t *benchmarkTraverser) traverse(preprocessor objectMorpher, processor obje
 
 		name := t.toReversedString(i) // this gives an even distribution through the namespace (compare the starting characters, for 0 to 199, when reversed or not). This is useful for performance when High Throughput Block Blob pathway does not apply
 		relativePath := name
+
+		if t.numOfFolders > 0 {
+			assignedFolder := t.toReversedString(i % t.numOfFolders)
+			relativePath = assignedFolder + common.AZCOPY_PATH_SEPARATOR_STRING + relativePath
+		}
 
 		if t.incrementEnumerationCounter != nil {
 			t.incrementEnumerationCounter(common.EEntityType.File())

--- a/cmd/zc_traverser_blob.go
+++ b/cmd/zc_traverser_blob.go
@@ -179,8 +179,6 @@ func (t *blobTraverser) traverse(preprocessor objectMorpher, processor objectPro
 				}
 			}
 
-			marker = lResp.NextMarker
-
 			// process the blobs returned in this result segment
 			for _, blobInfo := range lResp.Segment.BlobItems {
 				// if the blob represents a hdi folder, then skip it
@@ -204,6 +202,8 @@ func (t *blobTraverser) traverse(preprocessor objectMorpher, processor objectPro
 				)
 				enqueueOutput(storedObject, nil)
 			}
+
+			marker = lResp.NextMarker
 		}
 		return nil
 	}

--- a/cmd/zc_traverser_blob.go
+++ b/cmd/zc_traverser_blob.go
@@ -171,6 +171,15 @@ func (t *blobTraverser) traverse(preprocessor objectMorpher, processor objectPro
 				return fmt.Errorf("cannot list files due to reason %s", err)
 			}
 
+			// queue up the sub virtual directories if recursive is true
+			if t.recursive {
+				for _, virtualDir := range lResp.Segment.BlobPrefixes {
+					enqueueDir(virtualDir.Name)
+				}
+			}
+
+			marker = lResp.NextMarker
+
 			// process the blobs returned in this result segment
 			for _, blobInfo := range lResp.Segment.BlobItems {
 				// if the blob represents a hdi folder, then skip it
@@ -194,15 +203,6 @@ func (t *blobTraverser) traverse(preprocessor objectMorpher, processor objectPro
 				)
 				enqueueOutput(storedObject, nil)
 			}
-
-			// queue up the sub virtual directories if recursive is true
-			if t.recursive {
-				for _, virtualDir := range lResp.Segment.BlobPrefixes {
-					enqueueDir(virtualDir.Name)
-				}
-			}
-
-			marker = lResp.NextMarker
 		}
 		return nil
 	}

--- a/cmd/zc_traverser_blob.go
+++ b/cmd/zc_traverser_blob.go
@@ -166,7 +166,8 @@ func (t *blobTraverser) traverse(preprocessor objectMorpher, processor objectPro
 	enumerateOneDir := func(dir parallel.Directory, enqueueDir func(parallel.Directory), enqueueOutput func(parallel.DirectoryEntry, error)) error {
 		currentDirPath := dir.(string)
 		for marker := (azblob.Marker{}); marker.NotDone(); {
-			lResp, err := containerURL.ListBlobsHierarchySegment(t.ctx, marker, "/", azblob.ListBlobsSegmentOptions{Prefix: currentDirPath})
+			lResp, err := containerURL.ListBlobsHierarchySegment(t.ctx, marker, "/", azblob.ListBlobsSegmentOptions{Prefix: currentDirPath,
+				Details: azblob.BlobListingDetails{Metadata: true}})
 			if err != nil {
 				return fmt.Errorf("cannot list files due to reason %s", err)
 			}

--- a/cmd/zt_remove_blob_test.go
+++ b/cmd/zt_remove_blob_test.go
@@ -412,7 +412,7 @@ func (s *cmdIntegrationSuite) TestRemoveBlobsWithDirectoryStubs(c *chk.C) {
 	runCopyAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)
 
-		// there should be exactly 20 top files, no directory stubs should included
+		// there should be exactly 20 top files, no directory stubs should be included
 		c.Assert(len(mockedRPC.transfers), chk.Equals, 20)
 
 		for _, transfer := range mockedRPC.transfers {

--- a/tool_test_perf.sh
+++ b/tool_test_perf.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# this script provides a quick way to validate whether a change causes a performance gain versus regression
+
+RunCurrent () {
+  ./azcopy_current cp 'src' 'dst' --recursive --log-level=WARNING --check-length=false
+}
+
+RunNew () {
+  ./azcopy_new cp 'src' 'dst' --recursive --log-level=WARNING --check-length=false
+}
+
+export AZCOPY_LOG_LOCATION=/datadrive/logs
+export AZCOPY_JOB_PLAN_LOCATION=/datadrive/plans
+
+for i in {1..5}
+do
+  # start with the new version, which might give it a disadvantage
+  # but since we run the experiment repeately, the results average out eventually
+  # in addition, it's better to give the disadvantage to the new version so that we can be extra sure that it's better/equal to current
+  echo Running new version for "$i"th time >> cmd-output.txt
+
+  # keep the result of the run, in case any error occurs
+  start_time=$(date +%s)
+  RunNew >> cmd-output.txt
+  end_time=$(date +%s)
+
+  # insert a record into the result CSV file
+  # this format is used so that we can import it easily into Excel
+  echo $i, new, $(expr "$end_time" - "$start_time") >> result.csv
+
+  # run the current version immedietely after
+  echo Running current version for "$i"th time >> cmd-output.txt
+
+  # do the same for current version
+  start_time=$(date +%s)
+  RunCurrent >> cmd-output.txt
+  end_time=$(date +%s)
+  echo $i, current, $(expr "$end_time" - "$start_time") >> result.csv
+done


### PR DESCRIPTION
Test   Scenario | 10.4.3 | Parallel | Improvements
-- | -- | -- | --
100 folders | 1385.2 | 1078 | 22.18%
50 folders | 1224.8 | 1123.6 | 8.26%
10 folders | 1185 | 1018.6 | 14.04%
No folders | 1110 | 1188.6 | -7.08%


Each scenario was run 5 times, with the new version interweaved with the current version (10.4.3). The dataset is 1 million blobs at 10KB each, which were generated using the benchmark command. The command is S2S copy from East US to West US 2.

The tests were run on Standard D8s v3 (8 vcpus, 32 GiB memory). 128 parallel parallel network connections, and 16 routines enumerating in parallel. 

Flags used: --log-level=WARNING --check-length=false

Notes:

1. The benchmark command was updated to support creation of sub-folders
2. A sample script is checked in to assist others in assessing performance gains/regressions more easily.