### PR TITLE
[AzCopyV10][Perf] Set tier directly at time of upload (instead of a separate set tier call)

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -648,12 +648,12 @@ func (raw rawCopyCmdArgs) cookWithId(jobId common.JobID) (cookedCopyCmdArgs, err
 		if cooked.blobType != common.EBlobType.Detect() && cooked.fromTo.To() != common.ELocation.Blob() {
 			return cooked, fmt.Errorf("blob-type is not supported for the scenario (%s)", cooked.fromTo.String())
 		}
-		// Disabling blob tier override, when copying block -> block blob or page -> page blob, blob tier will be kept,
-		// For s3 and file, only hot block blob tier is supported.
-		//if cooked.blockBlobTier != common.EBlockBlobTier.None() ||
-		//	cooked.pageBlobTier != common.EPageBlobTier.None() {
-		//	return cooked, fmt.Errorf("blob-tier is not supported while copying from service to service")
-		//}
+
+		// Setting blob tier is supported only when destination is a blob storage. Disabling it for all the other transfer scenarios.
+		if (cooked.blockBlobTier != common.EBlockBlobTier.None() || cooked.pageBlobTier != common.EPageBlobTier.None()) &&
+			cooked.fromTo.To() != common.ELocation.Blob() {
+			return cooked, fmt.Errorf("blob-tier is not supported for the scenario (%s)", cooked.fromTo.String())
+		}
 		if cooked.noGuessMimeType {
 			return cooked, fmt.Errorf("no-guess-mime-type is not supported while copying from service to service")
 		}

--- a/testSuite/scripts/utility.py
+++ b/testSuite/scripts/utility.py
@@ -518,7 +518,7 @@ def execute_azcopy_command(command):
     cmnd = azspath + " " + command
 
     try:
-        # executing the command with timeout to set 3 minutes / 180 sec.
+        # executing the command with timeout to set 3 minutes / 360 sec.
         subprocess.check_output(
             cmnd, stderr=subprocess.STDOUT, shell=True, timeout=360,
             universal_newlines=True)
@@ -556,9 +556,9 @@ def execute_azcopy_command_get_output(command):
     cmnd = azspath + " " + command
     output = ""
     try:
-        # executing the command with timeout set to 4 minutes / 240 sec.
+        # executing the command with timeout set to 6 minutes / 360 sec.
         output = subprocess.check_output(
-            cmnd, stderr=subprocess.STDOUT, shell=True, timeout=240,
+            cmnd, stderr=subprocess.STDOUT, shell=True, timeout=360,
             universal_newlines=True)
     except subprocess.CalledProcessError as exec:
         # print("command failed with error code ", exec.returncode, " and message " + exec.output)
@@ -574,9 +574,9 @@ def verify_operation(command):
     test_suite_path = os.path.join(test_directory_path, test_suite_executable_name)
     command = test_suite_path + " " + command
     try:
-        # executing the command with timeout set to 4 minutes / 240 sec.
+        # executing the command with timeout set to 6 minutes / 360 sec.
         subprocess.check_output(
-            command, stderr=subprocess.STDOUT, shell=True, timeout=240,
+            command, stderr=subprocess.STDOUT, shell=True, timeout=360,
             universal_newlines=True)
     except subprocess.CalledProcessError as exec:
         # print("command failed with error code ", exec.returncode, " and message " + exec.output)
@@ -590,7 +590,7 @@ def verify_operation_get_output(command):
     test_suite_path = os.path.join(test_directory_path, test_suite_executable_name)
     command = test_suite_path + " " + command
     try:
-        # executing the command with timeout set to 3 minutes / 180 sec.
+        # executing the command with timeout set to 10 minutes / 600 sec.
         output = subprocess.check_output(
             command, stderr=subprocess.STDOUT, shell=True, timeout=600,
             universal_newlines=True)


### PR DESCRIPTION
[Setting access tier at the time of Upload](https://docs.microsoft.com/en-us/rest/api/storageservices/put-blob#request-headers-all-blob-types), instead of invoking ``SetTier()`` method separately, will improve the performance.

Note 1: **``block-blob-tier``** flag is used to set access tier of block blob. Valid tiers are - **``Hot/Cool/Archive``**
Note 2: **``page-blob-tier``** flag is used to set access tier of page blob. Valid tiers are - **``P10/P15/P20/P30/P4/P40/P50/P6/P60/P70/P80``**. 

e.g. `"cp" "https://[accountName].blob.core.windows.net/[sourceContainerName]/[blobname]?[SASQuery]" "https://[accountName].blob.core.windows.net/[destinationContainerName]/[blobname]?[SASQuery]" --block-blob-tier="[valid-tier]"`

For more information on access tiers, refer [this](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-storage-tiers?tabs=azure-portal).