### PR TITLE
Fix GetFileInformation()  error on Windows drive root

### DIFF
--- a/common/writeThoughFile_windows.go
+++ b/common/writeThoughFile_windows.go
@@ -100,7 +100,7 @@ func CreateFileOfSizeWithWriteThroughOption(destinationPath string, fileSize int
 		// cleared. (But then, given the download implementation as at 10.3.x,
 		// we'll try to clean up by deleting the file at the end of our job anyway, so we won't be
 		// leaving damaged trash around if the delete works).
-		// TODO: is that acceptable? Seems overkill to re-instate the attribute if the open fails...
+		// TODO: is that acceptable? Seems overkill to re-instate the attribute if the open fails....
 		newAttrs := fi.FileAttributes &^ toClear
 		err = windows.SetFileAttributes(destPtr, newAttrs)
 		return err == nil

--- a/common/writeThoughFile_windows.go
+++ b/common/writeThoughFile_windows.go
@@ -23,14 +23,29 @@ package common
 import (
 	"errors"
 	"fmt"
-	"golang.org/x/sys/windows"
 	"os"
+	"path/filepath"
 	"reflect"
 	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
+func isDriveRoot(path string) bool {
+	// VolumeName will not have trailing backslash
+	if last := len(path) - 1; last >= 0 && path[last] == '\\' {
+		path = path[:last]
+	}
+
+	return filepath.VolumeName(path) == path
+}
+
 func GetFileInformation(path string) (windows.ByHandleFileInformation, error) {
+
+	if isDriveRoot(path) {
+		path = ToShortPath(path)
+	}
 
 	srcPtr, err := syscall.UTF16PtrFromString(path)
 	if err != nil {


### PR DESCRIPTION
GetFileInformationByHandle() on Windows returns EINVAL if the file handle is created with an Extended path for a drive root. Change the path to a short path if we're referring to a Drive root.