### PR TITLE
Conflict for file share folder with name ";"

### DIFF
--- a/common/folderCreationTracker.go
+++ b/common/folderCreationTracker.go
@@ -65,13 +65,8 @@ type simpleFolderTracker struct {
 func (f *simpleFolderTracker) RecordCreation(folder string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	decodedFolderName, err := url.QueryUnescape(folder)
-	if err == nil {
-		f.contents[decodedFolderName] = struct{}{}
-	} else {
-		f.contents[folder] = struct{}{}
-	}
 
+	f.contents[folder] = struct{}{}
 }
 
 func (f *simpleFolderTracker) ShouldSetProperties(folder string, overwrite OverwriteOption, prompter prompter) bool {
@@ -86,12 +81,6 @@ func (f *simpleFolderTracker) ShouldSetProperties(folder string, overwrite Overw
 		defer f.mu.Unlock()
 
 		_, exists := f.contents[folder] // should only set properties if this job created the folder (i.e. it's in the map)
-		if !exists {
-			decodedFolderName, err := url.QueryUnescape(folder)
-			if err == nil {
-				_, exists = f.contents[decodedFolderName]
-			}
-		}
 
 		// prompt only if we didn't create this folder
 		if overwrite == EOverwriteOption.Prompt() && !exists {
@@ -122,10 +111,7 @@ func (f *simpleFolderTracker) ShouldSetProperties(folder string, overwrite Overw
 func (f *simpleFolderTracker) StopTracking(folder string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	decodedFolderName, err := url.QueryUnescape(folder)
-	if err == nil {
-		delete(f.contents, decodedFolderName)
-	}
+
 	delete(f.contents, folder)
 }
 

--- a/e2etest/zt_naming_file_and_folder_test.go
+++ b/e2etest/zt_naming_file_and_folder_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Upload, Download, S2S transfer of folders/files with special characters. Required for avoiding regression.
-func TestNaming_FoldersWithSpecialCharacter(t *testing.T) {
+func TestNaming_ShareFileFoldersSpecialChar(t *testing.T) {
 	files := []string{"file1.txt", "fi,le2.pdf", "fil%e3.mp3", "file 4.jpg", "file;a5.csv", "file_a6.cpp", "file+a7.mp4"}
 	folders := []string{";", ";;", "%", "_", "+", "test%folder1", "test+folder2", "test%folder3", "test folder4", "test_folder5"}
 	transfers := make([]interface{}, 0)
@@ -39,7 +39,7 @@ func TestNaming_FoldersWithSpecialCharacter(t *testing.T) {
 	}
 	RunScenarios(
 		t,
-		eOperation.Copy(),
+		eOperation.CopyAndSync(),
 		eTestFromTo.Other(common.EFromTo.FileFile(), common.EFromTo.FileLocal(), common.EFromTo.LocalFile()),
 		eValidate.Auto(),
 		params{

--- a/e2etest/zt_naming_file_and_folder_test.go
+++ b/e2etest/zt_naming_file_and_folder_test.go
@@ -28,7 +28,7 @@ import (
 // Upload, Download, S2S transfer of folders/files with special characters. Required for avoiding regression.
 func TestNaming_ShareFileFoldersSpecialChar(t *testing.T) {
 	files := []string{"file1.txt", "fi,le2.pdf", "fil%e3.mp3", "file 4.jpg", "file;a5.csv", "file_a6.cpp", "file+a7.mp4"}
-	folders := []string{";", ";;", "%", "_", "+", "test%folder1", "test+folder2", "test%folder3", "test folder4", "test_folder5"}
+	folders := []string{";", ";;", "%", "_", "+", "test%folder1", "test+folder2", "test,folder3", "test folder4", "test_folder5", "test;folder6"}
 	transfers := make([]interface{}, 0)
 	transfers = append(transfers, folder(""))
 	for i := 0; i < len(folders); i++ {

--- a/e2etest/zt_naming_file_and_folder_test.go
+++ b/e2etest/zt_naming_file_and_folder_test.go
@@ -1,0 +1,53 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package e2etest
+
+import (
+	"github.com/Azure/azure-storage-azcopy/common"
+	"testing"
+)
+
+// Upload, Download, S2S transfer of folders/files with special characters. Required for avoiding regression.
+func TestNaming_FoldersWithSpecialCharacter(t *testing.T) {
+	files := []string{"file1.txt", "fi,le2.pdf", "fil%e3.mp3", "file 4.jpg", "file;a5.csv", "file_a6.cpp", "file+a7.mp4"}
+	folders := []string{";", ";;", "%", "_", "+", "test%folder1", "test+folder2", "test%folder3", "test folder4", "test_folder5"}
+	transfers := make([]interface{}, 0)
+	transfers = append(transfers, folder(""))
+	for i := 0; i < len(folders); i++ {
+		transfers = append(transfers, folder(folders[i]))
+		for j := 0; j < len(files); j++ {
+			transfers = append(transfers, f(folders[i]+"/"+files[j]))
+		}
+	}
+	RunScenarios(
+		t,
+		eOperation.Copy(),
+		eTestFromTo.Other(common.EFromTo.FileFile(), common.EFromTo.FileLocal(), common.EFromTo.LocalFile()),
+		eValidate.Auto(),
+		params{
+			recursive: true,
+		},
+		nil,
+		testFiles{
+			defaultSize:    "1K",
+			shouldTransfer: transfers,
+		})
+}

--- a/ste/sender-azureFile.go
+++ b/ste/sender-azureFile.go
@@ -446,8 +446,7 @@ func (d AzureFileParentDirCreator) CreateDirToRoot(ctx context.Context, dirURL a
 					// Must do it here, in the routine that is shared by both the folder and the file code,
 					// because due to the parallelism of AzCopy, we don't know which will get here first, file code, or folder code.
 					dirUrl := curDirURL.URL()
-					dirUrlStr := strings.Replace(dirUrl.String(), ";", url.QueryEscape(";"), -1)
-					t.RecordCreation(dirUrlStr)
+					t.RecordCreation(dirUrl.String())
 				}
 				if verifiedErr := d.verifyAndHandleCreateErrors(err); verifiedErr != nil {
 					return verifiedErr

--- a/ste/sender-azureFile.go
+++ b/ste/sender-azureFile.go
@@ -383,6 +383,11 @@ func (u *azureFileSenderBase) SetFolderProperties() error {
 	return err
 }
 
+func (u *azureFileSenderBase) DirUrlToString() string {
+	dirUrl := (common.FileURLPartsExtension{FileURLParts: azfile.NewFileURLParts(u.dirURL().URL())}).URL()
+	return dirUrl.String()
+}
+
 // namespace for functions related to creating parent directories in Azure File
 // to avoid free floating global funcs
 type AzureFileParentDirCreator struct{}

--- a/ste/sender-azureFile.go
+++ b/ste/sender-azureFile.go
@@ -384,7 +384,7 @@ func (u *azureFileSenderBase) SetFolderProperties() error {
 }
 
 func (u *azureFileSenderBase) DirUrlToString() string {
-	dirUrl := (common.FileURLPartsExtension{FileURLParts: azfile.NewFileURLParts(u.dirURL().URL())}).URL()
+	dirUrl := azfile.NewFileURLParts(u.dirURL().URL()).URL()
 	return dirUrl.String()
 }
 

--- a/ste/sender-azureFile.go
+++ b/ste/sender-azureFile.go
@@ -446,7 +446,7 @@ func (d AzureFileParentDirCreator) CreateDirToRoot(ctx context.Context, dirURL a
 					// Must do it here, in the routine that is shared by both the folder and the file code,
 					// because due to the parallelism of AzCopy, we don't know which will get here first, file code, or folder code.
 					dirUrl := curDirURL.URL()
-					dirUrlStr := strings.Replace(dirUrl.String(), segments[i], url.QueryEscape(segments[i]), -1)
+					dirUrlStr := strings.Replace(dirUrl.String(), ";", url.QueryEscape(";"), -1)
 					t.RecordCreation(dirUrlStr)
 				}
 				if verifiedErr := d.verifyAndHandleCreateErrors(err); verifiedErr != nil {

--- a/ste/sender-azureFile.go
+++ b/ste/sender-azureFile.go
@@ -446,7 +446,8 @@ func (d AzureFileParentDirCreator) CreateDirToRoot(ctx context.Context, dirURL a
 					// Must do it here, in the routine that is shared by both the folder and the file code,
 					// because due to the parallelism of AzCopy, we don't know which will get here first, file code, or folder code.
 					dirUrl := curDirURL.URL()
-					t.RecordCreation(dirUrl.String())
+					dirUrlStr := strings.Replace(dirUrl.String(), segments[i], url.QueryEscape(segments[i]), -1)
+					t.RecordCreation(dirUrlStr)
 				}
 				if verifiedErr := d.verifyAndHandleCreateErrors(err); verifiedErr != nil {
 					return verifiedErr

--- a/ste/sender-blobFS.go
+++ b/ste/sender-blobFS.go
@@ -217,3 +217,10 @@ func (u *blobFSSenderBase) SetFolderProperties() error {
 	// we don't currently preserve any properties for BlobFS folders
 	return nil
 }
+
+func (u *blobFSSenderBase) DirUrlToString() string {
+	dirUrl := u.dirURL().URL()
+	// To avoid encoding/decoding
+	dirUrl.RawPath = ""
+	return u.dirURL().String()
+}

--- a/ste/sender.go
+++ b/ste/sender.go
@@ -72,6 +72,7 @@ type sender interface {
 type folderSender interface {
 	EnsureFolderExists() error
 	SetFolderProperties() error
+	DirUrlToString() string
 }
 
 type senderFactory func(jptm IJobPartTransferMgr, destination string, p pipeline.Pipeline, pacer pacer, sip ISourceInfoProvider) (sender, error)

--- a/ste/xfer-anyToRemote-folder.go
+++ b/ste/xfer-anyToRemote-folder.go
@@ -73,8 +73,8 @@ func anyToRemote_folder(jptm IJobPartTransferMgr, info TransferInfo, p pipeline.
 	} else {
 
 		t := jptm.GetFolderCreationTracker()
-		defer t.StopTracking(info.Destination) // don't need it after this routine
-		shouldSetProps := t.ShouldSetProperties(info.Destination, jptm.GetOverwriteOption(), jptm.GetOverwritePrompter())
+		defer t.StopTracking(s.DirUrlToString()) // don't need it after this routine
+		shouldSetProps := t.ShouldSetProperties(s.DirUrlToString(), jptm.GetOverwriteOption(), jptm.GetOverwritePrompter())
 		if !shouldSetProps {
 			jptm.LogAtLevelForCurrentTransfer(pipeline.LogWarning, "Folder already exists, so due to the --overwrite option, its properties won't be set")
 			jptm.SetStatus(common.ETransferStatus.SkippedEntityAlreadyExists()) // using same status for both files and folders, for simplicity

--- a/testSuite/scripts/test_file_copy.py
+++ b/testSuite/scripts/test_file_copy.py
@@ -15,12 +15,12 @@ class File_Service_2_Service_Copy_User_Scenario(unittest.TestCase):
         remote_src_file_path = util.get_resource_sas_from_share(content_file_name_src)
         remote_dst_file_path = util.get_resource_sas_from_share(content_file_name_dst)
         result = util.Command("cp").add_arguments(content_file_path_src).add_arguments(remote_src_file_path). \
-            add_flags("log-level", "info").execute_azcopy_copy_command()
+            add_flags("log-level", "debug").execute_azcopy_copy_command()
         self.assertTrue(result)
 
         # perform the single file copy using azcopy.
         result = util.Command("copy").add_arguments(remote_src_file_path).add_arguments(remote_dst_file_path). \
-            add_flags("log-level", "info").execute_azcopy_copy_command()
+            add_flags("log-level", "debug").execute_azcopy_copy_command()
         self.assertTrue(result)
 
         # verifying the copy worked, both remote source and destination should be identical to the local source
@@ -42,14 +42,14 @@ class File_Service_2_Service_Copy_User_Scenario(unittest.TestCase):
 
         # upload to the source
         result = util.Command("copy").add_arguments(content_dir_path_src).add_arguments(util.test_share_url). \
-            add_flags("recursive", "true").add_flags("log-level", "info").execute_azcopy_copy_command()
+            add_flags("recursive", "true").add_flags("log-level", "debug").execute_azcopy_copy_command()
         self.assertTrue(result)
 
         # copy to destination
         remote_src_dir_path = util.get_resource_sas_from_share(content_dir_name_src)
         remote_dst_dir_path = util.get_resource_sas_from_share(content_dir_name_dst)
         result = util.Command("copy").add_arguments(util.get_resource_sas_from_share(content_dir_name_src+"/*"))\
-            .add_arguments(remote_dst_dir_path).add_flags("log-level", "info").add_flags("recursive", "true")\
+            .add_arguments(remote_dst_dir_path).add_flags("log-level", "debug").add_flags("recursive", "true")\
             .execute_azcopy_copy_command()
         self.assertTrue(result)
 

--- a/testSuite/scripts/test_file_download.py
+++ b/testSuite/scripts/test_file_download.py
@@ -16,7 +16,7 @@ class FileShare_Download_User_Scenario(unittest.TestCase):
         src = file_path
         dest = util.test_share_url
         result = util.Command("copy").add_arguments(src).add_arguments(dest). \
-            add_flags("log-level", "info").execute_azcopy_copy_command()
+            add_flags("log-level", "debug").execute_azcopy_copy_command()
         self.assertTrue(result)
 
         # Verifying the uploaded file.
@@ -30,7 +30,7 @@ class FileShare_Download_User_Scenario(unittest.TestCase):
         src = util.get_resource_sas_from_share(filename)
         dest = util.test_directory_path + "/test_1kb_file_download.txt"
         result = util.Command("copy").add_arguments(src).add_arguments(dest).add_flags("log-level",
-                                                                                       "info").execute_azcopy_copy_command()
+                                                                                       "debug").execute_azcopy_copy_command()
         self.assertTrue(result)
 
         # Verifying the downloaded file
@@ -192,7 +192,7 @@ class FileShare_Download_User_Scenario(unittest.TestCase):
 
         # execute azcopy command
         result = util.Command("copy").add_arguments(src_dir).add_arguments(dest_azure_dir). \
-            add_flags("recursive", recursive).add_flags("log-level", "info").execute_azcopy_copy_command()
+            add_flags("recursive", recursive).add_flags("log-level", "debug").execute_azcopy_copy_command()
         self.assertTrue(result)
         
         # execute the validator.
@@ -214,7 +214,7 @@ class FileShare_Download_User_Scenario(unittest.TestCase):
 
         # downloading the directory created from azure file directory through azcopy with recursive flag to true.
         result = util.Command("copy").add_arguments(download_azure_src_dir).add_arguments(
-            download_local_dest_dir).add_flags("log-level", "info"). \
+            download_local_dest_dir).add_flags("log-level", "debug"). \
             add_flags("recursive", recursive).execute_azcopy_copy_command()
         self.assertTrue(result)
 
@@ -242,7 +242,7 @@ class FileShare_Download_User_Scenario(unittest.TestCase):
         # upload file through azcopy.
         destination_sas = util.get_resource_sas_from_share(filename)
         result = util.Command("copy").add_arguments(file_path).add_arguments(destination_sas). \
-            add_flags("log-level", "info").add_flags("recursive", "true").execute_azcopy_copy_command()
+            add_flags("log-level", "debug").add_flags("recursive", "true").execute_azcopy_copy_command()
         self.assertTrue(result)
 
         # Verifying the uploaded file
@@ -254,7 +254,7 @@ class FileShare_Download_User_Scenario(unittest.TestCase):
         # download file through azcopy with flag preserve-last-modified-time set to true
         download_file_name = util.test_directory_path + "/test_download_preserve_last_mtime.txt"
         result = util.Command("copy").add_arguments(destination_sas).add_arguments(download_file_name).add_flags("log-level",
-                                                                                                                 "info").add_flags(
+                                                                                                                 "debug").add_flags(
             "preserve-last-modified-time", "true").execute_azcopy_copy_command()
         self.assertTrue(result)
 

--- a/testSuite/scripts/test_file_upload.py
+++ b/testSuite/scripts/test_file_upload.py
@@ -30,7 +30,7 @@ class FileShare_Upload_User_Scenario(unittest.TestCase):
 
         # execute azcopy upload.
         destination = util.get_resource_sas_from_share(file_name)
-        result = util.Command("copy").add_arguments(file_path).add_arguments(destination).add_flags("log-level", "info"). \
+        result = util.Command("copy").add_arguments(file_path).add_arguments(destination).add_flags("log-level", "debug"). \
             add_flags("block-size-mb", "4").execute_azcopy_copy_command()
         self.assertTrue(result)
 


### PR DESCRIPTION
Fix for [Issue 1107](https://github.com/Azure/azure-storage-azcopy/issues/1107)

Reason:

While creating file directories, we maintain a file creation tracker(which basically is a map).
When we create a folder, folder URL looks like - 
`https://<accountName>.file.core.windows.net/<fileShare>/<folder>`

In this case, where folder name contains a special character `;`, folder URL will look like -
`https://<accountName>.file.core.windows.net/<fileShare>/;`
After we're done with creating the folder, we make entry in the file creation tracker.

However the issue occurs when we try to lookup the created folders for transferring properties. During lookup, we're searching for folder `%3B` which is percentage encoding equivalent of `;` i.e. `https://<accountName>.file.core.windows.net/<fileShare>/%3B`

Fixed the issue by performing URL encoding on the directory name containing ";" before making an entry in the file tracker..