### PR TITLE
Improve Job Reporting infra

### DIFF
--- a/cmd/copyEnumeratorHelper.go
+++ b/cmd/copyEnumeratorHelper.go
@@ -2,10 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/Azure/azure-storage-azcopy/ste"
 	"math/rand"
 	"strings"
+
+	"github.com/Azure/azure-pipeline-go/pipeline"
+	"github.com/Azure/azure-storage-azcopy/ste"
 
 	"github.com/Azure/azure-storage-azcopy/common"
 )
@@ -22,8 +23,8 @@ func addTransfer(e *common.CopyJobPartOrderRequest, transfer common.CopyTransfer
 	// dispatch the transfers once the number reaches NumOfFilesPerDispatchJobPart
 	// we do this so that in the case of large transfer, the transfer engine can get started
 	// while the frontend is still gathering more transfers
-	if len(e.Transfers) == NumOfFilesPerDispatchJobPart {
-		shuffleTransfers(e.Transfers)
+	if len(e.Transfers.List) == NumOfFilesPerDispatchJobPart {
+		shuffleTransfers(e.Transfers.List)
 		resp := common.CopyJobPartOrderResponse{}
 
 		Rpc(common.ERpcCmd.CopyJobPartOrder(), (*common.CopyJobPartOrderRequest)(e), &resp)
@@ -35,13 +36,13 @@ func addTransfer(e *common.CopyJobPartOrderRequest, transfer common.CopyTransfer
 		if e.PartNum == 0 {
 			cca.waitUntilJobCompletion(false)
 		}
-		e.Transfers = []common.CopyTransfer{}
+		e.Transfers = common.Transfers{}
 		e.PartNum++
 	}
 
 	// only append the transfer after we've checked and dispatched a part
 	// so that there is at least one transfer for the final part
-	e.Transfers = append(e.Transfers, transfer)
+	e.Transfers.List = append(e.Transfers.List, transfer)
 
 	return nil
 }
@@ -56,7 +57,7 @@ func shuffleTransfers(transfers []common.CopyTransfer) {
 // we need to send a last part with isFinalPart set to true, along with whatever transfers that still haven't been sent
 // dispatchFinalPart sends a last part with isFinalPart set to true, along with whatever transfers that still haven't been sent.
 func dispatchFinalPart(e *common.CopyJobPartOrderRequest, cca *cookedCopyCmdArgs) error {
-	shuffleTransfers(e.Transfers)
+	shuffleTransfers(e.Transfers.List)
 	e.IsFinalPart = true
 	var resp common.CopyJobPartOrderResponse
 	Rpc(common.ERpcCmd.CopyJobPartOrder(), (*common.CopyJobPartOrderRequest)(e), &resp)

--- a/cmd/copyEnumeratorHelper.go
+++ b/cmd/copyEnumeratorHelper.go
@@ -42,7 +42,16 @@ func addTransfer(e *common.CopyJobPartOrderRequest, transfer common.CopyTransfer
 
 	// only append the transfer after we've checked and dispatched a part
 	// so that there is at least one transfer for the final part
-	e.Transfers.List = append(e.Transfers.List, transfer)
+	{
+		//Should this block be a function?
+		e.Transfers.List = append(e.Transfers.List, transfer)
+		e.Transfers.TotalSizeInBytes += uint64(transfer.SourceSize)
+		if transfer.EntityType == common.EEntityType.File() {
+			e.Transfers.FileTransferCount++
+		} else {
+			e.Transfers.FolderTransferCount++
+		}
+	}
 
 	return nil
 }

--- a/cmd/copyEnumeratorHelper_test.go
+++ b/cmd/copyEnumeratorHelper_test.go
@@ -58,6 +58,6 @@ func (s *copyEnumeratorHelperTestSuite) TestAddTransferPathRootsTrimmed(c *chk.C
 
 	// assert
 	c.Assert(err, chk.IsNil)
-	c.Assert(request.Transfers[0].Source, chk.Equals, "c.txt")
-	c.Assert(request.Transfers[0].Destination, chk.Equals, "c.txt")
+	c.Assert(request.Transfers.List[0].Source, chk.Equals, "c.txt")
+	c.Assert(request.Transfers.List[0].Destination, chk.Equals, "c.txt")
 }

--- a/cmd/zc_processor.go
+++ b/cmd/zc_processor.go
@@ -22,6 +22,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/Azure/azure-pipeline-go/pipeline"
 
 	"github.com/pkg/errors"
@@ -79,7 +80,7 @@ func (s *copyTransferProcessor) scheduleCopyTransfer(storedObject storedObject) 
 		return nil // skip this one
 	}
 
-	if len(s.copyJobTemplate.Transfers) == s.numOfTransfersPerPart {
+	if len(s.copyJobTemplate.Transfers.List) == s.numOfTransfersPerPart {
 		resp := s.sendPartToSte()
 
 		// TODO: If we ever do launch errors outside of the final "no transfers" error, make them output nicer things here.
@@ -88,13 +89,13 @@ func (s *copyTransferProcessor) scheduleCopyTransfer(storedObject storedObject) 
 		}
 
 		// reset the transfers buffer
-		s.copyJobTemplate.Transfers = []common.CopyTransfer{}
+		s.copyJobTemplate.Transfers = common.Transfers{}
 		s.copyJobTemplate.PartNum++
 	}
 
 	// only append the transfer after we've checked and dispatched a part
 	// so that there is at least one transfer for the final part
-	s.copyJobTemplate.Transfers = append(s.copyJobTemplate.Transfers, copyTransfer)
+	s.copyJobTemplate.Transfers.List = append(s.copyJobTemplate.Transfers.List, copyTransfer)
 
 	return nil
 }

--- a/cmd/zt_interceptors_for_test.go
+++ b/cmd/zt_interceptors_for_test.go
@@ -37,7 +37,7 @@ func (i *interceptor) intercept(cmd common.RpcCmd, request interface{}, response
 	case common.ERpcCmd.CopyJobPartOrder():
 		// cache the transfers
 		copyRequest := *request.(*common.CopyJobPartOrderRequest)
-		i.transfers = append(i.transfers, copyRequest.Transfers...)
+		i.transfers = append(i.transfers, copyRequest.Transfers.List...)
 		i.lastRequest = request
 
 		// mock the result

--- a/common/rpc-models.go
+++ b/common/rpc-models.go
@@ -111,9 +111,9 @@ func ConsolidatePathSeparators(path string) string {
 //other auxilliary details of this order.
 type Transfers struct {
 	List                []CopyTransfer
-	TotalSizeBytes      int64
-	FileTransferCount   int
-	FolderTransferCount int
+	TotalSizeInBytes    uint64
+	FileTransferCount   uint32
+	FolderTransferCount uint32
 }
 
 // This struct represents the job info (a single part) to be sent to the storage engine
@@ -306,6 +306,7 @@ type TransferDetail struct {
 	Dst                string
 	IsFolderProperties bool
 	TransferStatus     TransferStatus
+	TransferSize       uint64
 	ErrorCode          int32 `json:",string"`
 }
 

--- a/common/rpc-models.go
+++ b/common/rpc-models.go
@@ -107,6 +107,15 @@ func ConsolidatePathSeparators(path string) string {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+//Transfers describes each file/folder being transferred in a given JobPartOrder, and
+//other auxilliary details of this order.
+type Transfers struct {
+	List                []CopyTransfer
+	TotalSizeBytes      int64
+	FileTransferCount   int
+	FolderTransferCount int
+}
+
 // This struct represents the job info (a single part) to be sent to the storage engine
 type CopyJobPartOrderRequest struct {
 	Version         Version         // version of azcopy
@@ -125,7 +134,7 @@ type CopyJobPartOrderRequest struct {
 	SourceRoot      ResourceString
 	DestinationRoot ResourceString
 
-	Transfers      []CopyTransfer
+	Transfers      Transfers
 	LogLevel       LogLevel
 	BlobAttributes BlobTransferAttributes
 	CommandString  string // commandString hold the user given command which is logged to the Job log file

--- a/ste/JobPartPlanFileName.go
+++ b/ste/JobPartPlanFileName.go
@@ -173,7 +173,7 @@ func (jpfn JobPartPlanFileName) Create(order common.CopyJobPartOrderRequest) {
 		FromTo:                 order.FromTo,
 		Fpo:                    order.Fpo,
 		CommandStringLength:    uint32(len(order.CommandString)),
-		NumTransfers:           uint32(len(order.Transfers)),
+		NumTransfers:           uint32(len(order.Transfers.List)),
 		LogLevel:               order.LogLevel,
 		DstBlobData: JobPartPlanDstBlob{
 			BlobType:                 order.BlobAttributes.BlobType,
@@ -235,58 +235,58 @@ func (jpfn JobPartPlanFileName) Create(order common.CopyJobPartOrderRequest) {
 	currentSrcStringOffset := eof + int64(unsafe.Sizeof(JobPartPlanTransfer{}))*int64(jpph.NumTransfers)
 
 	// Write each transfer to the Job Part Plan file (except for the src/dst strings; comes come later)
-	for t := range order.Transfers {
-		if len(order.Transfers[t].Source) > math.MaxInt16 || len(order.Transfers[t].Destination) > math.MaxInt16 {
-			panic(fmt.Sprintf("The file %s exceeds azcopy's current maximum path length on either the source or the destination.", order.Transfers[t].Source))
+	for t := range order.Transfers.List {
+		if len(order.Transfers.List[t].Source) > math.MaxInt16 || len(order.Transfers.List[t].Destination) > math.MaxInt16 {
+			panic(fmt.Sprintf("The file %s exceeds azcopy's current maximum path length on either the source or the destination.", order.Transfers.List[t].Source))
 		}
 
 		// Prepare info for JobPartPlanTransfer
 		// Sending Metadata type to Transfer could ensure strong type validation.
 		// TODO: discuss the performance drop of marshaling metadata twice
 		srcMetadataLength := 0
-		if order.Transfers[t].Metadata != nil {
-			metadataStr, err := order.Transfers[t].Metadata.Marshal()
+		if order.Transfers.List[t].Metadata != nil {
+			metadataStr, err := order.Transfers.List[t].Metadata.Marshal()
 			if err != nil {
 				panic(err)
 			}
 			srcMetadataLength = len(metadataStr)
 		}
 		if srcMetadataLength > math.MaxInt16 {
-			panic(fmt.Sprintf("The metadata on source file %s exceeds azcopy's current maximum metadata length, and cannot be processed.", order.Transfers[t].Source))
+			panic(fmt.Sprintf("The metadata on source file %s exceeds azcopy's current maximum metadata length, and cannot be processed.", order.Transfers.List[t].Source))
 		}
 
 		srcBlobTagsLength := 0
-		if order.Transfers[t].BlobTags != nil {
-			blobTagsStr := order.Transfers[t].BlobTags.ToString()
+		if order.Transfers.List[t].BlobTags != nil {
+			blobTagsStr := order.Transfers.List[t].BlobTags.ToString()
 			srcBlobTagsLength = len(blobTagsStr)
 		}
 		if srcBlobTagsLength > math.MaxInt16 {
-			panic(fmt.Sprintf("The length of tags %s exceeds maximum allowed length, and cannot be processed.", order.Transfers[t].BlobTags))
+			panic(fmt.Sprintf("The length of tags %s exceeds maximum allowed length, and cannot be processed.", order.Transfers.List[t].BlobTags))
 		}
 		// Create & initialize this transfer's Job Part Plan Transfer
 		jppt := JobPartPlanTransfer{
 			SrcOffset:      currentSrcStringOffset, // SrcOffset of the src string
-			SrcLength:      int16(len(order.Transfers[t].Source)),
-			DstLength:      int16(len(order.Transfers[t].Destination)),
-			EntityType:     order.Transfers[t].EntityType,
-			ModifiedTime:   order.Transfers[t].LastModifiedTime.UnixNano(),
-			SourceSize:     order.Transfers[t].SourceSize,
+			SrcLength:      int16(len(order.Transfers.List[t].Source)),
+			DstLength:      int16(len(order.Transfers.List[t].Destination)),
+			EntityType:     order.Transfers.List[t].EntityType,
+			ModifiedTime:   order.Transfers.List[t].LastModifiedTime.UnixNano(),
+			SourceSize:     order.Transfers.List[t].SourceSize,
 			CompletionTime: 0,
 			// For S2S copy, per Transfer source's properties
-			SrcContentTypeLength:        int16(len(order.Transfers[t].ContentType)),
-			SrcContentEncodingLength:    int16(len(order.Transfers[t].ContentEncoding)),
-			SrcContentLanguageLength:    int16(len(order.Transfers[t].ContentLanguage)),
-			SrcContentDispositionLength: int16(len(order.Transfers[t].ContentDisposition)),
-			SrcCacheControlLength:       int16(len(order.Transfers[t].CacheControl)),
-			SrcContentMD5Length:         int16(len(order.Transfers[t].ContentMD5)),
+			SrcContentTypeLength:        int16(len(order.Transfers.List[t].ContentType)),
+			SrcContentEncodingLength:    int16(len(order.Transfers.List[t].ContentEncoding)),
+			SrcContentLanguageLength:    int16(len(order.Transfers.List[t].ContentLanguage)),
+			SrcContentDispositionLength: int16(len(order.Transfers.List[t].ContentDisposition)),
+			SrcCacheControlLength:       int16(len(order.Transfers.List[t].CacheControl)),
+			SrcContentMD5Length:         int16(len(order.Transfers.List[t].ContentMD5)),
 			SrcMetadataLength:           int16(srcMetadataLength),
-			SrcBlobTypeLength:           int16(len(order.Transfers[t].BlobType)),
-			SrcBlobTierLength:           int16(len(order.Transfers[t].BlobTier)),
-			SrcBlobVersionIDLength:      int16(len(order.Transfers[t].BlobVersionID)),
+			SrcBlobTypeLength:           int16(len(order.Transfers.List[t].BlobType)),
+			SrcBlobTierLength:           int16(len(order.Transfers.List[t].BlobTier)),
+			SrcBlobVersionIDLength:      int16(len(order.Transfers.List[t].BlobVersionID)),
 			SrcBlobTagsLength:           int16(srcBlobTagsLength),
 
 			atomicTransferStatus: common.ETransferStatus.Started(), // Default
-			//ChunkNum:                getNumChunks(uint64(order.Transfers[t].SourceSize), uint64(data.BlockSize)),
+			//ChunkNum:                getNumChunks(uint64(order.Transfers.List[t].SourceSize), uint64(data.BlockSize)),
 		}
 		eof += writeValue(file, &jppt) // Write the transfer entry
 
@@ -300,79 +300,79 @@ func (jpfn JobPartPlanFileName) Create(order common.CopyJobPartOrderRequest) {
 	}
 
 	// All the transfers were written; now write each transfer's src/dst strings
-	for t := range order.Transfers {
+	for t := range order.Transfers.List {
 		// Sanity check: Verify that we are were we think we are and that no bug has occurred
 		if eof != srcDstStringsOffset[t] {
-			panic(errors.New("job plan file's EOF and the transfer's offset didn't line up; filename: " + order.Transfers[t].Source))
+			panic(errors.New("job plan file's EOF and the transfer's offset didn't line up; filename: " + order.Transfers.List[t].Source))
 		}
 
 		// Write the src & dst strings to the job part plan file
-		bytesWritten, err := file.WriteString(order.Transfers[t].Source)
+		bytesWritten, err := file.WriteString(order.Transfers.List[t].Source)
 		common.PanicIfErr(err)
 		eof += int64(bytesWritten)
 		// write the destination string in memory map file
-		bytesWritten, err = file.WriteString(order.Transfers[t].Destination)
+		bytesWritten, err = file.WriteString(order.Transfers.List[t].Destination)
 		common.PanicIfErr(err)
 		eof += int64(bytesWritten)
 
 		// For S2S copy (and, in the case of Content-MD5, always), write the src properties
-		if len(order.Transfers[t].ContentType) != 0 {
-			bytesWritten, err = file.WriteString(order.Transfers[t].ContentType)
+		if len(order.Transfers.List[t].ContentType) != 0 {
+			bytesWritten, err = file.WriteString(order.Transfers.List[t].ContentType)
 			common.PanicIfErr(err)
 			eof += int64(bytesWritten)
 		}
-		if len(order.Transfers[t].ContentEncoding) != 0 {
-			bytesWritten, err = file.WriteString(order.Transfers[t].ContentEncoding)
+		if len(order.Transfers.List[t].ContentEncoding) != 0 {
+			bytesWritten, err = file.WriteString(order.Transfers.List[t].ContentEncoding)
 			common.PanicIfErr(err)
 			eof += int64(bytesWritten)
 		}
-		if len(order.Transfers[t].ContentLanguage) != 0 {
-			bytesWritten, err = file.WriteString(order.Transfers[t].ContentLanguage)
+		if len(order.Transfers.List[t].ContentLanguage) != 0 {
+			bytesWritten, err = file.WriteString(order.Transfers.List[t].ContentLanguage)
 			common.PanicIfErr(err)
 			eof += int64(bytesWritten)
 		}
-		if len(order.Transfers[t].ContentDisposition) != 0 {
-			bytesWritten, err = file.WriteString(order.Transfers[t].ContentDisposition)
+		if len(order.Transfers.List[t].ContentDisposition) != 0 {
+			bytesWritten, err = file.WriteString(order.Transfers.List[t].ContentDisposition)
 			common.PanicIfErr(err)
 			eof += int64(bytesWritten)
 		}
-		if len(order.Transfers[t].CacheControl) != 0 {
-			bytesWritten, err = file.WriteString(order.Transfers[t].CacheControl)
+		if len(order.Transfers.List[t].CacheControl) != 0 {
+			bytesWritten, err = file.WriteString(order.Transfers.List[t].CacheControl)
 			common.PanicIfErr(err)
 			eof += int64(bytesWritten)
 		}
-		if order.Transfers[t].ContentMD5 != nil { // if non-nil but 0 len, will simply not be read by the consumer (since length is zero)
-			bytesWritten, err = file.WriteString(string(order.Transfers[t].ContentMD5))
+		if order.Transfers.List[t].ContentMD5 != nil { // if non-nil but 0 len, will simply not be read by the consumer (since length is zero)
+			bytesWritten, err = file.WriteString(string(order.Transfers.List[t].ContentMD5))
 			common.PanicIfErr(err)
 			eof += int64(bytesWritten)
 		}
 		// For S2S copy, write the src metadata
-		if order.Transfers[t].Metadata != nil {
-			metadataStr, err := order.Transfers[t].Metadata.Marshal()
+		if order.Transfers.List[t].Metadata != nil {
+			metadataStr, err := order.Transfers.List[t].Metadata.Marshal()
 			common.PanicIfErr(err)
 
 			bytesWritten, err = file.WriteString(metadataStr)
 			common.PanicIfErr(err)
 			eof += int64(bytesWritten)
 		}
-		if len(order.Transfers[t].BlobType) != 0 {
-			bytesWritten, err = file.WriteString(string(order.Transfers[t].BlobType))
+		if len(order.Transfers.List[t].BlobType) != 0 {
+			bytesWritten, err = file.WriteString(string(order.Transfers.List[t].BlobType))
 			common.PanicIfErr(err)
 			eof += int64(bytesWritten)
 		}
-		if len(order.Transfers[t].BlobTier) != 0 {
-			bytesWritten, err = file.WriteString(string(order.Transfers[t].BlobTier))
+		if len(order.Transfers.List[t].BlobTier) != 0 {
+			bytesWritten, err = file.WriteString(string(order.Transfers.List[t].BlobTier))
 			common.PanicIfErr(err)
 			eof += int64(bytesWritten)
 		}
-		if len(order.Transfers[t].BlobVersionID) != 0 {
-			bytesWritten, err = file.WriteString(order.Transfers[t].BlobVersionID)
+		if len(order.Transfers.List[t].BlobVersionID) != 0 {
+			bytesWritten, err = file.WriteString(order.Transfers.List[t].BlobVersionID)
 			common.PanicIfErr(err)
 			eof += int64(bytesWritten)
 		}
 		// For S2S copy, write the source tags in job part plan transfer
-		if len(order.Transfers[t].BlobTags) != 0 {
-			blobTagsStr := order.Transfers[t].BlobTags.ToString()
+		if len(order.Transfers.List[t].BlobTags) != 0 {
+			blobTagsStr := order.Transfers.List[t].BlobTags.ToString()
 			bytesWritten, err = file.WriteString(blobTagsStr)
 			common.PanicIfErr(err)
 			eof += int64(bytesWritten)

--- a/ste/JobsAdmin.go
+++ b/ste/JobsAdmin.go
@@ -648,6 +648,11 @@ func (ja *jobsAdmin) ResurrectJob(jobId common.JobID, sourceSAS string, destinat
 		jm := ja.JobMgrEnsureExists(jobID, mmf.Plan().LogLevel, "")
 		jm.AddJobPart(partNum, planFile, mmf, sourceSAS, destinationSAS, false)
 	}
+
+	jm, _ := ja.JobMgr(jobId)
+	js := resurrectJobSummary(jm)
+	jm.ResurrectSummary(js)
+
 	return true
 }
 

--- a/ste/init.go
+++ b/ste/init.go
@@ -417,6 +417,10 @@ func GetJobSummary(jobID common.JobID) common.ListJobSummaryResponse {
 	}
 
 	js := jm.ListJobSummary()
+	js.Timestamp = time.Now().UTC()
+	js.JobID = jm.JobID()
+	js.ErrorMsg = ""
+
 	part0, ok := jm.JobPartMgr(0)
 	if !ok {
 		return js

--- a/ste/init.go
+++ b/ste/init.go
@@ -416,9 +416,13 @@ func GetJobSummary(jobID common.JobID) common.ListJobSummaryResponse {
 		jm, _ = JobsAdmin.JobMgr(jobID)
 	}
 
+	return jm.ListJobSummary()
+}
+
+func resurrectJobSummary(jm IJobMgr) common.ListJobSummaryResponse {
 	js := common.ListJobSummaryResponse{
 		Timestamp:          time.Now().UTC(),
-		JobID:              jobID,
+		JobID:              jm.JobID(),
 		ErrorMsg:           "",
 		JobStatus:          common.EJobStatus.InProgress(), // Default
 		CompleteJobOrdered: false,                          // default to false; returns true if ALL job parts have been ordered
@@ -431,7 +435,7 @@ func GetJobSummary(jobID common.JobID) common.ListJobSummaryResponse {
 	// Better to check overall status first, and see it as uncompleted on this call (and completed on the next call).
 	part0, ok := jm.JobPartMgr(0)
 	if !ok {
-		panic(fmt.Errorf("error getting the 0th part of Job %s", jobID))
+		panic(fmt.Errorf("error getting the 0th part of Job %s", jm.JobID()))
 	}
 	part0PlanStatus := part0.Plan().JobStatus()
 

--- a/ste/init.go
+++ b/ste/init.go
@@ -160,6 +160,11 @@ func ExecuteNewCopyJobPartOrder(order common.CopyJobPartOrderRequest) common.Cop
 	jpm.AddJobPart(order.PartNum, jppfn, nil, order.SourceRoot.SAS, order.DestinationRoot.SAS, true) // Add this part to the Job and schedule its transfers
 
 	// Update jobPart Status with the status Manager
+	jpm.SendJobPartCreatedMsg(jobPartCreatedMsg{totalTransfers: uint32(len(order.Transfers.List)),
+		isFinalPart:          order.IsFinalPart,
+		totalBytesEnumerated: order.Transfers.TotalSizeInBytes,
+		fileTransfers:        order.Transfers.FileTransferCount,
+		folderTransfer:       order.Transfers.FolderTransferCount})
 
 	return common.CopyJobPartOrderResponse{JobStarted: true}
 }

--- a/ste/init.go
+++ b/ste/init.go
@@ -143,7 +143,7 @@ func ExecuteNewCopyJobPartOrder(order common.CopyJobPartOrderRequest) common.Cop
 	jppfn.Create(order)                                                                   // Convert the order to a plan file
 	jpm := JobsAdmin.JobMgrEnsureExists(order.JobID, order.LogLevel, order.CommandString) // Get a this job part's job manager (create it if it doesn't exist)
 
-	if len(order.Transfers) == 0 && order.IsFinalPart {
+	if len(order.Transfers.List) == 0 && order.IsFinalPart {
 		/*
 		 * We set the status of this jobPart to Completed()
 		 * immediately after it is scheduled, and wind down
@@ -158,6 +158,9 @@ func ExecuteNewCopyJobPartOrder(order common.CopyJobPartOrderRequest) common.Cop
 		})
 	// Supply no plan MMF because we don't have one, and AddJobPart will create one on its own.
 	jpm.AddJobPart(order.PartNum, jppfn, nil, order.SourceRoot.SAS, order.DestinationRoot.SAS, true) // Add this part to the Job and schedule its transfers
+
+	// Update jobPart Status with the status Manager
+
 	return common.CopyJobPartOrderResponse{JobStarted: true}
 }
 

--- a/ste/jobStatusManager.go
+++ b/ste/jobStatusManager.go
@@ -99,63 +99,6 @@ func (jm *jobMgr) handleStatusUpdateMessage() {
 			/* Display stats */
 			js.Timestamp = time.Now().UTC()
 			jstm.respChan <- *js
-
-		case <-time.After(2 * time.Second):
-			part0, ok := jm.JobPartMgr(0)
-			if !ok {
-				break
-			}
-			part0PlanStatus := part0.Plan().JobStatus()
-
-			// Add on byte count from files in flight, to get a more accurate running total
-			js.TotalBytesTransferred += JobsAdmin.SuccessfulBytesInActiveFiles()
-			if js.TotalBytesExpected == 0 {
-				// if no bytes expected, and we should avoid dividing by 0 (which results in NaN)
-				js.PercentComplete = 100
-			} else {
-				js.PercentComplete = 100 * float32(js.TotalBytesTransferred) / float32(js.TotalBytesExpected)
-			}
-
-			// This is added to let FE to continue fetching the Job Progress Summary
-			// in case of resume. In case of resume, the Job is already completely
-			// ordered so the progress summary should be fetched until all job parts
-			// are iterated and have been scheduled
-			js.CompleteJobOrdered = js.CompleteJobOrdered || jm.AllTransfersScheduled()
-
-			js.BytesOverWire = uint64(JobsAdmin.BytesOverWire())
-
-			// Get the number of active go routines performing the transfer or executing the chunk Func
-			// TODO: added for debugging purpose. remove later (is covered by GetPerfInfo now anyway)
-			js.ActiveConnections = jm.ActiveConnections()
-
-			js.PerfStrings, js.PerfConstraint = jm.GetPerfInfo()
-
-			pipeStats := jm.PipelineNetworkStats()
-			if pipeStats != nil {
-				js.AverageIOPS = pipeStats.OperationsPerSecond()
-				js.AverageE2EMilliseconds = pipeStats.AverageE2EMilliseconds()
-				js.NetworkErrorPercentage = pipeStats.NetworkErrorPercentage()
-				js.ServerBusyPercentage = pipeStats.TotalServerBusyPercentage()
-			}
-
-			// If the status is cancelled, then no need to check for completerJobOrdered
-			// since user must have provided the consent to cancel an incompleteJob if that
-			// is the case.
-			if part0PlanStatus == common.EJobStatus.Cancelled() {
-				js.JobStatus = part0PlanStatus
-				js.PerformanceAdvice = jm.TryGetPerformanceAdvice(js.TotalBytesExpected, js.TotalTransfers-js.TransfersSkipped, part0.Plan().FromTo)
-			} else {
-				// Job is completed if Job order is complete AND ALL transfers are completed/failed
-				// FIX: active or inactive state, then job order is said to be completed if final part of job has been ordered.
-				if (js.CompleteJobOrdered) && (part0PlanStatus.IsJobDone()) {
-					js.JobStatus = part0PlanStatus
-				}
-
-				if js.JobStatus.IsJobDone() {
-					js.PerformanceAdvice = jm.TryGetPerformanceAdvice(js.TotalBytesExpected, js.TotalTransfers-js.TransfersSkipped, part0.Plan().FromTo)
-				}
-			}
-
 		}
 	}
 }

--- a/ste/jobStatusManager.go
+++ b/ste/jobStatusManager.go
@@ -1,0 +1,37 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ste
+
+import "github.com/Azure/azure-storage-azcopy/common"
+
+var jpp chan JobPartPlanHeader
+var js common.ListJobSummaryResponse
+
+func handleUpdateStatusMessage() {
+
+	jpp = make(chan JobPartPlanHeader)
+
+	select {
+	case jpph := <-jpp:
+		js.CompleteJobOrdered = js.CompleteJobOrdered || jpph.IsFinalPart
+
+	}
+}

--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -81,6 +81,10 @@ type IJobMgr interface {
 	PipelineNetworkStats() *pipelineNetworkStats
 	getOverwritePrompter() *overwritePrompter
 	common.ILoggerCloser
+
+	/* Status update functions */
+	SendJobPartCreatedMsg(msg jobPartCreatedMsg)
+	SendXferDoneMsg(msg xferDoneMsg)
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -98,8 +98,8 @@ func newJobMgr(concurrency ConcurrencySettings, jobID common.JobID, appCtx conte
 	jobPartProgressCh := make(chan jobPartProgressInfo)
 	jstm.respChan = make(chan common.ListJobSummaryResponse)
 	jstm.listReq = make(chan bool)
-	jstm.partCreated = make(chan jobPartCreatedMsg)
-	jstm.xferDone = make(chan xferDoneMsg)
+	jstm.partCreated = make(chan jobPartCreatedMsg, 100)
+	jstm.xferDone = make(chan xferDoneMsg, 1000)
 
 	jm := jobMgr{jobID: jobID, jobPartMgrs: newJobPartToJobPartMgr(), include: map[string]int{}, exclude: map[string]int{},
 		httpClient:                    NewAzcopyHTTPClient(concurrency.MaxIdleConnections),

--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -82,9 +82,11 @@ type IJobMgr interface {
 	getOverwritePrompter() *overwritePrompter
 	common.ILoggerCloser
 
-	/* Status update functions */
+	/* Status related functions */
 	SendJobPartCreatedMsg(msg jobPartCreatedMsg)
 	SendXferDoneMsg(msg xferDoneMsg)
+	ListJobSummary() common.ListJobSummaryResponse
+	ResurrectSummary(js common.ListJobSummaryResponse)
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -54,6 +54,9 @@ type IJobPartMgr interface {
 	getFolderCreationTracker() common.FolderCreationTracker
 	SecurityInfoPersistenceManager() *securityInfoPersistenceManager
 	FolderDeletionManager() common.FolderDeletionManager
+
+	/* Status Manager Updates */
+	SendXferDoneMsg(msg xferDoneMsg)
 }
 
 type serviceAPIVersionOverride struct{}
@@ -753,6 +756,11 @@ func (jpm *jobPartMgr) ChunkStatusLogger() common.ChunkStatusLogger {
 
 func (jpm *jobPartMgr) SourceProviderPipeline() pipeline.Pipeline {
 	return jpm.sourceProviderPipeline
+}
+
+/* Status update messages should not fail */
+func (jpm *jobPartMgr) SendXferDoneMsg(msg xferDoneMsg) {
+	jpm.jobMgr.SendXferDoneMsg(msg)
 }
 
 // TODO: Can we delete this method?

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -863,6 +863,8 @@ func (jptm *jobPartTransferMgr) ReportTransferDone() uint32 {
 		panic("cannot report the same transfer done twice")
 	}
 
+	//Update Status Manager
+
 	return jptm.jobPartMgr.ReportTransferDone(jptm.jobPartPlanTransfer.TransferStatus())
 }
 

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -864,6 +864,13 @@ func (jptm *jobPartTransferMgr) ReportTransferDone() uint32 {
 	}
 
 	//Update Status Manager
+	jptm.jobPartMgr.SendXferDoneMsg(xferDoneMsg{Src: jptm.transferInfo.Source,
+		Dst:                jptm.transferInfo.Destination,
+		IsFolderProperties: jptm.transferInfo.IsFolderPropertiesTransfer(),
+		TransferStatus:     jptm.jobPartPlanTransfer.TransferStatus(),
+		TransferSize:       uint64(jptm.transferInfo.SourceSize),
+		ErrorCode:          jptm.ErrorCode(),
+	})
 
 	return jptm.jobPartMgr.ReportTransferDone(jptm.jobPartPlanTransfer.TransferStatus())
 }

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -864,11 +864,11 @@ func (jptm *jobPartTransferMgr) ReportTransferDone() uint32 {
 	}
 
 	//Update Status Manager
-	jptm.jobPartMgr.SendXferDoneMsg(xferDoneMsg{Src: jptm.transferInfo.Source,
-		Dst:                jptm.transferInfo.Destination,
-		IsFolderProperties: jptm.transferInfo.IsFolderPropertiesTransfer(),
+	jptm.jobPartMgr.SendXferDoneMsg(xferDoneMsg{Src: jptm.Info().Source,
+		Dst:                jptm.Info().Destination,
+		IsFolderProperties: jptm.Info().IsFolderPropertiesTransfer(),
 		TransferStatus:     jptm.jobPartPlanTransfer.TransferStatus(),
-		TransferSize:       uint64(jptm.transferInfo.SourceSize),
+		TransferSize:       uint64(jptm.Info().SourceSize),
 		ErrorCode:          jptm.ErrorCode(),
 	})
 


### PR DESCRIPTION
AzCopy reports the total number of transfers, # of transfers completed and percentage transfer while the transfer is in progress. These are fetched by looping through all the jobparts individually. All this data will be saved in mem and reported to the frontend whenever queried.

1. A separate Summary struct is introduced to hold all stats to be reported - ListJobSummaryResponse
2. A separate Goroutine is introduced to interact with this struct. This shall be only thread which modifies above struct. Change 482196a
3. At time where each part is created, total number of transfers are updated (change 6dab8c7 & 482196a)
4. At end of each transfer, completed or failure count in updated. (Change 
d941b28)
5. FE requests status to the go-routine, which then creates a copy of statement at that point. 
(2811adf)
6. Using buffered channels to reduce contention. In a very large job, a small offset should not matter. In a small job, the channels are not full.