### PR TITLE
Content Type Bug (Preserve content type in S2S transfer + Upload 0B files and infer content type based on extension)

### DIFF
--- a/common/prologueState.go
+++ b/common/prologueState.go
@@ -32,10 +32,6 @@ type PrologueState struct {
 	LeadingBytes []byte
 }
 
-func (ps PrologueState) CanInferContentType(fromTo FromTo) bool {
-	return fromTo.From() == ELocation.Local() || len(ps.LeadingBytes) > 0 // we can have a go, if we have some leading bytes
-}
-
 func (ps PrologueState) GetInferredContentType(jptm cutdownJptm) string {
 	headers, _, _ := jptm.ResourceDstData(ps.LeadingBytes)
 	return headers.ContentType

--- a/common/prologueState.go
+++ b/common/prologueState.go
@@ -32,9 +32,9 @@ type PrologueState struct {
 	LeadingBytes []byte
 }
 
-//func (ps PrologueState) CanInferContentType() bool {
-//	return len(ps.LeadingBytes) > 0 // we can have a go, if we have some leading bytes
-//}
+func (ps PrologueState) CanInferContentType() bool {
+	return len(ps.LeadingBytes) > 0 // we can have a go, if we have some leading bytes
+}
 
 func (ps PrologueState) GetInferredContentType(jptm cutdownJptm) string {
 	headers, _, _ := jptm.ResourceDstData(ps.LeadingBytes)

--- a/common/prologueState.go
+++ b/common/prologueState.go
@@ -32,8 +32,8 @@ type PrologueState struct {
 	LeadingBytes []byte
 }
 
-func (ps PrologueState) CanInferContentType() bool {
-	return len(ps.LeadingBytes) > 0 // we can have a go, if we have some leading bytes
+func (ps PrologueState) CanInferContentType(fromTo FromTo) bool {
+	return fromTo.From() == ELocation.Local() || len(ps.LeadingBytes) > 0 // we can have a go, if we have some leading bytes
 }
 
 func (ps PrologueState) GetInferredContentType(jptm cutdownJptm) string {

--- a/e2etest/declarativeScenario.go
+++ b/e2etest/declarativeScenario.go
@@ -350,22 +350,22 @@ func (s *scenario) validateContentHeaders(expected, actual *contentHeaders) {
 
 	if expected.cacheControl != nil {
 		s.a.Assert(expected.cacheControl, equals(), actual.cacheControl,
-			fmt.Sprintf("Content cache control mismatch: Expected %v, obtained %v", expected.cacheControl, actual.cacheControl))
+			fmt.Sprintf("Content cache control mismatch: Expected %v, obtained %v", *expected.cacheControl, *actual.cacheControl))
 	}
 
 	if expected.contentDisposition != nil {
 		s.a.Assert(expected.contentDisposition, equals(), actual.contentDisposition,
-			fmt.Sprintf("Content disposition mismatch: Expected %v, obtained %v", expected.contentDisposition, actual.contentDisposition))
+			fmt.Sprintf("Content disposition mismatch: Expected %v, obtained %v", *expected.contentDisposition, *actual.contentDisposition))
 	}
 
 	if expected.contentEncoding != nil {
 		s.a.Assert(expected.contentEncoding, equals(), actual.contentEncoding,
-			fmt.Sprintf("Content encoding mismatch: Expected %v, obtained %v", expected.contentEncoding, actual.contentEncoding))
+			fmt.Sprintf("Content encoding mismatch: Expected %v, obtained %v", *expected.contentEncoding, *actual.contentEncoding))
 	}
 
 	if expected.contentLanguage != nil {
 		s.a.Assert(expected.contentLanguage, equals(), actual.contentLanguage,
-			fmt.Sprintf("Content language mismatch: Expected %v, obtained %v", expected.contentLanguage, actual.contentLanguage))
+			fmt.Sprintf("Content language mismatch: Expected %v, obtained %v", *expected.contentLanguage, *actual.contentLanguage))
 	}
 
 	if expected.contentType != nil {

--- a/e2etest/declarativeScenario.go
+++ b/e2etest/declarativeScenario.go
@@ -370,7 +370,7 @@ func (s *scenario) validateContentHeaders(expected, actual *contentHeaders) {
 
 	if expected.contentType != nil {
 		s.a.Assert(expected.contentType, equals(), actual.contentType,
-			fmt.Sprintf("Content type mismatch: Expected %v, obtained %v", expected.contentType, actual.contentType))
+			fmt.Sprintf("Content type mismatch: Expected %v, obtained %v", *expected.contentType, *actual.contentType))
 	}
 
 	if expected.contentMD5 != nil {

--- a/e2etest/helpers.go
+++ b/e2etest/helpers.go
@@ -31,6 +31,7 @@ import (
 	chk "gopkg.in/check.v1"
 	"io/ioutil"
 	"math/rand"
+	"mime"
 	"net/url"
 	"os"
 	"strings"
@@ -656,4 +657,15 @@ func (checker *stringContainsChecker) Check(params []interface{}, names []string
 	return false, fmt.Sprintf("Failed to find substring in source string:\n\n"+
 		"SOURCE: %s\n"+
 		"EXPECTED: %s\n", aStr, bStr)
+}
+
+func GetContentTypeMap(fileExtensions []string) map[string]string {
+
+	extensionsMap := make(map[string]string, 0)
+	for _, ext := range fileExtensions {
+		if guessedType := mime.TypeByExtension(ext); guessedType != "" {
+			extensionsMap[ext] = strings.Split(guessedType, ";")[0]
+		}
+	}
+	return extensionsMap
 }

--- a/e2etest/zt_content_header_test.go
+++ b/e2etest/zt_content_header_test.go
@@ -25,7 +25,10 @@ import (
 	"testing"
 )
 
+var fileExtensions = []string{".exe", ".cpp", ".java", ".py", ".go", ".mp3", ".mp4", ".pdf", ".gzip", ".txt", ".dat", ".bat", ".xlsx"}
+
 func TestHeader_SourceLocal(t *testing.T) {
+	extensionsMap := GetContentTypeMap(fileExtensions)
 	RunScenarios(
 		t,
 		eOperation.Copy(),
@@ -39,14 +42,18 @@ func TestHeader_SourceLocal(t *testing.T) {
 			defaultSize: "1M",
 			shouldTransfer: []interface{}{
 				//folder("", ),
-				f("file1.mp3", with{contentType: "audio/mpeg"}),
-				f("file2.pdf", with{contentType: "application/pdf"}),
-				f("file4.txt", with{contentType: "text/plain"}),
+				f("file1.mp3", with{contentType: extensionsMap[".mp3"]}),
+				f("file2.pdf", with{contentType: extensionsMap[".pdf"]}),
+				f("file3.exe", with{contentType: extensionsMap[".exe"]}),
+				f("file4.txt", with{contentType: extensionsMap[".txt"]}),
+				f("file5.mp4", with{contentType: extensionsMap[".mp4"]}),
+				f("file6.xlsx", with{contentType: extensionsMap[".xlsx"]}),
 			},
 		})
 }
 
 func TestHeader_SourceLocalEmptyFiles(t *testing.T) {
+	extensionsMap := GetContentTypeMap(fileExtensions)
 	RunScenarios(
 		t,
 		eOperation.Copy(),
@@ -60,14 +67,18 @@ func TestHeader_SourceLocalEmptyFiles(t *testing.T) {
 			defaultSize: "0K",
 			shouldTransfer: []interface{}{
 				//folder("", ),
-				f("file1.mp3", with{contentType: "audio/mpeg"}),
-				f("file2.pdf", with{contentType: "application/pdf"}),
-				f("file4.txt", with{contentType: "text/plain"}),
+				f("file1.mp3", with{contentType: extensionsMap[".mp3"]}),
+				f("file2.pdf", with{contentType: extensionsMap[".pdf"]}),
+				f("file3.exe", with{contentType: extensionsMap[".exe"]}),
+				f("file4.txt", with{contentType: extensionsMap[".txt"]}),
+				f("file3.mp4", with{contentType: extensionsMap[".mp4"]}),
+				f("file5.xlsx", with{contentType: extensionsMap[".xlsx"]}),
 			},
 		})
 }
 
 func TestHeader_AllS2S(t *testing.T) {
+	extensionsMap := GetContentTypeMap(fileExtensions)
 	RunScenarios(
 		t,
 		eOperation.Copy(),
@@ -81,16 +92,19 @@ func TestHeader_AllS2S(t *testing.T) {
 			defaultSize: "1K",
 			shouldTransfer: []interface{}{
 				//folder("", ),
-				f("file1.mp3", with{contentType: "audio/mpeg"}),
-				f("file2.pdf", with{contentType: "application/pdf"}),
-				f("file3.exe", with{contentType: "application/x-msdownload"}),
-				f("file4.txt", with{contentType: "text/plain"}),
+				f("file1.mp3", with{contentType: extensionsMap[".mp3"]}),
+				f("file2.pdf", with{contentType: extensionsMap[".pdf"]}),
+				f("file3.exe", with{contentType: extensionsMap[".exe"]}),
+				f("file4.txt", with{contentType: extensionsMap[".txt"]}),
+				f("file3.mp4", with{contentType: extensionsMap[".mp4"]}),
+				f("file5.xlsx", with{contentType: extensionsMap[".xlsx"]}),
 			},
 		})
 }
 
 // TODO: AutoPlusContent is not thread-safe. Look into that.
 func TestHeader_SourceBlobEmptyBlob(t *testing.T) {
+	extensionsMap := GetContentTypeMap(fileExtensions)
 	RunScenarios(
 		t,
 		eOperation.Copy(),
@@ -104,10 +118,12 @@ func TestHeader_SourceBlobEmptyBlob(t *testing.T) {
 			defaultSize: "0K",
 			shouldTransfer: []interface{}{
 				//folder("", ),
-				f("file1.mp3", with{contentType: "audio/mpeg"}),
-				f("file2.pdf", with{contentType: "application/pdf"}),
-				f("file3.exe", with{contentType: "application/x-msdownload"}),
-				f("file4.txt", with{contentType: "text/plain"}),
+				f("file1.mp3", with{contentType: extensionsMap[".mp3"]}),
+				f("file2.pdf", with{contentType: extensionsMap[".pdf"]}),
+				f("file3.exe", with{contentType: extensionsMap[".exe"]}),
+				f("file4.txt", with{contentType: extensionsMap[".txt"]}),
+				f("file3.mp4", with{contentType: extensionsMap[".mp4"]}),
+				f("file5.xlsx", with{contentType: extensionsMap[".xlsx"]}),
 			},
 		})
 }

--- a/e2etest/zt_content_header_test.go
+++ b/e2etest/zt_content_header_test.go
@@ -25,49 +25,47 @@ import (
 	"testing"
 )
 
-//func TestHeader_SourceLocal(t *testing.T) {
-//	RunScenarios(
-//		t,
-//		eOperation.Copy(),
-//		eTestFromTo.Other(common.EFromTo.LocalBlob()),
-//		eValidate.AutoPlusContent(),
-//		params{
-//			recursive: true,
-//		},
-//		nil,
-//		testFiles{
-//			defaultSize: "1M",
-//			shouldTransfer: []interface{}{
-//				//folder("", ),
-//				f("file1.mp3", with{contentType: "audio/mpeg"}),
-//				f("file2.pdf", with{contentType: "application/pdf"}),
-//				f("file3.exe", with{contentType: "application/x-msdownload"}),
-//				f("file4.txt", with{contentType: "text/plain"}),
-//			},
-//		})
-//}
+func TestHeader_SourceLocal(t *testing.T) {
+	RunScenarios(
+		t,
+		eOperation.Copy(),
+		eTestFromTo.Other(common.EFromTo.LocalBlob()),
+		eValidate.AutoPlusContent(),
+		params{
+			recursive: true,
+		},
+		nil,
+		testFiles{
+			defaultSize: "1M",
+			shouldTransfer: []interface{}{
+				//folder("", ),
+				f("file1.mp3", with{contentType: "audio/mpeg"}),
+				f("file2.pdf", with{contentType: "application/pdf"}),
+				f("file4.txt", with{contentType: "text/plain"}),
+			},
+		})
+}
 
-//func TestHeader_SourceLocalEmptyFiles(t *testing.T) {
-//	RunScenarios(
-//		t,
-//		eOperation.Copy(),
-//		eTestFromTo.Other(common.EFromTo.LocalBlob()),
-//		eValidate.AutoPlusContent(),
-//		params{
-//			recursive: true,
-//		},
-//		nil,
-//		testFiles{
-//			defaultSize: "0K",
-//			shouldTransfer: []interface{}{
-//				//folder("", ),
-//				f("file1.mp3", with{contentType: "audio/mpeg"}),
-//				f("file2.pdf", with{contentType: "application/pdf"}),
-//				f("file3.exe", with{contentType: "application/x-msdownload"}),
-//				f("file4.txt", with{contentType: "text/plain"}),
-//			},
-//		})
-//}
+func TestHeader_SourceLocalEmptyFiles(t *testing.T) {
+	RunScenarios(
+		t,
+		eOperation.Copy(),
+		eTestFromTo.Other(common.EFromTo.LocalBlob()),
+		eValidate.AutoPlusContent(),
+		params{
+			recursive: true,
+		},
+		nil,
+		testFiles{
+			defaultSize: "0K",
+			shouldTransfer: []interface{}{
+				//folder("", ),
+				f("file1.mp3", with{contentType: "audio/mpeg"}),
+				f("file2.pdf", with{contentType: "application/pdf"}),
+				f("file4.txt", with{contentType: "text/plain"}),
+			},
+		})
+}
 
 func TestHeader_AllS2S(t *testing.T) {
 	RunScenarios(

--- a/e2etest/zt_content_header_test.go
+++ b/e2etest/zt_content_header_test.go
@@ -1,0 +1,115 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package e2etest
+
+import (
+	"github.com/Azure/azure-storage-azcopy/common"
+	"testing"
+)
+
+func TestHeader_SourceLocal(t *testing.T) {
+	RunScenarios(
+		t,
+		eOperation.Copy(),
+		eTestFromTo.Other(common.EFromTo.LocalBlob()),
+		eValidate.AutoPlusContent(),
+		params{
+			recursive: true,
+		},
+		nil,
+		testFiles{
+			defaultSize: "1M",
+			shouldTransfer: []interface{}{
+				//folder("", ),
+				f("file1.mp3", with{contentType: "audio/mpeg"}),
+				f("file2.pdf", with{contentType: "application/pdf"}),
+				f("file3.exe", with{contentType: "application/x-msdownload"}),
+				f("file4.txt", with{contentType: "text/plain"}),
+			},
+		})
+}
+
+func TestHeader_SourceLocalEmptyFiles(t *testing.T) {
+	RunScenarios(
+		t,
+		eOperation.Copy(),
+		eTestFromTo.Other(common.EFromTo.LocalBlob()),
+		eValidate.AutoPlusContent(),
+		params{
+			recursive: true,
+		},
+		nil,
+		testFiles{
+			defaultSize: "0K",
+			shouldTransfer: []interface{}{
+				//folder("", ),
+				f("file1.mp3", with{contentType: "audio/mpeg"}),
+				f("file2.pdf", with{contentType: "application/pdf"}),
+				f("file3.exe", with{contentType: "application/x-msdownload"}),
+				f("file4.txt", with{contentType: "text/plain"}),
+			},
+		})
+}
+
+func TestHeader_AllS2S(t *testing.T) {
+	RunScenarios(
+		t,
+		eOperation.Copy(),
+		eTestFromTo.AllS2S(),
+		eValidate.Auto(),
+		params{
+			recursive: true,
+		},
+		nil,
+		testFiles{
+			defaultSize: "1K",
+			shouldTransfer: []interface{}{
+				//folder("", ),
+				f("file1.mp3", with{contentType: "audio/mpeg"}),
+				f("file2.pdf", with{contentType: "application/pdf"}),
+				f("file3.exe", with{contentType: "application/x-msdownload"}),
+				f("file4.txt", with{contentType: "text/plain"}),
+			},
+		})
+}
+
+// TODO: AutoPlusContent is not thread-safe. Look into that.
+func TestHeader_SourceBlobEmptyBlob(t *testing.T) {
+	RunScenarios(
+		t,
+		eOperation.Copy(),
+		eTestFromTo.Other(common.EFromTo.BlobBlob()),
+		eValidate.AutoPlusContent(),
+		params{
+			recursive: true,
+		},
+		nil,
+		testFiles{
+			defaultSize: "0K",
+			shouldTransfer: []interface{}{
+				//folder("", ),
+				f("file1.mp3", with{contentType: "audio/mpeg"}),
+				f("file2.pdf", with{contentType: "application/pdf"}),
+				f("file3.exe", with{contentType: "application/x-msdownload"}),
+				f("file4.txt", with{contentType: "text/plain"}),
+			},
+		})
+}

--- a/e2etest/zt_content_header_test.go
+++ b/e2etest/zt_content_header_test.go
@@ -25,49 +25,49 @@ import (
 	"testing"
 )
 
-func TestHeader_SourceLocal(t *testing.T) {
-	RunScenarios(
-		t,
-		eOperation.Copy(),
-		eTestFromTo.Other(common.EFromTo.LocalBlob()),
-		eValidate.AutoPlusContent(),
-		params{
-			recursive: true,
-		},
-		nil,
-		testFiles{
-			defaultSize: "1M",
-			shouldTransfer: []interface{}{
-				//folder("", ),
-				f("file1.mp3", with{contentType: "audio/mpeg"}),
-				f("file2.pdf", with{contentType: "application/pdf"}),
-				f("file3.exe", with{contentType: "application/x-msdownload"}),
-				f("file4.txt", with{contentType: "text/plain"}),
-			},
-		})
-}
+//func TestHeader_SourceLocal(t *testing.T) {
+//	RunScenarios(
+//		t,
+//		eOperation.Copy(),
+//		eTestFromTo.Other(common.EFromTo.LocalBlob()),
+//		eValidate.AutoPlusContent(),
+//		params{
+//			recursive: true,
+//		},
+//		nil,
+//		testFiles{
+//			defaultSize: "1M",
+//			shouldTransfer: []interface{}{
+//				//folder("", ),
+//				f("file1.mp3", with{contentType: "audio/mpeg"}),
+//				f("file2.pdf", with{contentType: "application/pdf"}),
+//				f("file3.exe", with{contentType: "application/x-msdownload"}),
+//				f("file4.txt", with{contentType: "text/plain"}),
+//			},
+//		})
+//}
 
-func TestHeader_SourceLocalEmptyFiles(t *testing.T) {
-	RunScenarios(
-		t,
-		eOperation.Copy(),
-		eTestFromTo.Other(common.EFromTo.LocalBlob()),
-		eValidate.AutoPlusContent(),
-		params{
-			recursive: true,
-		},
-		nil,
-		testFiles{
-			defaultSize: "0K",
-			shouldTransfer: []interface{}{
-				//folder("", ),
-				f("file1.mp3", with{contentType: "audio/mpeg"}),
-				f("file2.pdf", with{contentType: "application/pdf"}),
-				f("file3.exe", with{contentType: "application/x-msdownload"}),
-				f("file4.txt", with{contentType: "text/plain"}),
-			},
-		})
-}
+//func TestHeader_SourceLocalEmptyFiles(t *testing.T) {
+//	RunScenarios(
+//		t,
+//		eOperation.Copy(),
+//		eTestFromTo.Other(common.EFromTo.LocalBlob()),
+//		eValidate.AutoPlusContent(),
+//		params{
+//			recursive: true,
+//		},
+//		nil,
+//		testFiles{
+//			defaultSize: "0K",
+//			shouldTransfer: []interface{}{
+//				//folder("", ),
+//				f("file1.mp3", with{contentType: "audio/mpeg"}),
+//				f("file2.pdf", with{contentType: "application/pdf"}),
+//				f("file3.exe", with{contentType: "application/x-msdownload"}),
+//				f("file4.txt", with{contentType: "text/plain"}),
+//			},
+//		})
+//}
 
 func TestHeader_AllS2S(t *testing.T) {
 	RunScenarios(

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -629,7 +629,6 @@ func (jpm *jobPartMgr) inferContentType(fullFilePath string, dataFileToXfer []by
 		return strings.Split(guessedType, ";")[0]
 	}
 
-	// if dataFileToXfer is nil, the default content type will be "application/octet-stream"
 	return strings.Split(http.DetectContentType(dataFileToXfer), ";")[0]
 }
 

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -86,6 +86,7 @@ type IJobPartTransferMgr interface {
 	SecurityInfoPersistenceManager() *securityInfoPersistenceManager
 	FolderDeletionManager() common.FolderDeletionManager
 	GetDestinationRoot() string
+	CanInferContentType() bool
 }
 
 type TransferInfo struct {
@@ -880,4 +881,11 @@ func (jptm *jobPartTransferMgr) FolderDeletionManager() common.FolderDeletionMan
 func (jptm *jobPartTransferMgr) GetDestinationRoot() string {
 	p := jptm.jobPartMgr.Plan()
 	return string(p.DestinationRoot[:p.DestinationRootLength])
+}
+
+func (jptm *jobPartTransferMgr) CanInferContentType() bool {
+	// For remote files, we preserve the content-type and we don't have to infer it using AzCopy
+	// For local files, even if the file size is 0B, we try to infer the content based on file extension
+	fromTo := jptm.FromTo()
+	return fromTo.From() == common.ELocation.Local()
 }

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -86,7 +86,7 @@ type IJobPartTransferMgr interface {
 	SecurityInfoPersistenceManager() *securityInfoPersistenceManager
 	FolderDeletionManager() common.FolderDeletionManager
 	GetDestinationRoot() string
-	CanInferContentType() bool
+	ShouldInferContentType() bool
 }
 
 type TransferInfo struct {
@@ -883,7 +883,7 @@ func (jptm *jobPartTransferMgr) GetDestinationRoot() string {
 	return string(p.DestinationRoot[:p.DestinationRootLength])
 }
 
-func (jptm *jobPartTransferMgr) CanInferContentType() bool {
+func (jptm *jobPartTransferMgr) ShouldInferContentType() bool {
 	// For remote files, we preserve the content-type and we don't have to infer it using AzCopy
 	// For local files, even if the file size is 0B, we try to infer the content based on file extension
 	fromTo := jptm.FromTo()

--- a/ste/sender-appendBlob.go
+++ b/ste/sender-appendBlob.go
@@ -136,7 +136,8 @@ func (s *appendBlobSenderBase) generateAppendBlockToRemoteFunc(id common.ChunkID
 }
 
 func (s *appendBlobSenderBase) Prologue(ps common.PrologueState) (destinationModified bool) {
-	if ps.CanInferContentType() {
+	fromTo := s.jptm.FromTo()
+	if ps.CanInferContentType(fromTo) {
 		// sometimes, specifically when reading local files, we have more info
 		// about the file type at this time than what we had before
 		s.headersToApply.ContentType = ps.GetInferredContentType(s.jptm)

--- a/ste/sender-appendBlob.go
+++ b/ste/sender-appendBlob.go
@@ -136,7 +136,7 @@ func (s *appendBlobSenderBase) generateAppendBlockToRemoteFunc(id common.ChunkID
 }
 
 func (s *appendBlobSenderBase) Prologue(ps common.PrologueState) (destinationModified bool) {
-	if s.jptm.CanInferContentType() {
+	if s.jptm.ShouldInferContentType() {
 		// sometimes, specifically when reading local files, we have more info
 		// about the file type at this time than what we had before
 		s.headersToApply.ContentType = ps.GetInferredContentType(s.jptm)

--- a/ste/sender-appendBlob.go
+++ b/ste/sender-appendBlob.go
@@ -136,9 +136,11 @@ func (s *appendBlobSenderBase) generateAppendBlockToRemoteFunc(id common.ChunkID
 }
 
 func (s *appendBlobSenderBase) Prologue(ps common.PrologueState) (destinationModified bool) {
-	// sometimes, specifically when reading local files, we have more info
-	// about the file type at this time than what we had before
-	s.headersToApply.ContentType = ps.GetInferredContentType(s.jptm)
+	if ps.CanInferContentType() {
+		// sometimes, specifically when reading local files, we have more info
+		// about the file type at this time than what we had before
+		s.headersToApply.ContentType = ps.GetInferredContentType(s.jptm)
+	}
 
 	destinationModified = true
 	blobTags := s.blobTagsToApply

--- a/ste/sender-appendBlob.go
+++ b/ste/sender-appendBlob.go
@@ -136,8 +136,7 @@ func (s *appendBlobSenderBase) generateAppendBlockToRemoteFunc(id common.ChunkID
 }
 
 func (s *appendBlobSenderBase) Prologue(ps common.PrologueState) (destinationModified bool) {
-	fromTo := s.jptm.FromTo()
-	if ps.CanInferContentType(fromTo) {
+	if s.jptm.CanInferContentType() {
 		// sometimes, specifically when reading local files, we have more info
 		// about the file type at this time than what we had before
 		s.headersToApply.ContentType = ps.GetInferredContentType(s.jptm)

--- a/ste/sender-azureFile.go
+++ b/ste/sender-azureFile.go
@@ -152,9 +152,11 @@ func (u *azureFileSenderBase) Prologue(state common.PrologueState) (destinationM
 		return
 	}
 
-	// sometimes, specifically when reading local files, we have more info
-	// about the file type at this time than what we had before
-	u.headersToApply.ContentType = state.GetInferredContentType(u.jptm)
+	if state.CanInferContentType() {
+		// sometimes, specifically when reading local files, we have more info
+		// about the file type at this time than what we had before
+		u.headersToApply.ContentType = state.GetInferredContentType(u.jptm)
+	}
 
 	stage, err := u.addPermissionsToHeaders(info, u.fileURL().URL())
 	if err != nil {

--- a/ste/sender-azureFile.go
+++ b/ste/sender-azureFile.go
@@ -152,8 +152,7 @@ func (u *azureFileSenderBase) Prologue(state common.PrologueState) (destinationM
 		return
 	}
 
-	fromTo := jptm.FromTo()
-	if state.CanInferContentType(fromTo) {
+	if jptm.CanInferContentType() {
 		// sometimes, specifically when reading local files, we have more info
 		// about the file type at this time than what we had before
 		u.headersToApply.ContentType = state.GetInferredContentType(u.jptm)

--- a/ste/sender-azureFile.go
+++ b/ste/sender-azureFile.go
@@ -152,7 +152,7 @@ func (u *azureFileSenderBase) Prologue(state common.PrologueState) (destinationM
 		return
 	}
 
-	if jptm.CanInferContentType() {
+	if jptm.ShouldInferContentType() {
 		// sometimes, specifically when reading local files, we have more info
 		// about the file type at this time than what we had before
 		u.headersToApply.ContentType = state.GetInferredContentType(u.jptm)

--- a/ste/sender-azureFile.go
+++ b/ste/sender-azureFile.go
@@ -152,7 +152,8 @@ func (u *azureFileSenderBase) Prologue(state common.PrologueState) (destinationM
 		return
 	}
 
-	if state.CanInferContentType() {
+	fromTo := jptm.FromTo()
+	if state.CanInferContentType(fromTo) {
 		// sometimes, specifically when reading local files, we have more info
 		// about the file type at this time than what we had before
 		u.headersToApply.ContentType = state.GetInferredContentType(u.jptm)

--- a/ste/sender-blockBlob.go
+++ b/ste/sender-blockBlob.go
@@ -157,7 +157,8 @@ func (s *blockBlobSenderBase) RemoteFileExists() (bool, time.Time, error) {
 }
 
 func (s *blockBlobSenderBase) Prologue(ps common.PrologueState) (destinationModified bool) {
-	if ps.CanInferContentType() {
+	fromTo := s.jptm.FromTo()
+	if ps.CanInferContentType(fromTo) {
 		// sometimes, specifically when reading local files, we have more info
 		// about the file type at this time than what we had before
 		s.headersToApply.ContentType = ps.GetInferredContentType(s.jptm)

--- a/ste/sender-blockBlob.go
+++ b/ste/sender-blockBlob.go
@@ -157,10 +157,7 @@ func (s *blockBlobSenderBase) RemoteFileExists() (bool, time.Time, error) {
 }
 
 func (s *blockBlobSenderBase) Prologue(ps common.PrologueState) (destinationModified bool) {
-	fromTo := s.jptm.FromTo()
-	if ps.CanInferContentType(fromTo) {
-		// sometimes, specifically when reading local files, we have more info
-		// about the file type at this time than what we had before
+	if s.jptm.CanInferContentType() {
 		s.headersToApply.ContentType = ps.GetInferredContentType(s.jptm)
 	}
 	return false

--- a/ste/sender-blockBlob.go
+++ b/ste/sender-blockBlob.go
@@ -157,9 +157,11 @@ func (s *blockBlobSenderBase) RemoteFileExists() (bool, time.Time, error) {
 }
 
 func (s *blockBlobSenderBase) Prologue(ps common.PrologueState) (destinationModified bool) {
-	// sometimes, specifically when reading local files, we have more info
-	// about the file type at this time than what we had before
-	s.headersToApply.ContentType = ps.GetInferredContentType(s.jptm)
+	if ps.CanInferContentType() {
+		// sometimes, specifically when reading local files, we have more info
+		// about the file type at this time than what we had before
+		s.headersToApply.ContentType = ps.GetInferredContentType(s.jptm)
+	}
 	return false
 }
 

--- a/ste/sender-blockBlob.go
+++ b/ste/sender-blockBlob.go
@@ -157,7 +157,7 @@ func (s *blockBlobSenderBase) RemoteFileExists() (bool, time.Time, error) {
 }
 
 func (s *blockBlobSenderBase) Prologue(ps common.PrologueState) (destinationModified bool) {
-	if s.jptm.CanInferContentType() {
+	if s.jptm.ShouldInferContentType() {
 		s.headersToApply.ContentType = ps.GetInferredContentType(s.jptm)
 	}
 	return false

--- a/ste/sender-pageBlob.go
+++ b/ste/sender-pageBlob.go
@@ -225,8 +225,7 @@ func (s *pageBlobSenderBase) Prologue(ps common.PrologueState) (destinationModif
 		destinationModified = true
 	}
 
-	fromTo := s.jptm.FromTo()
-	if ps.CanInferContentType(fromTo) {
+	if s.jptm.CanInferContentType() {
 		// sometimes, specifically when reading local files, we have more info
 		// about the file type at this time than what we had before
 		s.headersToApply.ContentType = ps.GetInferredContentType(s.jptm)

--- a/ste/sender-pageBlob.go
+++ b/ste/sender-pageBlob.go
@@ -225,9 +225,11 @@ func (s *pageBlobSenderBase) Prologue(ps common.PrologueState) (destinationModif
 		destinationModified = true
 	}
 
-	// sometimes, specifically when reading local files, we have more info
-	// about the file type at this time than what we had before
-	s.headersToApply.ContentType = ps.GetInferredContentType(s.jptm)
+	if ps.CanInferContentType() {
+		// sometimes, specifically when reading local files, we have more info
+		// about the file type at this time than what we had before
+		s.headersToApply.ContentType = ps.GetInferredContentType(s.jptm)
+	}
 
 	destBlobTier := azblob.PremiumPageBlobAccessTierType(s.destBlobTier)
 	if !ValidateTier(s.jptm, s.destBlobTier, s.destPageBlobURL.BlobURL, s.jptm.Context()) {

--- a/ste/sender-pageBlob.go
+++ b/ste/sender-pageBlob.go
@@ -225,7 +225,7 @@ func (s *pageBlobSenderBase) Prologue(ps common.PrologueState) (destinationModif
 		destinationModified = true
 	}
 
-	if s.jptm.CanInferContentType() {
+	if s.jptm.ShouldInferContentType() {
 		// sometimes, specifically when reading local files, we have more info
 		// about the file type at this time than what we had before
 		s.headersToApply.ContentType = ps.GetInferredContentType(s.jptm)

--- a/ste/sender-pageBlob.go
+++ b/ste/sender-pageBlob.go
@@ -225,7 +225,8 @@ func (s *pageBlobSenderBase) Prologue(ps common.PrologueState) (destinationModif
 		destinationModified = true
 	}
 
-	if ps.CanInferContentType() {
+	fromTo := s.jptm.FromTo()
+	if ps.CanInferContentType(fromTo) {
 		// sometimes, specifically when reading local files, we have more info
 		// about the file type at this time than what we had before
 		s.headersToApply.ContentType = ps.GetInferredContentType(s.jptm)


### PR DESCRIPTION
Scenarios to consider
- Remote source: Content Type should always be preserved.
- Local File:
    -  Files with size less than ``512 bytes`` including ``0 byte``.
    -  File with size greater than or equal to ``512 bytes``.

FYI: How Infer Content Type works for local files
1. Try to infer content type on the basis of file extension. 
    1. [Get file extension](https://golang.org/pkg/path/filepath/#Ext).
    2. [Get MIME type using file extension](https://golang.org/pkg/mime/#TypeByExtension)
2. If above step fails, try to [get the content type by considering at most the first 512 bytes of data](https://golang.org/pkg/net/http/#DetectContentType). 
