### PR TITLE
UpdateProgessPanic: Reduce severity to logging

### DIFF
--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -670,7 +670,7 @@ func (jpm *jobPartMgr) updateJobPartProgress(status common.TransferStatus) {
 		atomic.AddUint32(&jpm.atomicTransfersSkipped, 1)
 	case common.ETransferStatus.Cancelled():
 	default:
-		panic("Unexpected status")
+		jpm.Log(pipeline.LogError, fmt.Sprintf("Unexpected status: %v", status.String()))
 	}
 }
 


### PR DESCRIPTION
There can be a race such that the file is transferred, but before we report the jptm to be done, the context of this jptm can be cancelled. This is to acknowledge the race.