### PR TITLE
[AzCopyV10] Content-type for auto detected types should be set in the create call as well for 0 length files

### DIFF
--- a/common/prologueState.go
+++ b/common/prologueState.go
@@ -32,9 +32,9 @@ type PrologueState struct {
 	LeadingBytes []byte
 }
 
-func (ps PrologueState) CanInferContentType() bool {
-	return len(ps.LeadingBytes) > 0 // we can have a go, if we have some leading bytes
-}
+//func (ps PrologueState) CanInferContentType() bool {
+//	return len(ps.LeadingBytes) > 0 // we can have a go, if we have some leading bytes
+//}
 
 func (ps PrologueState) GetInferredContentType(jptm cutdownJptm) string {
 	headers, _ := jptm.ResourceDstData(ps.LeadingBytes)

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -61,8 +61,7 @@ type serviceAPIVersionOverride struct{}
 var ServiceAPIVersionOverride = serviceAPIVersionOverride{}
 
 // DefaultServiceApiVersion is the default value of service api version that is set as value to the ServiceAPIVersionOverride in every Job's context.
-var DefaultServiceApiVersion = comm
-on.GetLifecycleMgr().GetEnvironmentVariable(common.EEnvironmentVariable.DefaultServiceApiVersion())
+var DefaultServiceApiVersion = common.GetLifecycleMgr().GetEnvironmentVariable(common.EEnvironmentVariable.DefaultServiceApiVersion())
 
 // NewVersionPolicy creates a factory that can override the service version
 // set in the request header.

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -568,7 +568,10 @@ func (jpm *jobPartMgr) AutoDecompress() bool {
 }
 
 func (jpm *jobPartMgr) resourceDstData(fullFilePath string, dataFileToXfer []byte) (headers common.ResourceHTTPHeaders, metadata common.Metadata) {
-	// if dataFileToXfer is nil or len(dataFileToXfer) < 512, the default content type will be "application/octet-stream"
+	if jpm.planMMF.Plan().DstBlobData.NoGuessMimeType {
+		return jpm.httpHeaders, jpm.metadata
+	}
+
 	return common.ResourceHTTPHeaders{
 		ContentType:        jpm.inferContentType(fullFilePath, dataFileToXfer),
 		ContentLanguage:    jpm.httpHeaders.ContentLanguage,
@@ -608,6 +611,7 @@ func (jpm *jobPartMgr) inferContentType(fullFilePath string, dataFileToXfer []by
 		return guessedType
 	}
 
+	// if dataFileToXfer is nil, the default content type will be "application/octet-stream"
 	return http.DetectContentType(dataFileToXfer)
 }
 

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -568,11 +568,13 @@ func (jpm *jobPartMgr) AutoDecompress() bool {
 }
 
 func (jpm *jobPartMgr) resourceDstData(fullFilePath string, dataFileToXfer []byte) (headers common.ResourceHTTPHeaders, metadata common.Metadata) {
-	if jpm.planMMF.Plan().DstBlobData.NoGuessMimeType || dataFileToXfer == nil {
-		return jpm.httpHeaders, jpm.metadata
-	}
-
-	return common.ResourceHTTPHeaders{ContentType: jpm.inferContentType(fullFilePath, dataFileToXfer), ContentLanguage: jpm.httpHeaders.ContentLanguage, ContentDisposition: jpm.httpHeaders.ContentDisposition, ContentEncoding: jpm.httpHeaders.ContentEncoding, CacheControl: jpm.httpHeaders.CacheControl}, jpm.metadata
+	// if dataFileToXfer is nil or len(dataFileToXfer) < 512, the default content type will be "application/octet-stream"
+	return common.ResourceHTTPHeaders{
+		ContentType:        jpm.inferContentType(fullFilePath, dataFileToXfer),
+		ContentLanguage:    jpm.httpHeaders.ContentLanguage,
+		ContentDisposition: jpm.httpHeaders.ContentDisposition,
+		ContentEncoding:    jpm.httpHeaders.ContentEncoding,
+		CacheControl:       jpm.httpHeaders.CacheControl}, jpm.metadata
 }
 
 // TODO do we want these charset=utf-8?

--- a/ste/sender-appendBlob.go
+++ b/ste/sender-appendBlob.go
@@ -134,11 +134,9 @@ func (s *appendBlobSenderBase) generateAppendBlockToRemoteFunc(id common.ChunkID
 }
 
 func (s *appendBlobSenderBase) Prologue(ps common.PrologueState) (destinationModified bool) {
-	if ps.CanInferContentType() {
-		// sometimes, specifically when reading local files, we have more info
-		// about the file type at this time than what we had before
-		s.headersToApply.ContentType = ps.GetInferredContentType(s.jptm)
-	}
+	// sometimes, specifically when reading local files, we have more info
+	// about the file type at this time than what we had before
+	s.headersToApply.ContentType = ps.GetInferredContentType(s.jptm)
 
 	destinationModified = true
 	_, err := s.destAppendBlobURL.Create(s.jptm.Context(), s.headersToApply, s.metadataToApply, azblob.BlobAccessConditions{})

--- a/ste/sender-azureFile.go
+++ b/ste/sender-azureFile.go
@@ -152,11 +152,9 @@ func (u *azureFileSenderBase) Prologue(state common.PrologueState) (destinationM
 		return
 	}
 
-	if state.CanInferContentType() {
-		// sometimes, specifically when reading local files, we have more info
-		// about the file type at this time than what we had before
-		u.headersToApply.ContentType = state.GetInferredContentType(u.jptm)
-	}
+	// sometimes, specifically when reading local files, we have more info
+	// about the file type at this time than what we had before
+	u.headersToApply.ContentType = state.GetInferredContentType(u.jptm)
 
 	stage, err := u.addPermissionsToHeaders(info, u.fileURL().URL())
 	if err != nil {

--- a/ste/sender-blockBlob.go
+++ b/ste/sender-blockBlob.go
@@ -155,11 +155,9 @@ func (s *blockBlobSenderBase) RemoteFileExists() (bool, time.Time, error) {
 }
 
 func (s *blockBlobSenderBase) Prologue(ps common.PrologueState) (destinationModified bool) {
-	if ps.CanInferContentType() {
-		// sometimes, specifically when reading local files, we have more info
-		// about the file type at this time than what we had before
-		s.headersToApply.ContentType = ps.GetInferredContentType(s.jptm)
-	}
+	// sometimes, specifically when reading local files, we have more info
+	// about the file type at this time than what we had before
+	s.headersToApply.ContentType = ps.GetInferredContentType(s.jptm)
 	return false
 }
 

--- a/ste/sender-pageBlob.go
+++ b/ste/sender-pageBlob.go
@@ -223,11 +223,9 @@ func (s *pageBlobSenderBase) Prologue(ps common.PrologueState) (destinationModif
 		destinationModified = true
 	}
 
-	if ps.CanInferContentType() {
-		// sometimes, specifically when reading local files, we have more info
-		// about the file type at this time than what we had before
-		s.headersToApply.ContentType = ps.GetInferredContentType(s.jptm)
-	}
+	// sometimes, specifically when reading local files, we have more info
+	// about the file type at this time than what we had before
+	s.headersToApply.ContentType = ps.GetInferredContentType(s.jptm)
 
 	if _, err := s.destPageBlobURL.Create(s.jptm.Context(),
 		s.srcSize,


### PR DESCRIPTION
AzCopy always sets content-type of a zero-bytes file to upload as “application/octet-stream” regardless of its extension name while other tools or APIs don’t.  Content-type is supposed to be determined by an extension name of a file to upload if it is failed to be detected by a body of the file. Even for an empty file, the content-type should be set based on the extension name.