### PR TITLE
Fixed Issue:1028

### DIFF
--- a/cmd/zc_attr_filter_windows.go
+++ b/cmd/zc_attr_filter_windows.go
@@ -45,7 +45,14 @@ func (f *attrFilter) appliesOnlyToFiles() bool {
 }
 
 func (f *attrFilter) doesPass(storedObject storedObject) bool {
-	fileName := common.GenerateFullPath(f.filePath, storedObject.relativePath)
+	fileName := ""
+	if strings.Index(f.filePath, "*") == -1 {
+		fileName = common.GenerateFullPath(f.filePath, storedObject.relativePath)
+	} else {
+		basePath := getPathBeforeFirstWildcard(f.filePath)
+		fileName = common.GenerateFullPath(basePath, storedObject.relativePath)
+	}
+
 	lpFileName, _ := syscall.UTF16PtrFromString(fileName)
 	attributes, err := syscall.GetFileAttributes(lpFileName)
 


### PR DESCRIPTION
Issue [Link](https://github.com/Azure/azure-storage-azcopy/issues/1028)

Whenever a file path contains wildcard character such as *  (F:\202* ) and file attribute filter --include-attributes A  is specified, the code skips file attribute filter. 

This is because when we create filters inside initModularFilters() function, we get the file path from cca.source.ValueLocal() which contains "F:\202*". And when we try to get the file attributes by generating full path inside doesPath method [zc_attr_filter_windows.go], it appends F:\202* with 2020\temp.txt to get "F:\202*\2020\temp.txt"  but it should be **F:\2020\temp.txt**

To solve this, first get the base file path without wildcard and then append it with the relative paths.

Another possible way to solve this is add fix inside initModularFilters but filter.filepath maybe getting used somewhere in the code and it might  break other functionalities.