### PR TITLE
Issue1051: Removed %00 <-> 0x00 encoding/decoding

### DIFF
--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -427,7 +427,6 @@ func (cca *cookedCopyCmdArgs) createDstContainer(containerName string, dstWithSA
 
 // Because some invalid characters weren't being properly encoded by url.PathEscape, we're going to instead manually encode them.
 var encodedInvalidCharacters = map[rune]string{
-	0x00: "%00",
 	'<':  "%3C",
 	'>':  "%3E",
 	'\\': "%5C",
@@ -440,7 +439,6 @@ var encodedInvalidCharacters = map[rune]string{
 }
 
 var reverseEncodedChars = map[string]rune{
-	"%00": 0x00,
 	"%3C": '<',
 	"%3E": '>',
 	"%5C": '\\',


### PR DESCRIPTION
**Issue**: If we try to upload files with name or extension containing % followed by number such as [%00 to %19, %0A to %0F, and %1A to %1F], upload/download fails on windows. However it works fine on Mac & Linux (UNIX). 
FYI: These ASCII Characters were created to handle hardware devices and these are not part of default UTF-8 character set. 

For example: If we try to upload **abcdef.%008** to Azure storage, it'll fail with **HTTP Error 400. The request URL is invalid.**
URL is  "https://[accountName].blob.core.windows.net/[containerName]/**abcdef.%008**?se=2020-06-30t04%3A34%3A00z&sig=-REDACTED-&sp=racwdl&sr=c&st=2020-06-22t04%3A34%3A16z&sv=2019-02-02". If you notice, **%** in the name didn't get encoded to **%25** i.e. the name of the file getting uploaded is **abcdef.%008** but it should have been **abcdef.%25008**.

Issue was not with Azure Storage GO SDK. Verified it by creating a standalone mini project to upload/download such files and it worked just fine. 

Found that we were trying to encode/decode **%00** as **0x00** which is not required. So removed it from the map and it is working fine well.


