### PR TITLE
Download to temp-file before moving to original path

### DIFF
--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -90,6 +90,7 @@ type IJobPartTransferMgr interface {
 }
 
 type TransferInfo struct {
+	JobID 				   common.JobID
 	BlockSize              int64
 	Source                 string
 	SourceSize             int64
@@ -326,6 +327,7 @@ func (jptm *jobPartTransferMgr) Info() TransferInfo {
 	}
 
 	jptm.transferInfo = &TransferInfo{
+		JobID: 							plan.JobID,
 		BlockSize:                      blockSize,
 		Source:                         src,
 		SourceSize:                     sourceSize,


### PR DESCRIPTION
- Downloads will happen to a temp file named `.azDownload-<jobID>-fileName`, in the same directory where file is being downloaded, before being moved to `fileName`.
- Partial/failed transfers will be cleaned as before.
- This will be default behaviour for downloads. Zero byte files, downloads to NULL and directories are not impacted.
- If files exist with similar name, they'll be overwritten. (But given we include jobID in name, if such files exist, that is user trying to spite AzCopy.)
- Name clashes may happen in certain cases described [here](https://github.com/Azure/azure-storage-azcopy/blob/630b37f8c8554f5b96d000dabfcb9342a9ad31c8/ste/mgr-JobPartTransferMgr.go#L368). This behaviour is retained.