### PR TITLE
Fix module import problem for V10

### DIFF
--- a/azbfs/zt_retry_reader_test.go
+++ b/azbfs/zt_retry_reader_test.go
@@ -5,7 +5,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	"github.com/Azure/azure-storage-azcopy/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
 	"io"
 	"net"
 	"net/http"

--- a/azbfs/zt_test.go
+++ b/azbfs/zt_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/azure-storage-azcopy/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
 	chk "gopkg.in/check.v1"
 )
 

--- a/azbfs/zt_url_directory_test.go
+++ b/azbfs/zt_url_directory_test.go
@@ -2,7 +2,7 @@ package azbfs_test
 
 import (
 	"context"
-	"github.com/Azure/azure-storage-azcopy/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
 	chk "gopkg.in/check.v1"
 	"net/http"
 )

--- a/azbfs/zt_url_file_test.go
+++ b/azbfs/zt_url_file_test.go
@@ -14,7 +14,7 @@ import (
 	"net/url"
 	//"strings"
 
-	"github.com/Azure/azure-storage-azcopy/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
 	chk "gopkg.in/check.v1" // go get gopkg.in/check.v1
 	"io/ioutil"
 	"net/http"

--- a/azbfs/zt_url_filesystem_test.go
+++ b/azbfs/zt_url_filesystem_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/Azure/azure-storage-azcopy/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
 	chk "gopkg.in/check.v1"
 	"net/http"
 	"net/url"

--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -28,8 +28,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Azure/azure-storage-azcopy/azbfs"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/Azure/azure-storage-file-go/azfile"
 	"github.com/spf13/cobra"

--- a/cmd/cancel.go
+++ b/cmd/cancel.go
@@ -24,7 +24,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -40,8 +40,8 @@ import (
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/spf13/cobra"
 
-	"github.com/Azure/azure-storage-azcopy/common"
-	"github.com/Azure/azure-storage-azcopy/ste"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
 )
 
 const pipingUploadParallelism = 5

--- a/cmd/copyEnumeratorHelper.go
+++ b/cmd/copyEnumeratorHelper.go
@@ -2,13 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/Azure/azure-pipeline-go/pipeline"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
 	"math/rand"
 	"strings"
 
-	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/ste"
-
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 var enumerationParallelism = 1

--- a/cmd/copyEnumeratorHelper_test.go
+++ b/cmd/copyEnumeratorHelper_test.go
@@ -21,7 +21,7 @@
 package cmd
 
 import (
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	chk "gopkg.in/check.v1"
 )
 

--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -18,8 +18,8 @@ import (
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/Azure/azure-storage-file-go/azfile"
 
-	"github.com/Azure/azure-storage-azcopy/common"
-	"github.com/Azure/azure-storage-azcopy/ste"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
 )
 
 type BucketToContainerNameResolver interface {

--- a/cmd/copyUtil.go
+++ b/cmd/copyUtil.go
@@ -28,9 +28,9 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/azbfs"
-	"github.com/Azure/azure-storage-azcopy/common"
-	"github.com/Azure/azure-storage-azcopy/ste"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/Azure/azure-storage-file-go/azfile"

--- a/cmd/credentialUtil.go
+++ b/cmd/credentialUtil.go
@@ -37,9 +37,9 @@ import (
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/Azure/azure-storage-file-go/azfile"
 
-	"github.com/Azure/azure-storage-azcopy/azbfs"
-	"github.com/Azure/azure-storage-azcopy/common"
-	"github.com/Azure/azure-storage-azcopy/ste"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
 )
 
 var once sync.Once

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -16,7 +16,7 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/gcpNameResolver_test.go
+++ b/cmd/gcpNameResolver_test.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	chk "gopkg.in/check.v1"
 	"strings"
 )

--- a/cmd/helpMessages.go
+++ b/cmd/helpMessages.go
@@ -1,6 +1,6 @@
 package cmd
 
-import "github.com/Azure/azure-storage-azcopy/common"
+import "github.com/Azure/azure-storage-azcopy/v10/common"
 
 // ===================================== ROOT COMMAND ===================================== //
 const rootCmdShortDescription = "AzCopy is a command line tool that moves data into and out of Azure Storage."

--- a/cmd/jobsClean.go
+++ b/cmd/jobsClean.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 func init() {

--- a/cmd/jobsList.go
+++ b/cmd/jobsList.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/jobsList_test.go
+++ b/cmd/jobsList_test.go
@@ -23,7 +23,7 @@ package cmd
 import (
 	"time"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 
 	chk "gopkg.in/check.v1"
 )

--- a/cmd/jobsRemove.go
+++ b/cmd/jobsRemove.go
@@ -28,7 +28,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/jobsResume.go
+++ b/cmd/jobsResume.go
@@ -28,8 +28,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-storage-azcopy/common"
-	"github.com/Azure/azure-storage-azcopy/ste"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/jobsShow.go
+++ b/cmd/jobsShow.go
@@ -27,7 +27,7 @@ import (
 
 	"encoding/json"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -30,8 +30,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Azure/azure-storage-azcopy/common"
-	"github.com/Azure/azure-storage-azcopy/ste"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
 )
 
 type rawListCmdArgs struct {

--- a/cmd/loadCLFS.go
+++ b/cmd/loadCLFS.go
@@ -33,7 +33,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
 

--- a/cmd/loadOutputTranslation.go
+++ b/cmd/loadOutputTranslation.go
@@ -27,9 +27,9 @@ import (
 	"io"
 	"strings"
 
-	"github.com/Azure/azure-storage-azcopy/ste"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 const (

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -25,7 +25,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/make.go
+++ b/cmd/make.go
@@ -29,9 +29,9 @@ import (
 
 	"errors"
 
-	"github.com/Azure/azure-storage-azcopy/azbfs"
-	"github.com/Azure/azure-storage-azcopy/common"
-	"github.com/Azure/azure-storage-azcopy/ste"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/Azure/azure-storage-file-go/azfile"
 	"github.com/spf13/cobra"

--- a/cmd/pathUtils.go
+++ b/cmd/pathUtils.go
@@ -9,8 +9,8 @@ import (
 	"github.com/Azure/azure-storage-file-go/azfile"
 	"github.com/pkg/errors"
 
-	"github.com/Azure/azure-storage-azcopy/azbfs"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // ----- LOCATION LEVEL HANDLING -----

--- a/cmd/pause.go
+++ b/cmd/pause.go
@@ -23,7 +23,7 @@ package cmd
 import (
 	"errors"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -23,7 +23,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/removeEnumerator.go
+++ b/cmd/removeEnumerator.go
@@ -29,9 +29,9 @@ import (
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
 
-	"github.com/Azure/azure-storage-azcopy/azbfs"
-	"github.com/Azure/azure-storage-azcopy/common"
-	"github.com/Azure/azure-storage-azcopy/ste"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
 )
 
 var NothingToRemoveError = errors.New("nothing found to remove")

--- a/cmd/removeProcessor.go
+++ b/cmd/removeProcessor.go
@@ -21,7 +21,7 @@
 package cmd
 
 import (
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // extract the right info from cooked arguments and instantiate a generic copy transfer processor from it

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,8 +32,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Azure/azure-storage-azcopy/common"
-	"github.com/Azure/azure-storage-azcopy/ste"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/spf13/cobra"
 )

--- a/cmd/rpc.go
+++ b/cmd/rpc.go
@@ -27,8 +27,8 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/Azure/azure-storage-azcopy/common"
-	"github.com/Azure/azure-storage-azcopy/ste"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
 )
 
 // Global singleton for sending RPC requests from the frontend to the STE

--- a/cmd/s3NameResolver_test.go
+++ b/cmd/s3NameResolver_test.go
@@ -23,7 +23,7 @@ package cmd
 import (
 	"strings"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	chk "gopkg.in/check.v1"
 )
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -30,8 +30,8 @@ import (
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
 
-	"github.com/Azure/azure-storage-azcopy/common"
-	"github.com/Azure/azure-storage-azcopy/ste"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/syncEnumerator.go
+++ b/cmd/syncEnumerator.go
@@ -27,8 +27,8 @@ import (
 	"github.com/Azure/azure-pipeline-go/pipeline"
 	"sync/atomic"
 
-	"github.com/Azure/azure-storage-azcopy/common"
-	"github.com/Azure/azure-storage-azcopy/ste"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
 )
 
 // -------------------------------------- Implemented Enumerators -------------------------------------- \\

--- a/cmd/syncProcessor.go
+++ b/cmd/syncProcessor.go
@@ -30,8 +30,8 @@ import (
 	"github.com/Azure/azure-storage-file-go/azfile"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/common"
-	"github.com/Azure/azure-storage-azcopy/ste"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 )
 

--- a/cmd/validators.go
+++ b/cmd/validators.go
@@ -26,7 +26,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 func validateFromTo(src, dst string, userSpecifiedFromTo string) (common.FromTo, error) {

--- a/cmd/zc_attr_filter_windows.go
+++ b/cmd/zc_attr_filter_windows.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 type attrFilter struct {

--- a/cmd/zc_enumerator.go
+++ b/cmd/zc_enumerator.go
@@ -35,9 +35,9 @@ import (
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/Azure/azure-storage-file-go/azfile"
 
-	"github.com/Azure/azure-storage-azcopy/azbfs"
-	"github.com/Azure/azure-storage-azcopy/common"
-	"github.com/Azure/azure-storage-azcopy/ste"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
 )
 
 // -------------------------------------- Component Definitions -------------------------------------- \\

--- a/cmd/zc_filter.go
+++ b/cmd/zc_filter.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // Design explanation:

--- a/cmd/zc_newobjectadapters.go
+++ b/cmd/zc_newobjectadapters.go
@@ -21,7 +21,7 @@
 package cmd
 
 import (
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 )
 

--- a/cmd/zc_pipeline_init.go
+++ b/cmd/zc_pipeline_init.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 func initPipeline(ctx context.Context, location common.Location, credential common.CredentialInfo, logLevel pipeline.LogLevel) (p pipeline.Pipeline, err error) {

--- a/cmd/zc_processor.go
+++ b/cmd/zc_processor.go
@@ -27,9 +27,9 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/Azure/azure-storage-azcopy/ste"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 type copyTransferProcessor struct {

--- a/cmd/zc_traverser_benchmark.go
+++ b/cmd/zc_traverser_benchmark.go
@@ -22,7 +22,7 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 type benchmarkTraverser struct {

--- a/cmd/zc_traverser_blob.go
+++ b/cmd/zc_traverser_blob.go
@@ -23,7 +23,7 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/Azure/azure-storage-azcopy/common/parallel"
+	"github.com/Azure/azure-storage-azcopy/v10/common/parallel"
 	"net/url"
 	"strings"
 
@@ -31,7 +31,7 @@ import (
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/pkg/errors"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // allow us to iterate through a path pointing to the blob endpoint

--- a/cmd/zc_traverser_blob_account.go
+++ b/cmd/zc_traverser_blob_account.go
@@ -23,7 +23,7 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"net/url"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"

--- a/cmd/zc_traverser_blob_versions.go
+++ b/cmd/zc_traverser_blob_versions.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 )
 

--- a/cmd/zc_traverser_blobfs.go
+++ b/cmd/zc_traverser_blobfs.go
@@ -29,8 +29,8 @@ import (
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
 
-	"github.com/Azure/azure-storage-azcopy/azbfs"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 type blobFSTraverser struct {

--- a/cmd/zc_traverser_blobfs_account.go
+++ b/cmd/zc_traverser_blobfs_account.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
 
-	"github.com/Azure/azure-storage-azcopy/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
 )
 
 // We don't allow S2S from BlobFS, but what this gives us is the ability for users to download entire accounts at once.

--- a/cmd/zc_traverser_file.go
+++ b/cmd/zc_traverser_file.go
@@ -23,7 +23,7 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/Azure/azure-storage-azcopy/common/parallel"
+	"github.com/Azure/azure-storage-azcopy/v10/common/parallel"
 	"net/url"
 	"strings"
 	"time"
@@ -31,7 +31,7 @@ import (
 	"github.com/Azure/azure-pipeline-go/pipeline"
 	"github.com/Azure/azure-storage-file-go/azfile"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // allow us to iterate through a path pointing to the file endpoint

--- a/cmd/zc_traverser_gcp.go
+++ b/cmd/zc_traverser_gcp.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 type gcpTraverser struct {

--- a/cmd/zc_traverser_gcp_service.go
+++ b/cmd/zc_traverser_gcp_service.go
@@ -4,7 +4,7 @@ import (
 	gcpUtils "cloud.google.com/go/storage"
 	"context"
 	"fmt"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"google.golang.org/api/iterator"
 	"net/url"
 	"strings"

--- a/cmd/zc_traverser_list.go
+++ b/cmd/zc_traverser_list.go
@@ -26,7 +26,7 @@ import (
 	"github.com/Azure/azure-pipeline-go/pipeline"
 	"net/url"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // a meta traverser that goes through a list of paths (potentially directory entities) and scans them one by one

--- a/cmd/zc_traverser_local.go
+++ b/cmd/zc_traverser_local.go
@@ -23,8 +23,8 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"github.com/Azure/azure-storage-azcopy/common"
-	"github.com/Azure/azure-storage-azcopy/common/parallel"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common/parallel"
 	"io/ioutil"
 	"os"
 	"path"

--- a/cmd/zc_traverser_s3.go
+++ b/cmd/zc_traverser_s3.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/minio/minio-go"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 type s3Traverser struct {

--- a/cmd/zc_traverser_s3_service.go
+++ b/cmd/zc_traverser_s3_service.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/minio/minio-go"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // As we discussed, the general architecture is that this is going to search a list of buckets and spawn s3Traversers for each bucket.

--- a/cmd/zt_copy_blob_download_test.go
+++ b/cmd/zt_copy_blob_download_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	chk "gopkg.in/check.v1"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 func (s *cmdIntegrationSuite) TestInferredStripTopDirDownload(c *chk.C) {

--- a/cmd/zt_copy_blob_upload_test.go
+++ b/cmd/zt_copy_blob_upload_test.go
@@ -21,7 +21,7 @@
 package cmd
 
 import (
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	chk "gopkg.in/check.v1"
 	"net/url"
 	"os"
@@ -491,7 +491,6 @@ func (s *cmdIntegrationSuite) doTestUploadDirectoryToContainerWithIncludeBefore(
 			common.AZCOPY_PATH_SEPARATOR_STRING+filepath.Base(srcDirPath)+common.AZCOPY_PATH_SEPARATOR_STRING, expectedTransfers, mockedRPC)
 	})
 }
-
 
 func (s *cmdIntegrationSuite) TestUploadDirectoryToContainerWithIncludeAfter_UTC(c *chk.C) {
 	s.doTestUploadDirectoryToContainerWithIncludeAfter(true, c)

--- a/cmd/zt_copy_s2smigration_test.go
+++ b/cmd/zt_copy_s2smigration_test.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	chk "gopkg.in/check.v1"
 )

--- a/cmd/zt_credentialUtil_test.go
+++ b/cmd/zt_credentialUtil_test.go
@@ -22,7 +22,7 @@ package cmd
 
 import (
 	"context"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	chk "gopkg.in/check.v1"
 	"strings"
 )

--- a/cmd/zt_generic_processor_test.go
+++ b/cmd/zt_generic_processor_test.go
@@ -21,7 +21,7 @@
 package cmd
 
 import (
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	chk "gopkg.in/check.v1"
 	"os"
 	"path/filepath"

--- a/cmd/zt_generic_service_traverser_test.go
+++ b/cmd/zt_generic_service_traverser_test.go
@@ -5,8 +5,8 @@ import (
 	"github.com/Azure/azure-storage-file-go/azfile"
 	chk "gopkg.in/check.v1"
 
-	"github.com/Azure/azure-storage-azcopy/azbfs"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // Separated the ADLS tests from others as ADLS can't safely be tested on the same storage account

--- a/cmd/zt_generic_traverser_test.go
+++ b/cmd/zt_generic_traverser_test.go
@@ -35,9 +35,9 @@ import (
 	"github.com/minio/minio-go"
 	chk "gopkg.in/check.v1"
 
-	"github.com/Azure/azure-storage-azcopy/azbfs"
-	"github.com/Azure/azure-storage-azcopy/common"
-	"github.com/Azure/azure-storage-azcopy/ste"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
 )
 
 type genericTraverserSuite struct{}

--- a/cmd/zt_interceptors_for_test.go
+++ b/cmd/zt_interceptors_for_test.go
@@ -22,8 +22,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/Azure/azure-storage-azcopy/common"
 	"os"
+
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // the interceptor gathers/saves the job part orders for validation

--- a/cmd/zt_pathUtils_test.go
+++ b/cmd/zt_pathUtils_test.go
@@ -21,7 +21,7 @@
 package cmd
 
 import (
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	chk "gopkg.in/check.v1"
 )
 

--- a/cmd/zt_remove_adls_test.go
+++ b/cmd/zt_remove_adls_test.go
@@ -22,8 +22,8 @@ package cmd
 
 import (
 	"context"
-	"github.com/Azure/azure-storage-azcopy/azbfs"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	chk "gopkg.in/check.v1"
 	"strings"
 )

--- a/cmd/zt_remove_blob_test.go
+++ b/cmd/zt_remove_blob_test.go
@@ -21,7 +21,7 @@
 package cmd
 
 import (
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	chk "gopkg.in/check.v1"
 	"net/url"
 	"strings"

--- a/cmd/zt_remove_file_test.go
+++ b/cmd/zt_remove_file_test.go
@@ -21,7 +21,7 @@
 package cmd
 
 import (
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	chk "gopkg.in/check.v1"
 	"net/url"
 	"strings"

--- a/cmd/zt_scenario_helpers_for_test.go
+++ b/cmd/zt_scenario_helpers_for_test.go
@@ -34,10 +34,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-storage-azcopy/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
 	minio "github.com/minio/minio-go"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/Azure/azure-storage-file-go/azfile"
 	chk "gopkg.in/check.v1"

--- a/cmd/zt_sync_blob_blob_test.go
+++ b/cmd/zt_sync_blob_blob_test.go
@@ -25,7 +25,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	chk "gopkg.in/check.v1"
 )

--- a/cmd/zt_sync_blob_local_test.go
+++ b/cmd/zt_sync_blob_local_test.go
@@ -28,7 +28,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	chk "gopkg.in/check.v1"
 )

--- a/cmd/zt_sync_file_file_test.go
+++ b/cmd/zt_sync_file_file_test.go
@@ -24,7 +24,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-file-go/azfile"
 	chk "gopkg.in/check.v1"
 )

--- a/cmd/zt_sync_local_blob_test.go
+++ b/cmd/zt_sync_local_blob_test.go
@@ -26,7 +26,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	chk "gopkg.in/check.v1"
 )

--- a/cmd/zt_sync_processor_test.go
+++ b/cmd/zt_sync_processor_test.go
@@ -25,7 +25,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	chk "gopkg.in/check.v1"
 )

--- a/cmd/zt_test.go
+++ b/cmd/zt_test.go
@@ -26,7 +26,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"google.golang.org/api/iterator"
 	"io"
 	"io/ioutil"
@@ -38,8 +38,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/azure-storage-azcopy/azbfs"
-	"github.com/Azure/azure-storage-azcopy/ste"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
 	minio "github.com/minio/minio-go"
 
 	chk "gopkg.in/check.v1"

--- a/common/credentialFactory.go
+++ b/common/credentialFactory.go
@@ -30,7 +30,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Azure/azure-storage-azcopy/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/minio/minio-go"

--- a/common/extensions.go
+++ b/common/extensions.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/Azure/azure-storage-azcopy/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
 
 	"github.com/Azure/azure-storage-file-go/azfile"
 )

--- a/common/fe-ste-models.go
+++ b/common/fe-ste-models.go
@@ -30,7 +30,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/Azure/azure-storage-azcopy/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
 
 	"fmt"
 

--- a/common/fe-ste-models_test.go
+++ b/common/fe-ste-models_test.go
@@ -21,7 +21,7 @@
 package common_test
 
 import (
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	chk "gopkg.in/check.v1"
 )
 

--- a/common/genericResourceURLParts.go
+++ b/common/genericResourceURLParts.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/Azure/azure-storage-file-go/azfile"
 
-	"github.com/Azure/azure-storage-azcopy/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
 )
 
 // GenericResourceURLParts is intended to be a generic solution to code duplication when using *URLParts
@@ -20,7 +20,7 @@ type GenericResourceURLParts struct {
 	fileURLParts azfile.FileURLParts
 	bfsURLParts  azbfs.BfsURLParts
 	s3URLParts   S3URLParts
-	gcpURLParts GCPURLParts
+	gcpURLParts  GCPURLParts
 }
 
 func NewGenericResourceURLParts(resourceURL url.URL, location Location) GenericResourceURLParts {

--- a/e2etest/declarativeHelpers.go
+++ b/e2etest/declarativeHelpers.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/JeffreyRichter/enum/enum"
 )
 

--- a/e2etest/declarativeScenario.go
+++ b/e2etest/declarativeScenario.go
@@ -29,7 +29,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // E.g. if we have enumerationSuite/TestFooBar/Copy-LocalBlob the scenario is "Copy-LocalBlob"

--- a/e2etest/declarativeTestFiles.go
+++ b/e2etest/declarativeTestFiles.go
@@ -28,8 +28,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-storage-azcopy/cmd"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/cmd"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 ///////////////

--- a/e2etest/declarativeWithPropertyProviders.go
+++ b/e2etest/declarativeWithPropertyProviders.go
@@ -23,8 +23,8 @@ package e2etest
 import (
 	"time"
 
-	"github.com/Azure/azure-storage-azcopy/cmd"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/cmd"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // All the structs in this file have names starting with "with", to make the readability flow when they are used

--- a/e2etest/factory.go
+++ b/e2etest/factory.go
@@ -31,7 +31,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/azure-storage-azcopy/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/Azure/azure-storage-file-go/azfile"
 )

--- a/e2etest/helpers.go
+++ b/e2etest/helpers.go
@@ -27,7 +27,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	chk "gopkg.in/check.v1"
 	"io/ioutil"
 	"math/rand"
@@ -37,8 +37,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-storage-azcopy/azbfs"
-	"github.com/Azure/azure-storage-azcopy/ste"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
 	minio "github.com/minio/minio-go"
 
 	"github.com/Azure/azure-storage-blob-go/azblob"

--- a/e2etest/runner.go
+++ b/e2etest/runner.go
@@ -29,7 +29,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // encapsulates the interaction with the AzCopy instance that is being tested

--- a/e2etest/scenario_helpers.go
+++ b/e2etest/scenario_helpers.go
@@ -35,10 +35,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-storage-azcopy/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
 	minio "github.com/minio/minio-go"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/Azure/azure-storage-file-go/azfile"
 )

--- a/e2etest/scenario_os_helpers_for_windows.go
+++ b/e2etest/scenario_os_helpers_for_windows.go
@@ -29,8 +29,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Azure/azure-storage-azcopy/common"
-	"github.com/Azure/azure-storage-azcopy/ste"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
 	"golang.org/x/sys/windows"
 )
 

--- a/e2etest/validator.go
+++ b/e2etest/validator.go
@@ -26,7 +26,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 type Validator struct{}

--- a/e2etest/zt_blob_index_tags_test.go
+++ b/e2etest/zt_blob_index_tags_test.go
@@ -21,7 +21,7 @@
 package e2etest
 
 import (
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"testing"
 )
 

--- a/e2etest/zt_content_header_test.go
+++ b/e2etest/zt_content_header_test.go
@@ -21,7 +21,7 @@
 package e2etest
 
 import (
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"testing"
 )
 

--- a/e2etest/zt_copy_file_smb_test.go
+++ b/e2etest/zt_copy_file_smb_test.go
@@ -1,7 +1,7 @@
 package e2etest
 
 import (
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"testing"
 )
 

--- a/e2etest/zt_enumeration_other_test.go
+++ b/e2etest/zt_enumeration_other_test.go
@@ -21,7 +21,7 @@
 package e2etest
 
 import (
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"testing"
 )
 

--- a/e2etest/zt_naming_file_and_folder_test.go
+++ b/e2etest/zt_naming_file_and_folder_test.go
@@ -21,7 +21,7 @@
 package e2etest
 
 import (
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"testing"
 )
 

--- a/e2etest/zt_preserve_content_test.go
+++ b/e2etest/zt_preserve_content_test.go
@@ -21,7 +21,7 @@
 package e2etest
 
 import (
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"testing"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Azure/azure-storage-azcopy
+module github.com/Azure/azure-storage-azcopy/v10
 
 require (
 	cloud.google.com/go/storage v1.8.0

--- a/main.go
+++ b/main.go
@@ -30,8 +30,8 @@ import (
 	"time"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/cmd"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/cmd"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // get the lifecycle manager to print messages

--- a/main_unix.go
+++ b/main_unix.go
@@ -28,7 +28,7 @@ import (
 	"path"
 	"syscall"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // ProcessOSSpecificInitialization changes the soft limit for file descriptor for process

--- a/main_windows.go
+++ b/main_windows.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/minio/minio-go"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 func osModifyProcessCommand(cmd *exec.Cmd) *exec.Cmd {

--- a/sddl/sddlSplitter_test.go
+++ b/sddl/sddlSplitter_test.go
@@ -25,7 +25,7 @@ import (
 
 	chk "gopkg.in/check.v1"
 
-	"github.com/Azure/azure-storage-azcopy/sddl"
+	"github.com/Azure/azure-storage-azcopy/v10/sddl"
 )
 
 // Hookup to the testing framework

--- a/ste/ErrorExt.go
+++ b/ste/ErrorExt.go
@@ -3,7 +3,7 @@ package ste
 import (
 	"net/http"
 
-	"github.com/Azure/azure-storage-azcopy/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/Azure/azure-storage-file-go/azfile"
 )

--- a/ste/JobPartPlan.go
+++ b/ste/JobPartPlan.go
@@ -7,7 +7,7 @@ import (
 
 	"sync/atomic"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 )
 

--- a/ste/JobPartPlanFileName.go
+++ b/ste/JobPartPlanFileName.go
@@ -12,7 +12,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 type JobPartPlanFileName string

--- a/ste/JobsAdmin.go
+++ b/ste/JobsAdmin.go
@@ -34,7 +34,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // sortPlanFiles is struct that implements len, swap and less than functions

--- a/ste/concurrency.go
+++ b/ste/concurrency.go
@@ -26,7 +26,7 @@ import (
 	"runtime"
 	"strconv"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // ConfiguredInt is an integer which may be optionally configured by user through an environment variable

--- a/ste/concurrencyTuner.go
+++ b/ste/concurrencyTuner.go
@@ -21,7 +21,7 @@
 package ste
 
 import (
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"sync"
 	"sync/atomic"
 )

--- a/ste/downloader-azureFiles.go
+++ b/ste/downloader-azureFiles.go
@@ -27,7 +27,7 @@ import (
 	"github.com/Azure/azure-pipeline-go/pipeline"
 	"github.com/Azure/azure-storage-file-go/azfile"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 type azureFilesDownloader struct {

--- a/ste/downloader-azureFiles_windows.go
+++ b/ste/downloader-azureFiles_windows.go
@@ -12,7 +12,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 
 	"golang.org/x/sys/windows"
 )

--- a/ste/downloader-blob.go
+++ b/ste/downloader-blob.go
@@ -25,7 +25,7 @@ import (
 	"net/url"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 )
 

--- a/ste/downloader-blobFS.go
+++ b/ste/downloader-blobFS.go
@@ -26,8 +26,8 @@ import (
 	"time"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/azbfs"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 type blobFSDownloader struct{}

--- a/ste/downloader.go
+++ b/ste/downloader.go
@@ -22,7 +22,7 @@ package ste
 
 import (
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // Abstraction of the methods needed to download files/blobs from a remote location

--- a/ste/init.go
+++ b/ste/init.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 var steCtx = context.Background()

--- a/ste/jobStatusManager.go
+++ b/ste/jobStatusManager.go
@@ -23,7 +23,7 @@ package ste
 import (
 	"time"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 type jobPartCreatedMsg struct {

--- a/ste/joblog_lcm_wrapper.go
+++ b/ste/joblog_lcm_wrapper.go
@@ -3,7 +3,7 @@ package ste
 import (
 	"github.com/Azure/azure-pipeline-go/pipeline"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 type jobLogLCMWrapper struct {

--- a/ste/md5Comparer.go
+++ b/ste/md5Comparer.go
@@ -24,7 +24,7 @@ import (
 	"bytes"
 	"errors"
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 type transferSpecificLogger interface {

--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 var _ IJobMgr = &jobMgr{}

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -14,8 +14,8 @@ import (
 	"time"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/azbfs"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/Azure/azure-storage-file-go/azfile"
 	"golang.org/x/sync/semaphore"

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -11,8 +11,8 @@ import (
 	"net/url"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/azbfs"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/Azure/azure-storage-file-go/azfile"
 )

--- a/ste/overwritePrompter.go
+++ b/ste/overwritePrompter.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // asks questions to confirm overwrite, one routine at a time, i.e. only one active question at a time

--- a/ste/pacer-autoPacer.go
+++ b/ste/pacer-autoPacer.go
@@ -28,7 +28,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 type autopacer interface {

--- a/ste/pacer-tokenBucketPacer.go
+++ b/ste/pacer-tokenBucketPacer.go
@@ -25,7 +25,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // pacer is used by callers whose activity must be controlled to a certain pace

--- a/ste/performanceAdvisor.go
+++ b/ste/performanceAdvisor.go
@@ -23,7 +23,7 @@ package ste
 import (
 	"bytes"
 	"fmt"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"net/http"
 	"runtime"
 	"time"

--- a/ste/s2sCopier-URLToBlob.go
+++ b/ste/s2sCopier-URLToBlob.go
@@ -26,7 +26,7 @@ import (
 	"net/url"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 )
 

--- a/ste/sender-appendBlob.go
+++ b/ste/sender-appendBlob.go
@@ -29,7 +29,7 @@ import (
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"golang.org/x/sync/semaphore"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 type appendBlobSenderBase struct {

--- a/ste/sender-appendBlobFromLocal.go
+++ b/ste/sender-appendBlobFromLocal.go
@@ -22,7 +22,7 @@ package ste
 
 import (
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 )
 

--- a/ste/sender-appendBlobFromURL.go
+++ b/ste/sender-appendBlobFromURL.go
@@ -25,7 +25,7 @@ import (
 	"net/url"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 )
 

--- a/ste/sender-azureFile.go
+++ b/ste/sender-azureFile.go
@@ -32,7 +32,7 @@ import (
 	"github.com/Azure/azure-pipeline-go/pipeline"
 	"github.com/Azure/azure-storage-file-go/azfile"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 type URLHolder interface {

--- a/ste/sender-azureFileFromLocal.go
+++ b/ste/sender-azureFileFromLocal.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 type azureFileUploader struct {

--- a/ste/sender-azureFileFromURL.go
+++ b/ste/sender-azureFileFromURL.go
@@ -24,7 +24,7 @@ import (
 	"net/url"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 type urlToAzureFileCopier struct {

--- a/ste/sender-blobFS.go
+++ b/ste/sender-blobFS.go
@@ -28,8 +28,8 @@ import (
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
 
-	"github.com/Azure/azure-storage-azcopy/azbfs"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 type blobFSSenderBase struct {

--- a/ste/sender-blobFSFromLocal.go
+++ b/ste/sender-blobFSFromLocal.go
@@ -22,7 +22,7 @@ package ste
 
 import (
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"math"
 )
 

--- a/ste/sender-blockBlob.go
+++ b/ste/sender-blockBlob.go
@@ -32,7 +32,7 @@ import (
 	"github.com/Azure/azure-pipeline-go/pipeline"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 var lowMemoryLimitAdvice sync.Once

--- a/ste/sender-blockBlobFromLocal.go
+++ b/ste/sender-blockBlobFromLocal.go
@@ -26,7 +26,7 @@ import (
 	"github.com/Azure/azure-pipeline-go/pipeline"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 type blockBlobUploader struct {

--- a/ste/sender-blockBlobFromURL.go
+++ b/ste/sender-blockBlobFromURL.go
@@ -28,7 +28,7 @@ import (
 	"github.com/Azure/azure-pipeline-go/pipeline"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 type urlToBlockBlobCopier struct {

--- a/ste/sender-pageBlob.go
+++ b/ste/sender-pageBlob.go
@@ -32,7 +32,7 @@ import (
 	"github.com/Azure/azure-pipeline-go/pipeline"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 type pageBlobSenderBase struct {

--- a/ste/sender-pageBlobFromLocal.go
+++ b/ste/sender-pageBlobFromLocal.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 )
 

--- a/ste/sender-pageBlobFromURL.go
+++ b/ste/sender-pageBlobFromURL.go
@@ -28,7 +28,7 @@ import (
 	"github.com/Azure/azure-pipeline-go/pipeline"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 type urlToPageBlobCopier struct {

--- a/ste/sender.go
+++ b/ste/sender.go
@@ -27,7 +27,7 @@ import (
 	"github.com/Azure/azure-pipeline-go/pipeline"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 /////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ste/sourceInfoProvider-Benchmark.go
+++ b/ste/sourceInfoProvider-Benchmark.go
@@ -23,7 +23,7 @@ package ste
 import (
 	"time"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 type benchmarkSourceInfoProvider struct {

--- a/ste/sourceInfoProvider-Blob.go
+++ b/ste/sourceInfoProvider-Blob.go
@@ -21,7 +21,7 @@
 package ste
 
 import (
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"time"
 
 	"github.com/Azure/azure-storage-blob-go/azblob"

--- a/ste/sourceInfoProvider-File.go
+++ b/ste/sourceInfoProvider-File.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/Azure/azure-storage-file-go/azfile"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 type richSMBPropertyHolder interface {

--- a/ste/sourceInfoProvider-GCP.go
+++ b/ste/sourceInfoProvider-GCP.go
@@ -4,7 +4,7 @@ import (
 	gcpUtils "cloud.google.com/go/storage"
 	"fmt"
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"golang.org/x/oauth2/google"
 	"io/ioutil"
 	"net/url"

--- a/ste/sourceInfoProvider-Local.go
+++ b/ste/sourceInfoProvider-Local.go
@@ -24,7 +24,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // Source info provider for local files

--- a/ste/sourceInfoProvider-Local_windows.go
+++ b/ste/sourceInfoProvider-Local_windows.go
@@ -3,7 +3,7 @@
 package ste
 
 import (
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"os"
 	"strings"
 	"syscall"
@@ -12,7 +12,7 @@ import (
 	"github.com/Azure/azure-storage-file-go/azfile"
 	"golang.org/x/sys/windows"
 
-	"github.com/Azure/azure-storage-azcopy/sddl"
+	"github.com/Azure/azure-storage-azcopy/v10/sddl"
 )
 
 // This file os-triggers the ISMBPropertyBearingSourceInfoProvider and CustomLocalOpener interfaces on a local SIP.

--- a/ste/sourceInfoProvider-S3.go
+++ b/ste/sourceInfoProvider-S3.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	minio "github.com/minio/minio-go"
 )
 

--- a/ste/sourceInfoProvider.go
+++ b/ste/sourceInfoProvider.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/Azure/azure-storage-file-go/azfile"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
 )

--- a/ste/xfer-anyToRemote-file.go
+++ b/ste/xfer-anyToRemote-file.go
@@ -34,7 +34,7 @@ import (
 	"sync"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // This code for blob tier safety is _not_ safe for multiple jobs at once.

--- a/ste/xfer-anyToRemote-folder.go
+++ b/ste/xfer-anyToRemote-folder.go
@@ -22,7 +22,7 @@ package ste
 
 import (
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // anyToRemote_folder handles all kinds of sender operations for FOLDERS - both uploads from local files, and S2S copies

--- a/ste/xfer-deleteBlob.go
+++ b/ste/xfer-deleteBlob.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 )
 

--- a/ste/xfer-deleteFile.go
+++ b/ste/xfer-deleteFile.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-file-go/azfile"
 )
 

--- a/ste/xfer-remoteToLocal-file.go
+++ b/ste/xfer-remoteToLocal-file.go
@@ -29,7 +29,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 const azcopyTempDownloadPrefix string = ".azDownload-%s-"

--- a/ste/xfer-remoteToLocal-folder.go
+++ b/ste/xfer-remoteToLocal-folder.go
@@ -22,7 +22,7 @@ package ste
 
 import (
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // general-purpose "any remote persistence location" to local, for folders

--- a/ste/xfer.go
+++ b/ste/xfer.go
@@ -29,7 +29,7 @@ import (
 	"github.com/Azure/azure-pipeline-go/pipeline"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // upload related

--- a/ste/xferLogPolicy.go
+++ b/ste/xferLogPolicy.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // This file is copied and extended from Azure Storage Blob Go SDK.

--- a/ste/xferRetrypolicy.go
+++ b/ste/xferRetrypolicy.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/azbfs"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 )
 

--- a/ste/xferStatsPolicy.go
+++ b/ste/xferStatsPolicy.go
@@ -24,7 +24,7 @@ import (
 	"bytes"
 	"context"
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"io/ioutil"
 	"net/http"
 	"strings"

--- a/ste/zt_performanceAdvisor_test.go
+++ b/ste/zt_performanceAdvisor_test.go
@@ -21,7 +21,7 @@
 package ste
 
 import (
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	chk "gopkg.in/check.v1"
 )
 

--- a/testSuite/cmd/clean.go
+++ b/testSuite/cmd/clean.go
@@ -13,8 +13,8 @@ import (
 	"time"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/azbfs"
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/Azure/azure-storage-file-go/azfile"
 	"github.com/JeffreyRichter/enum/enum"

--- a/testSuite/cmd/common.go
+++ b/testSuite/cmd/common.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	minio "github.com/minio/minio-go"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // validateString compares the two strings.

--- a/testSuite/cmd/create.go
+++ b/testSuite/cmd/create.go
@@ -16,7 +16,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/Azure/azure-storage-file-go/azfile"
 	minio "github.com/minio/minio-go"

--- a/testSuite/cmd/list.go
+++ b/testSuite/cmd/list.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/Azure/azure-storage-azcopy/ste"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/spf13/cobra"
 )

--- a/testSuite/cmd/platdiff_windows.go
+++ b/testSuite/cmd/platdiff_windows.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // GetAzCopyAppPath returns the path of Azcopy in local appdata.

--- a/testSuite/cmd/testblob.go
+++ b/testSuite/cmd/testblob.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
 
-	"github.com/Azure/azure-storage-azcopy/common"
-	"github.com/Azure/azure-storage-azcopy/ste"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/spf13/cobra"

--- a/testSuite/cmd/testblobFS.go
+++ b/testSuite/cmd/testblobFS.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Azure/azure-storage-azcopy/azbfs"
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
 	"github.com/spf13/cobra"
 )
 

--- a/testSuite/cmd/upload.go
+++ b/testSuite/cmd/upload.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/minio/minio-go"
 
-	"github.com/Azure/azure-storage-azcopy/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/spf13/cobra"
 )
 

--- a/testSuite/main.go
+++ b/testSuite/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/Azure/azure-storage-azcopy/testSuite/cmd"
+	"github.com/Azure/azure-storage-azcopy/v10/testSuite/cmd"
 )
 
 func main() {


### PR DESCRIPTION
We forgot to upgrade the import path for v10, which causes a problem when others want to import AzCopyV10 as a module.