### PR TITLE
[AzCopyV10][Feature] Display more fields for list command

### DIFF
--- a/cmd/helpMessages.go
+++ b/cmd/helpMessages.go
@@ -253,7 +253,9 @@ const listCmdShortDescription = "List the entities in a given resource"
 
 const listCmdLongDescription = `List the entities in a given resource. Blob, Files, and ADLS Gen 2 containers, folders, and accounts are supported.`
 
-const listCmdExample = "azcopy list [containerURL]"
+const listCmdExample = "azcopy list [containerURL] --properties [semicolon(;) separated list of attributes " +
+	"(LastModifiedTime, VersionId, BlobType, BlobAccessTier, ContentType, ContentEncoding, LeaseState, LeaseDuration, LeaseStatus) " +
+	"enclosed in double quotes (\")]"
 
 // ===================================== LOGIN COMMAND ===================================== //
 const loginCmdShortDescription = "Log in to Azure Active Directory (AD) to access Azure Storage resources."

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -45,7 +45,15 @@ type rawListCmdArgs struct {
 }
 
 var validProperties = []string{
-	"LastModifiedTime", "VersionId", "BlobType", "BlobAccessTier", "ContentType", "ContentEncoding",
+	"LastModifiedTime",
+	"VersionId",
+	"BlobType",
+	"BlobAccessTier",
+	"ContentType",
+	"ContentEncoding",
+	"LeaseState",
+	"LeaseDuration",
+	"LeaseStatus",
 }
 
 func (raw *rawListCmdArgs) parseProperties(rawProperties string) []string {
@@ -158,6 +166,12 @@ func (cooked cookedListCmdArgs) processProperties(object storedObject) string {
 			builder.WriteString(property + ": " + object.contentType + "; ")
 		case "ContentEncoding":
 			builder.WriteString(property + ": " + object.contentEncoding + "; ")
+		case "LeaseState":
+			builder.WriteString(property + ": " + string(object.leaseState) + "; ")
+		case "LeaseStatus":
+			builder.WriteString(property + ": " + string(object.leaseStatus) + "; ")
+		case "LeaseDuration":
+			builder.WriteString(property + ": " + string(object.leaseDuration) + "; ")
 		}
 	}
 	return builder.String()
@@ -255,18 +269,6 @@ func (cooked cookedListCmdArgs) HandleListContainerCommand() (err error) {
 	return nil
 }
 
-//// printListContainerResponse prints the list container response
-//func printListContainerResponse(lsResponse *common.ListContainerResponse) {
-//	if len(lsResponse.Blobs) == 0 {
-//		return
-//	}
-//	// TODO determine what's the best way to display the blobs in JSON
-//	// TODO no partner team needs this functionality right now so the blobs are just outputted as info
-//	for index := 0; index < len(lsResponse.Blobs); index++ {
-//		glcm.Info(lsResponse.Blobs[index])
-//	}
-//}
-
 var megaSize = []string{
 	"B",
 	"KB",
@@ -285,7 +287,7 @@ func byteSizeToString(size int64) string {
 		"GiB",
 		"TiB",
 		"PiB",
-		"EiB", // Let's face it, a file, account, or container probably won't be more than 1000 exabytes in YEARS. (and int64 literally isn't large enough to handle too many exbibytes. 128 bit processors when)
+		"EiB", // Let's face it, a file, account, or container probably won't be more than 1000 exabytes in YEARS. (and int64 literally isn't large enough to handle too many exabytes. 128 bit processors when)
 	}
 	unit := 0
 	floatSize := float64(size)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -296,7 +296,8 @@ func byteSizeToString(size int64) string {
 		"GiB",
 		"TiB",
 		"PiB",
-		"EiB", // Let's face it, a file, account, or container probably won't be more than 1000 exabytes in YEARS. (and int64 literally isn't large enough to handle too many exabytes. 128 bit processors when)
+		"EiB", // Let's face it, a file, account, or container probably won't be more than 1000 exabytes in YEARS.
+		// (and int64 literally isn't large enough to handle too many exbibytes. 128 bit processors when)
 	}
 	unit := 0
 	floatSize := float64(size)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -44,26 +44,34 @@ type rawListCmdArgs struct {
 	MegaUnits       bool
 }
 
-var validProperties = []string{
-	"LastModifiedTime",
-	"VersionId",
-	"BlobType",
-	"BlobAccessTier",
-	"ContentType",
-	"ContentEncoding",
-	"LeaseState",
-	"LeaseDuration",
-	"LeaseStatus",
+type validProperty string
+
+const (
+	lastModifiedTime validProperty = "LastModifiedTime"
+	versionId        validProperty = "VersionId"
+	blobType         validProperty = "BlobType"
+	blobAccessTier   validProperty = "BlobAccessTier"
+	contentType      validProperty = "ContentType"
+	contentEncoding  validProperty = "ContentEncoding"
+	leaseState       validProperty = "LeaseState"
+	leaseDuration    validProperty = "LeaseDuration"
+	leaseStatus      validProperty = "LeaseStatus"
+)
+
+// validProperties returns an array of possible values for the validProperty const type.
+func validProperties() []validProperty {
+	return []validProperty{lastModifiedTime, versionId, blobType, blobAccessTier,
+		contentType, contentEncoding, leaseState, leaseDuration, leaseStatus}
 }
 
-func (raw *rawListCmdArgs) parseProperties(rawProperties string) []string {
-	parsedProperties := make([]string, 0)
+func (raw *rawListCmdArgs) parseProperties(rawProperties string) []validProperty {
+	parsedProperties := make([]validProperty, 0)
 	listProperties := strings.Split(rawProperties, ";")
-	for _, property := range listProperties {
-		property = strings.TrimSpace(property)
-		for _, validProperty := range validProperties {
-			if len(property) != 0 && validProperty == property {
-				parsedProperties = append(parsedProperties, property)
+	for _, p := range listProperties {
+		for _, vp := range validProperties() {
+			// check for empty string and also ignore the case
+			if len(p) != 0 && strings.EqualFold(string(vp), p) {
+				parsedProperties = append(parsedProperties, vp)
 				break
 			}
 		}
@@ -97,7 +105,7 @@ type cookedListCmdArgs struct {
 	sourcePath string
 	location   common.Location
 
-	properties      []string
+	properties      []validProperty
 	MachineReadable bool
 	RunningTally    bool
 	MegaUnits       bool
@@ -153,25 +161,26 @@ func init() {
 func (cooked cookedListCmdArgs) processProperties(object storedObject) string {
 	builder := strings.Builder{}
 	for _, property := range cooked.properties {
+		propertyStr := string(property)
 		switch property {
-		case "LastModifiedTime":
-			builder.WriteString(property + ": " + object.lastModifiedTime.String() + "; ")
-		case "VersionId":
-			builder.WriteString(property + ": " + object.blobVersionID + "; ")
-		case "BlobType":
-			builder.WriteString(property + ": " + string(object.blobType) + "; ")
-		case "BlobAccessTier":
-			builder.WriteString(property + ": " + string(object.blobAccessTier) + "; ")
-		case "ContentType":
-			builder.WriteString(property + ": " + object.contentType + "; ")
-		case "ContentEncoding":
-			builder.WriteString(property + ": " + object.contentEncoding + "; ")
-		case "LeaseState":
-			builder.WriteString(property + ": " + string(object.leaseState) + "; ")
-		case "LeaseStatus":
-			builder.WriteString(property + ": " + string(object.leaseStatus) + "; ")
-		case "LeaseDuration":
-			builder.WriteString(property + ": " + string(object.leaseDuration) + "; ")
+		case lastModifiedTime:
+			builder.WriteString(propertyStr + ": " + object.lastModifiedTime.String() + "; ")
+		case versionId:
+			builder.WriteString(propertyStr + ": " + object.blobVersionID + "; ")
+		case blobType:
+			builder.WriteString(propertyStr + ": " + string(object.blobType) + "; ")
+		case blobAccessTier:
+			builder.WriteString(propertyStr + ": " + string(object.blobAccessTier) + "; ")
+		case contentType:
+			builder.WriteString(propertyStr + ": " + object.contentType + "; ")
+		case contentEncoding:
+			builder.WriteString(propertyStr + ": " + object.contentEncoding + "; ")
+		case leaseState:
+			builder.WriteString(propertyStr + ": " + string(object.leaseState) + "; ")
+		case leaseStatus:
+			builder.WriteString(propertyStr + ": " + string(object.leaseStatus) + "; ")
+		case leaseDuration:
+			builder.WriteString(propertyStr + ": " + string(object.leaseDuration) + "; ")
 		}
 	}
 	return builder.String()

--- a/cmd/zc_enumerator.go
+++ b/cmd/zc_enumerator.go
@@ -82,6 +82,11 @@ type storedObject struct {
 	Metadata      common.Metadata
 	blobVersionID string
 	blobTags      common.BlobTags
+
+	// Lease information
+	leaseState    azblob.LeaseStateType
+	leaseStatus   azblob.LeaseStatusType
+	leaseDuration azblob.LeaseDurationType
 }
 
 const (
@@ -208,6 +213,9 @@ type contentPropsProvider interface {
 type blobPropsProvider interface {
 	BlobType() azblob.BlobType
 	AccessTier() azblob.AccessTierType
+	LeaseStatus() azblob.LeaseStatusType
+	LeaseDuration() azblob.LeaseDurationType
+	LeaseState() azblob.LeaseStateType
 }
 
 // a constructor is used so that in case the storedObject has to change, the callers would get a compilation error
@@ -229,6 +237,10 @@ func newStoredObject(morpher objectMorpher, name string, relativePath string, en
 		blobAccessTier:     blobProps.AccessTier(),
 		Metadata:           meta,
 		containerName:      containerName,
+		// Additional lease properties. To be used in listing
+		leaseStatus:   blobProps.LeaseStatus(),
+		leaseState:    blobProps.LeaseState(),
+		leaseDuration: blobProps.LeaseDuration(),
 	}
 
 	// Folders don't have size, and root ones shouldn't have names in the storedObject. Ensure those rules are consistently followed

--- a/cmd/zc_newobjectadapters.go
+++ b/cmd/zc_newobjectadapters.go
@@ -65,6 +65,18 @@ func (e emptyPropertiesAdapter) AccessTier() azblob.AccessTierType {
 	return azblob.AccessTierNone
 }
 
+func (e emptyPropertiesAdapter) LeaseDuration() azblob.LeaseDurationType {
+	return azblob.LeaseDurationNone
+}
+
+func (e emptyPropertiesAdapter) LeaseState() azblob.LeaseStateType {
+	return azblob.LeaseStateNone
+}
+
+func (e emptyPropertiesAdapter) LeaseStatus() azblob.LeaseStatusType {
+	return azblob.LeaseStatusNone
+}
+
 // md5OnlyAdapter is like emptyProperties adapter, except for the ContentMD5
 // method, for which it returns a real value
 type md5OnlyAdapter struct {
@@ -121,4 +133,19 @@ func (a blobPropertiesAdapter) BlobType() azblob.BlobType {
 
 func (a blobPropertiesAdapter) AccessTier() azblob.AccessTierType {
 	return a.BlobProperties.AccessTier
+}
+
+// LeaseDuration returns the value for header x-ms-lease-duration.
+func (a blobPropertiesAdapter) LeaseDuration() azblob.LeaseDurationType {
+	return a.BlobProperties.LeaseDuration
+}
+
+// LeaseState returns the value for header x-ms-lease-state.
+func (a blobPropertiesAdapter) LeaseState() azblob.LeaseStateType {
+	return a.BlobProperties.LeaseState
+}
+
+// LeaseStatus returns the value for header x-ms-lease-status.
+func (a blobPropertiesAdapter) LeaseStatus() azblob.LeaseStatusType {
+	return a.BlobProperties.LeaseStatus
 }


### PR DESCRIPTION
Added flag `--properties` in the list command which takes `;` separated list of properties and will display these fields in list command output. 
Currently list of supported properties is `"LastModifiedTime", "VersionId", "BlobType", "BlobAccessTier", "ContentType", and "ContentEncoding"` . Based on requirement, we can add more parameters in the future.