### PR TITLE
[AzCopyV10][Feature] Offer knob to disable application logging (Syslog/Windows Evert Log)

### DIFF
--- a/azbfs/zc_policy_request_log.go
+++ b/azbfs/zc_policy_request_log.go
@@ -22,6 +22,7 @@ type RequestLogOptions struct {
 	// LogWarningIfTryOverThreshold logs a warning if a tried operation takes longer than the specified
 	// duration (-1=no logging; 0=default threshold).
 	LogWarningIfTryOverThreshold time.Duration
+	ForceLog                     bool
 }
 
 func (o RequestLogOptions) defaults() RequestLogOptions {
@@ -64,18 +65,18 @@ func NewRequestLogPolicyFactory_Deprecated(o RequestLogOptions) pipeline.Factory
 			// If the response took too long, we'll upgrade to warning.
 			if o.LogWarningIfTryOverThreshold > 0 && tryDuration > o.LogWarningIfTryOverThreshold {
 				// Log a warning if the try duration exceeded the specified threshold
-				logLevel, forceLog = pipeline.LogWarning, true
+				logLevel, forceLog = pipeline.LogWarning, o.ForceLog
 			}
 
 			if err == nil { // We got a response from the service
 				sc := response.Response().StatusCode
 				if ((sc >= 400 && sc <= 499) && sc != http.StatusNotFound && sc != http.StatusConflict && sc != http.StatusPreconditionFailed && sc != http.StatusRequestedRangeNotSatisfiable) || (sc >= 500 && sc <= 599) {
-					logLevel, forceLog = pipeline.LogError, true // Promote to Error any 4xx (except those listed is an error) or any 5xx
+					logLevel, forceLog = pipeline.LogError, o.ForceLog // Promote to Error any 4xx (except those listed is an error) or any 5xx
 				} else {
 					// For other status codes, we leave the level as is.
 				}
 			} else { // This error did not get an HTTP response from the service; upgrade the severity to Error
-				logLevel, forceLog = pipeline.LogError, true
+				logLevel, forceLog = pipeline.LogError, o.ForceLog
 			}
 
 			if shouldLog := po.ShouldLog(logLevel); forceLog || shouldLog {

--- a/azbfs/zc_policy_request_log.go
+++ b/azbfs/zc_policy_request_log.go
@@ -22,7 +22,11 @@ type RequestLogOptions struct {
 	// LogWarningIfTryOverThreshold logs a warning if a tried operation takes longer than the specified
 	// duration (-1=no logging; 0=default threshold).
 	LogWarningIfTryOverThreshold time.Duration
-	ForceLog                     bool
+
+	// SyslogDisabled is a flag to check if logging to Syslog/Windows-Event-Logger is enabled or not
+	// We by default print to Syslog/Windows-Event-Logger.
+	// If SyslogDisabled is not provided explicitly, the default value will be false.
+	SyslogDisabled bool
 }
 
 func (o RequestLogOptions) defaults() RequestLogOptions {
@@ -65,18 +69,18 @@ func NewRequestLogPolicyFactory_Deprecated(o RequestLogOptions) pipeline.Factory
 			// If the response took too long, we'll upgrade to warning.
 			if o.LogWarningIfTryOverThreshold > 0 && tryDuration > o.LogWarningIfTryOverThreshold {
 				// Log a warning if the try duration exceeded the specified threshold
-				logLevel, forceLog = pipeline.LogWarning, o.ForceLog
+				logLevel, forceLog = pipeline.LogWarning, !o.SyslogDisabled
 			}
 
 			if err == nil { // We got a response from the service
 				sc := response.Response().StatusCode
 				if ((sc >= 400 && sc <= 499) && sc != http.StatusNotFound && sc != http.StatusConflict && sc != http.StatusPreconditionFailed && sc != http.StatusRequestedRangeNotSatisfiable) || (sc >= 500 && sc <= 599) {
-					logLevel, forceLog = pipeline.LogError, o.ForceLog // Promote to Error any 4xx (except those listed is an error) or any 5xx
+					logLevel, forceLog = pipeline.LogError, !o.SyslogDisabled // Promote to Error any 4xx (except those listed is an error) or any 5xx
 				} else {
 					// For other status codes, we leave the level as is.
 				}
 			} else { // This error did not get an HTTP response from the service; upgrade the severity to Error
-				logLevel, forceLog = pipeline.LogError, o.ForceLog
+				logLevel, forceLog = pipeline.LogError, !o.SyslogDisabled
 			}
 
 			if shouldLog := po.ShouldLog(logLevel); forceLog || shouldLog {

--- a/cmd/credentialUtil.go
+++ b/cmd/credentialUtil.go
@@ -159,6 +159,9 @@ func getBlobCredentialType(ctx context.Context, blobResourceURL string, canBePub
 					RetryDelay:    ste.UploadRetryDelay,
 					MaxRetryDelay: ste.UploadMaxRetryDelay,
 				},
+				RequestLog: azblob.RequestLogOptions{
+					SyslogDisabled: common.IsForceLoggingDisabled(),
+				},
 			})
 
 		isContainer := copyHandlerUtil{}.urlIsContainerOrVirtualDirectory(resourceURL)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -78,6 +78,8 @@ var rootCmd = &cobra.Command{
 			return err
 		}
 
+		glcm.SetForceLogging()
+
 		// warn Windows users re quoting (since our docs all use single quotes, but CMD needs double)
 		// Single ones just come through as part of the args, in CMD.
 		// Ideally, for usability, we'd ideally have this info come back in the result of url.Parse. But that's hard to

--- a/cmd/zt_interceptors_for_test.go
+++ b/cmd/zt_interceptors_for_test.go
@@ -130,8 +130,8 @@ func (*mockedLifecycleManager) AddUserAgentPrefix(userAgent string) string {
 
 func (*mockedLifecycleManager) SetForceLogging() {}
 
-func (*mockedLifecycleManager) IsForceLoggingEnabled() bool {
-	return true
+func (*mockedLifecycleManager) IsForceLoggingDisabled() bool {
+	return false
 }
 
 func (*mockedLifecycleManager) E2EAwaitContinue() {

--- a/cmd/zt_interceptors_for_test.go
+++ b/cmd/zt_interceptors_for_test.go
@@ -22,9 +22,8 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-
 	"github.com/Azure/azure-storage-azcopy/common"
+	"os"
 )
 
 // the interceptor gathers/saves the job part orders for validation
@@ -127,6 +126,12 @@ func (*mockedLifecycleManager) EnableInputWatcher()                 {}
 func (*mockedLifecycleManager) EnableCancelFromStdIn()              {}
 func (*mockedLifecycleManager) AddUserAgentPrefix(userAgent string) string {
 	return userAgent
+}
+
+func (*mockedLifecycleManager) SetForceLogging() {}
+
+func (*mockedLifecycleManager) IsForceLoggingEnabled() bool {
+	return true
 }
 
 func (*mockedLifecycleManager) E2EAwaitContinue() {

--- a/common/environment.go
+++ b/common/environment.go
@@ -65,6 +65,7 @@ var VisibleEnvironmentVariables = []EnvironmentVariable{
 	EEnvironmentVariable.ManagedIdentityClientID(),
 	EEnvironmentVariable.ManagedIdentityObjectID(),
 	EEnvironmentVariable.ManagedIdentityResourceString(),
+	EEnvironmentVariable.EnableSyslog(),
 }
 
 var EEnvironmentVariable = EnvironmentVariable{}
@@ -322,5 +323,13 @@ func (EnvironmentVariable) UserAgentPrefix() EnvironmentVariable {
 	return EnvironmentVariable{
 		Name:        "AZCOPY_USER_AGENT_PREFIX",
 		Description: "Add a prefix to the default AzCopy User Agent, which is used for telemetry purposes. A space is automatically inserted.",
+	}
+}
+
+func (EnvironmentVariable) EnableSyslog() EnvironmentVariable {
+	return EnvironmentVariable{
+		Name:         "AZCOPY_ENABLE_SYSLOG",
+		DefaultValue: "true",
+		Description:  "Enables logging in Syslog or Windows Event Logger. By default we log to these channels. However. to reduce the noise in syslog, consider setting this environment variable to false.",
 	}
 }

--- a/common/environment.go
+++ b/common/environment.go
@@ -329,7 +329,8 @@ func (EnvironmentVariable) UserAgentPrefix() EnvironmentVariable {
 func (EnvironmentVariable) DisableSyslog() EnvironmentVariable {
 	return EnvironmentVariable{
 		Name:         "AZCOPY_DISABLE_SYSLOG",
-		DefaultValue: "true",
-		Description:  "Disables logging in Syslog or Windows Event Logger. By default we log to these channels. However, to reduce the noise in Syslog/Windows Event Log, consider setting this environment variable to true.",
+		DefaultValue: "false",
+		Description: "Disables logging in Syslog or Windows Event Logger. By default we log to these channels. " +
+			"However, to reduce the noise in Syslog/Windows Event Log, consider setting this environment variable to true.",
 	}
 }

--- a/common/environment.go
+++ b/common/environment.go
@@ -65,7 +65,7 @@ var VisibleEnvironmentVariables = []EnvironmentVariable{
 	EEnvironmentVariable.ManagedIdentityClientID(),
 	EEnvironmentVariable.ManagedIdentityObjectID(),
 	EEnvironmentVariable.ManagedIdentityResourceString(),
-	EEnvironmentVariable.EnableSyslog(),
+	EEnvironmentVariable.DisableSyslog(),
 }
 
 var EEnvironmentVariable = EnvironmentVariable{}
@@ -326,10 +326,10 @@ func (EnvironmentVariable) UserAgentPrefix() EnvironmentVariable {
 	}
 }
 
-func (EnvironmentVariable) EnableSyslog() EnvironmentVariable {
+func (EnvironmentVariable) DisableSyslog() EnvironmentVariable {
 	return EnvironmentVariable{
-		Name:         "AZCOPY_ENABLE_SYSLOG",
+		Name:         "AZCOPY_DISABLE_SYSLOG",
 		DefaultValue: "true",
-		Description:  "Enables logging in Syslog or Windows Event Logger. By default we log to these channels. However. to reduce the noise in syslog, consider setting this environment variable to false.",
+		Description:  "Disables logging in Syslog or Windows Event Logger. By default we log to these channels. However, to reduce the noise in Syslog/Windows Event Log, consider setting this environment variable to true.",
 	}
 }

--- a/common/lifecyleMgr.go
+++ b/common/lifecyleMgr.go
@@ -66,7 +66,7 @@ type LifecycleMgr interface {
 	E2EEnableAwaitAllowOpenFiles(enable bool)                    // used by E2E tests
 	RegisterCloseFunc(func())
 	SetForceLogging()
-	IsForceLoggingEnabled() bool
+	IsForceLoggingDisabled() bool
 }
 
 func GetLifecycleMgr() LifecycleMgr {
@@ -562,6 +562,8 @@ func (lcm *lifecycleMgr) E2EEnableAwaitAllowOpenFiles(enable bool) {
 	}
 }
 
+// Fetching `AZCOPY_DISABLE_SYSLOG` from the environment variables and
+// setting `disableSyslog` flag in LifeCycleManager to avoid Env Vars Lookup redundantly
 func (lcm *lifecycleMgr) SetForceLogging() {
 	disableSyslog, err := strconv.ParseBool(lcm.GetEnvironmentVariable(EEnvironmentVariable.DisableSyslog()))
 	if err != nil {
@@ -571,8 +573,8 @@ func (lcm *lifecycleMgr) SetForceLogging() {
 	lcm.disableSyslog = disableSyslog
 }
 
-func (lcm *lifecycleMgr) IsForceLoggingEnabled() bool {
-	return lcm.disableSyslog == false
+func (lcm *lifecycleMgr) IsForceLoggingDisabled() bool {
+	return lcm.disableSyslog
 }
 
 // captures the common logic of exiting if there's an expected error

--- a/common/lifecyleMgr.go
+++ b/common/lifecyleMgr.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"runtime"
 	"runtime/pprof"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -64,6 +65,8 @@ type LifecycleMgr interface {
 	E2EAwaitAllowOpenFiles()                                     // used by E2E tests
 	E2EEnableAwaitAllowOpenFiles(enable bool)                    // used by E2E tests
 	RegisterCloseFunc(func())
+	SetForceLogging()
+	IsForceLoggingEnabled() bool
 }
 
 func GetLifecycleMgr() LifecycleMgr {
@@ -86,6 +89,7 @@ type lifecycleMgr struct {
 	e2eAllowAwaitContinue bool           // allow the user to send 'continue' from stdin to start the current job
 	e2eAllowAwaitOpen     bool           // allow the user to send 'open' from stdin to allow the opening of the first file
 	closeFunc             func()         // used to close logs before exiting
+	enableSyslog          bool
 }
 
 type userInput struct {
@@ -556,6 +560,18 @@ func (lcm *lifecycleMgr) E2EEnableAwaitAllowOpenFiles(enable bool) {
 	} else {
 		close(lcm.e2eAllowOpenChannel) // so that E2EAwaitAllowOpenFiles will instantly return every time
 	}
+}
+
+func (lcm *lifecycleMgr) SetForceLogging() {
+	enableSyslog, err := strconv.ParseBool(lcm.GetEnvironmentVariable(EEnvironmentVariable.EnableSyslog()))
+	if err != nil {
+		enableSyslog = true
+	}
+	lcm.enableSyslog = enableSyslog
+}
+
+func (lcm *lifecycleMgr) IsForceLoggingEnabled() bool {
+	return lcm.enableSyslog
 }
 
 // captures the common logic of exiting if there's an expected error

--- a/common/lifecyleMgr.go
+++ b/common/lifecyleMgr.go
@@ -89,7 +89,7 @@ type lifecycleMgr struct {
 	e2eAllowAwaitContinue bool           // allow the user to send 'continue' from stdin to start the current job
 	e2eAllowAwaitOpen     bool           // allow the user to send 'open' from stdin to allow the opening of the first file
 	closeFunc             func()         // used to close logs before exiting
-	enableSyslog          bool
+	disableSyslog         bool
 }
 
 type userInput struct {
@@ -563,15 +563,16 @@ func (lcm *lifecycleMgr) E2EEnableAwaitAllowOpenFiles(enable bool) {
 }
 
 func (lcm *lifecycleMgr) SetForceLogging() {
-	enableSyslog, err := strconv.ParseBool(lcm.GetEnvironmentVariable(EEnvironmentVariable.EnableSyslog()))
+	disableSyslog, err := strconv.ParseBool(lcm.GetEnvironmentVariable(EEnvironmentVariable.DisableSyslog()))
 	if err != nil {
-		enableSyslog = true
+		// By default, we'll retain the current behaviour. i.e. To log in Syslog/WindowsEventLog if not specified by the user
+		disableSyslog = false
 	}
-	lcm.enableSyslog = enableSyslog
+	lcm.disableSyslog = disableSyslog
 }
 
 func (lcm *lifecycleMgr) IsForceLoggingEnabled() bool {
-	return lcm.enableSyslog
+	return lcm.disableSyslog == false
 }
 
 // captures the common logic of exiting if there's an expected error

--- a/common/logger.go
+++ b/common/logger.go
@@ -219,3 +219,7 @@ func NewReadLogFunc(logger ILogger, fullUrl *url.URL) func(int, error, int64, in
 			redactedUrl))
 	}
 }
+
+func IsForceLoggingEnabled() bool {
+	return GetLifecycleMgr().IsForceLoggingEnabled()
+}

--- a/common/logger.go
+++ b/common/logger.go
@@ -220,6 +220,6 @@ func NewReadLogFunc(logger ILogger, fullUrl *url.URL) func(int, error, int64, in
 	}
 }
 
-func IsForceLoggingEnabled() bool {
-	return GetLifecycleMgr().IsForceLoggingEnabled()
+func IsForceLoggingDisabled() bool {
+	return GetLifecycleMgr().IsForceLoggingDisabled()
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/azure-storage-azcopy
 require (
 	cloud.google.com/go/storage v1.8.0
 	github.com/Azure/azure-pipeline-go v0.2.3
-	github.com/Azure/azure-storage-blob-go v0.10.1-0.20210205091829-70af83555b62
+	github.com/Azure/azure-storage-blob-go v0.10.1-0.20210323030536-9958b4a69771
 	github.com/Azure/azure-storage-file-go v0.6.1-0.20201111053559-3c1754dc00a5
 	github.com/Azure/go-autorest/autorest/adal v0.9.2
 	github.com/JeffreyRichter/enum v0.0.0-20180725232043-2567042f9cda

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/azure-storage-azcopy
 require (
 	cloud.google.com/go/storage v1.8.0
 	github.com/Azure/azure-pipeline-go v0.2.3
-	github.com/Azure/azure-storage-blob-go v0.10.1-0.20210323030536-9958b4a69771
+	github.com/Azure/azure-storage-blob-go v0.10.1-0.20210325045028-fa5d89d7d3c9
 	github.com/Azure/azure-storage-file-go v0.6.1-0.20201111053559-3c1754dc00a5
 	github.com/Azure/go-autorest/autorest/adal v0.9.2
 	github.com/JeffreyRichter/enum v0.0.0-20180725232043-2567042f9cda

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/Azure/azure-pipeline-go v0.2.3 h1:7U9HBg1JFK3jHl5qmo4CTZKFTVgMwdFHMVt
 github.com/Azure/azure-pipeline-go v0.2.3/go.mod h1:x841ezTBIMG6O3lAcl8ATHnsOPVl2bqk7S3ta6S6u4k=
 github.com/Azure/azure-storage-blob-go v0.10.1-0.20210205091829-70af83555b62 h1:QHM6dKVFOJZuuXJjw+ilT8mfJi6o1jiUabhUdP/W+tg=
 github.com/Azure/azure-storage-blob-go v0.10.1-0.20210205091829-70af83555b62/go.mod h1:pA9kNqtjUeQF2zOSu4s//nUdBD+e64lEuc4sVnuOfNs=
+github.com/Azure/azure-storage-blob-go v0.10.1-0.20210323030536-9958b4a69771 h1:05MaoneN7crgShJvWeXlgdF35z5LtB9ZJebt3BCKGok=
+github.com/Azure/azure-storage-blob-go v0.10.1-0.20210323030536-9958b4a69771/go.mod h1:pA9kNqtjUeQF2zOSu4s//nUdBD+e64lEuc4sVnuOfNs=
 github.com/Azure/azure-storage-file-go v0.6.1-0.20201111053559-3c1754dc00a5 h1:aHEvBM4oXIWSTOVdL55nCYXO0Cl7ie3Ui5xMQhLVez8=
 github.com/Azure/azure-storage-file-go v0.6.1-0.20201111053559-3c1754dc00a5/go.mod h1:++L7GP2pRyUNuastZ7m02vYV69JHmqlWXfCaGoL0v4s=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=

--- a/go.sum
+++ b/go.sum
@@ -34,10 +34,8 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/azure-pipeline-go v0.2.3 h1:7U9HBg1JFK3jHl5qmo4CTZKFTVgMwdFHMVtCdfBE21U=
 github.com/Azure/azure-pipeline-go v0.2.3/go.mod h1:x841ezTBIMG6O3lAcl8ATHnsOPVl2bqk7S3ta6S6u4k=
-github.com/Azure/azure-storage-blob-go v0.10.1-0.20210205091829-70af83555b62 h1:QHM6dKVFOJZuuXJjw+ilT8mfJi6o1jiUabhUdP/W+tg=
-github.com/Azure/azure-storage-blob-go v0.10.1-0.20210205091829-70af83555b62/go.mod h1:pA9kNqtjUeQF2zOSu4s//nUdBD+e64lEuc4sVnuOfNs=
-github.com/Azure/azure-storage-blob-go v0.10.1-0.20210323030536-9958b4a69771 h1:05MaoneN7crgShJvWeXlgdF35z5LtB9ZJebt3BCKGok=
-github.com/Azure/azure-storage-blob-go v0.10.1-0.20210323030536-9958b4a69771/go.mod h1:pA9kNqtjUeQF2zOSu4s//nUdBD+e64lEuc4sVnuOfNs=
+github.com/Azure/azure-storage-blob-go v0.10.1-0.20210325045028-fa5d89d7d3c9 h1:8wuFu0skmvvjxn0Idgguo/WLvp7HxNzD3XMNaCp/kt4=
+github.com/Azure/azure-storage-blob-go v0.10.1-0.20210325045028-fa5d89d7d3c9/go.mod h1:pA9kNqtjUeQF2zOSu4s//nUdBD+e64lEuc4sVnuOfNs=
 github.com/Azure/azure-storage-file-go v0.6.1-0.20201111053559-3c1754dc00a5 h1:aHEvBM4oXIWSTOVdL55nCYXO0Cl7ie3Ui5xMQhLVez8=
 github.com/Azure/azure-storage-file-go v0.6.1-0.20201111053559-3c1754dc00a5/go.mod h1:++L7GP2pRyUNuastZ7m02vYV69JHmqlWXfCaGoL0v4s=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ import (
 var glcm = common.GetLifecycleMgr()
 
 func main() {
-	pipeline.SetLogSanitizer(common.NewAzCopyLogSanitizer()) // make sure ForceLog logs get secrets redacted
+	pipeline.SetLogSanitizer(common.NewAzCopyLogSanitizer()) // make sure SyslogDisabled logs get secrets redacted
 
 	rand.Seed(time.Now().UnixNano()) // make sure our random numbers actually are random (but remember, use crypto/rand for anything where strong/reliable randomness is required
 

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -166,7 +166,7 @@ func NewBlobPipeline(c azblob.Credential, o azblob.PipelineOptions, r XferRetryO
 		NewVersionPolicyFactory(),
 		NewRequestLogPolicyFactory(RequestLogOptions{
 			LogWarningIfTryOverThreshold: o.RequestLog.LogWarningIfTryOverThreshold,
-			ForceLog:                     common.IsForceLoggingEnabled(),
+			SyslogDisabled:               common.IsForceLoggingDisabled(),
 		}),
 		newXferStatsPolicyFactory(statsAcc),
 	}
@@ -193,7 +193,7 @@ func NewBlobFSPipeline(c azbfs.Credential, o azbfs.PipelineOptions, r XferRetryO
 		pipeline.MethodFactoryMarker(), // indicates at what stage in the pipeline the method factory is invoked
 		NewRequestLogPolicyFactory(RequestLogOptions{
 			LogWarningIfTryOverThreshold: o.RequestLog.LogWarningIfTryOverThreshold,
-			ForceLog:                     common.IsForceLoggingEnabled(),
+			SyslogDisabled:               common.IsForceLoggingDisabled(),
 		}),
 		newXferStatsPolicyFactory(statsAcc))
 
@@ -216,7 +216,7 @@ func NewFilePipeline(c azfile.Credential, o azfile.PipelineOptions, r azfile.Ret
 		NewVersionPolicyFactory(),
 		NewRequestLogPolicyFactory(RequestLogOptions{
 			LogWarningIfTryOverThreshold: o.RequestLog.LogWarningIfTryOverThreshold,
-			ForceLog:                     common.IsForceLoggingEnabled(),
+			SyslogDisabled:               common.IsForceLoggingDisabled(),
 		}),
 		newXferStatsPolicyFactory(statsAcc),
 	}

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -164,7 +164,10 @@ func NewBlobPipeline(c azblob.Credential, o azblob.PipelineOptions, r XferRetryO
 		pipeline.MethodFactoryMarker(), // indicates at what stage in the pipeline the method factory is invoked
 		//NewPacerPolicyFactory(p),
 		NewVersionPolicyFactory(),
-		NewRequestLogPolicyFactory(RequestLogOptions{LogWarningIfTryOverThreshold: o.RequestLog.LogWarningIfTryOverThreshold}),
+		NewRequestLogPolicyFactory(RequestLogOptions{
+			LogWarningIfTryOverThreshold: o.RequestLog.LogWarningIfTryOverThreshold,
+			ForceLog:                     common.IsForceLoggingEnabled(),
+		}),
 		newXferStatsPolicyFactory(statsAcc),
 	}
 	return pipeline.NewPipeline(f, pipeline.Options{HTTPSender: newAzcopyHTTPClientFactory(client), Log: o.Log})
@@ -188,7 +191,10 @@ func NewBlobFSPipeline(c azbfs.Credential, o azbfs.PipelineOptions, r XferRetryO
 
 	f = append(f,
 		pipeline.MethodFactoryMarker(), // indicates at what stage in the pipeline the method factory is invoked
-		NewRequestLogPolicyFactory(RequestLogOptions{LogWarningIfTryOverThreshold: o.RequestLog.LogWarningIfTryOverThreshold}),
+		NewRequestLogPolicyFactory(RequestLogOptions{
+			LogWarningIfTryOverThreshold: o.RequestLog.LogWarningIfTryOverThreshold,
+			ForceLog:                     common.IsForceLoggingEnabled(),
+		}),
 		newXferStatsPolicyFactory(statsAcc))
 
 	return pipeline.NewPipeline(f, pipeline.Options{HTTPSender: newAzcopyHTTPClientFactory(client), Log: o.Log})
@@ -208,7 +214,10 @@ func NewFilePipeline(c azfile.Credential, o azfile.PipelineOptions, r azfile.Ret
 		c,
 		pipeline.MethodFactoryMarker(), // indicates at what stage in the pipeline the method factory is invoked
 		NewVersionPolicyFactory(),
-		NewRequestLogPolicyFactory(RequestLogOptions{LogWarningIfTryOverThreshold: o.RequestLog.LogWarningIfTryOverThreshold}),
+		NewRequestLogPolicyFactory(RequestLogOptions{
+			LogWarningIfTryOverThreshold: o.RequestLog.LogWarningIfTryOverThreshold,
+			ForceLog:                     common.IsForceLoggingEnabled(),
+		}),
 		newXferStatsPolicyFactory(statsAcc),
 	}
 	return pipeline.NewPipeline(f, pipeline.Options{HTTPSender: newAzcopyHTTPClientFactory(client), Log: o.Log})
@@ -428,9 +437,9 @@ func (jpm *jobPartMgr) createPipelines(ctx context.Context) {
 	userAgent := common.UserAgent
 	if fromTo.From() == common.ELocation.S3() {
 		userAgent = common.S3ImportUserAgent
-	}else if fromTo.From() == common.ELocation.GCP(){
+	} else if fromTo.From() == common.ELocation.GCP() {
 		userAgent = common.GCPImportUserAgent
-	}else if fromTo.From() == common.ELocation.Benchmark() || fromTo.To() == common.ELocation.Benchmark() {
+	} else if fromTo.From() == common.ELocation.Benchmark() || fromTo.To() == common.ELocation.Benchmark() {
 		userAgent = common.BenchmarkUserAgent
 	}
 	userAgent = common.GetLifecycleMgr().AddUserAgentPrefix(common.UserAgent)

--- a/ste/xferLogPolicy.go
+++ b/ste/xferLogPolicy.go
@@ -28,9 +28,11 @@ type RequestLogOptions struct {
 	// LogWarningIfTryOverThreshold logs a warning if a tried operation takes longer than the specified
 	// duration (-1=no logging; 0=default threshold).
 	LogWarningIfTryOverThreshold time.Duration
-	// ForceLog is a boolean flag which enables logging on Syslog/WindowsEventLog
-	// By default ForceLog is true unless specified by the user specifically.
-	ForceLog bool
+
+	// SyslogDisabled is a flag to check if logging to Syslog/Windows-Event-Logger is enabled or not
+	// We by default print to Syslog/Windows-Event-Logger.
+	// If SyslogDisabled is not provided explicitly, the default value will be false.
+	SyslogDisabled bool
 }
 
 func (o RequestLogOptions) defaults() RequestLogOptions {
@@ -90,13 +92,13 @@ func NewRequestLogPolicyFactory(o RequestLogOptions) pipeline.Factory {
 			// If the response took too long, we'll upgrade to warning.
 			if o.LogWarningIfTryOverThreshold > 0 && tryDuration > o.LogWarningIfTryOverThreshold {
 				// Log a warning if the try duration exceeded the specified threshold
-				logLevel, forceLog = pipeline.LogWarning, o.ForceLog
+				logLevel, forceLog = pipeline.LogWarning, !o.SyslogDisabled
 			}
 
 			if err == nil { // We got a response from the service
 				sc := response.Response().StatusCode
 				if ((sc >= 400 && sc <= 499) && sc != http.StatusNotFound && sc != http.StatusConflict && sc != http.StatusPreconditionFailed && sc != http.StatusRequestedRangeNotSatisfiable) || (sc >= 500 && sc <= 599) {
-					logLevel, forceLog, httpError = pipeline.LogError, o.ForceLog, true // Promote to Error any 4xx (except those listed is an error) or any 5xx
+					logLevel, forceLog, httpError = pipeline.LogError, !o.SyslogDisabled, true // Promote to Error any 4xx (except those listed is an error) or any 5xx
 				} else if sc == http.StatusNotFound || sc == http.StatusConflict || sc == http.StatusPreconditionFailed || sc == http.StatusRequestedRangeNotSatisfiable {
 					httpError = true
 				}
@@ -108,7 +110,7 @@ func NewRequestLogPolicyFactory(o RequestLogOptions) pipeline.Factory {
 				logLevel, forceLog = pipeline.LogDebug, false
 			} else {
 				// This error did not get an HTTP response from the service; upgrade the severity to Error
-				logLevel, forceLog = pipeline.LogError, o.ForceLog
+				logLevel, forceLog = pipeline.LogError, !o.SyslogDisabled
 			}
 
 			logBody := false

--- a/ste/xferLogPolicy.go
+++ b/ste/xferLogPolicy.go
@@ -28,6 +28,9 @@ type RequestLogOptions struct {
 	// LogWarningIfTryOverThreshold logs a warning if a tried operation takes longer than the specified
 	// duration (-1=no logging; 0=default threshold).
 	LogWarningIfTryOverThreshold time.Duration
+	// ForceLog is a boolean flag which enables logging on Syslog/WindowsEventLog
+	// By default ForceLog is true unless specified by the user specifically.
+	ForceLog bool
 }
 
 func (o RequestLogOptions) defaults() RequestLogOptions {
@@ -87,13 +90,13 @@ func NewRequestLogPolicyFactory(o RequestLogOptions) pipeline.Factory {
 			// If the response took too long, we'll upgrade to warning.
 			if o.LogWarningIfTryOverThreshold > 0 && tryDuration > o.LogWarningIfTryOverThreshold {
 				// Log a warning if the try duration exceeded the specified threshold
-				logLevel, forceLog = pipeline.LogWarning, true
+				logLevel, forceLog = pipeline.LogWarning, o.ForceLog
 			}
 
 			if err == nil { // We got a response from the service
 				sc := response.Response().StatusCode
 				if ((sc >= 400 && sc <= 499) && sc != http.StatusNotFound && sc != http.StatusConflict && sc != http.StatusPreconditionFailed && sc != http.StatusRequestedRangeNotSatisfiable) || (sc >= 500 && sc <= 599) {
-					logLevel, forceLog, httpError = pipeline.LogError, true, true // Promote to Error any 4xx (except those listed is an error) or any 5xx
+					logLevel, forceLog, httpError = pipeline.LogError, o.ForceLog, true // Promote to Error any 4xx (except those listed is an error) or any 5xx
 				} else if sc == http.StatusNotFound || sc == http.StatusConflict || sc == http.StatusPreconditionFailed || sc == http.StatusRequestedRangeNotSatisfiable {
 					httpError = true
 				}
@@ -105,7 +108,7 @@ func NewRequestLogPolicyFactory(o RequestLogOptions) pipeline.Factory {
 				logLevel, forceLog = pipeline.LogDebug, false
 			} else {
 				// This error did not get an HTTP response from the service; upgrade the severity to Error
-				logLevel, forceLog = pipeline.LogError, true
+				logLevel, forceLog = pipeline.LogError, o.ForceLog
 			}
 
 			logBody := false


### PR DESCRIPTION
By default, AzCopy logs errors and warnings in Syslog/Windows Event Log in addition to logging in AzCopy log file. 
It can be useful for monitoring warnings/errors when the job is very large. But it can also create noise by polluting system logs.

Here is a knob to disable logging in these channels (Syslog/Windows Event Log). We fetch environment variable  `AZCOPY_DISABLE_SYSLOG`. If the value of `AZCOPY_DISABLE_SYSLOG` is set to true, we stop force logging in these channels.