### PR TITLE
[AzCopyV10][Feature] Add support for CPK-N and CPK-V

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -1070,7 +1070,7 @@ func (cca *cookedCopyCmdArgs) processRedirectionDownload(blobResource common.Res
 
 	// step 3: start download
 	blobURL := azblob.NewBlobURL(*u, p)
-	blobStream, err := blobURL.Download(ctx, 0, azblob.CountToEnd, azblob.BlobAccessConditions{}, false)
+	blobStream, err := blobURL.Download(ctx, 0, azblob.CountToEnd, azblob.BlobAccessConditions{}, false, azblob.ClientProvidedKeyOptions{})
 	if err != nil {
 		return fmt.Errorf("fatal: cannot download blob due to error: %s", err.Error())
 	}

--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -240,6 +240,7 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 			jobPartOrder.Fpo,
 		)
 		transfer.BlobTags = cca.blobTags
+		transfer.CpkScopeInfo = cca.cpkScopeInfo
 
 		if shouldSendToSte {
 			return addTransfer(&jobPartOrder, transfer, cca)

--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -54,7 +54,7 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 	jobPartOrder.DestLengthValidation = cca.CheckLength
 	jobPartOrder.S2SInvalidMetadataHandleOption = cca.s2sInvalidMetadataHandleOption
 
-	traverser, err = initResourceTraverser(cca.source, cca.fromTo.From(), &ctx, &srcCredInfo, &cca.followSymlinks, cca.listOfFilesChannel, cca.recursive, getRemoteProperties, cca.includeDirectoryStubs, func(common.EntityType) {}, cca.listOfVersionIDs)
+	traverser, err = initResourceTraverser(cca.source, cca.fromTo.From(), &ctx, &srcCredInfo, &cca.followSymlinks, cca.listOfFilesChannel, cca.recursive, getRemoteProperties, cca.includeDirectoryStubs, func(common.EntityType) {}, cca.listOfVersionIDs, cca.cpkInfo, cca.cpkScopeInfo)
 
 	if err != nil {
 		return nil, err
@@ -240,6 +240,7 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 			jobPartOrder.Fpo,
 		)
 		transfer.BlobTags = cca.blobTags
+		transfer.CpkInfo = cca.cpkInfo
 		transfer.CpkScopeInfo = cca.cpkScopeInfo
 
 		if shouldSendToSte {
@@ -269,7 +270,7 @@ func (cca *cookedCopyCmdArgs) isDestDirectory(dst common.ResourceString, ctx *co
 		return false
 	}
 
-	rt, err := initResourceTraverser(dst, cca.fromTo.To(), ctx, &dstCredInfo, nil, nil, false, false, false, func(common.EntityType) {}, cca.listOfVersionIDs)
+	rt, err := initResourceTraverser(dst, cca.fromTo.To(), ctx, &dstCredInfo, nil, nil, false, false, false, func(common.EntityType) {}, cca.listOfVersionIDs, common.CpkInfo{}, common.CpkScopeInfo{})
 
 	if err != nil {
 		return false

--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -270,7 +270,7 @@ func (cca *cookedCopyCmdArgs) isDestDirectory(dst common.ResourceString, ctx *co
 		return false
 	}
 
-	rt, err := initResourceTraverser(dst, cca.fromTo.To(), ctx, &dstCredInfo, nil, nil, false, false, false, func(common.EntityType) {}, cca.listOfVersionIDs, common.CpkInfo{}, common.CpkScopeInfo{})
+	rt, err := initResourceTraverser(dst, cca.fromTo.To(), ctx, &dstCredInfo, nil, nil, false, false, false, func(common.EntityType) {}, cca.listOfVersionIDs, cca.cpkInfo, cca.cpkScopeInfo)
 
 	if err != nil {
 		return false

--- a/cmd/credentialUtil.go
+++ b/cmd/credentialUtil.go
@@ -184,7 +184,7 @@ func getBlobCredentialType(ctx context.Context, blobResourceURL string, canBePub
 		if !isContainer {
 			// Scenario 3: When resourceURL points to a blob
 			blobURL := azblob.NewBlobURL(*resourceURL, p)
-			if _, err := blobURL.GetProperties(ctx, azblob.BlobAccessConditions{}); err == nil {
+			if _, err := blobURL.GetProperties(ctx, azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{}); err == nil {
 				return true
 			}
 		}

--- a/cmd/credentialUtil.go
+++ b/cmd/credentialUtil.go
@@ -251,6 +251,24 @@ func getBlobFSCredentialType(ctx context.Context, blobResourceURL string, standa
 	}
 }
 
+// Default Encryption Algorithm Supported
+const EncryptionAlgorithmAES256 string = "AES256"
+
+func getCPKInfo() (common.CpkInfo, error) {
+	encryptionKey := glcm.GetEnvironmentVariable(common.EEnvironmentVariable.CPKEncryptionKey())
+	encryptionKeySha256 := glcm.GetEnvironmentVariable(common.EEnvironmentVariable.CPKEncryptionKeySha256())
+	encryptionAlgorithmAES256 := EncryptionAlgorithmAES256
+	if encryptionKey == "" || encryptionKeySha256 == "" {
+		return common.CpkInfo{}, errors.New("failed to fetch cpk encryption key or hash")
+	}
+	return common.CpkInfo{
+		EncryptionKey:       &encryptionKey,
+		EncryptionKeySha256: &encryptionKeySha256,
+		EncryptionAlgorithm: &encryptionAlgorithmAES256,
+	}, nil
+
+}
+
 var announceOAuthTokenOnce sync.Once
 
 func oAuthTokenExists() (oauthTokenExists bool) {

--- a/cmd/credentialUtil.go
+++ b/cmd/credentialUtil.go
@@ -184,6 +184,7 @@ func getBlobCredentialType(ctx context.Context, blobResourceURL string, canBePub
 		if !isContainer {
 			// Scenario 3: When resourceURL points to a blob
 			blobURL := azblob.NewBlobURL(*resourceURL, p)
+			// TODO: Come here. CPK needs to be passed here
 			if _, err := blobURL.GetProperties(ctx, azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{}); err == nil {
 				return true
 			}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -119,7 +119,7 @@ func HandleListContainerCommand(unparsedSource string, location common.Location)
 		}
 	}
 
-	traverser, err := initResourceTraverser(source, location, &ctx, &credentialInfo, nil, nil, true, false, false, func(common.EntityType) {}, nil)
+	traverser, err := initResourceTraverser(source, location, &ctx, &credentialInfo, nil, nil, true, false, false, func(common.EntityType) {}, nil, common.CpkInfo{}, common.CpkScopeInfo{})
 
 	if err != nil {
 		return fmt.Errorf("failed to initialize traverser: %s", err.Error())

--- a/cmd/removeEnumerator.go
+++ b/cmd/removeEnumerator.go
@@ -46,8 +46,7 @@ func newRemoveEnumerator(cca *cookedCopyCmdArgs) (enumerator *copyEnumerator, er
 	ctx := context.WithValue(context.TODO(), ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
 
 	// Include-path is handled by ListOfFilesChannel.
-	sourceTraverser, err = initResourceTraverser(cca.source, cca.fromTo.From(), &ctx, &cca.credentialInfo, nil,
-		cca.listOfFilesChannel, cca.recursive, false, cca.includeDirectoryStubs, func(common.EntityType) {}, cca.listOfVersionIDs)
+	sourceTraverser, err = initResourceTraverser(cca.source, cca.fromTo.From(), &ctx, &cca.credentialInfo, nil, cca.listOfFilesChannel, cca.recursive, false, cca.includeDirectoryStubs, func(common.EntityType) {}, cca.listOfVersionIDs, common.CpkInfo{}, common.CpkScopeInfo{})
 
 	// report failure to create traverser
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -208,7 +208,7 @@ func beginDetectNewVersion() chan struct{} {
 
 		// step 3: start download
 		blobURL := azblob.NewBlobURL(*u, p)
-		blobStream, err := blobURL.Download(context.TODO(), 0, azblob.CountToEnd, azblob.BlobAccessConditions{}, false)
+		blobStream, err := blobURL.Download(context.TODO(), 0, azblob.CountToEnd, azblob.BlobAccessConditions{}, false, azblob.ClientProvidedKeyOptions{})
 		if err != nil {
 			return
 		}

--- a/cmd/syncEnumerator.go
+++ b/cmd/syncEnumerator.go
@@ -62,7 +62,7 @@ func (cca *cookedSyncCmdArgs) initEnumerator(ctx context.Context) (enumerator *s
 		if entityType == common.EEntityType.File() {
 			atomic.AddUint64(&cca.atomicSourceFilesScanned, 1)
 		}
-	}, nil)
+	}, nil, common.CpkInfo{}, common.CpkScopeInfo{})
 
 	if err != nil {
 		return nil, err
@@ -82,7 +82,7 @@ func (cca *cookedSyncCmdArgs) initEnumerator(ctx context.Context) (enumerator *s
 		if entityType == common.EEntityType.File() {
 			atomic.AddUint64(&cca.atomicDestinationFilesScanned, 1)
 		}
-	}, nil)
+	}, nil, common.CpkInfo{}, common.CpkScopeInfo{})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/syncTraverser.go
+++ b/cmd/syncTraverser.go
@@ -70,7 +70,7 @@ func newLocalTraverserForSync(cca *cookedSyncCmdArgs, isSource bool) (*localTrav
 	return traverser, nil
 }
 
-func newBlobTraverserForSync(cca *cookedSyncCmdArgs, isSource bool) (t *blobTraverser, err error) {
+func newBlobTraverserForSync(cca *cookedSyncCmdArgs, isSource bool, cpkInfo common.CpkScopeInfo) (t *blobTraverser, err error) {
 	ctx := context.WithValue(context.TODO(), ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
 
 	// figure out the right URL
@@ -109,5 +109,5 @@ func newBlobTraverserForSync(cca *cookedSyncCmdArgs, isSource bool) (t *blobTrav
 		}
 	}
 
-	return newBlobTraverser(rawURL, p, ctx, cca.recursive, false, incrementEnumerationCounter), nil
+	return newBlobTraverser(rawURL, p, ctx, cca.recursive, false, incrementEnumerationCounter, cpkInfo), nil
 }

--- a/cmd/syncTraverser.go
+++ b/cmd/syncTraverser.go
@@ -70,7 +70,7 @@ func newLocalTraverserForSync(cca *cookedSyncCmdArgs, isSource bool) (*localTrav
 	return traverser, nil
 }
 
-func newBlobTraverserForSync(cca *cookedSyncCmdArgs, isSource bool, cpkInfo common.CpkScopeInfo) (t *blobTraverser, err error) {
+func newBlobTraverserForSync(cca *cookedSyncCmdArgs, isSource bool, cpkInfo common.CpkInfo, cpkScopeInfo common.CpkScopeInfo) (t *blobTraverser, err error) {
 	ctx := context.WithValue(context.TODO(), ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
 
 	// figure out the right URL
@@ -109,5 +109,5 @@ func newBlobTraverserForSync(cca *cookedSyncCmdArgs, isSource bool, cpkInfo comm
 		}
 	}
 
-	return newBlobTraverser(rawURL, p, ctx, cca.recursive, false, incrementEnumerationCounter, cpkInfo), nil
+	return newBlobTraverser(rawURL, p, ctx, cca.recursive, false, incrementEnumerationCounter, cpkInfo, cpkScopeInfo), nil
 }

--- a/cmd/zc_enumerator.go
+++ b/cmd/zc_enumerator.go
@@ -293,8 +293,7 @@ type enumerationCounterFunc func(entityType common.EntityType)
 // ctx, pipeline are only required for remote resources.
 // followSymlinks is only required for local resources (defaults to false)
 // errorOnDirWOutRecursive is used by copy.
-func initResourceTraverser(resource common.ResourceString, location common.Location, ctx *context.Context, credential *common.CredentialInfo,
-	followSymlinks *bool, listOfFilesChannel chan string, recursive, getProperties, includeDirectoryStubs bool, incrementEnumerationCounter enumerationCounterFunc, listOfVersionIds chan string) (resourceTraverser, error) {
+func initResourceTraverser(resource common.ResourceString, location common.Location, ctx *context.Context, credential *common.CredentialInfo, followSymlinks *bool, listOfFilesChannel chan string, recursive, getProperties, includeDirectoryStubs bool, incrementEnumerationCounter enumerationCounterFunc, listOfVersionIds chan string, cpkInfo common.CpkInfo, cpkScopeInfo common.CpkScopeInfo) (resourceTraverser, error) {
 	var output resourceTraverser
 	var p *pipeline.Pipeline
 
@@ -389,11 +388,11 @@ func initResourceTraverser(resource common.ResourceString, location common.Locat
 				return nil, errors.New(accountTraversalInherentlyRecursiveError)
 			}
 
-			output = newBlobAccountTraverser(resourceURL, *p, *ctx, includeDirectoryStubs, incrementEnumerationCounter, common.CpkScopeInfo{})
+			output = newBlobAccountTraverser(resourceURL, *p, *ctx, includeDirectoryStubs, incrementEnumerationCounter, cpkInfo, cpkScopeInfo)
 		} else if listOfVersionIds != nil {
-			output = newBlobVersionsTraverser(resourceURL, *p, *ctx, recursive, includeDirectoryStubs, incrementEnumerationCounter, listOfVersionIds, common.CpkScopeInfo{})
+			output = newBlobVersionsTraverser(resourceURL, *p, *ctx, recursive, includeDirectoryStubs, incrementEnumerationCounter, listOfVersionIds, cpkInfo, cpkScopeInfo)
 		} else {
-			output = newBlobTraverser(resourceURL, *p, *ctx, recursive, includeDirectoryStubs, incrementEnumerationCounter, common.CpkScopeInfo{})
+			output = newBlobTraverser(resourceURL, *p, *ctx, recursive, includeDirectoryStubs, incrementEnumerationCounter, cpkInfo, cpkScopeInfo)
 		}
 	case common.ELocation.File():
 		resourceURL, err := resource.FullURL()

--- a/cmd/zc_enumerator.go
+++ b/cmd/zc_enumerator.go
@@ -389,11 +389,11 @@ func initResourceTraverser(resource common.ResourceString, location common.Locat
 				return nil, errors.New(accountTraversalInherentlyRecursiveError)
 			}
 
-			output = newBlobAccountTraverser(resourceURL, *p, *ctx, includeDirectoryStubs, incrementEnumerationCounter)
+			output = newBlobAccountTraverser(resourceURL, *p, *ctx, includeDirectoryStubs, incrementEnumerationCounter, common.CpkScopeInfo{})
 		} else if listOfVersionIds != nil {
-			output = newBlobVersionsTraverser(resourceURL, *p, *ctx, recursive, includeDirectoryStubs, incrementEnumerationCounter, listOfVersionIds)
+			output = newBlobVersionsTraverser(resourceURL, *p, *ctx, recursive, includeDirectoryStubs, incrementEnumerationCounter, listOfVersionIds, common.CpkScopeInfo{})
 		} else {
-			output = newBlobTraverser(resourceURL, *p, *ctx, recursive, includeDirectoryStubs, incrementEnumerationCounter)
+			output = newBlobTraverser(resourceURL, *p, *ctx, recursive, includeDirectoryStubs, incrementEnumerationCounter, common.CpkScopeInfo{})
 		}
 	case common.ELocation.File():
 		resourceURL, err := resource.FullURL()

--- a/cmd/zc_traverser_blob.go
+++ b/cmd/zc_traverser_blob.go
@@ -81,7 +81,7 @@ func (t *blobTraverser) getPropertiesIfSingleBlob() (props *azblob.BlobGetProper
 
 	// perform the check
 	blobURL := azblob.NewBlobURL(blobUrlParts.URL(), t.p)
-	props, err = blobURL.GetProperties(t.ctx, azblob.BlobAccessConditions{})
+	props, err = blobURL.GetProperties(t.ctx, azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
 
 	// if there was no problem getting the properties, it means that we are looking at a single blob
 	if err == nil {

--- a/cmd/zc_traverser_blob_account.go
+++ b/cmd/zc_traverser_blob_account.go
@@ -38,7 +38,8 @@ type blobAccountTraverser struct {
 	containerPattern      string
 	cachedContainers      []string
 	includeDirectoryStubs bool
-	cpkInfo               common.CpkScopeInfo
+	cpkInfo               common.CpkInfo
+	cpkScopeInfo          common.CpkScopeInfo
 
 	// a generic function to notify that a new stored object has been enumerated
 	incrementEnumerationCounter enumerationCounterFunc
@@ -97,7 +98,7 @@ func (t *blobAccountTraverser) traverse(preprocessor objectMorpher, processor ob
 
 	for _, v := range cList {
 		containerURL := t.accountURL.NewContainerURL(v).URL()
-		containerTraverser := newBlobTraverser(&containerURL, t.p, t.ctx, true, t.includeDirectoryStubs, t.incrementEnumerationCounter, t.cpkInfo)
+		containerTraverser := newBlobTraverser(&containerURL, t.p, t.ctx, true, t.includeDirectoryStubs, t.incrementEnumerationCounter, t.cpkInfo, t.cpkScopeInfo)
 
 		preprocessorForThisChild := preprocessor.FollowedBy(newContainerDecorator(v))
 
@@ -112,7 +113,7 @@ func (t *blobAccountTraverser) traverse(preprocessor objectMorpher, processor ob
 	return nil
 }
 
-func newBlobAccountTraverser(rawURL *url.URL, p pipeline.Pipeline, ctx context.Context, includeDirectoryStubs bool, incrementEnumerationCounter enumerationCounterFunc, cpkInfo common.CpkScopeInfo) (t *blobAccountTraverser) {
+func newBlobAccountTraverser(rawURL *url.URL, p pipeline.Pipeline, ctx context.Context, includeDirectoryStubs bool, incrementEnumerationCounter enumerationCounterFunc, cpkInfo common.CpkInfo, cpkScopeInfo common.CpkScopeInfo) (t *blobAccountTraverser) {
 	bURLParts := azblob.NewBlobURLParts(*rawURL)
 	cPattern := bURLParts.ContainerName
 
@@ -121,8 +122,16 @@ func newBlobAccountTraverser(rawURL *url.URL, p pipeline.Pipeline, ctx context.C
 		bURLParts.ContainerName = ""
 	}
 
-	t = &blobAccountTraverser{p: p, ctx: ctx, incrementEnumerationCounter: incrementEnumerationCounter,
-		accountURL: azblob.NewServiceURL(bURLParts.URL(), p), containerPattern: cPattern, includeDirectoryStubs: includeDirectoryStubs, cpkInfo: cpkInfo}
+	t = &blobAccountTraverser{
+		p:                           p,
+		ctx:                         ctx,
+		incrementEnumerationCounter: incrementEnumerationCounter,
+		accountURL:                  azblob.NewServiceURL(bURLParts.URL(), p),
+		containerPattern:            cPattern,
+		includeDirectoryStubs:       includeDirectoryStubs,
+		cpkInfo:                     cpkInfo,
+		cpkScopeInfo:                cpkScopeInfo,
+	}
 
 	return
 }

--- a/cmd/zc_traverser_blob_versions.go
+++ b/cmd/zc_traverser_blob_versions.go
@@ -60,7 +60,7 @@ func (t *blobVersionsTraverser) getBlobProperties(versionID string) (props *azbl
 	}
 
 	blobURL := azblob.NewBlobURL(blobURLParts.URL(), t.p)
-	props, err = blobURL.GetProperties(t.ctx, azblob.BlobAccessConditions{})
+	props, err = blobURL.GetProperties(t.ctx, azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
 	return props, err
 }
 

--- a/cmd/zc_traverser_list.go
+++ b/cmd/zc_traverser_list.go
@@ -104,7 +104,7 @@ func newListTraverser(parent common.ResourceString, parentType common.Location, 
 		}
 
 		// Construct a traverser that goes through the child
-		traverser, err := initResourceTraverser(source, parentType, ctx, credential, &followSymlinks, nil, recursive, getProperties, includeDirectoryStubs, incrementEnumerationCounter, nil)
+		traverser, err := initResourceTraverser(source, parentType, ctx, credential, &followSymlinks, nil, recursive, getProperties, includeDirectoryStubs, incrementEnumerationCounter, nil, common.CpkInfo{}, common.CpkScopeInfo{})
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/zt_copy_blob_download_test.go
+++ b/cmd/zt_copy_blob_download_test.go
@@ -171,7 +171,7 @@ func (s *cmdIntegrationSuite) TestDownloadAccount(c *chk.C) {
 
 	// Traverse the account ahead of time and determine the relative paths for testing.
 	relPaths := make([]string, 0) // Use a map for easy lookup
-	blobTraverser := newBlobAccountTraverser(&rawBSU, p, ctx, false, func(common.EntityType) {})
+	blobTraverser := newBlobAccountTraverser(&rawBSU, p, ctx, false, func(common.EntityType) {}, common.CpkScopeInfo{})
 	processor := func(object storedObject) error {
 		// Append the container name to the relative path
 		relPath := "/" + object.containerName + "/" + object.relativePath
@@ -219,7 +219,7 @@ func (s *cmdIntegrationSuite) TestDownloadAccountWildcard(c *chk.C) {
 
 	// Traverse the account ahead of time and determine the relative paths for testing.
 	relPaths := make([]string, 0) // Use a map for easy lookup
-	blobTraverser := newBlobAccountTraverser(&rawBSU, p, ctx, false, func(common.EntityType) {})
+	blobTraverser := newBlobAccountTraverser(&rawBSU, p, ctx, false, func(common.EntityType) {}, common.CpkScopeInfo{})
 	processor := func(object storedObject) error {
 		// Append the container name to the relative path
 		relPath := "/" + object.containerName + "/" + object.relativePath

--- a/cmd/zt_copy_blob_download_test.go
+++ b/cmd/zt_copy_blob_download_test.go
@@ -171,7 +171,7 @@ func (s *cmdIntegrationSuite) TestDownloadAccount(c *chk.C) {
 
 	// Traverse the account ahead of time and determine the relative paths for testing.
 	relPaths := make([]string, 0) // Use a map for easy lookup
-	blobTraverser := newBlobAccountTraverser(&rawBSU, p, ctx, false, func(common.EntityType) {}, common.CpkScopeInfo{})
+	blobTraverser := newBlobAccountTraverser(&rawBSU, p, ctx, false, func(common.EntityType) {}, common.CpkInfo{}, common.CpkScopeInfo{})
 	processor := func(object storedObject) error {
 		// Append the container name to the relative path
 		relPath := "/" + object.containerName + "/" + object.relativePath
@@ -219,7 +219,7 @@ func (s *cmdIntegrationSuite) TestDownloadAccountWildcard(c *chk.C) {
 
 	// Traverse the account ahead of time and determine the relative paths for testing.
 	relPaths := make([]string, 0) // Use a map for easy lookup
-	blobTraverser := newBlobAccountTraverser(&rawBSU, p, ctx, false, func(common.EntityType) {}, common.CpkScopeInfo{})
+	blobTraverser := newBlobAccountTraverser(&rawBSU, p, ctx, false, func(common.EntityType) {}, common.CpkInfo{}, common.CpkScopeInfo{})
 	processor := func(object storedObject) error {
 		// Append the container name to the relative path
 		relPath := "/" + object.containerName + "/" + object.relativePath

--- a/cmd/zt_generic_service_traverser_test.go
+++ b/cmd/zt_generic_service_traverser_test.go
@@ -165,7 +165,7 @@ func (s *genericTraverserSuite) TestServiceTraverserWithManyObjects(c *chk.C) {
 	// construct a blob account traverser
 	blobPipeline := azblob.NewPipeline(azblob.NewAnonymousCredential(), azblob.PipelineOptions{})
 	rawBSU := scenarioHelper{}.getRawBlobServiceURLWithSAS(c)
-	blobAccountTraverser := newBlobAccountTraverser(&rawBSU, blobPipeline, ctx, false, func(common.EntityType) {}, common.CpkScopeInfo{})
+	blobAccountTraverser := newBlobAccountTraverser(&rawBSU, blobPipeline, ctx, false, func(common.EntityType) {}, common.CpkInfo{}, common.CpkScopeInfo{})
 
 	// invoke the blob account traversal with a dummy processor
 	blobDummyProcessor := dummyProcessor{}
@@ -316,7 +316,7 @@ func (s *genericTraverserSuite) TestServiceTraverserWithWildcards(c *chk.C) {
 	blobPipeline := azblob.NewPipeline(azblob.NewAnonymousCredential(), azblob.PipelineOptions{})
 	rawBSU := scenarioHelper{}.getRawBlobServiceURLWithSAS(c)
 	rawBSU.Path = "/objectmatch*" // set the container name to contain a wildcard
-	blobAccountTraverser := newBlobAccountTraverser(&rawBSU, blobPipeline, ctx, false, func(common.EntityType) {}, common.CpkScopeInfo{})
+	blobAccountTraverser := newBlobAccountTraverser(&rawBSU, blobPipeline, ctx, false, func(common.EntityType) {}, common.CpkInfo{}, common.CpkScopeInfo{})
 
 	// invoke the blob account traversal with a dummy processor
 	blobDummyProcessor := dummyProcessor{}

--- a/cmd/zt_generic_service_traverser_test.go
+++ b/cmd/zt_generic_service_traverser_test.go
@@ -165,7 +165,7 @@ func (s *genericTraverserSuite) TestServiceTraverserWithManyObjects(c *chk.C) {
 	// construct a blob account traverser
 	blobPipeline := azblob.NewPipeline(azblob.NewAnonymousCredential(), azblob.PipelineOptions{})
 	rawBSU := scenarioHelper{}.getRawBlobServiceURLWithSAS(c)
-	blobAccountTraverser := newBlobAccountTraverser(&rawBSU, blobPipeline, ctx, false, func(common.EntityType) {})
+	blobAccountTraverser := newBlobAccountTraverser(&rawBSU, blobPipeline, ctx, false, func(common.EntityType) {}, common.CpkScopeInfo{})
 
 	// invoke the blob account traversal with a dummy processor
 	blobDummyProcessor := dummyProcessor{}
@@ -316,7 +316,7 @@ func (s *genericTraverserSuite) TestServiceTraverserWithWildcards(c *chk.C) {
 	blobPipeline := azblob.NewPipeline(azblob.NewAnonymousCredential(), azblob.PipelineOptions{})
 	rawBSU := scenarioHelper{}.getRawBlobServiceURLWithSAS(c)
 	rawBSU.Path = "/objectmatch*" // set the container name to contain a wildcard
-	blobAccountTraverser := newBlobAccountTraverser(&rawBSU, blobPipeline, ctx, false, func(common.EntityType) {})
+	blobAccountTraverser := newBlobAccountTraverser(&rawBSU, blobPipeline, ctx, false, func(common.EntityType) {}, common.CpkScopeInfo{})
 
 	// invoke the blob account traversal with a dummy processor
 	blobDummyProcessor := dummyProcessor{}

--- a/cmd/zt_generic_traverser_test.go
+++ b/cmd/zt_generic_traverser_test.go
@@ -421,7 +421,7 @@ func (s *genericTraverserSuite) TestTraverserWithSingleObject(c *chk.C) {
 		ctx := context.WithValue(context.TODO(), ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
 		p := azblob.NewPipeline(azblob.NewAnonymousCredential(), azblob.PipelineOptions{})
 		rawBlobURLWithSAS := scenarioHelper{}.getRawBlobURLWithSAS(c, containerName, blobList[0])
-		blobTraverser := newBlobTraverser(&rawBlobURLWithSAS, p, ctx, false, false, func(common.EntityType) {}, common.CpkScopeInfo{})
+		blobTraverser := newBlobTraverser(&rawBlobURLWithSAS, p, ctx, false, false, func(common.EntityType) {}, common.CpkInfo{}, common.CpkScopeInfo{})
 
 		// invoke the blob traversal with a dummy processor
 		blobDummyProcessor := dummyProcessor{}
@@ -554,7 +554,7 @@ func (s *genericTraverserSuite) TestTraverserContainerAndLocalDirectory(c *chk.C
 		ctx := context.WithValue(context.TODO(), ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
 		p := azblob.NewPipeline(azblob.NewAnonymousCredential(), azblob.PipelineOptions{})
 		rawContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, containerName)
-		blobTraverser := newBlobTraverser(&rawContainerURLWithSAS, p, ctx, isRecursiveOn, false, func(common.EntityType) {}, common.CpkScopeInfo{})
+		blobTraverser := newBlobTraverser(&rawContainerURLWithSAS, p, ctx, isRecursiveOn, false, func(common.EntityType) {}, common.CpkInfo{}, common.CpkScopeInfo{})
 
 		// invoke the local traversal with a dummy processor
 		blobDummyProcessor := dummyProcessor{}
@@ -694,7 +694,7 @@ func (s *genericTraverserSuite) TestTraverserWithVirtualAndLocalDirectory(c *chk
 		ctx := context.WithValue(context.TODO(), ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
 		p := azblob.NewPipeline(azblob.NewAnonymousCredential(), azblob.PipelineOptions{})
 		rawVirDirURLWithSAS := scenarioHelper{}.getRawBlobURLWithSAS(c, containerName, virDirName)
-		blobTraverser := newBlobTraverser(&rawVirDirURLWithSAS, p, ctx, isRecursiveOn, false, func(common.EntityType) {}, common.CpkScopeInfo{})
+		blobTraverser := newBlobTraverser(&rawVirDirURLWithSAS, p, ctx, isRecursiveOn, false, func(common.EntityType) {}, common.CpkInfo{}, common.CpkScopeInfo{})
 
 		// invoke the local traversal with a dummy processor
 		blobDummyProcessor := dummyProcessor{}
@@ -791,10 +791,10 @@ func (s *genericTraverserSuite) TestSerialAndParallelBlobTraverser(c *chk.C) {
 		ctx := context.WithValue(context.TODO(), ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
 		p := azblob.NewPipeline(azblob.NewAnonymousCredential(), azblob.PipelineOptions{})
 		rawVirDirURLWithSAS := scenarioHelper{}.getRawBlobURLWithSAS(c, containerName, virDirName)
-		parallelBlobTraverser := newBlobTraverser(&rawVirDirURLWithSAS, p, ctx, isRecursiveOn, false, func(common.EntityType) {}, common.CpkScopeInfo{})
+		parallelBlobTraverser := newBlobTraverser(&rawVirDirURLWithSAS, p, ctx, isRecursiveOn, false, func(common.EntityType) {}, common.CpkInfo{}, common.CpkScopeInfo{})
 
 		// construct a serial blob traverser
-		serialBlobTraverser := newBlobTraverser(&rawVirDirURLWithSAS, p, ctx, isRecursiveOn, false, func(common.EntityType) {}, common.CpkScopeInfo{})
+		serialBlobTraverser := newBlobTraverser(&rawVirDirURLWithSAS, p, ctx, isRecursiveOn, false, func(common.EntityType) {}, common.CpkInfo{}, common.CpkScopeInfo{})
 		serialBlobTraverser.parallelListing = false
 
 		// invoke the parallel traversal with a dummy processor

--- a/cmd/zt_generic_traverser_test.go
+++ b/cmd/zt_generic_traverser_test.go
@@ -421,7 +421,7 @@ func (s *genericTraverserSuite) TestTraverserWithSingleObject(c *chk.C) {
 		ctx := context.WithValue(context.TODO(), ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
 		p := azblob.NewPipeline(azblob.NewAnonymousCredential(), azblob.PipelineOptions{})
 		rawBlobURLWithSAS := scenarioHelper{}.getRawBlobURLWithSAS(c, containerName, blobList[0])
-		blobTraverser := newBlobTraverser(&rawBlobURLWithSAS, p, ctx, false, false, func(common.EntityType) {})
+		blobTraverser := newBlobTraverser(&rawBlobURLWithSAS, p, ctx, false, false, func(common.EntityType) {}, common.CpkScopeInfo{})
 
 		// invoke the blob traversal with a dummy processor
 		blobDummyProcessor := dummyProcessor{}
@@ -554,7 +554,7 @@ func (s *genericTraverserSuite) TestTraverserContainerAndLocalDirectory(c *chk.C
 		ctx := context.WithValue(context.TODO(), ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
 		p := azblob.NewPipeline(azblob.NewAnonymousCredential(), azblob.PipelineOptions{})
 		rawContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, containerName)
-		blobTraverser := newBlobTraverser(&rawContainerURLWithSAS, p, ctx, isRecursiveOn, false, func(common.EntityType) {})
+		blobTraverser := newBlobTraverser(&rawContainerURLWithSAS, p, ctx, isRecursiveOn, false, func(common.EntityType) {}, common.CpkScopeInfo{})
 
 		// invoke the local traversal with a dummy processor
 		blobDummyProcessor := dummyProcessor{}
@@ -694,7 +694,7 @@ func (s *genericTraverserSuite) TestTraverserWithVirtualAndLocalDirectory(c *chk
 		ctx := context.WithValue(context.TODO(), ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
 		p := azblob.NewPipeline(azblob.NewAnonymousCredential(), azblob.PipelineOptions{})
 		rawVirDirURLWithSAS := scenarioHelper{}.getRawBlobURLWithSAS(c, containerName, virDirName)
-		blobTraverser := newBlobTraverser(&rawVirDirURLWithSAS, p, ctx, isRecursiveOn, false, func(common.EntityType) {})
+		blobTraverser := newBlobTraverser(&rawVirDirURLWithSAS, p, ctx, isRecursiveOn, false, func(common.EntityType) {}, common.CpkScopeInfo{})
 
 		// invoke the local traversal with a dummy processor
 		blobDummyProcessor := dummyProcessor{}
@@ -791,10 +791,10 @@ func (s *genericTraverserSuite) TestSerialAndParallelBlobTraverser(c *chk.C) {
 		ctx := context.WithValue(context.TODO(), ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
 		p := azblob.NewPipeline(azblob.NewAnonymousCredential(), azblob.PipelineOptions{})
 		rawVirDirURLWithSAS := scenarioHelper{}.getRawBlobURLWithSAS(c, containerName, virDirName)
-		parallelBlobTraverser := newBlobTraverser(&rawVirDirURLWithSAS, p, ctx, isRecursiveOn, false, func(common.EntityType) {})
+		parallelBlobTraverser := newBlobTraverser(&rawVirDirURLWithSAS, p, ctx, isRecursiveOn, false, func(common.EntityType) {}, common.CpkScopeInfo{})
 
 		// construct a serial blob traverser
-		serialBlobTraverser := newBlobTraverser(&rawVirDirURLWithSAS, p, ctx, isRecursiveOn, false, func(common.EntityType) {})
+		serialBlobTraverser := newBlobTraverser(&rawVirDirURLWithSAS, p, ctx, isRecursiveOn, false, func(common.EntityType) {}, common.CpkScopeInfo{})
 		serialBlobTraverser.parallelListing = false
 
 		// invoke the parallel traversal with a dummy processor

--- a/cmd/zt_scenario_helpers_for_test.go
+++ b/cmd/zt_scenario_helpers_for_test.go
@@ -285,7 +285,7 @@ func (scenarioHelper) generateBlobsFromList(c *chk.C, containerURL azblob.Contai
 	for _, blobName := range blobList {
 		blob := containerURL.NewBlockBlobURL(blobName)
 		cResp, err := blob.Upload(ctx, strings.NewReader(data), azblob.BlobHTTPHeaders{},
-			nil, azblob.BlobAccessConditions{}, azblob.DefaultAccessTier, nil)
+			nil, azblob.BlobAccessConditions{}, azblob.DefaultAccessTier, nil, azblob.ClientProvidedKeyOptions{})
 		c.Assert(err, chk.IsNil)
 		c.Assert(cResp.StatusCode(), chk.Equals, 201)
 	}
@@ -307,7 +307,8 @@ func (scenarioHelper) generatePageBlobsFromList(c *chk.C, containerURL azblob.Co
 			azblob.Metadata{},
 			azblob.BlobAccessConditions{},
 			azblob.DefaultPremiumBlobAccessTier,
-			nil,
+			nil, // Blob Tags Map
+			azblob.ClientProvidedKeyOptions{},
 		)
 		c.Assert(err, chk.IsNil)
 		c.Assert(cResp.StatusCode(), chk.Equals, 201)
@@ -317,7 +318,8 @@ func (scenarioHelper) generatePageBlobsFromList(c *chk.C, containerURL azblob.Co
 			0,
 			strings.NewReader(data),
 			azblob.PageBlobAccessConditions{},
-			nil,
+			nil, // Transactional MD5
+			azblob.ClientProvidedKeyOptions{},
 		)
 		c.Assert(err, chk.IsNil)
 		c.Assert(uResp.StatusCode(), chk.Equals, 201)
@@ -338,6 +340,7 @@ func (scenarioHelper) generateAppendBlobsFromList(c *chk.C, containerURL azblob.
 			azblob.Metadata{},
 			azblob.BlobAccessConditions{},
 			nil,
+			azblob.ClientProvidedKeyOptions{},
 		)
 		c.Assert(err, chk.IsNil)
 		c.Assert(cResp.StatusCode(), chk.Equals, 201)
@@ -346,7 +349,9 @@ func (scenarioHelper) generateAppendBlobsFromList(c *chk.C, containerURL azblob.
 		uResp, err := blob.AppendBlock(ctx,
 			strings.NewReader(data),
 			azblob.AppendBlobAccessConditions{},
-			nil)
+			nil, // Transactional MD5
+			azblob.ClientProvidedKeyOptions{},
+		)
 		c.Assert(err, chk.IsNil)
 		c.Assert(uResp.StatusCode(), chk.Equals, 201)
 	}
@@ -358,7 +363,7 @@ func (scenarioHelper) generateAppendBlobsFromList(c *chk.C, containerURL azblob.
 func (scenarioHelper) generateBlockBlobWithAccessTier(c *chk.C, containerURL azblob.ContainerURL, blobName string, accessTier azblob.AccessTierType) {
 	blob := containerURL.NewBlockBlobURL(blobName)
 	cResp, err := blob.Upload(ctx, strings.NewReader(blockBlobDefaultData), azblob.BlobHTTPHeaders{},
-		nil, azblob.BlobAccessConditions{}, accessTier, nil)
+		nil, azblob.BlobAccessConditions{}, accessTier, nil, azblob.ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(cResp.StatusCode(), chk.Equals, 201)
 }
@@ -622,7 +627,7 @@ func (scenarioHelper) getRawShareURLWithSAS(c *chk.C, shareName string) url.URL 
 }
 
 func (scenarioHelper) blobExists(blobURL azblob.BlobURL) bool {
-	_, err := blobURL.GetProperties(context.Background(), azblob.BlobAccessConditions{})
+	_, err := blobURL.GetProperties(context.Background(), azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
 	if err == nil {
 		return true
 	}

--- a/cmd/zt_sync_blob_blob_test.go
+++ b/cmd/zt_sync_blob_blob_test.go
@@ -648,7 +648,7 @@ func (s *cmdIntegrationSuite) TestSyncS2SADLSDirectory(c *chk.C) {
 
 	// create an ADLS Gen2 directory at the source with the exact same name as the vdir
 	_, err := srcContainerURL.NewBlockBlobURL(vdirName).Upload(context.Background(), bytes.NewReader(nil),
-		azblob.BlobHTTPHeaders{}, azblob.Metadata{"hdi_isfolder": "true"}, azblob.BlobAccessConditions{}, azblob.DefaultAccessTier, nil)
+		azblob.BlobHTTPHeaders{}, azblob.Metadata{"hdi_isfolder": "true"}, azblob.BlobAccessConditions{}, azblob.DefaultAccessTier, nil, azblob.ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	// set up interceptor

--- a/cmd/zt_sync_blob_local_test.go
+++ b/cmd/zt_sync_blob_local_test.go
@@ -531,7 +531,7 @@ func (s *cmdIntegrationSuite) TestSyncDownloadADLSDirectoryTypeMismatch(c *chk.C
 
 	// create a single blob that represents an ADLS directory
 	_, err := containerURL.NewBlockBlobURL(blobName).Upload(context.Background(), bytes.NewReader(nil),
-		azblob.BlobHTTPHeaders{}, azblob.Metadata{"hdi_isfolder": "true"}, azblob.BlobAccessConditions{}, azblob.DefaultAccessTier, nil)
+		azblob.BlobHTTPHeaders{}, azblob.Metadata{"hdi_isfolder": "true"}, azblob.BlobAccessConditions{}, azblob.DefaultAccessTier, nil, azblob.ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	// set up interceptor
@@ -568,12 +568,12 @@ func (s *cmdIntegrationSuite) TestSyncDownloadWithADLSDirectory(c *chk.C) {
 	// create a single blob that represents the ADLS directory
 	dirBlob := containerURL.NewBlockBlobURL(adlsDirName)
 	_, err := dirBlob.Upload(context.Background(), bytes.NewReader(nil),
-		azblob.BlobHTTPHeaders{}, azblob.Metadata{"hdi_isfolder": "true"}, azblob.BlobAccessConditions{}, azblob.DefaultAccessTier, nil)
+		azblob.BlobHTTPHeaders{}, azblob.Metadata{"hdi_isfolder": "true"}, azblob.BlobAccessConditions{}, azblob.DefaultAccessTier, nil, azblob.ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	// create an extra blob that represents an empty ADLS directory, which should never be picked up
 	_, err = containerURL.NewBlockBlobURL(adlsDirName+"/neverpickup").Upload(context.Background(), bytes.NewReader(nil),
-		azblob.BlobHTTPHeaders{}, azblob.Metadata{"hdi_isfolder": "true"}, azblob.BlobAccessConditions{}, azblob.DefaultAccessTier, nil)
+		azblob.BlobHTTPHeaders{}, azblob.Metadata{"hdi_isfolder": "true"}, azblob.BlobAccessConditions{}, azblob.DefaultAccessTier, nil, azblob.ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	// set up the destination with an empty folder

--- a/cmd/zt_sync_processor_test.go
+++ b/cmd/zt_sync_processor_test.go
@@ -74,7 +74,7 @@ func (s *syncProcessorSuite) TestBlobDeleter(c *chk.C) {
 
 	// validate that the blob exists
 	blobURL := containerURL.NewBlobURL(blobName)
-	_, err := blobURL.GetProperties(context.Background(), azblob.BlobAccessConditions{})
+	_, err := blobURL.GetProperties(context.Background(), azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	// construct the cooked input to simulate user input
@@ -95,7 +95,7 @@ func (s *syncProcessorSuite) TestBlobDeleter(c *chk.C) {
 	c.Assert(err, chk.IsNil)
 
 	// validate that the blob was deleted
-	_, err = blobURL.GetProperties(context.Background(), azblob.BlobAccessConditions{})
+	_, err = blobURL.GetProperties(context.Background(), azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
 	c.Assert(err, chk.NotNil)
 }
 

--- a/cmd/zt_test.go
+++ b/cmd/zt_test.go
@@ -312,7 +312,7 @@ func createNewBlockBlob(c *chk.C, container azblob.ContainerURL, prefix string) 
 	blob, name = getBlockBlobURL(c, container, prefix)
 
 	cResp, err := blob.Upload(ctx, strings.NewReader(blockBlobDefaultData), azblob.BlobHTTPHeaders{},
-		nil, azblob.BlobAccessConditions{}, azblob.DefaultAccessTier, nil)
+		nil, azblob.BlobAccessConditions{}, azblob.DefaultAccessTier, nil, azblob.ClientProvidedKeyOptions{})
 
 	c.Assert(err, chk.IsNil)
 	c.Assert(cResp.StatusCode(), chk.Equals, 201)
@@ -324,7 +324,7 @@ func createNewDirectoryStub(c *chk.C, container azblob.ContainerURL, dirPath str
 	dir := container.NewBlockBlobURL(dirPath)
 
 	cResp, err := dir.Upload(ctx, bytes.NewReader(nil), azblob.BlobHTTPHeaders{},
-		azblob.Metadata{"hdi_isfolder": "true"}, azblob.BlobAccessConditions{}, azblob.DefaultAccessTier, nil)
+		azblob.Metadata{"hdi_isfolder": "true"}, azblob.BlobAccessConditions{}, azblob.DefaultAccessTier, nil, azblob.ClientProvidedKeyOptions{})
 
 	c.Assert(err, chk.IsNil)
 	c.Assert(cResp.StatusCode(), chk.Equals, 201)
@@ -365,7 +365,7 @@ func generateParentsForAzureFile(c *chk.C, fileURL azfile.FileURL) {
 func createNewAppendBlob(c *chk.C, container azblob.ContainerURL, prefix string) (blob azblob.AppendBlobURL, name string) {
 	blob, name = getAppendBlobURL(c, container, prefix)
 
-	resp, err := blob.Create(ctx, azblob.BlobHTTPHeaders{}, nil, azblob.BlobAccessConditions{}, nil)
+	resp, err := blob.Create(ctx, azblob.BlobHTTPHeaders{}, nil, azblob.BlobAccessConditions{}, nil, azblob.ClientProvidedKeyOptions{})
 
 	c.Assert(err, chk.IsNil)
 	c.Assert(resp.StatusCode(), chk.Equals, 201)
@@ -375,7 +375,7 @@ func createNewAppendBlob(c *chk.C, container azblob.ContainerURL, prefix string)
 func createNewPageBlob(c *chk.C, container azblob.ContainerURL, prefix string) (blob azblob.PageBlobURL, name string) {
 	blob, name = getPageBlobURL(c, container, prefix)
 
-	resp, err := blob.Create(ctx, azblob.PageBlobPageBytes*10, 0, azblob.BlobHTTPHeaders{}, nil, azblob.BlobAccessConditions{}, azblob.DefaultPremiumBlobAccessTier, nil)
+	resp, err := blob.Create(ctx, azblob.PageBlobPageBytes*10, 0, azblob.BlobHTTPHeaders{}, nil, azblob.BlobAccessConditions{}, azblob.DefaultPremiumBlobAccessTier, nil, azblob.ClientProvidedKeyOptions{})
 
 	c.Assert(err, chk.IsNil)
 	c.Assert(resp.StatusCode(), chk.Equals, 201)
@@ -614,7 +614,7 @@ func disableSoftDelete(c *chk.C, bsu azblob.ServiceURL) {
 }
 
 func validateUpload(c *chk.C, blobURL azblob.BlockBlobURL) {
-	resp, err := blobURL.Download(ctx, 0, 0, azblob.BlobAccessConditions{}, false)
+	resp, err := blobURL.Download(ctx, 0, 0, azblob.BlobAccessConditions{}, false, azblob.ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	data, _ := ioutil.ReadAll(resp.Response().Body)
 	c.Assert(data, chk.HasLen, 0)

--- a/common/environment.go
+++ b/common/environment.go
@@ -62,6 +62,8 @@ var VisibleEnvironmentVariables = []EnvironmentVariable{
 	EEnvironmentVariable.ManagedIdentityClientID(),
 	EEnvironmentVariable.ManagedIdentityObjectID(),
 	EEnvironmentVariable.ManagedIdentityResourceString(),
+	EEnvironmentVariable.CPKEncryptionKey(),
+	EEnvironmentVariable.CPKEncryptionKeySha256(),
 }
 
 var EEnvironmentVariable = EnvironmentVariable{}
@@ -306,4 +308,12 @@ func (EnvironmentVariable) UserAgentPrefix() EnvironmentVariable {
 		Name:        "AZCOPY_USER_AGENT_PREFIX",
 		Description: "Add a prefix to the default AzCopy User Agent, which is used for telemetry purposes. A space is automatically inserted.",
 	}
+}
+
+func (EnvironmentVariable) CPKEncryptionKey() EnvironmentVariable {
+	return EnvironmentVariable{Name: "CPK_ENCRYPTION_KEY", Hidden: true}
+}
+
+func (EnvironmentVariable) CPKEncryptionKeySha256() EnvironmentVariable {
+	return EnvironmentVariable{Name: "CPK_ENCRYPTION_KEY_SHA256", Hidden: true}
 }

--- a/common/fe-ste-models.go
+++ b/common/fe-ste-models.go
@@ -910,6 +910,7 @@ type CopyTransfer struct {
 	ContentLanguage    string
 	CacheControl       string
 	ContentMD5         []byte
+	CpkInfo            CpkInfo
 	CpkScopeInfo       CpkScopeInfo
 	Metadata           Metadata
 
@@ -1370,7 +1371,7 @@ func (p PreservePermissionsOption) IsTruthy() bool {
 // CpkScopeInfo specifies the name of the encryption scope to use to encrypt the data provided in the request. If not specified,
 // encryption is performed with the default account encryption scope. For more information, see Encryption at Rest for Azure Storage Services.
 type CpkScopeInfo struct {
-	EncryptionScope string
+	EncryptionScope *string
 }
 
 func (csi CpkScopeInfo) Marshal() (string, error) {
@@ -1391,4 +1392,44 @@ func UnmarshalToCpkScopeInfo(cpkScopeInfoStr string) (CpkScopeInfo, error) {
 	}
 
 	return result, nil
+}
+
+type CpkInfo struct {
+	// The algorithm used to produce the encryption key hash. Currently, the only accepted value is "AES256". Must be provided if the x-ms-encryption-key header
+	// is provided.
+	EncryptionAlgorithm *string
+	// Optional. Specifies the encryption key to use to encrypt the data provided in the request. If not specified, encryption is performed with the root account
+	// encryption key.
+	EncryptionKey *string
+	// The SHA-256 hash of the provided encryption key. Must be provided if the x-ms-encryption-key header is provided.
+	EncryptionKeySha256 *string
+}
+
+func (csi CpkInfo) Marshal() (string, error) {
+	result, err := json.Marshal(csi)
+	if err != nil {
+		return "", err
+	}
+	return string(result), nil
+}
+
+func UnmarshalToCpkInfo(cpkInfoStr string) (CpkInfo, error) {
+	var result CpkInfo
+	if cpkInfoStr != "" {
+		err := json.Unmarshal([]byte(cpkInfoStr), &result)
+		if err != nil {
+			return result, err
+		}
+	}
+
+	return result, nil
+}
+
+func ToClientProvidedKeyOptions(cpkInfo CpkInfo, cpkScopeInfo CpkScopeInfo) azblob.ClientProvidedKeyOptions {
+	return azblob.ClientProvidedKeyOptions{
+		EncryptionKey:       cpkInfo.EncryptionKey,
+		EncryptionAlgorithm: azblob.EncryptionAlgorithmAES256,
+		EncryptionKeySha256: cpkInfo.EncryptionKeySha256,
+		EncryptionScope:     cpkScopeInfo.EncryptionScope,
+	}
 }

--- a/common/fe-ste-models.go
+++ b/common/fe-ste-models.go
@@ -910,6 +910,7 @@ type CopyTransfer struct {
 	ContentLanguage    string
 	CacheControl       string
 	ContentMD5         []byte
+	CpkScopeInfo       CpkScopeInfo
 	Metadata           Metadata
 
 	// Properties for S2S blob copy
@@ -1364,4 +1365,30 @@ func (p PreservePermissionsOption) IsTruthy() bool {
 	default:
 		panic("unknown permissions option")
 	}
+}
+
+// CpkScopeInfo specifies the name of the encryption scope to use to encrypt the data provided in the request. If not specified,
+// encryption is performed with the default account encryption scope. For more information, see Encryption at Rest for Azure Storage Services.
+type CpkScopeInfo struct {
+	EncryptionScope string
+}
+
+func (csi CpkScopeInfo) Marshal() (string, error) {
+	result, err := json.Marshal(csi)
+	if err != nil {
+		return "", err
+	}
+	return string(result), nil
+}
+
+func UnmarshalToCpkScopeInfo(cpkScopeInfoStr string) (CpkScopeInfo, error) {
+	var result CpkScopeInfo
+	if cpkScopeInfoStr != "" {
+		err := json.Unmarshal([]byte(cpkScopeInfoStr), &result)
+		if err != nil {
+			return result, err
+		}
+	}
+
+	return result, nil
 }

--- a/common/prologueState.go
+++ b/common/prologueState.go
@@ -21,7 +21,7 @@
 package common
 
 type cutdownJptm interface {
-	ResourceDstData(dataFileToXfer []byte) (headers ResourceHTTPHeaders, metadata Metadata, blobTags BlobTags)
+	ResourceDstData(dataFileToXfer []byte) (headers ResourceHTTPHeaders, metadata Metadata, blobTags BlobTags, info CpkScopeInfo)
 }
 
 // PrologueState contains info necessary for different sending operations' prologue.
@@ -33,6 +33,6 @@ type PrologueState struct {
 }
 
 func (ps PrologueState) GetInferredContentType(jptm cutdownJptm) string {
-	headers, _, _ := jptm.ResourceDstData(ps.LeadingBytes)
+	headers, _, _, _ := jptm.ResourceDstData(ps.LeadingBytes)
 	return headers.ContentType
 }

--- a/common/prologueState.go
+++ b/common/prologueState.go
@@ -21,7 +21,7 @@
 package common
 
 type cutdownJptm interface {
-	ResourceDstData(dataFileToXfer []byte) (headers ResourceHTTPHeaders, metadata Metadata, blobTags BlobTags, info CpkScopeInfo)
+	ResourceDstData(dataFileToXfer []byte) (headers ResourceHTTPHeaders, metadata Metadata, blobTags BlobTags, cpkInfo CpkInfo, cpkScopeInfo CpkScopeInfo)
 }
 
 // PrologueState contains info necessary for different sending operations' prologue.
@@ -33,6 +33,6 @@ type PrologueState struct {
 }
 
 func (ps PrologueState) GetInferredContentType(jptm cutdownJptm) string {
-	headers, _, _, _ := jptm.ResourceDstData(ps.LeadingBytes)
+	headers, _, _, _, _ := jptm.ResourceDstData(ps.LeadingBytes)
 	return headers.ContentType
 }

--- a/common/rpc-models.go
+++ b/common/rpc-models.go
@@ -181,6 +181,7 @@ type BlobTransferAttributes struct {
 	ContentLanguage          string                // Specifies the language of the content
 	ContentDisposition       string                // Specifies the content disposition
 	CacheControl             string                // Specifies the cache control header
+	CpkScopeInfo             CpkScopeInfo          //
 	BlockBlobTier            BlockBlobTier         // Specifies the tier to set on the block blobs.
 	PageBlobTier             PageBlobTier          // Specifies the tier to set on the page blobs.
 	Metadata                 string                // User-defined Name-value pairs associated with the blob

--- a/common/rpc-models.go
+++ b/common/rpc-models.go
@@ -181,6 +181,7 @@ type BlobTransferAttributes struct {
 	ContentLanguage          string                // Specifies the language of the content
 	ContentDisposition       string                // Specifies the content disposition
 	CacheControl             string                // Specifies the cache control header
+	CpkInfo                  CpkInfo               //
 	CpkScopeInfo             CpkScopeInfo          //
 	BlockBlobTier            BlockBlobTier         // Specifies the tier to set on the block blobs.
 	PageBlobTier             PageBlobTier          // Specifies the tier to set on the page blobs.

--- a/e2etest/helpers.go
+++ b/e2etest/helpers.go
@@ -222,7 +222,7 @@ func createNewBlockBlob(c asserter, container azblob.ContainerURL, prefix string
 	blob, name = getBlockBlobURL(c, container, prefix)
 
 	cResp, err := blob.Upload(ctx, strings.NewReader(blockBlobDefaultData), azblob.BlobHTTPHeaders{},
-		nil, azblob.BlobAccessConditions{}, azblob.DefaultAccessTier, nil)
+		nil, azblob.BlobAccessConditions{}, azblob.DefaultAccessTier, nil, azblob.ClientProvidedKeyOptions{})
 
 	c.AssertNoErr(err)
 	c.Assert(cResp.StatusCode(), equals(), 201)
@@ -266,7 +266,7 @@ func generateParentsForAzureFile(c asserter, fileURL azfile.FileURL) {
 func createNewAppendBlob(c asserter, container azblob.ContainerURL, prefix string) (blob azblob.AppendBlobURL, name string) {
 	blob, name = getAppendBlobURL(c, container, prefix)
 
-	resp, err := blob.Create(ctx, azblob.BlobHTTPHeaders{}, nil, azblob.BlobAccessConditions{}, nil)
+	resp, err := blob.Create(ctx, azblob.BlobHTTPHeaders{}, nil, azblob.BlobAccessConditions{}, nil, azblob.ClientProvidedKeyOptions{})
 
 	c.AssertNoErr(err)
 	c.Assert(resp.StatusCode(), equals(), 201)
@@ -276,7 +276,7 @@ func createNewAppendBlob(c asserter, container azblob.ContainerURL, prefix strin
 func createNewPageBlob(c asserter, container azblob.ContainerURL, prefix string) (blob azblob.PageBlobURL, name string) {
 	blob, name = getPageBlobURL(c, container, prefix)
 
-	resp, err := blob.Create(ctx, azblob.PageBlobPageBytes*10, 0, azblob.BlobHTTPHeaders{}, nil, azblob.BlobAccessConditions{}, azblob.DefaultPremiumBlobAccessTier, nil)
+	resp, err := blob.Create(ctx, azblob.PageBlobPageBytes*10, 0, azblob.BlobHTTPHeaders{}, nil, azblob.BlobAccessConditions{}, azblob.DefaultPremiumBlobAccessTier, nil, azblob.ClientProvidedKeyOptions{})
 
 	c.AssertNoErr(err)
 	c.Assert(resp.StatusCode(), equals(), 201)
@@ -515,7 +515,7 @@ func disableSoftDelete(c asserter, bsu azblob.ServiceURL) {
 }
 
 func validateUpload(c asserter, blobURL azblob.BlockBlobURL) {
-	resp, err := blobURL.Download(ctx, 0, 0, azblob.BlobAccessConditions{}, false)
+	resp, err := blobURL.Download(ctx, 0, 0, azblob.BlobAccessConditions{}, false, azblob.ClientProvidedKeyOptions{})
 	c.AssertNoErr(err)
 	data, _ := ioutil.ReadAll(resp.Response().Body)
 	c.Assert(len(data), equals(), 0)

--- a/e2etest/scenario_helpers.go
+++ b/e2etest/scenario_helpers.go
@@ -332,7 +332,10 @@ func (scenarioHelper) generateBlobsFromList(c asserter, containerURL azblob.Cont
 			reader,
 			headers,
 			ad.toMetadata(),
-			azblob.BlobAccessConditions{}, azblob.DefaultAccessTier, nil)
+			azblob.BlobAccessConditions{},
+			azblob.DefaultAccessTier,
+			nil, // Blob Tags Map
+			azblob.ClientProvidedKeyOptions{})
 		c.AssertNoErr(err)
 		c.Assert(cResp.StatusCode(), equals(), 201)
 	}
@@ -386,7 +389,7 @@ func (s scenarioHelper) enumerateContainerBlobProperties(a asserter, containerUR
 
 func (s scenarioHelper) downloadBlobContent(a asserter, containerURL azblob.ContainerURL, resourceRelPath string) []byte {
 	blobURL := containerURL.NewBlobURL(resourceRelPath)
-	downloadResp, err := blobURL.Download(ctx, 0, azblob.CountToEnd, azblob.BlobAccessConditions{}, false)
+	downloadResp, err := blobURL.Download(ctx, 0, azblob.CountToEnd, azblob.BlobAccessConditions{}, false, azblob.ClientProvidedKeyOptions{})
 	a.AssertNoErr(err)
 
 	retryReader := downloadResp.Body(azblob.RetryReaderOptions{})
@@ -423,7 +426,8 @@ func (scenarioHelper) generatePageBlobsFromList(c asserter, containerURL azblob.
 			azblob.Metadata{},
 			azblob.BlobAccessConditions{},
 			azblob.DefaultPremiumBlobAccessTier,
-			nil,
+			nil, // Blob Tags Map
+			azblob.ClientProvidedKeyOptions{},
 		)
 		c.AssertNoErr(err)
 		c.Assert(cResp.StatusCode(), equals(), 201)
@@ -433,7 +437,8 @@ func (scenarioHelper) generatePageBlobsFromList(c asserter, containerURL azblob.
 			0,
 			strings.NewReader(data),
 			azblob.PageBlobAccessConditions{},
-			nil,
+			nil, // Transactional MD5
+			azblob.ClientProvidedKeyOptions{},
 		)
 		c.AssertNoErr(err)
 		c.Assert(uResp.StatusCode(), equals(), 201)
@@ -453,7 +458,8 @@ func (scenarioHelper) generateAppendBlobsFromList(c asserter, containerURL azblo
 			},
 			azblob.Metadata{},
 			azblob.BlobAccessConditions{},
-			nil,
+			nil, // Blob Tags Map
+			azblob.ClientProvidedKeyOptions{},
 		)
 		c.AssertNoErr(err)
 		c.Assert(cResp.StatusCode(), equals(), 201)
@@ -462,7 +468,8 @@ func (scenarioHelper) generateAppendBlobsFromList(c asserter, containerURL azblo
 		uResp, err := blob.AppendBlock(ctx,
 			strings.NewReader(data),
 			azblob.AppendBlobAccessConditions{},
-			nil)
+			nil, //Transactional MD5
+			azblob.ClientProvidedKeyOptions{})
 		c.AssertNoErr(err)
 		c.Assert(uResp.StatusCode(), equals(), 201)
 	}
@@ -474,7 +481,7 @@ func (scenarioHelper) generateAppendBlobsFromList(c asserter, containerURL azblo
 func (scenarioHelper) generateBlockBlobWithAccessTier(c asserter, containerURL azblob.ContainerURL, blobName string, accessTier azblob.AccessTierType) {
 	blob := containerURL.NewBlockBlobURL(blobName)
 	cResp, err := blob.Upload(ctx, strings.NewReader(blockBlobDefaultData), azblob.BlobHTTPHeaders{},
-		nil, azblob.BlobAccessConditions{}, accessTier, nil)
+		nil, azblob.BlobAccessConditions{}, accessTier, nil, azblob.ClientProvidedKeyOptions{})
 	c.AssertNoErr(err)
 	c.Assert(cResp.StatusCode(), equals(), 201)
 }
@@ -849,7 +856,7 @@ func (scenarioHelper) getRawShareURLWithSAS(c asserter, shareName string) url.UR
 }
 
 func (scenarioHelper) blobExists(blobURL azblob.BlobURL) bool {
-	_, err := blobURL.GetProperties(context.Background(), azblob.BlobAccessConditions{})
+	_, err := blobURL.GetProperties(context.Background(), azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
 	if err == nil {
 		return true
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/Azure/azure-storage-azcopy
 
 require (
 	github.com/Azure/azure-pipeline-go v0.2.3
-	github.com/Azure/azure-storage-blob-go v0.10.1-0.20201022074806-8d8fc11be726
+	github.com/Azure/azure-storage-blob-go v0.12.0
 	github.com/Azure/azure-storage-file-go v0.6.1-0.20201111053559-3c1754dc00a5
 	github.com/Azure/go-autorest/autorest/adal v0.9.2
 	github.com/JeffreyRichter/enum v0.0.0-20180725232043-2567042f9cda

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Azure/azure-pipeline-go v0.2.3 h1:7U9HBg1JFK3jHl5qmo4CTZKFTVgMwdFHMVtCdfBE21U=
 github.com/Azure/azure-pipeline-go v0.2.3/go.mod h1:x841ezTBIMG6O3lAcl8ATHnsOPVl2bqk7S3ta6S6u4k=
-github.com/Azure/azure-storage-blob-go v0.10.1-0.20201022074806-8d8fc11be726 h1:4lkg21Kc87fF+d+A424tMeVwuXhaCCIyfk/rrRpw9pI=
-github.com/Azure/azure-storage-blob-go v0.10.1-0.20201022074806-8d8fc11be726/go.mod h1:A0u4VjtpgZJ7Y7um/+ix2DHBuEKFC6sEIlj0xc13a4Q=
+github.com/Azure/azure-storage-blob-go v0.12.0 h1:7bFXA1QB+lOK2/ASWHhp6/vnxjaeeZq6t8w1Jyp0Iaw=
+github.com/Azure/azure-storage-blob-go v0.12.0/go.mod h1:A0u4VjtpgZJ7Y7um/+ix2DHBuEKFC6sEIlj0xc13a4Q=
 github.com/Azure/azure-storage-file-go v0.6.1-0.20201111053559-3c1754dc00a5 h1:aHEvBM4oXIWSTOVdL55nCYXO0Cl7ie3Ui5xMQhLVez8=
 github.com/Azure/azure-storage-file-go v0.6.1-0.20201111053559-3c1754dc00a5/go.mod h1:++L7GP2pRyUNuastZ7m02vYV69JHmqlWXfCaGoL0v4s=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=

--- a/ste/JobPartPlan.go
+++ b/ste/JobPartPlan.go
@@ -268,6 +268,9 @@ type JobPartPlanDstBlob struct {
 	// Specifies the cache control of the blob
 	CacheControl [CustomHeaderMaxBytes]byte
 
+	CpkInfo       [CustomHeaderMaxBytes]byte
+	CpkInfoLength uint16
+
 	CpkScopeInfo       [CustomHeaderMaxBytes]byte
 	CpkScopeInfoLength uint16
 

--- a/ste/JobPartPlan.go
+++ b/ste/JobPartPlan.go
@@ -268,6 +268,9 @@ type JobPartPlanDstBlob struct {
 	// Specifies the cache control of the blob
 	CacheControl [CustomHeaderMaxBytes]byte
 
+	CpkScopeInfo       [CustomHeaderMaxBytes]byte
+	CpkScopeInfoLength uint16
+
 	// Specifies the tier if this is a block or page blob
 	BlockBlobTier common.BlockBlobTier
 	PageBlobTier  common.PageBlobTier

--- a/ste/JobPartPlanFileName.go
+++ b/ste/JobPartPlanFileName.go
@@ -164,6 +164,7 @@ func (jpfn JobPartPlanFileName) Create(order common.CopyJobPartOrderRequest) {
 	//	}*/
 	//}
 
+	cpkInfoStr, _ := order.BlobAttributes.CpkInfo.Marshal()
 	cpkScopeInfoStr, _ := order.BlobAttributes.CpkScopeInfo.Marshal()
 
 	// Initialize the Job Part's Plan header
@@ -201,6 +202,7 @@ func (jpfn JobPartPlanFileName) Create(order common.CopyJobPartOrderRequest) {
 			MetadataLength:           uint16(len(order.BlobAttributes.Metadata)),
 			BlockSize:                blockSize,
 			BlobTagsLength:           uint16(len(order.BlobAttributes.BlobTagsString)),
+			CpkInfoLength:            uint16(len(cpkInfoStr)),
 			CpkScopeInfoLength:       uint16(len(cpkScopeInfoStr)),
 		},
 		DstLocalData: JobPartPlanDstLocal{
@@ -231,6 +233,7 @@ func (jpfn JobPartPlanFileName) Create(order common.CopyJobPartOrderRequest) {
 	copy(jpph.DstBlobData.CacheControl[:], order.BlobAttributes.CacheControl)
 	copy(jpph.DstBlobData.Metadata[:], order.BlobAttributes.Metadata)
 	copy(jpph.DstBlobData.BlobTags[:], order.BlobAttributes.BlobTagsString)
+	copy(jpph.DstBlobData.CpkInfo[:], cpkInfoStr)
 	copy(jpph.DstBlobData.CpkScopeInfo[:], cpkScopeInfoStr)
 
 	eof += writeValue(file, &jpph)

--- a/ste/JobPartPlanFileName.go
+++ b/ste/JobPartPlanFileName.go
@@ -163,6 +163,9 @@ func (jpfn JobPartPlanFileName) Create(order common.CopyJobPartOrderRequest) {
 	//		panic(errors.New("unrecognized blob type"))
 	//	}*/
 	//}
+
+	cpkScopeInfoStr, _ := order.BlobAttributes.CpkScopeInfo.Marshal()
+
 	// Initialize the Job Part's Plan header
 	jpph := JobPartPlanHeader{
 		Version:                DataSchemaVersion,
@@ -198,6 +201,7 @@ func (jpfn JobPartPlanFileName) Create(order common.CopyJobPartOrderRequest) {
 			MetadataLength:           uint16(len(order.BlobAttributes.Metadata)),
 			BlockSize:                blockSize,
 			BlobTagsLength:           uint16(len(order.BlobAttributes.BlobTagsString)),
+			CpkScopeInfoLength:       uint16(len(cpkScopeInfoStr)),
 		},
 		DstLocalData: JobPartPlanDstLocal{
 			PreserveLastModifiedTime: order.BlobAttributes.PreserveLastModifiedTime,
@@ -227,6 +231,7 @@ func (jpfn JobPartPlanFileName) Create(order common.CopyJobPartOrderRequest) {
 	copy(jpph.DstBlobData.CacheControl[:], order.BlobAttributes.CacheControl)
 	copy(jpph.DstBlobData.Metadata[:], order.BlobAttributes.Metadata)
 	copy(jpph.DstBlobData.BlobTags[:], order.BlobAttributes.BlobTagsString)
+	copy(jpph.DstBlobData.CpkScopeInfo[:], cpkScopeInfoStr)
 
 	eof += writeValue(file, &jpph)
 

--- a/ste/downloader-blob.go
+++ b/ste/downloader-blob.go
@@ -114,7 +114,7 @@ func (bd *blobDownloader) GenerateDownloadFunc(jptm IJobPartTransferMgr, srcPipe
 		// The Download method encapsulates any retries that may be necessary to get to the point of receiving response headers.
 		jptm.LogChunkStatus(id, common.EWaitReason.HeaderResponse())
 		enrichedContext := withRetryNotification(jptm.Context(), bd.filePacer)
-		get, err := srcBlobURL.Download(enrichedContext, id.OffsetInFile(), length, accessConditions, false)
+		get, err := srcBlobURL.Download(enrichedContext, id.OffsetInFile(), length, accessConditions, false, azblob.ClientProvidedKeyOptions{})
 		if err != nil {
 			jptm.FailActiveDownload("Downloading response body", err) // cancel entire transfer because this chunk has failed
 			return

--- a/ste/downloader-blob.go
+++ b/ste/downloader-blob.go
@@ -110,8 +110,7 @@ func (bd *blobDownloader) GenerateDownloadFunc(jptm IJobPartTransferMgr, srcPipe
 		}
 
 		// Once track2 goes live, we'll not need to do this conversion/casting and can directly use CpkInfo & CpkScopeInfo
-		encryptionScope := jptm.CpkScopeInfo().EncryptionScope
-		cpkOptions := azblob.ClientProvidedKeyOptions{EncryptionScope: &encryptionScope}
+		cpkOptions := common.ToClientProvidedKeyOptions(jptm.CpkInfo(), jptm.CpkScopeInfo())
 
 		// At this point we create an HTTP(S) request for the desired portion of the blob, and
 		// wait until we get the headers back... but we have not yet read its whole body.

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -20,7 +20,7 @@ import (
 type IJobPartTransferMgr interface {
 	FromTo() common.FromTo
 	Info() TransferInfo
-	ResourceDstData(dataFileToXfer []byte) (headers common.ResourceHTTPHeaders, metadata common.Metadata, blobTags common.BlobTags, info common.CpkScopeInfo)
+	ResourceDstData(dataFileToXfer []byte) (headers common.ResourceHTTPHeaders, metadata common.Metadata, blobTags common.BlobTags, cpkInfo common.CpkInfo, cpkScopeInfo common.CpkScopeInfo)
 	LastModifiedTime() time.Time
 	PreserveLastModifiedTime() (time.Time, bool)
 	ShouldPutMd5() bool
@@ -28,6 +28,7 @@ type IJobPartTransferMgr interface {
 	BlobTypeOverride() common.BlobType
 	BlobTiers() (blockBlobTier common.BlockBlobTier, pageBlobTier common.PageBlobTier)
 	JobHasLowFileCount() bool
+	CpkInfo() common.CpkInfo
 	CpkScopeInfo() common.CpkScopeInfo
 	Context() context.Context
 	SlicePool() common.ByteSlicePooler
@@ -442,7 +443,7 @@ func (jptm *jobPartTransferMgr) ScheduleChunks(chunkFunc chunkFunc) {
 	jptm.jobPartMgr.ScheduleChunks(chunkFunc)
 }
 
-func (jptm *jobPartTransferMgr) ResourceDstData(dataFileToXfer []byte) (headers common.ResourceHTTPHeaders, metadata common.Metadata, blobTags common.BlobTags, info common.CpkScopeInfo) {
+func (jptm *jobPartTransferMgr) ResourceDstData(dataFileToXfer []byte) (headers common.ResourceHTTPHeaders, metadata common.Metadata, blobTags common.BlobTags, cpkInfo common.CpkInfo, cpkScopeInfo common.CpkScopeInfo) {
 	return jptm.jobPartMgr.(*jobPartMgr).resourceDstData(jptm.Info().Source, dataFileToXfer)
 }
 
@@ -479,6 +480,10 @@ func (jptm *jobPartTransferMgr) BlobTypeOverride() common.BlobType {
 
 func (jptm *jobPartTransferMgr) BlobTiers() (blockBlobTier common.BlockBlobTier, pageBlobTier common.PageBlobTier) {
 	return jptm.jobPartMgr.BlobTiers()
+}
+
+func (jptm *jobPartTransferMgr) CpkInfo() common.CpkInfo {
+	return jptm.jobPartMgr.CpkInfo()
 }
 
 func (jptm *jobPartTransferMgr) CpkScopeInfo() common.CpkScopeInfo {

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -20,7 +20,7 @@ import (
 type IJobPartTransferMgr interface {
 	FromTo() common.FromTo
 	Info() TransferInfo
-	ResourceDstData(dataFileToXfer []byte) (headers common.ResourceHTTPHeaders, metadata common.Metadata, blobTags common.BlobTags)
+	ResourceDstData(dataFileToXfer []byte) (headers common.ResourceHTTPHeaders, metadata common.Metadata, blobTags common.BlobTags, info common.CpkScopeInfo)
 	LastModifiedTime() time.Time
 	PreserveLastModifiedTime() (time.Time, bool)
 	ShouldPutMd5() bool
@@ -28,7 +28,7 @@ type IJobPartTransferMgr interface {
 	BlobTypeOverride() common.BlobType
 	BlobTiers() (blockBlobTier common.BlockBlobTier, pageBlobTier common.PageBlobTier)
 	JobHasLowFileCount() bool
-	//ScheduleChunk(chunkFunc chunkFunc)
+	CpkScopeInfo() common.CpkScopeInfo
 	Context() context.Context
 	SlicePool() common.ByteSlicePooler
 	CacheLimiter() common.CacheLimiter
@@ -147,6 +147,7 @@ type SrcProperties struct {
 	SrcHTTPHeaders common.ResourceHTTPHeaders // User for S2S copy, where per transfer's src properties need be set in destination.
 	SrcMetadata    common.Metadata
 	SrcBlobTags    common.BlobTags
+	// SrcCpkScopeInfo common.CpkScopeInfo
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -441,7 +442,7 @@ func (jptm *jobPartTransferMgr) ScheduleChunks(chunkFunc chunkFunc) {
 	jptm.jobPartMgr.ScheduleChunks(chunkFunc)
 }
 
-func (jptm *jobPartTransferMgr) ResourceDstData(dataFileToXfer []byte) (headers common.ResourceHTTPHeaders, metadata common.Metadata, blobTags common.BlobTags) {
+func (jptm *jobPartTransferMgr) ResourceDstData(dataFileToXfer []byte) (headers common.ResourceHTTPHeaders, metadata common.Metadata, blobTags common.BlobTags, info common.CpkScopeInfo) {
 	return jptm.jobPartMgr.(*jobPartMgr).resourceDstData(jptm.Info().Source, dataFileToXfer)
 }
 
@@ -478,6 +479,10 @@ func (jptm *jobPartTransferMgr) BlobTypeOverride() common.BlobType {
 
 func (jptm *jobPartTransferMgr) BlobTiers() (blockBlobTier common.BlockBlobTier, pageBlobTier common.PageBlobTier) {
 	return jptm.jobPartMgr.BlobTiers()
+}
+
+func (jptm *jobPartTransferMgr) CpkScopeInfo() common.CpkScopeInfo {
+	return jptm.jobPartMgr.CpkScopeInfo()
 }
 
 // JobHasLowFileCount returns an estimate of whether we only have a very small number of files in the overall job

--- a/ste/sender-appendBlob.go
+++ b/ste/sender-appendBlob.go
@@ -79,7 +79,7 @@ func newAppendBlobSenderBase(jptm IJobPartTransferMgr, destination string, p pip
 	}
 
 	// Once track2 goes live, we'll not need to do this conversion/casting and can directly use CpkInfo & CpkScopeInfo
-	encryptionScope := jptm.CpkScopeInfo().EncryptionScope
+	cpkOptions := common.ToClientProvidedKeyOptions(jptm.CpkInfo(), jptm.CpkScopeInfo())
 
 	return &appendBlobSenderBase{
 		jptm:                   jptm,
@@ -90,7 +90,7 @@ func newAppendBlobSenderBase(jptm IJobPartTransferMgr, destination string, p pip
 		headersToApply:         props.SrcHTTPHeaders.ToAzBlobHTTPHeaders(),
 		metadataToApply:        props.SrcMetadata.ToAzBlobMetadata(),
 		blobTagsToApply:        props.SrcBlobTags.ToAzBlobTagsMap(),
-		cpkOptions:             azblob.ClientProvidedKeyOptions{EncryptionScope: &encryptionScope},
+		cpkOptions:             cpkOptions,
 		soleChunkFuncSemaphore: semaphore.NewWeighted(1)}, nil
 }
 

--- a/ste/sender-appendBlob.go
+++ b/ste/sender-appendBlob.go
@@ -42,10 +42,10 @@ type appendBlobSenderBase struct {
 	// object. For S2S, these come from the source service.
 	// When sending local data, they are computed based on
 	// the properties of the local file
-	headersToApply  azblob.BlobHTTPHeaders
-	metadataToApply azblob.Metadata
-	blobTagsToApply azblob.BlobTagsMap
-
+	headersToApply         azblob.BlobHTTPHeaders
+	metadataToApply        azblob.Metadata
+	blobTagsToApply        azblob.BlobTagsMap
+	cpkOptions             azblob.ClientProvidedKeyOptions
 	soleChunkFuncSemaphore *semaphore.Weighted
 }
 
@@ -78,6 +78,9 @@ func newAppendBlobSenderBase(jptm IJobPartTransferMgr, destination string, p pip
 		return nil, err
 	}
 
+	// Once track2 goes live, we'll not need to do this conversion/casting and can directly use CpkInfo & CpkScopeInfo
+	encryptionScope := jptm.CpkScopeInfo().EncryptionScope
+
 	return &appendBlobSenderBase{
 		jptm:                   jptm,
 		destAppendBlobURL:      destAppendBlobURL,
@@ -87,6 +90,7 @@ func newAppendBlobSenderBase(jptm IJobPartTransferMgr, destination string, p pip
 		headersToApply:         props.SrcHTTPHeaders.ToAzBlobHTTPHeaders(),
 		metadataToApply:        props.SrcMetadata.ToAzBlobMetadata(),
 		blobTagsToApply:        props.SrcBlobTags.ToAzBlobTagsMap(),
+		cpkOptions:             azblob.ClientProvidedKeyOptions{EncryptionScope: &encryptionScope},
 		soleChunkFuncSemaphore: semaphore.NewWeighted(1)}, nil
 }
 
@@ -103,7 +107,7 @@ func (s *appendBlobSenderBase) NumChunks() uint32 {
 }
 
 func (s *appendBlobSenderBase) RemoteFileExists() (bool, time.Time, error) {
-	return remoteObjectExists(s.destAppendBlobURL.GetProperties(s.jptm.Context(), azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{}))
+	return remoteObjectExists(s.destAppendBlobURL.GetProperties(s.jptm.Context(), azblob.BlobAccessConditions{}, s.cpkOptions))
 }
 
 // Returns a chunk-func for sending append blob to remote
@@ -148,7 +152,7 @@ func (s *appendBlobSenderBase) Prologue(ps common.PrologueState) (destinationMod
 	if separateSetTagsRequired || len(blobTags) == 0 {
 		blobTags = nil
 	}
-	if _, err := s.destAppendBlobURL.Create(s.jptm.Context(), s.headersToApply, s.metadataToApply, azblob.BlobAccessConditions{}, blobTags, azblob.ClientProvidedKeyOptions{}); err != nil {
+	if _, err := s.destAppendBlobURL.Create(s.jptm.Context(), s.headersToApply, s.metadataToApply, azblob.BlobAccessConditions{}, blobTags, s.cpkOptions); err != nil {
 		s.jptm.FailActiveSend("Creating blob", err)
 		return
 	}

--- a/ste/sender-appendBlob.go
+++ b/ste/sender-appendBlob.go
@@ -103,7 +103,7 @@ func (s *appendBlobSenderBase) NumChunks() uint32 {
 }
 
 func (s *appendBlobSenderBase) RemoteFileExists() (bool, time.Time, error) {
-	return remoteObjectExists(s.destAppendBlobURL.GetProperties(s.jptm.Context(), azblob.BlobAccessConditions{}))
+	return remoteObjectExists(s.destAppendBlobURL.GetProperties(s.jptm.Context(), azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{}))
 }
 
 // Returns a chunk-func for sending append blob to remote
@@ -148,7 +148,7 @@ func (s *appendBlobSenderBase) Prologue(ps common.PrologueState) (destinationMod
 	if separateSetTagsRequired || len(blobTags) == 0 {
 		blobTags = nil
 	}
-	if _, err := s.destAppendBlobURL.Create(s.jptm.Context(), s.headersToApply, s.metadataToApply, azblob.BlobAccessConditions{}, blobTags); err != nil {
+	if _, err := s.destAppendBlobURL.Create(s.jptm.Context(), s.headersToApply, s.metadataToApply, azblob.BlobAccessConditions{}, blobTags, azblob.ClientProvidedKeyOptions{}); err != nil {
 		s.jptm.FailActiveSend("Creating blob", err)
 		return
 	}

--- a/ste/sender-appendBlobFromLocal.go
+++ b/ste/sender-appendBlobFromLocal.go
@@ -52,7 +52,7 @@ func (u *appendBlobUploader) GenerateUploadFunc(id common.ChunkID, blockIndex in
 		_, err := u.destAppendBlobURL.AppendBlock(u.jptm.Context(), body,
 			azblob.AppendBlobAccessConditions{
 				AppendPositionAccessConditions: azblob.AppendPositionAccessConditions{IfAppendPositionEqual: id.OffsetInFile()},
-			}, nil, azblob.ClientProvidedKeyOptions{})
+			}, nil, u.cpkOptions)
 		if err != nil {
 			u.jptm.FailActiveUpload("Appending block", err)
 			return
@@ -79,7 +79,7 @@ func (u *appendBlobUploader) Epilogue() {
 }
 
 func (u *appendBlobUploader) GetDestinationLength() (int64, error) {
-	prop, err := u.destAppendBlobURL.GetProperties(u.jptm.Context(), azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
+	prop, err := u.destAppendBlobURL.GetProperties(u.jptm.Context(), azblob.BlobAccessConditions{}, u.cpkOptions)
 
 	if err != nil {
 		return -1, err

--- a/ste/sender-appendBlobFromLocal.go
+++ b/ste/sender-appendBlobFromLocal.go
@@ -52,7 +52,7 @@ func (u *appendBlobUploader) GenerateUploadFunc(id common.ChunkID, blockIndex in
 		_, err := u.destAppendBlobURL.AppendBlock(u.jptm.Context(), body,
 			azblob.AppendBlobAccessConditions{
 				AppendPositionAccessConditions: azblob.AppendPositionAccessConditions{IfAppendPositionEqual: id.OffsetInFile()},
-			}, nil)
+			}, nil, azblob.ClientProvidedKeyOptions{})
 		if err != nil {
 			u.jptm.FailActiveUpload("Appending block", err)
 			return
@@ -79,7 +79,7 @@ func (u *appendBlobUploader) Epilogue() {
 }
 
 func (u *appendBlobUploader) GetDestinationLength() (int64, error) {
-	prop, err := u.destAppendBlobURL.GetProperties(u.jptm.Context(), azblob.BlobAccessConditions{})
+	prop, err := u.destAppendBlobURL.GetProperties(u.jptm.Context(), azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
 
 	if err != nil {
 		return -1, err

--- a/ste/sender-appendBlobFromURL.go
+++ b/ste/sender-appendBlobFromURL.go
@@ -65,7 +65,7 @@ func (c *urlToAppendBlobCopier) GenerateCopyFunc(id common.ChunkID, blockIndex i
 		_, err := c.destAppendBlobURL.AppendBlockFromURL(ctxWithLatestServiceVersion, c.srcURL, id.OffsetInFile(), adjustedChunkSize,
 			azblob.AppendBlobAccessConditions{
 				AppendPositionAccessConditions: azblob.AppendPositionAccessConditions{IfAppendPositionEqual: id.OffsetInFile()},
-			}, azblob.ModifiedAccessConditions{}, nil, azblob.ClientProvidedKeyOptions{})
+			}, azblob.ModifiedAccessConditions{}, nil, c.cpkOptions)
 		if err != nil {
 			c.jptm.FailActiveS2SCopy("Appending block from URL", err)
 			return
@@ -77,7 +77,7 @@ func (c *urlToAppendBlobCopier) GenerateCopyFunc(id common.ChunkID, blockIndex i
 
 // GetDestinationLength gets the destination length.
 func (c *urlToAppendBlobCopier) GetDestinationLength() (int64, error) {
-	properties, err := c.destAppendBlobURL.GetProperties(c.jptm.Context(), azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
+	properties, err := c.destAppendBlobURL.GetProperties(c.jptm.Context(), azblob.BlobAccessConditions{}, c.cpkOptions)
 	if err != nil {
 		return -1, err
 	}

--- a/ste/sender-appendBlobFromURL.go
+++ b/ste/sender-appendBlobFromURL.go
@@ -65,7 +65,7 @@ func (c *urlToAppendBlobCopier) GenerateCopyFunc(id common.ChunkID, blockIndex i
 		_, err := c.destAppendBlobURL.AppendBlockFromURL(ctxWithLatestServiceVersion, c.srcURL, id.OffsetInFile(), adjustedChunkSize,
 			azblob.AppendBlobAccessConditions{
 				AppendPositionAccessConditions: azblob.AppendPositionAccessConditions{IfAppendPositionEqual: id.OffsetInFile()},
-			}, azblob.ModifiedAccessConditions{}, nil)
+			}, azblob.ModifiedAccessConditions{}, nil, azblob.ClientProvidedKeyOptions{})
 		if err != nil {
 			c.jptm.FailActiveS2SCopy("Appending block from URL", err)
 			return
@@ -77,7 +77,7 @@ func (c *urlToAppendBlobCopier) GenerateCopyFunc(id common.ChunkID, blockIndex i
 
 // GetDestinationLength gets the destination length.
 func (c *urlToAppendBlobCopier) GetDestinationLength() (int64, error) {
-	properties, err := c.destAppendBlobURL.GetProperties(c.jptm.Context(), azblob.BlobAccessConditions{})
+	properties, err := c.destAppendBlobURL.GetProperties(c.jptm.Context(), azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
 	if err != nil {
 		return -1, err
 	}

--- a/ste/sender-blockBlob.go
+++ b/ste/sender-blockBlob.go
@@ -153,7 +153,7 @@ func (s *blockBlobSenderBase) NumChunks() uint32 {
 }
 
 func (s *blockBlobSenderBase) RemoteFileExists() (bool, time.Time, error) {
-	return remoteObjectExists(s.destBlockBlobURL.GetProperties(s.jptm.Context(), azblob.BlobAccessConditions{}))
+	return remoteObjectExists(s.destBlockBlobURL.GetProperties(s.jptm.Context(), azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{}))
 }
 
 func (s *blockBlobSenderBase) Prologue(ps common.PrologueState) (destinationModified bool) {
@@ -191,7 +191,7 @@ func (s *blockBlobSenderBase) Epilogue() {
 			blobTags = nil
 		}
 
-		if _, err := s.destBlockBlobURL.CommitBlockList(jptm.Context(), blockIDs, s.headersToApply, s.metadataToApply, azblob.BlobAccessConditions{}, s.destBlobTier, blobTags); err != nil {
+		if _, err := s.destBlockBlobURL.CommitBlockList(jptm.Context(), blockIDs, s.headersToApply, s.metadataToApply, azblob.BlobAccessConditions{}, s.destBlobTier, blobTags, azblob.ClientProvidedKeyOptions{}); err != nil {
 			jptm.FailActiveSend("Committing block list", err)
 			return
 		}

--- a/ste/sender-blockBlob.go
+++ b/ste/sender-blockBlob.go
@@ -125,7 +125,7 @@ func newBlockBlobSenderBase(jptm IJobPartTransferMgr, destination string, p pipe
 	blockBlobTierOverride, _ := jptm.BlobTiers()
 
 	// Once track2 goes live, we'll not need to do this conversion/casting and can directly use CpkInfo & CpkScopeInfo
-	encryptionScope := jptm.CpkScopeInfo().EncryptionScope
+	cpkOptions := common.ToClientProvidedKeyOptions(jptm.CpkInfo(), jptm.CpkScopeInfo())
 	if blockBlobTierOverride != common.EBlockBlobTier.None() {
 		destBlobTier = blockBlobTierOverride.ToAccessTierType()
 	}
@@ -140,7 +140,7 @@ func newBlockBlobSenderBase(jptm IJobPartTransferMgr, destination string, p pipe
 		headersToApply:   props.SrcHTTPHeaders.ToAzBlobHTTPHeaders(),
 		metadataToApply:  props.SrcMetadata.ToAzBlobMetadata(),
 		blobTagsToApply:  props.SrcBlobTags.ToAzBlobTagsMap(),
-		cpkOptions:       azblob.ClientProvidedKeyOptions{EncryptionScope: &encryptionScope},
+		cpkOptions:       cpkOptions,
 		destBlobTier:     destBlobTier,
 		muBlockIDs:       &sync.Mutex{}}, nil
 }

--- a/ste/sender-blockBlobFromLocal.go
+++ b/ste/sender-blockBlobFromLocal.go
@@ -74,7 +74,7 @@ func (u *blockBlobUploader) generatePutBlock(id common.ChunkID, blockIndex int32
 		// step 3: put block to remote
 		u.jptm.LogChunkStatus(id, common.EWaitReason.Body())
 		body := newPacedRequestBody(u.jptm.Context(), reader, u.pacer)
-		_, err := u.destBlockBlobURL.StageBlock(u.jptm.Context(), encodedBlockID, body, azblob.LeaseAccessConditions{}, nil)
+		_, err := u.destBlockBlobURL.StageBlock(u.jptm.Context(), encodedBlockID, body, azblob.LeaseAccessConditions{}, nil, azblob.ClientProvidedKeyOptions{})
 		if err != nil {
 			u.jptm.FailActiveUpload("Staging block", err)
 			return
@@ -102,7 +102,7 @@ func (u *blockBlobUploader) generatePutWholeBlob(id common.ChunkID, blockIndex i
 		}
 
 		if jptm.Info().SourceSize == 0 {
-			_, err = u.destBlockBlobURL.Upload(jptm.Context(), bytes.NewReader(nil), u.headersToApply, u.metadataToApply, azblob.BlobAccessConditions{}, u.destBlobTier, blobTags)
+			_, err = u.destBlockBlobURL.Upload(jptm.Context(), bytes.NewReader(nil), u.headersToApply, u.metadataToApply, azblob.BlobAccessConditions{}, u.destBlobTier, blobTags, azblob.ClientProvidedKeyOptions{})
 		} else {
 			// File with content
 
@@ -116,7 +116,7 @@ func (u *blockBlobUploader) generatePutWholeBlob(id common.ChunkID, blockIndex i
 
 			// Upload the file
 			body := newPacedRequestBody(jptm.Context(), reader, u.pacer)
-			_, err = u.destBlockBlobURL.Upload(jptm.Context(), body, u.headersToApply, u.metadataToApply, azblob.BlobAccessConditions{}, u.destBlobTier, blobTags)
+			_, err = u.destBlockBlobURL.Upload(jptm.Context(), body, u.headersToApply, u.metadataToApply, azblob.BlobAccessConditions{}, u.destBlobTier, blobTags, azblob.ClientProvidedKeyOptions{})
 		}
 
 		// if the put blob is a failure, update the transfer status to failed
@@ -153,7 +153,7 @@ func (u *blockBlobUploader) Epilogue() {
 }
 
 func (u *blockBlobUploader) GetDestinationLength() (int64, error) {
-	prop, err := u.destBlockBlobURL.GetProperties(u.jptm.Context(), azblob.BlobAccessConditions{})
+	prop, err := u.destBlockBlobURL.GetProperties(u.jptm.Context(), azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
 
 	if err != nil {
 		return -1, err

--- a/ste/sender-blockBlobFromLocal.go
+++ b/ste/sender-blockBlobFromLocal.go
@@ -74,7 +74,7 @@ func (u *blockBlobUploader) generatePutBlock(id common.ChunkID, blockIndex int32
 		// step 3: put block to remote
 		u.jptm.LogChunkStatus(id, common.EWaitReason.Body())
 		body := newPacedRequestBody(u.jptm.Context(), reader, u.pacer)
-		_, err := u.destBlockBlobURL.StageBlock(u.jptm.Context(), encodedBlockID, body, azblob.LeaseAccessConditions{}, nil, azblob.ClientProvidedKeyOptions{})
+		_, err := u.destBlockBlobURL.StageBlock(u.jptm.Context(), encodedBlockID, body, azblob.LeaseAccessConditions{}, nil, u.cpkOptions)
 		if err != nil {
 			u.jptm.FailActiveUpload("Staging block", err)
 			return
@@ -102,7 +102,7 @@ func (u *blockBlobUploader) generatePutWholeBlob(id common.ChunkID, blockIndex i
 		}
 
 		if jptm.Info().SourceSize == 0 {
-			_, err = u.destBlockBlobURL.Upload(jptm.Context(), bytes.NewReader(nil), u.headersToApply, u.metadataToApply, azblob.BlobAccessConditions{}, u.destBlobTier, blobTags, azblob.ClientProvidedKeyOptions{})
+			_, err = u.destBlockBlobURL.Upload(jptm.Context(), bytes.NewReader(nil), u.headersToApply, u.metadataToApply, azblob.BlobAccessConditions{}, u.destBlobTier, blobTags, u.cpkOptions)
 		} else {
 			// File with content
 
@@ -116,7 +116,7 @@ func (u *blockBlobUploader) generatePutWholeBlob(id common.ChunkID, blockIndex i
 
 			// Upload the file
 			body := newPacedRequestBody(jptm.Context(), reader, u.pacer)
-			_, err = u.destBlockBlobURL.Upload(jptm.Context(), body, u.headersToApply, u.metadataToApply, azblob.BlobAccessConditions{}, u.destBlobTier, blobTags, azblob.ClientProvidedKeyOptions{})
+			_, err = u.destBlockBlobURL.Upload(jptm.Context(), body, u.headersToApply, u.metadataToApply, azblob.BlobAccessConditions{}, u.destBlobTier, blobTags, u.cpkOptions)
 		}
 
 		// if the put blob is a failure, update the transfer status to failed
@@ -153,7 +153,7 @@ func (u *blockBlobUploader) Epilogue() {
 }
 
 func (u *blockBlobUploader) GetDestinationLength() (int64, error) {
-	prop, err := u.destBlockBlobURL.GetProperties(u.jptm.Context(), azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
+	prop, err := u.destBlockBlobURL.GetProperties(u.jptm.Context(), azblob.BlobAccessConditions{}, u.cpkOptions)
 
 	if err != nil {
 		return -1, err

--- a/ste/sender-blockBlobFromURL.go
+++ b/ste/sender-blockBlobFromURL.go
@@ -105,7 +105,7 @@ func (c *urlToBlockBlobCopier) generateCreateEmptyBlob(id common.ChunkID) chunkF
 		if separateSetTagsRequired || len(blobTags) == 0 {
 			blobTags = nil
 		}
-		if _, err := c.destBlockBlobURL.Upload(c.jptm.Context(), bytes.NewReader(nil), c.headersToApply, c.metadataToApply, azblob.BlobAccessConditions{}, c.destBlobTier, blobTags, azblob.ClientProvidedKeyOptions{}); err != nil {
+		if _, err := c.destBlockBlobURL.Upload(c.jptm.Context(), bytes.NewReader(nil), c.headersToApply, c.metadataToApply, azblob.BlobAccessConditions{}, c.destBlobTier, blobTags, c.cpkOptions); err != nil {
 			jptm.FailActiveSend("Creating empty blob", err)
 			return
 		}
@@ -155,7 +155,7 @@ func (c *urlToBlockBlobCopier) generatePutBlockFromURL(id common.ChunkID, blockI
 			c.jptm.FailActiveUpload("Pacing block", err)
 		}
 		_, err := c.destBlockBlobURL.StageBlockFromURL(ctxWithLatestServiceVersion, encodedBlockID, c.srcURL,
-			id.OffsetInFile(), adjustedChunkSize, azblob.LeaseAccessConditions{}, azblob.ModifiedAccessConditions{}, azblob.ClientProvidedKeyOptions{})
+			id.OffsetInFile(), adjustedChunkSize, azblob.LeaseAccessConditions{}, azblob.ModifiedAccessConditions{}, c.cpkOptions)
 		if err != nil {
 			c.jptm.FailActiveSend("Staging block from URL", err)
 			return
@@ -166,7 +166,7 @@ func (c *urlToBlockBlobCopier) generatePutBlockFromURL(id common.ChunkID, blockI
 // GetDestinationLength gets the destination length.
 func (c *urlToBlockBlobCopier) GetDestinationLength() (int64, error) {
 	ctxWithLatestServiceVersion := context.WithValue(c.jptm.Context(), ServiceAPIVersionOverride, azblob.ServiceVersion)
-	properties, err := c.destBlockBlobURL.GetProperties(ctxWithLatestServiceVersion, azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
+	properties, err := c.destBlockBlobURL.GetProperties(ctxWithLatestServiceVersion, azblob.BlobAccessConditions{}, c.cpkOptions)
 	if err != nil {
 		return -1, err
 	}

--- a/ste/sender-blockBlobFromURL.go
+++ b/ste/sender-blockBlobFromURL.go
@@ -105,7 +105,7 @@ func (c *urlToBlockBlobCopier) generateCreateEmptyBlob(id common.ChunkID) chunkF
 		if separateSetTagsRequired || len(blobTags) == 0 {
 			blobTags = nil
 		}
-		if _, err := c.destBlockBlobURL.Upload(c.jptm.Context(), bytes.NewReader(nil), c.headersToApply, c.metadataToApply, azblob.BlobAccessConditions{}, c.destBlobTier, blobTags); err != nil {
+		if _, err := c.destBlockBlobURL.Upload(c.jptm.Context(), bytes.NewReader(nil), c.headersToApply, c.metadataToApply, azblob.BlobAccessConditions{}, c.destBlobTier, blobTags, azblob.ClientProvidedKeyOptions{}); err != nil {
 			jptm.FailActiveSend("Creating empty blob", err)
 			return
 		}
@@ -155,7 +155,7 @@ func (c *urlToBlockBlobCopier) generatePutBlockFromURL(id common.ChunkID, blockI
 			c.jptm.FailActiveUpload("Pacing block", err)
 		}
 		_, err := c.destBlockBlobURL.StageBlockFromURL(ctxWithLatestServiceVersion, encodedBlockID, c.srcURL,
-			id.OffsetInFile(), adjustedChunkSize, azblob.LeaseAccessConditions{}, azblob.ModifiedAccessConditions{})
+			id.OffsetInFile(), adjustedChunkSize, azblob.LeaseAccessConditions{}, azblob.ModifiedAccessConditions{}, azblob.ClientProvidedKeyOptions{})
 		if err != nil {
 			c.jptm.FailActiveSend("Staging block from URL", err)
 			return
@@ -166,7 +166,7 @@ func (c *urlToBlockBlobCopier) generatePutBlockFromURL(id common.ChunkID, blockI
 // GetDestinationLength gets the destination length.
 func (c *urlToBlockBlobCopier) GetDestinationLength() (int64, error) {
 	ctxWithLatestServiceVersion := context.WithValue(c.jptm.Context(), ServiceAPIVersionOverride, azblob.ServiceVersion)
-	properties, err := c.destBlockBlobURL.GetProperties(ctxWithLatestServiceVersion, azblob.BlobAccessConditions{})
+	properties, err := c.destBlockBlobURL.GetProperties(ctxWithLatestServiceVersion, azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
 	if err != nil {
 		return -1, err
 	}

--- a/ste/sender-pageBlob.go
+++ b/ste/sender-pageBlob.go
@@ -122,7 +122,7 @@ func newPageBlobSenderBase(jptm IJobPartTransferMgr, destination string, p pipel
 	}
 
 	// Once track2 goes live, we'll not need to do this conversion/casting and can directly use CpkInfo & CpkScopeInfo
-	encryptionScope := jptm.CpkScopeInfo().EncryptionScope
+	cpkOptions := common.ToClientProvidedKeyOptions(jptm.CpkInfo(), jptm.CpkScopeInfo())
 
 	s := &pageBlobSenderBase{
 		jptm:                   jptm,
@@ -137,7 +137,7 @@ func newPageBlobSenderBase(jptm IJobPartTransferMgr, destination string, p pipel
 		destBlobTier:           destBlobTier,
 		filePacer:              newNullAutoPacer(), // defer creation of real one to Prologue
 		destPageRangeOptimizer: destRangeOptimizer,
-		cpkOptions:             azblob.ClientProvidedKeyOptions{EncryptionScope: &encryptionScope},
+		cpkOptions:             cpkOptions,
 	}
 
 	if s.isInManagedDiskImportExportAccount() && jptm.ShouldPutMd5() {

--- a/ste/sender-pageBlob.go
+++ b/ste/sender-pageBlob.go
@@ -173,7 +173,7 @@ func (s *pageBlobSenderBase) NumChunks() uint32 {
 }
 
 func (s *pageBlobSenderBase) RemoteFileExists() (bool, time.Time, error) {
-	return remoteObjectExists(s.destPageBlobURL.GetProperties(s.jptm.Context(), azblob.BlobAccessConditions{}))
+	return remoteObjectExists(s.destPageBlobURL.GetProperties(s.jptm.Context(), azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{}))
 }
 
 var premiumPageBlobTierRegex = regexp.MustCompile(`P\d+`)
@@ -204,7 +204,7 @@ func (s *pageBlobSenderBase) Prologue(ps common.PrologueState) (destinationModif
 		// FileSize                : 1073742336  (equals our s.srcSize, i.e. the size of the disk file)
 		// Size                    : 1073741824
 
-		p, err := s.destPageBlobURL.GetProperties(s.jptm.Context(), azblob.BlobAccessConditions{})
+		p, err := s.destPageBlobURL.GetProperties(s.jptm.Context(), azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
 		if err != nil {
 			s.jptm.FailActiveSend("Checking size of managed disk blob", err)
 			return
@@ -249,7 +249,7 @@ func (s *pageBlobSenderBase) Prologue(ps common.PrologueState) (destinationModif
 		s.metadataToApply,
 		azblob.BlobAccessConditions{},
 		destBlobTier,
-		blobTags); err != nil {
+		blobTags, azblob.ClientProvidedKeyOptions{}); err != nil {
 		s.jptm.FailActiveSend("Creating blob", err)
 		return
 	}

--- a/ste/sender-pageBlobFromLocal.go
+++ b/ste/sender-pageBlobFromLocal.go
@@ -93,7 +93,7 @@ func (u *pageBlobUploader) GenerateUploadFunc(id common.ChunkID, blockIndex int3
 		jptm.LogChunkStatus(id, common.EWaitReason.Body())
 		body := newPacedRequestBody(jptm.Context(), reader, u.pacer)
 		enrichedContext := withRetryNotification(jptm.Context(), u.filePacer)
-		_, err := u.destPageBlobURL.UploadPages(enrichedContext, id.OffsetInFile(), body, azblob.PageBlobAccessConditions{}, nil, azblob.ClientProvidedKeyOptions{})
+		_, err := u.destPageBlobURL.UploadPages(enrichedContext, id.OffsetInFile(), body, azblob.PageBlobAccessConditions{}, nil, u.cpkOptions)
 		if err != nil {
 			jptm.FailActiveUpload("Uploading page", err)
 			return
@@ -118,7 +118,7 @@ func (u *pageBlobUploader) Epilogue() {
 }
 
 func (u *pageBlobUploader) GetDestinationLength() (int64, error) {
-	prop, err := u.destPageBlobURL.GetProperties(u.jptm.Context(), azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
+	prop, err := u.destPageBlobURL.GetProperties(u.jptm.Context(), azblob.BlobAccessConditions{}, u.cpkOptions)
 
 	if err != nil {
 		return -1, err

--- a/ste/sender-pageBlobFromLocal.go
+++ b/ste/sender-pageBlobFromLocal.go
@@ -93,7 +93,7 @@ func (u *pageBlobUploader) GenerateUploadFunc(id common.ChunkID, blockIndex int3
 		jptm.LogChunkStatus(id, common.EWaitReason.Body())
 		body := newPacedRequestBody(jptm.Context(), reader, u.pacer)
 		enrichedContext := withRetryNotification(jptm.Context(), u.filePacer)
-		_, err := u.destPageBlobURL.UploadPages(enrichedContext, id.OffsetInFile(), body, azblob.PageBlobAccessConditions{}, nil)
+		_, err := u.destPageBlobURL.UploadPages(enrichedContext, id.OffsetInFile(), body, azblob.PageBlobAccessConditions{}, nil, azblob.ClientProvidedKeyOptions{})
 		if err != nil {
 			jptm.FailActiveUpload("Uploading page", err)
 			return
@@ -118,7 +118,7 @@ func (u *pageBlobUploader) Epilogue() {
 }
 
 func (u *pageBlobUploader) GetDestinationLength() (int64, error) {
-	prop, err := u.destPageBlobURL.GetProperties(u.jptm.Context(), azblob.BlobAccessConditions{})
+	prop, err := u.destPageBlobURL.GetProperties(u.jptm.Context(), azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
 
 	if err != nil {
 		return -1, err

--- a/ste/sender-pageBlobFromURL.go
+++ b/ste/sender-pageBlobFromURL.go
@@ -123,7 +123,7 @@ func (c *urlToPageBlobCopier) GenerateCopyFunc(id common.ChunkID, blockIndex int
 		}
 		_, err := c.destPageBlobURL.UploadPagesFromURL(
 			enrichedContext, c.srcURL, id.OffsetInFile(), id.OffsetInFile(), adjustedChunkSize, nil,
-			azblob.PageBlobAccessConditions{}, azblob.ModifiedAccessConditions{}, azblob.ClientProvidedKeyOptions{})
+			azblob.PageBlobAccessConditions{}, azblob.ModifiedAccessConditions{}, c.cpkOptions)
 		if err != nil {
 			c.jptm.FailActiveS2SCopy("Uploading page from URL", err)
 			return
@@ -133,7 +133,7 @@ func (c *urlToPageBlobCopier) GenerateCopyFunc(id common.ChunkID, blockIndex int
 
 // GetDestinationLength gets the destination length.
 func (c *urlToPageBlobCopier) GetDestinationLength() (int64, error) {
-	properties, err := c.destPageBlobURL.GetProperties(c.jptm.Context(), azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
+	properties, err := c.destPageBlobURL.GetProperties(c.jptm.Context(), azblob.BlobAccessConditions{}, c.cpkOptions)
 	if err != nil {
 		return -1, err
 	}

--- a/ste/sender-pageBlobFromURL.go
+++ b/ste/sender-pageBlobFromURL.go
@@ -123,7 +123,7 @@ func (c *urlToPageBlobCopier) GenerateCopyFunc(id common.ChunkID, blockIndex int
 		}
 		_, err := c.destPageBlobURL.UploadPagesFromURL(
 			enrichedContext, c.srcURL, id.OffsetInFile(), id.OffsetInFile(), adjustedChunkSize, nil,
-			azblob.PageBlobAccessConditions{}, azblob.ModifiedAccessConditions{})
+			azblob.PageBlobAccessConditions{}, azblob.ModifiedAccessConditions{}, azblob.ClientProvidedKeyOptions{})
 		if err != nil {
 			c.jptm.FailActiveS2SCopy("Uploading page from URL", err)
 			return
@@ -133,7 +133,7 @@ func (c *urlToPageBlobCopier) GenerateCopyFunc(id common.ChunkID, blockIndex int
 
 // GetDestinationLength gets the destination length.
 func (c *urlToPageBlobCopier) GetDestinationLength() (int64, error) {
-	properties, err := c.destPageBlobURL.GetProperties(c.jptm.Context(), azblob.BlobAccessConditions{})
+	properties, err := c.destPageBlobURL.GetProperties(c.jptm.Context(), azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
 	if err != nil {
 		return -1, err
 	}

--- a/ste/sourceInfoProvider-Blob.go
+++ b/ste/sourceInfoProvider-Blob.go
@@ -55,7 +55,7 @@ func (p *blobSourceInfoProvider) GetFreshFileLastModifiedTime() (time.Time, erro
 	}
 
 	blobURL := azblob.NewBlobURL(*presignedURL, p.jptm.SourceProviderPipeline())
-	properties, err := blobURL.GetProperties(p.jptm.Context(), azblob.BlobAccessConditions{})
+	properties, err := blobURL.GetProperties(p.jptm.Context(), azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
 	if err != nil {
 		return time.Time{}, err
 	}

--- a/ste/sourceInfoProvider-Blob.go
+++ b/ste/sourceInfoProvider-Blob.go
@@ -55,7 +55,8 @@ func (p *blobSourceInfoProvider) GetFreshFileLastModifiedTime() (time.Time, erro
 	}
 
 	blobURL := azblob.NewBlobURL(*presignedURL, p.jptm.SourceProviderPipeline())
-	properties, err := blobURL.GetProperties(p.jptm.Context(), azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
+	encryptionScope := p.jptm.CpkScopeInfo().EncryptionScope
+	properties, err := blobURL.GetProperties(p.jptm.Context(), azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{EncryptionScope: &encryptionScope})
 	if err != nil {
 		return time.Time{}, err
 	}

--- a/ste/sourceInfoProvider-Blob.go
+++ b/ste/sourceInfoProvider-Blob.go
@@ -21,6 +21,7 @@
 package ste
 
 import (
+	"github.com/Azure/azure-storage-azcopy/common"
 	"time"
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
@@ -55,8 +56,8 @@ func (p *blobSourceInfoProvider) GetFreshFileLastModifiedTime() (time.Time, erro
 	}
 
 	blobURL := azblob.NewBlobURL(*presignedURL, p.jptm.SourceProviderPipeline())
-	encryptionScope := p.jptm.CpkScopeInfo().EncryptionScope
-	properties, err := blobURL.GetProperties(p.jptm.Context(), azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{EncryptionScope: &encryptionScope})
+	cpkOptions := common.ToClientProvidedKeyOptions(p.jptm.CpkInfo(), p.jptm.CpkScopeInfo())
+	properties, err := blobURL.GetProperties(p.jptm.Context(), azblob.BlobAccessConditions{}, cpkOptions)
 	if err != nil {
 		return time.Time{}, err
 	}

--- a/ste/sourceInfoProvider-Local.go
+++ b/ste/sourceInfoProvider-Local.go
@@ -41,7 +41,7 @@ func (f localFileSourceInfoProvider) Properties() (*SrcProperties, error) {
 	// create simulated headers, to represent what we want to propagate to the destination based on
 	// this file
 
-	headers, metadata, blobTags := f.jptm.ResourceDstData(nil) // we don't have a known MIME type yet, so pass nil for the sniffed content of thefile
+	headers, metadata, blobTags, _ := f.jptm.ResourceDstData(nil) // we don't have a known MIME type yet, so pass nil for the sniffed content of thefile
 
 	return &SrcProperties{
 		SrcHTTPHeaders: common.ResourceHTTPHeaders{

--- a/ste/sourceInfoProvider-Local.go
+++ b/ste/sourceInfoProvider-Local.go
@@ -41,7 +41,7 @@ func (f localFileSourceInfoProvider) Properties() (*SrcProperties, error) {
 	// create simulated headers, to represent what we want to propagate to the destination based on
 	// this file
 
-	headers, metadata, blobTags, _ := f.jptm.ResourceDstData(nil) // we don't have a known MIME type yet, so pass nil for the sniffed content of thefile
+	headers, metadata, blobTags, _, _ := f.jptm.ResourceDstData(nil) // we don't have a known MIME type yet, so pass nil for the sniffed content of thefile
 
 	return &SrcProperties{
 		SrcHTTPHeaders: common.ResourceHTTPHeaders{

--- a/testSuite/cmd/create.go
+++ b/testSuite/cmd/create.go
@@ -258,7 +258,7 @@ func createBlob(blobURL string, blobSize uint32, metadata azblob.Metadata, blobH
 		metadata,
 		azblob.BlobAccessConditions{},
 		tier,
-		nil)
+		nil, azblob.ClientProvidedKeyOptions{})
 	if err != nil {
 		fmt.Println(fmt.Sprintf("error uploading the blob %v", err))
 		os.Exit(1)

--- a/testSuite/cmd/testblob.go
+++ b/testSuite/cmd/testblob.go
@@ -112,7 +112,7 @@ func init() {
 
 func verifyBlobType(url url.URL, ctx context.Context, p pipeline.Pipeline, intendedBlobType string) (bool, error) {
 	bURL := azblob.NewBlobURL(url, p)
-	pResp, err := bURL.GetProperties(ctx, azblob.BlobAccessConditions{})
+	pResp, err := bURL.GetProperties(ctx, azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
 
 	if err != nil {
 		return false, err
@@ -186,7 +186,7 @@ func verifyBlockBlobDirUpload(testBlobCmd TestBlobCommand) {
 			// get the blob
 			size := blobInfo.Properties.ContentLength
 			get, err := containerUrl.NewBlobURL(blobInfo.Name).Download(testCtx,
-				0, *size, azblob.BlobAccessConditions{}, false)
+				0, *size, azblob.BlobAccessConditions{}, false, azblob.ClientProvidedKeyOptions{})
 
 			if err != nil {
 				fmt.Println(fmt.Sprintf("error downloading the blob %s", blobInfo.Name))
@@ -321,7 +321,7 @@ func verifySinglePageBlobUpload(testBlobCmd TestBlobCommand) {
 
 	// get the blob properties and check the blob tier.
 	if azblob.AccessTierType(testBlobCmd.BlobTier) != azblob.AccessTierNone {
-		blobProperties, err := pageBlobUrl.GetProperties(testCtx, azblob.BlobAccessConditions{})
+		blobProperties, err := pageBlobUrl.GetProperties(testCtx, azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
 		if err != nil {
 			fmt.Println(fmt.Sprintf("error getting the properties of the blob. failed with error %s", err.Error()))
 			os.Exit(1)
@@ -338,7 +338,7 @@ func verifySinglePageBlobUpload(testBlobCmd TestBlobCommand) {
 		}
 	}
 
-	get, err := pageBlobUrl.Download(testCtx, 0, fileInfo.Size(), azblob.BlobAccessConditions{}, false)
+	get, err := pageBlobUrl.Download(testCtx, 0, fileInfo.Size(), azblob.BlobAccessConditions{}, false, azblob.ClientProvidedKeyOptions{})
 	if err != nil {
 		fmt.Println("unable to get blob properties ", err.Error())
 		os.Exit(1)
@@ -497,7 +497,7 @@ func verifySingleBlockBlob(testBlobCmd TestBlobCommand) {
 	// check for access tier type
 	// get the blob properties and get the Access Tier Type.
 	if azblob.AccessTierType(testBlobCmd.BlobTier) != azblob.AccessTierNone {
-		blobProperties, err := blobUrl.GetProperties(testCtx, azblob.BlobAccessConditions{})
+		blobProperties, err := blobUrl.GetProperties(testCtx, azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
 		if err != nil {
 			fmt.Println(fmt.Sprintf("error getting the blob properties. Failed with error %s", err.Error()))
 			os.Exit(1)
@@ -519,7 +519,7 @@ func verifySingleBlockBlob(testBlobCmd TestBlobCommand) {
 		}
 	}
 
-	get, err := blobUrl.Download(testCtx, 0, fileInfo.Size(), azblob.BlobAccessConditions{}, false)
+	get, err := blobUrl.Download(testCtx, 0, fileInfo.Size(), azblob.BlobAccessConditions{}, false, azblob.ClientProvidedKeyOptions{})
 	if err != nil {
 		fmt.Println("unable to get blob properties ", err.Error())
 		os.Exit(1)
@@ -666,7 +666,7 @@ func verifySingleAppendBlob(testBlobCmd TestBlobCommand) {
 
 	// get the blob properties and check the blob tier.
 	if azblob.AccessTierType(testBlobCmd.BlobTier) != azblob.AccessTierNone {
-		blobProperties, err := appendBlobURL.GetProperties(testCtx, azblob.BlobAccessConditions{})
+		blobProperties, err := appendBlobURL.GetProperties(testCtx, azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
 		if err != nil {
 			fmt.Println(fmt.Sprintf("error getting the properties of the blob. failed with error %s", err.Error()))
 			os.Exit(1)
@@ -683,7 +683,7 @@ func verifySingleAppendBlob(testBlobCmd TestBlobCommand) {
 		}
 	}
 
-	get, err := appendBlobURL.Download(testCtx, 0, fileInfo.Size(), azblob.BlobAccessConditions{}, false)
+	get, err := appendBlobURL.Download(testCtx, 0, fileInfo.Size(), azblob.BlobAccessConditions{}, false, azblob.ClientProvidedKeyOptions{})
 	if err != nil {
 		fmt.Println("unable to get blob properties ", err.Error())
 		os.Exit(1)


### PR DESCRIPTION
- Clients making requests against Azure Blob storage have the option to provide an encryption key on a per-request basis.
- Including the encryption key on the request provides granular control over encryption settings for Blob storage operations.
-  Customer-provided keys can be stored in Azure Key Vault or in another key store.

[Public Documentation - 1](https://docs.microsoft.com/en-us/azure/storage/blobs/encryption-customer-provided-keys)
[Public Documentation - 2](https://azure.microsoft.com/en-in/blog/customer-provided-keys-with-azure-storage-service-encryption/)