### PR TITLE
Allow finer values for job status in jptm

### DIFF
--- a/cmd/jobsClean.go
+++ b/cmd/jobsClean.go
@@ -90,7 +90,7 @@ func handleCleanJobsCommand(givenStatus common.JobStatus) error {
 
 	// we must query the jobs and find out which one to remove
 	resp := common.ListJobsResponse{}
-	Rpc(common.ERpcCmd.ListJobs(), nil, &resp)
+	Rpc(common.ERpcCmd.ListJobs(), common.EJobStatus.All(), &resp)
 
 	if resp.ErrorMessage != "" {
 		return errors.New("failed to query the list of jobs")

--- a/cmd/jobsClean.go
+++ b/cmd/jobsClean.go
@@ -79,7 +79,7 @@ func init() {
 	// NOTE: we have way more job status than we normally need, only show the most common ones
 	jobsCleanCmd.PersistentFlags().StringVar(&commandLineInput.withStatus, "with-status", "All",
 		"only remove the jobs with this status, available values: All, Cancelled, Failed, Completed"+
-			" CompletedWithErrors, CompletedWithFailures, CompletedWithErrorsAndSkipped")
+			" CompletedWithErrors, CompletedWithSkipped, CompletedWithErrorsAndSkipped")
 }
 
 func handleCleanJobsCommand(givenStatus common.JobStatus) error {

--- a/cmd/jobsClean.go
+++ b/cmd/jobsClean.go
@@ -78,7 +78,8 @@ func init() {
 
 	// NOTE: we have way more job status than we normally need, only show the most common ones
 	jobsCleanCmd.PersistentFlags().StringVar(&commandLineInput.withStatus, "with-status", "All",
-		"only remove the jobs with this status, available values: Cancelled, Completed, Failed, InProgress, All")
+		"only remove the jobs with this status, available values: All, Cancelled, Failed, Completed"+
+			" CompletedWithErrors, CompletedWithFailures, CompletedWithErrorsAndSkipped")
 }
 
 func handleCleanJobsCommand(givenStatus common.JobStatus) error {

--- a/cmd/rpc.go
+++ b/cmd/rpc.go
@@ -47,7 +47,7 @@ func inprocSend(rpcCmd common.RpcCmd, requestData interface{}, responseData inte
 		*(responseData.(*common.LifecycleMgr)) = ste.GetJobLCMWrapper(*requestData.(*common.JobID))
 
 	case common.ERpcCmd.ListJobs():
-		*(responseData.(*common.ListJobsResponse)) = ste.ListJobs()
+		*(responseData.(*common.ListJobsResponse)) = ste.ListJobs(requestData.(common.JobStatus))
 
 	case common.ERpcCmd.ListJobSummary():
 		*(responseData.(*common.ListJobSummaryResponse)) = ste.GetJobSummary(*requestData.(*common.JobID))

--- a/common/fe-ste-models.go
+++ b/common/fe-ste-models.go
@@ -619,6 +619,7 @@ func (TransferStatus) NotStarted() TransferStatus { return TransferStatus(0) }
 //   Outdated:
 //     Transfer started & at least 1 chunk has successfully been transfered.
 //     Used to resume a transfer that started to avoid transferring all chunks thereby improving performance
+// Update(Jul 2020): This represents the state of transfer as soon as the file is scheduled.
 func (TransferStatus) Started() TransferStatus { return TransferStatus(1) }
 
 // Transfer successfully completed

--- a/common/fe-ste-models.go
+++ b/common/fe-ste-models.go
@@ -625,7 +625,7 @@ func (TransferStatus) Started() TransferStatus { return TransferStatus(1) }
 // Transfer successfully completed
 func (TransferStatus) Success() TransferStatus { return TransferStatus(2) }
 
-// Transfer failed due to some error. This status does represent the state when transfer is cancelled
+// Transfer failed due to some error.
 func (TransferStatus) Failed() TransferStatus { return TransferStatus(-1) }
 
 // Transfer failed due to failure while Setting blob tier.
@@ -636,6 +636,8 @@ func (TransferStatus) SkippedEntityAlreadyExists() TransferStatus { return Trans
 func (TransferStatus) SkippedBlobHasSnapshots() TransferStatus { return TransferStatus(-4) }
 
 func (TransferStatus) TierAvailabilityCheckFailure() TransferStatus { return TransferStatus(-5) }
+
+func (TransferStatus) Cancelled() TransferStatus { return TransferStatus(-6) }
 
 func (ts TransferStatus) ShouldTransfer() bool {
 	return ts == ETransferStatus.NotStarted() || ts == ETransferStatus.Started()

--- a/ste/JobsAdmin.go
+++ b/ste/JobsAdmin.go
@@ -455,6 +455,7 @@ func (ja *jobsAdmin) transferProcessor(workerID int) {
 			if jptm.ShouldLog(pipeline.LogInfo) {
 				jptm.Log(pipeline.LogInfo, fmt.Sprintf(" is not picked up worked %d because transfer was cancelled", workerID))
 			}
+			jptm.SetStatus(common.ETransferStatus.Failed())
 			jptm.ReportTransferDone()
 		} else {
 			// TODO fix preceding space

--- a/ste/JobsAdmin.go
+++ b/ste/JobsAdmin.go
@@ -455,7 +455,7 @@ func (ja *jobsAdmin) transferProcessor(workerID int) {
 			if jptm.ShouldLog(pipeline.LogInfo) {
 				jptm.Log(pipeline.LogInfo, fmt.Sprintf(" is not picked up worked %d because transfer was cancelled", workerID))
 			}
-			jptm.SetStatus(common.ETransferStatus.Failed())
+			jptm.SetStatus(common.ETransferStatus.Cancelled())
 			jptm.ReportTransferDone()
 		} else {
 			// TODO fix preceding space

--- a/ste/init.go
+++ b/ste/init.go
@@ -333,6 +333,9 @@ func ResumeJobOrder(req common.ResumeJobRequest) common.CancelPauseResumeRespons
 	// Resume all the failed / In Progress Transfers.
 	case common.EJobStatus.InProgress(),
 		common.EJobStatus.Completed(),
+		common.EJobStatus.CompletedWithErrors(),
+		common.EJobStatus.CompletedWithSkipped(),
+		common.EJobStatus.CompletedWithErrorsAndSkipped(),
 		common.EJobStatus.Cancelled(),
 		common.EJobStatus.Paused():
 		//go func() {

--- a/ste/init.go
+++ b/ste/init.go
@@ -521,16 +521,12 @@ func GetJobSummary(jobID common.JobID) common.ListJobSummaryResponse {
 	}
 	// Job is completed if Job order is complete AND ALL transfers are completed/failed
 	// FIX: active or inactive state, then job order is said to be completed if final part of job has been ordered.
-	if (js.CompleteJobOrdered) && (part0PlanStatus == common.EJobStatus.Completed()) {
+	if (js.CompleteJobOrdered) && (part0PlanStatus.IsJobDone()) {
 		js.JobStatus = part0PlanStatus
 	}
 
-	if js.JobStatus == common.EJobStatus.Completed() {
-		js.JobStatus = js.JobStatus.EnhanceJobStatusInfo(js.TransfersSkipped > 0, js.TransfersFailed > 0,
-			js.TransfersCompleted > 0)
-
+	if js.JobStatus.IsJobDone() {
 		js.PerformanceAdvice = jm.TryGetPerformanceAdvice(js.TotalBytesExpected, js.TotalTransfers-js.TransfersSkipped, part0.Plan().FromTo)
-
 	}
 
 	return js

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -657,6 +657,7 @@ func (jpm *jobPartMgr) updateJobPartProgress(status common.TransferStatus) {
 		atomic.AddUint32(&jpm.atomicTransfersFailed, 1)
 	case common.ETransferStatus.SkippedEntityAlreadyExists(), common.ETransferStatus.SkippedBlobHasSnapshots():
 		atomic.AddUint32(&jpm.atomicTransfersSkipped, 1)
+	case common.ETransferStatus.Cancelled():
 	default:
 		panic("Unexpected status")
 	}

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -697,7 +697,7 @@ func (jpm *jobPartMgr) ReportTransferDone() (transfersDone uint32) {
 		jpm.Log(pipeline.LogInfo, fmt.Sprintf("JobID=%v, Part#=%d, TransfersDone=%d of %d", plan.JobID, plan.PartNum, transfersDone, plan.NumTransfers))
 	}
 	if transfersDone == jpm.planMMF.Plan().NumTransfers {
-		jpm.jobMgr.ReportJobPartDone()
+		jpm.jobMgr.ReportJobPartDone(jpm.progressInfo)
 	}
 	return transfersDone
 }

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -818,8 +818,7 @@ func (jptm *jobPartTransferMgr) ReportTransferDone() uint32 {
 		panic("cannot report the same transfer done twice")
 	}
 
-	jptm.jobPartMgr.UpdateJobPartProgress(jptm.jobPartPlanTransfer.TransferStatus())
-	return jptm.jobPartMgr.ReportTransferDone()
+	return jptm.jobPartMgr.ReportTransferDone(jptm.jobPartPlanTransfer.TransferStatus())
 }
 
 func (jptm *jobPartTransferMgr) SourceProviderPipeline() pipeline.Pipeline {

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -818,6 +818,7 @@ func (jptm *jobPartTransferMgr) ReportTransferDone() uint32 {
 		panic("cannot report the same transfer done twice")
 	}
 
+	jptm.jobPartMgr.UpdateJobPartProgress(jptm.jobPartPlanTransfer.TransferStatus())
 	return jptm.jobPartMgr.ReportTransferDone()
 }
 

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -547,6 +547,7 @@ func (jptm *jobPartTransferMgr) hasStartedWork() bool {
 // the raw status values do not reflect possible cancellation.
 // Do not call directly. Use IsDeadBeforeStart or IsDeadInflight
 // instead because they usually require different handling
+// Practically, a jptm is dead as soon as the context is releeased.
 func (jptm *jobPartTransferMgr) isDead() bool {
 	return jptm.TransferStatusIgnoringCancellation() < 0 || jptm.WasCanceled()
 }

--- a/ste/xfer-anyToRemote-file.go
+++ b/ste/xfer-anyToRemote-file.go
@@ -34,7 +34,6 @@ import (
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
 	"github.com/Azure/azure-storage-blob-go/azblob"
-
 	"github.com/Azure/azure-storage-azcopy/common"
 )
 
@@ -42,7 +41,7 @@ import (
 // That's alright, but it's good to know on the off chance.
 // This sync.Once is present to ensure we output information about a S2S access tier preservation failure to stdout once
 var s2sAccessTierFailureLogStdout sync.Once
-var checkLengthFailureOnReadOnlyDst sync 	.Once
+var checkLengthFailureOnReadOnlyDst sync.Once
 
 // This sync.Once and string pair ensures that we only get a user's destination account kind once when handling set-tier
 // Premium block blob doesn't support tiering, and page blobs only support P1-80.
@@ -581,6 +580,7 @@ func commonSenderCompletion(jptm IJobPartTransferMgr, s sender, info TransferInf
 			jptm.Log(pipeline.LogDebug, "Finalizing Transfer")
 		}
 	} else {
+		jptm.SetStatus(common.ETransferStatus.Failed())
 		if jptm.ShouldLog(pipeline.LogDebug) {
 			jptm.Log(pipeline.LogDebug, "Finalizing Transfer Cancellation/Failure")
 		}

--- a/ste/xfer-anyToRemote-file.go
+++ b/ste/xfer-anyToRemote-file.go
@@ -196,6 +196,8 @@ func anyToRemote_file(jptm IJobPartTransferMgr, info TransferInfo, p pipeline.Pi
 
 	// step 1. perform initial checks
 	if jptm.WasCanceled() {
+		/* This is the earliest we detect jptm has been cancelled before scheduling chunks */
+		jptm.SetStatus(common.ETransferStatus.Failed())
 		jptm.ReportTransferDone()
 		return
 	}

--- a/ste/xfer-anyToRemote-folder.go
+++ b/ste/xfer-anyToRemote-folder.go
@@ -31,7 +31,7 @@ func anyToRemote_folder(jptm IJobPartTransferMgr, info TransferInfo, p pipeline.
 	// step 1. perform initial checks
 	if jptm.WasCanceled() {
 		/* This is earliest we detect that jptm has been cancelled before we reach destination */
-		jptm.SetStatus(common.ETransferStatus.Failed())
+		jptm.SetStatus(common.ETransferStatus.Cancelled())
 		jptm.ReportTransferDone()
 		return
 	}

--- a/ste/xfer-anyToRemote-folder.go
+++ b/ste/xfer-anyToRemote-folder.go
@@ -30,6 +30,8 @@ func anyToRemote_folder(jptm IJobPartTransferMgr, info TransferInfo, p pipeline.
 
 	// step 1. perform initial checks
 	if jptm.WasCanceled() {
+		/* This is earliest we detect that jptm has been cancelled before we reach destination */
+		jptm.SetStatus(common.ETransferStatus.Failed())
 		jptm.ReportTransferDone()
 		return
 	}

--- a/ste/xfer-remoteToLocal-file.go
+++ b/ste/xfer-remoteToLocal-file.go
@@ -371,6 +371,7 @@ func commonDownloaderCompletion(jptm IJobPartTransferMgr, info TransferInfo, ent
 	// we leave these transfer status alone
 	// in case of errors, the status was already set, so we don't need to do anything here either
 	if jptm.IsDeadInflight() || jptm.IsDeadBeforeStart() {
+		jptm.SetStatus(common.ETransferStatus.Failed())
 		// If failed, log and delete the "bad" local file
 		// If the current transfer status value is less than or equal to 0
 		// then transfer either failed or was cancelled

--- a/ste/xfer-remoteToLocal-file.go
+++ b/ste/xfer-remoteToLocal-file.go
@@ -59,6 +59,8 @@ func remoteToLocal_file(jptm IJobPartTransferMgr, p pipeline.Pipeline, pacer pac
 	// If the transfer was cancelled, then report transfer as done
 	// TODO Question: the above comment had this following text too: "and increasing the bytestransferred by the size of the source." what does it mean?
 	if jptm.WasCanceled() {
+		/* This is the earliest we detect that jptm has been cancelled before we schedule chunks */
+		jptm.SetStatus(common.ETransferStatus.Failed())
 		jptm.ReportTransferDone()
 		return
 	}

--- a/ste/xfer-remoteToLocal-folder.go
+++ b/ste/xfer-remoteToLocal-folder.go
@@ -33,6 +33,8 @@ func remoteToLocal_folder(jptm IJobPartTransferMgr, p pipeline.Pipeline, pacer p
 	// Perform initial checks
 	// If the transfer was cancelled, then report transfer as done
 	if jptm.WasCanceled() {
+		/* This is the earliest we detect that jptm was cancelled, before we go to destination */
+		jptm.SetStatus(common.ETransferStatus.Failed())
 		jptm.ReportTransferDone()
 		return
 	}

--- a/ste/xfer-remoteToLocal-folder.go
+++ b/ste/xfer-remoteToLocal-folder.go
@@ -34,7 +34,7 @@ func remoteToLocal_folder(jptm IJobPartTransferMgr, p pipeline.Pipeline, pacer p
 	// If the transfer was cancelled, then report transfer as done
 	if jptm.WasCanceled() {
 		/* This is the earliest we detect that jptm was cancelled, before we go to destination */
-		jptm.SetStatus(common.ETransferStatus.Failed())
+		jptm.SetStatus(common.ETransferStatus.Cancelled())
 		jptm.ReportTransferDone()
 		return
 	}


### PR DESCRIPTION
- jpm-runtime will have a progressInfo, consisting of atomic integers transfersSkipped, transfersFailed, transfersCompleted.
- Each jptm on completion reports to jpm through jpm.ReportTransferDone().This is enhanced to include  TransferStatus(Success/Failed/Skipped)argument. Depending on TransferStatus, above flags/counters are atomically updated throuth jpm.updateJobPartProgress()
- jobMgr.ReportJobPartDone() will now run as a thread (named reportJobPartDoneHandler). This will listen for progressInfo from each part.
- This handler will update its local counters maintaining Skipped/Failed/Completed transfers.
- On receiving the progressInfo from final jobPart, the handler will use above counters to update jobStatus in jpph(0) appropriately to Completed/CompletedWithErrors/CompletedWithSkipped.
- The instances where we close a transfer in jptm without setting TransferStatus to Success/Failed/Skipped are fixed.
- Modify 'azcopy jobs list' to report improved status