### PR TITLE
Create SAS tokens for blob->* transfers on the fly in the STE

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -1165,9 +1165,15 @@ func (cca *cookedCopyCmdArgs) processCopyJobPartOrders() (err error) {
 		return err
 	}
 
+	srcCredType, srcPublic, err := getCredentialTypeForLocation(ctx, cca.fromTo.From(), cca.source.Value, cca.source.SAS, true)
+
+	if err != nil {
+		return err
+	}
+
 	// For OAuthToken credential, assign OAuthTokenInfo to CopyJobPartOrderRequest properly,
 	// the info will be transferred to STE.
-	if cca.credentialInfo.CredentialType == common.ECredentialType.OAuthToken() {
+	if cca.credentialInfo.CredentialType == common.ECredentialType.OAuthToken() || srcCredType == common.ECredentialType.OAuthToken() {
 		uotm := GetUserOAuthTokenManagerInstance()
 		// Get token from env var or cache.
 		if tokenInfo, err := uotm.GetTokenInfo(ctx); err != nil {
@@ -1209,6 +1215,7 @@ func (cca *cookedCopyCmdArgs) processCopyJobPartOrders() (err error) {
 		},
 		CommandString:  cca.commandString,
 		CredentialInfo: cca.credentialInfo,
+		SourcePublic: srcPublic,
 	}
 
 	from := cca.fromTo.From()

--- a/cmd/credentialUtil.go
+++ b/cmd/credentialUtil.go
@@ -31,8 +31,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/minio/minio-go/pkg/s3utils"
-
 	"github.com/Azure/azure-pipeline-go/pipeline"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/Azure/azure-storage-file-go/azfile"
@@ -318,118 +316,6 @@ type rawFromToInfo struct {
 	sourceSAS, destinationSAS string // Standalone SAS which might be provided
 }
 
-const trustedSuffixesNameAAD = "trusted-microsoft-suffixes"
-const trustedSuffixesAAD = "*.core.windows.net;*.core.chinacloudapi.cn;*.core.cloudapi.de;*.core.usgovcloudapi.net"
-
-// checkAuthSafeForTarget checks our "implicit" auth types (those that pick up creds from the environment
-// or a prior login) to make sure they are only being used in places where we know those auth types are safe.
-// This prevents, for example, us accidentally sending OAuth creds to some place they don't belong
-func checkAuthSafeForTarget(ct common.CredentialType, resource, extraSuffixesAAD string, resourceType common.Location) error {
-
-	getSuffixes := func(list string, extras string) []string {
-		extras = strings.Trim(extras, " ")
-		if extras != "" {
-			list += ";" + extras
-		}
-		return strings.Split(list, ";")
-	}
-
-	isResourceInSuffixList := func(suffixes []string) (string, bool) {
-		u, err := url.Parse(resource)
-		if err != nil {
-			return "<unparsable>", false
-		}
-		host := strings.ToLower(u.Host)
-
-		for _, s := range suffixes {
-			s = strings.Trim(s, " *") // trim *.foo to .foo
-			s = strings.ToLower(s)
-			if strings.HasSuffix(host, s) {
-				return host, true
-			}
-		}
-		return host, false
-	}
-
-	switch ct {
-	case common.ECredentialType.Unknown(),
-		common.ECredentialType.Anonymous():
-		// these auth types don't pick up anything from environment vars, so they are not the focus of this routine
-		return nil
-	case common.ECredentialType.OAuthToken(),
-		common.ECredentialType.SharedKey():
-		// Files doesn't currently support OAuth, but it's a valid azure endpoint anyway, so it'll pass the check.
-		if resourceType != common.ELocation.Blob() && resourceType != common.ELocation.BlobFS() && resourceType != common.ELocation.File() {
-			// There may be a reason for files->blob to specify this.
-			if resourceType == common.ELocation.Local() {
-				return nil
-			}
-
-			return fmt.Errorf("azure OAuth authentication to %s is not enabled in AzCopy", resourceType.String())
-		}
-
-		// these are Azure auth types, so make sure the resource is known to be in Azure
-		domainSuffixes := getSuffixes(trustedSuffixesAAD, extraSuffixesAAD)
-		if host, ok := isResourceInSuffixList(domainSuffixes); !ok {
-			return fmt.Errorf(
-				"the URL requires authentication. If this URL is in fact an Azure service, you can enable Azure authentication to %s. "+
-					"To enable, view the documentation for "+
-					"the parameter --%s, by running 'AzCopy copy --help'. BUT if this URL is not an Azure service, do NOT enable Azure authentication to it. "+
-					"Instead, see if the URL host supports authentication by way of a token that can be included in the URL's query string",
-				// E.g. CDN apparently supports a non-SAS type of token as noted here: https://docs.microsoft.com/en-us/azure/cdn/cdn-token-auth#setting-up-token-authentication
-				// Including such a token in the URL will cause AzCopy to see it as a "public" URL (since the URL on its own will pass
-				// our "isPublic" access tests, which run before this routine).
-				host, trustedSuffixesNameAAD)
-		}
-
-	case common.ECredentialType.S3AccessKey():
-		if resourceType != common.ELocation.S3() {
-			//noinspection ALL
-			return fmt.Errorf("S3 access key authentication to %s is not enabled in AzCopy", resourceType.String())
-		}
-
-		// just check with minio. No need to have our own list of S3 domains, since minio effectively
-		// has that list already, we can't talk to anything outside that list because minio won't let us,
-		// and the parsing of s3 URL is non-trivial.  E.g. can't just look for the ending since
-		// something like https://someApi.execute-api.someRegion.amazonaws.com is AWS but is a customer-
-		// written code, not S3.
-		ok := false
-		host := "<unparseable url>"
-		u, err := url.Parse(resource)
-		if err == nil {
-			host = u.Host
-			parts, err := common.NewS3URLParts(*u) // strip any leading bucket name from URL, to get an endpoint we can pass to s3utils
-			if err == nil {
-				u, err := url.Parse("https://" + parts.Endpoint)
-				ok = err == nil && s3utils.IsAmazonEndpoint(*u)
-			}
-		}
-
-		if !ok {
-			return fmt.Errorf(
-				"s3 authentication to %s is not currently suported in AzCopy", host)
-		}
-	case common.ECredentialType.GoogleAppCredentials():
-		if resourceType != common.ELocation.GCP() {
-			return fmt.Errorf("Google Application Credentials to %s is not valid", resourceType.String())
-		}
-
-		host := "<unparseable url>"
-		u, err := url.Parse(resource)
-		if err == nil {
-			host = u.Host
-			_, err := common.NewGCPURLParts(*u)
-			if err != nil {
-				return fmt.Errorf("GCP authentication to %s is not currently supported", host)
-			}
-		}
-	default:
-		panic("unknown credential type")
-	}
-
-	return nil
-}
-
 func logAuthType(ct common.CredentialType, location common.Location, isSource bool) {
 	if location == common.ELocation.Unknown() {
 		return // nothing to log
@@ -514,7 +400,7 @@ func doGetCredentialTypeForLocation(ctx context.Context, location common.Locatio
 		}
 	}
 
-	if err = checkAuthSafeForTarget(credType, resource, cmdLineExtraSuffixesAAD, location); err != nil {
+	if err = common.CheckAuthSafeForTarget(credType, resource, common.CmdLineExtraSuffixesAAD, location); err != nil {
 		return common.ECredentialType.Unknown(), false, err
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,12 +51,6 @@ var azcopyAwaitAllowOpenFiles bool
 var azcopyScanningLogger common.ILoggerResetable
 var azcopyCurrentJobID common.JobID
 
-// It's not pretty that this one is read directly by credential util.
-// But doing otherwise required us passing it around in many places, even though really
-// it can be thought of as an "ambient" property. That's the (weak?) justification for implementing
-// it as a global
-var cmdLineExtraSuffixesAAD string
-
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Version: common.AzcopyVersion, // will enable the user to see the version info in the standard posix way: --version
@@ -163,8 +157,8 @@ func init() {
 	rootCmd.PersistentFlags().Float64Var(&cmdLineCapMegaBitsPerSecond, "cap-mbps", 0, "Caps the transfer rate, in megabits per second. Moment-by-moment throughput might vary slightly from the cap. If this option is set to zero, or it is omitted, the throughput isn't capped.")
 	rootCmd.PersistentFlags().StringVar(&outputFormatRaw, "output-type", "text", "Format of the command's output. The choices include: text, json. The default value is 'text'.")
 
-	rootCmd.PersistentFlags().StringVar(&cmdLineExtraSuffixesAAD, trustedSuffixesNameAAD, "", "Specifies additional domain suffixes where Azure Active Directory login tokens may be sent.  The default is '"+
-		trustedSuffixesAAD+"'. Any listed here are added to the default. For security, you should only put Microsoft Azure domains here. Separate multiple entries with semi-colons.")
+	rootCmd.PersistentFlags().StringVar(&common.CmdLineExtraSuffixesAAD, common.TrustedSuffixesNameAAD, "", "Specifies additional domain suffixes where Azure Active Directory login tokens may be sent.  The default is '"+
+		common.TrustedSuffixesAAD+"'. Any listed here are added to the default. For security, you should only put Microsoft Azure domains here. Separate multiple entries with semi-colons.")
 
 	// Note: this is due to Windows not supporting signals properly
 	rootCmd.PersistentFlags().BoolVar(&cancelFromStdin, "cancel-from-stdin", false, "Used by partner teams to send in `cancel` through stdin to stop a job.")

--- a/common/auth-safety.go
+++ b/common/auth-safety.go
@@ -1,0 +1,128 @@
+package common
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/minio/minio-go/pkg/s3utils"
+)
+
+// It's not pretty that this one is read directly by credential util.
+// But doing otherwise required us passing it around in many places, even though really
+// it can be thought of as an "ambient" property. That's the (weak?) justification for implementing
+// it as a global
+var CmdLineExtraSuffixesAAD string
+
+const TrustedSuffixesNameAAD = "trusted-microsoft-suffixes"
+// note: there is a duplicate of this in mgr-jobmgr.go regarding
+const TrustedSuffixesAAD = "*.core.windows.net;*.core.chinacloudapi.cn;*.core.cloudapi.de;*.core.usgovcloudapi.net"
+
+// CheckAuthSafeForTarget checks our "implicit" auth types (those that pick up creds from the environment
+// or a prior login) to make sure they are only being used in places where we know those auth types are safe.
+// This prevents, for example, us accidentally sending OAuth creds to some place they don't belong
+func CheckAuthSafeForTarget(ct CredentialType, resource, extraSuffixesAAD string, resourceType Location) error {
+
+	getSuffixes := func(list string, extras string) []string {
+		extras = strings.Trim(extras, " ")
+		if extras != "" {
+			list += ";" + extras
+		}
+		return strings.Split(list, ";")
+	}
+
+	isResourceInSuffixList := func(suffixes []string) (string, bool) {
+		u, err := url.Parse(resource)
+		if err != nil {
+			return "<unparsable>", false
+		}
+		host := strings.ToLower(u.Host)
+
+		for _, s := range suffixes {
+			s = strings.Trim(s, " *") // trim *.foo to .foo
+			s = strings.ToLower(s)
+			if strings.HasSuffix(host, s) {
+				return host, true
+			}
+		}
+		return host, false
+	}
+
+	switch ct {
+	case ECredentialType.Unknown(),
+		ECredentialType.Anonymous():
+		// these auth types don't pick up anything from environment vars, so they are not the focus of this routine
+		return nil
+	case ECredentialType.OAuthToken(),
+		ECredentialType.SharedKey():
+		// Files doesn't currently support OAuth, but it's a valid azure endpoint anyway, so it'll pass the check.
+		if resourceType != ELocation.Blob() && resourceType != ELocation.BlobFS() && resourceType != ELocation.File() {
+			// There may be a reason for files->blob to specify this.
+			if resourceType == ELocation.Local() {
+				return nil
+			}
+
+			return fmt.Errorf("azure OAuth authentication to %s is not enabled in AzCopy", resourceType.String())
+		}
+
+		// these are Azure auth types, so make sure the resource is known to be in Azure
+		domainSuffixes := getSuffixes(TrustedSuffixesAAD, extraSuffixesAAD)
+		if host, ok := isResourceInSuffixList(domainSuffixes); !ok {
+			return fmt.Errorf(
+				"the URL requires authentication. If this URL is in fact an Azure service, you can enable Azure authentication to %s. "+
+					"To enable, view the documentation for "+
+					"the parameter --%s, by running 'AzCopy copy --help'. BUT if this URL is not an Azure service, do NOT enable Azure authentication to it. "+
+					"Instead, see if the URL host supports authentication by way of a token that can be included in the URL's query string",
+				// E.g. CDN apparently supports a non-SAS type of token as noted here: https://docs.microsoft.com/en-us/azure/cdn/cdn-token-auth#setting-up-token-authentication
+				// Including such a token in the URL will cause AzCopy to see it as a "public" URL (since the URL on its own will pass
+				// our "isPublic" access tests, which run before this routine).
+				host, TrustedSuffixesNameAAD)
+		}
+
+	case ECredentialType.S3AccessKey():
+		if resourceType != ELocation.S3() {
+			//noinspection ALL
+			return fmt.Errorf("S3 access key authentication to %s is not enabled in AzCopy", resourceType.String())
+		}
+
+		// just check with minio. No need to have our own list of S3 domains, since minio effectively
+		// has that list already, we can't talk to anything outside that list because minio won't let us,
+		// and the parsing of s3 URL is non-trivial.  E.g. can't just look for the ending since
+		// something like https://someApi.execute-api.someRegion.amazonaws.com is AWS but is a customer-
+		// written code, not S3.
+		ok := false
+		host := "<unparseable url>"
+		u, err := url.Parse(resource)
+		if err == nil {
+			host = u.Host
+			parts, err := NewS3URLParts(*u) // strip any leading bucket name from URL, to get an endpoint we can pass to s3utils
+			if err == nil {
+				u, err := url.Parse("https://" + parts.Endpoint)
+				ok = err == nil && s3utils.IsAmazonEndpoint(*u)
+			}
+		}
+
+		if !ok {
+			return fmt.Errorf(
+				"s3 authentication to %s is not currently suported in AzCopy", host)
+		}
+	case ECredentialType.GoogleAppCredentials():
+		if resourceType != ELocation.GCP() {
+			return fmt.Errorf("Google Application Credentials to %s is not valid", resourceType.String())
+		}
+
+		host := "<unparseable url>"
+		u, err := url.Parse(resource)
+		if err == nil {
+			host = u.Host
+			_, err := NewGCPURLParts(*u)
+			if err != nil {
+				return fmt.Errorf("GCP authentication to %s is not currently supported", host)
+			}
+		}
+	default:
+		panic("unknown credential type")
+	}
+
+	return nil
+}

--- a/common/environment.go
+++ b/common/environment.go
@@ -22,6 +22,7 @@ package common
 
 import (
 	"runtime"
+	"strconv"
 )
 
 type EnvironmentVariable struct {
@@ -315,6 +316,32 @@ func (EnvironmentVariable) DefaultServiceApiVersion() EnvironmentVariable {
 		Name:         "AZCOPY_DEFAULT_SERVICE_API_VERSION",
 		DefaultValue: "2019-12-12",
 		Description:  "Overrides the service API version so that AzCopy could accommodate custom environments such as Azure Stack.",
+	}
+}
+
+// UDAMRefreshSpeed is only used for internal integration.
+// It is when the user delegation key refreshes, not necessarily when it expires.
+// It is measured in seconds.
+func (EnvironmentVariable) UDAMRefreshSpeed() EnvironmentVariable {
+	return EnvironmentVariable{
+		Name: "AZCOPY_UDAM_REFRESH_TIMER",
+		DefaultValue: strconv.Itoa(
+			((6 * 24) + 12) * // 6.5 days
+				(60 * 60), // Hours -> Minutes (*60), Minutes -> Seconds (*60)
+		),
+	}
+}
+
+// UDAMExpiryTime is only used for internal integration.
+// It is when the user delegation key expires, not necessarily it refreshes.
+// It is measured in seconds.
+func (EnvironmentVariable) UDAMExpiryTime() EnvironmentVariable {
+	return EnvironmentVariable{
+		Name: "AZCOPY_UDAM_EXPIRY_TIMER",
+		DefaultValue: strconv.Itoa(
+			(7 * 24) * // 7 days
+				(60 * 60), // Hours -> Minutes (*60), Minutes -> Seconds (*60)
+		),
 	}
 }
 

--- a/common/rpc-models.go
+++ b/common/rpc-models.go
@@ -123,6 +123,7 @@ type CopyJobPartOrderRequest struct {
 	ExcludeBlobType []azblob.BlobType
 
 	SourceRoot      ResourceString
+	SourcePublic    bool
 	DestinationRoot ResourceString
 
 	Transfers      []CopyTransfer

--- a/ste/JobPartPlan.go
+++ b/ste/JobPartPlan.go
@@ -44,6 +44,7 @@ type JobPartPlanHeader struct {
 	PartNum                common.PartNumber // Job Part's part number (0+)
 	SourceRootLength       uint16            // The length of the source root path
 	SourceRoot             [1000]byte        // The root directory of the source
+	SourcePublic           bool
 	SourceExtraQueryLength uint16
 	SourceExtraQuery       [1000]byte // Extra query params applicable to the source
 	DestinationRootLength  uint16     // The length of the destination root path

--- a/ste/JobPartPlan.go
+++ b/ste/JobPartPlan.go
@@ -14,7 +14,7 @@ import (
 // dataSchemaVersion defines the data schema version of JobPart order files supported by
 // current version of azcopy
 // To be Incremented every time when we release azcopy with changed dataSchema
-const DataSchemaVersion common.Version = 16
+const DataSchemaVersion common.Version = 17
 
 const (
 	CustomHeaderMaxBytes = 256

--- a/ste/JobPartPlanFileName.go
+++ b/ste/JobPartPlanFileName.go
@@ -162,6 +162,7 @@ func (jpfn JobPartPlanFileName) Create(order common.CopyJobPartOrderRequest) {
 		PartNum:                order.PartNum,
 		SourceRootLength:       uint16(len(order.SourceRoot.Value)),
 		SourceExtraQueryLength: uint16(len(order.SourceRoot.ExtraQuery)),
+		SourcePublic:           order.SourcePublic,
 		DestinationRootLength:  uint16(len(order.DestinationRoot.Value)),
 		DestExtraQueryLength:   uint16(len(order.DestinationRoot.ExtraQuery)),
 		IsFinalPart:            order.IsFinalPart,

--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -240,8 +240,6 @@ func (jm *jobMgr) Progress() (uint64, uint64) {
 
 //func (jm *jobMgr) Throughput() XferThroughput { return jm.throughput }
 
-var udamSetupOnce = &sync.Once{}
-
 func (jm *jobMgr) setupUserDelegationAuthManager(src string) {
 	// If the OAuth token is empty, this will fail anyway.
 	// Set an empty UDAM instance that does nothing.
@@ -256,9 +254,9 @@ func (jm *jobMgr) setupUserDelegationAuthManager(src string) {
 	common.PanicIfErr(err)
 
 	// Check if the source is pointing at Azure. We shouldn't send the OAuth token anywhere else.
-	// format is account.[blob.core.windows.net], [] is the selection
-	if srcURL.Host[strings.Index(srcURL.Host, ".")+1:] != "blob.core.windows.net" {
+	if common.CheckAuthSafeForTarget(common.ECredentialType.OAuthToken(), src, common.CmdLineExtraSuffixesAAD, common.ELocation.Blob()) != nil {
 		jm.initState.userDelegationAuthenticationManager = &userDelegationAuthenticationManager{}
+		return
 	}
 
 	// get a service-level URL

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -54,6 +54,7 @@ type IJobPartMgr interface {
 	getFolderCreationTracker() common.FolderCreationTracker
 	SecurityInfoPersistenceManager() *securityInfoPersistenceManager
 	FolderDeletionManager() common.FolderDeletionManager
+	GetUserDelegationAuthenticationManager() *userDelegationAuthenticationManager
 }
 
 type serviceAPIVersionOverride struct{}
@@ -286,6 +287,15 @@ type jobPartMgr struct {
 	atomicTransfersCompleted uint32
 	atomicTransfersFailed    uint32
 	atomicTransfersSkipped   uint32
+}
+
+func (jpm *jobPartMgr) GetUserDelegationAuthenticationManager() *userDelegationAuthenticationManager {
+	// Panic if udam isn't created-- this occurs before a transfer is scheduled!
+	if jpm.jobMgrInitState == nil || jpm.jobMgrInitState.userDelegationAuthenticationManager == nil {
+		panic("UDAM should be initialized already (Even as a dummy!)")
+	}
+
+	return jpm.jobMgrInitState.userDelegationAuthenticationManager
 }
 
 func (jpm *jobPartMgr) getOverwritePrompter() *overwritePrompter {

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -87,6 +87,7 @@ type IJobPartTransferMgr interface {
 	FolderDeletionManager() common.FolderDeletionManager
 	GetDestinationRoot() string
 	ShouldInferContentType() bool
+	GetUserDelegationAuthenticationManager() *userDelegationAuthenticationManager
 }
 
 type TransferInfo struct {
@@ -193,6 +194,10 @@ type jobPartTransferMgr struct {
 		@Parteek removed 3/23 morning, as jeff ad equivalent
 		// transfer chunks are put into this channel and execution engine takes chunk out of this channel.
 		chunkChannel chan<- ChunkMsg*/
+}
+
+func (jptm *jobPartTransferMgr) GetUserDelegationAuthenticationManager() *userDelegationAuthenticationManager {
+	return jptm.jobPartMgr.GetUserDelegationAuthenticationManager()
 }
 
 func (jptm *jobPartTransferMgr) GetOverwritePrompter() *overwritePrompter {

--- a/ste/sender-pageBlob.go
+++ b/ste/sender-pageBlob.go
@@ -103,7 +103,7 @@ func newPageBlobSenderBase(jptm IJobPartTransferMgr, destination string, p pipel
 	// Read the in struct explanation if necessary.
 	var destRangeOptimizer *pageRangeOptimizer
 	if isInManagedDiskImportExportAccount(*destURL) {
-		destRangeOptimizer = newPageRangeOptimizer(destPageBlobURL,
+		destRangeOptimizer = newPageRangeOptimizerFromURL(destURL, p,
 			context.WithValue(jptm.Context(), ServiceAPIVersionOverride, azblob.ServiceVersion))
 	}
 

--- a/ste/userDelegationAuthenticationManager.go
+++ b/ste/userDelegationAuthenticationManager.go
@@ -1,0 +1,148 @@
+package ste
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/Azure/azure-pipeline-go/pipeline"
+	"github.com/Azure/azure-storage-blob-go/azblob"
+	"github.com/golang/groupcache/lru"
+)
+
+// userDelegationAuthenticationManager manages the automatic creation of user delegation SAS tokens for each container.
+// UDAM is only triggered when
+// 1) The user performs a service-to-service transfer
+// and
+// 2) The user did not supply a source SAS token on a blob transfer.
+//
+// When UDAM spins up, a credential is created.
+// UDAM is not necessary in the frontend because if UDAM would succeed, the OAuth token would have to be capable of enumerating the container to start with.
+// However, calls like PutBlockFromURL require a SAS token on the source, which is where UDAM kicks in.
+type userDelegationAuthenticationManager struct {
+	validityTime time.Duration
+	// Because User Delegation SAS tokens cannot last longer than a user delegation credential, we must hold onto the key info.
+	credInfoLock *sync.Mutex
+	startTime    time.Time
+	expiryTime   time.Time
+	credential   azblob.UserDelegationCredential
+	serviceURL   azblob.ServiceURL
+	// sasCache makes use of the thread-safe common.LFUCache.
+	// Yes, some routines will inevitably step over eachother.
+	// But the stringtosign and such should be the exact same until a refresh.
+	sasCache *lru.Cache
+}
+
+// newUserDelegationAuthenticationManager uses an azblob service URL to obtain a user delegation credential, and returns a new userDelegationAuthenticationManager
+// serviceURL should have adequate permissions to generate a set of user delegation credentials.
+// KeyValidityTime should be longer than keyRefreshInterval, but have a sensible amount of downtime between the two so operations don't run into expiry time
+// Typically, this is 7 days to expire (This is the max), and 6.5 days until refresh.
+func newUserDelegationAuthenticationManager(serviceURL azblob.ServiceURL, keyValidityTime, keyRefreshInterval time.Duration) (userDelegationAuthenticationManager, error) {
+	if keyValidityTime < keyRefreshInterval {
+		return userDelegationAuthenticationManager{}, errors.New("Key validity must be longer than the refresh interval")
+	}
+
+	authManager := userDelegationAuthenticationManager{serviceURL: serviceURL, validityTime: keyValidityTime, credInfoLock: &sync.Mutex{}}
+	cache := lru.New(100000)
+	authManager.sasCache = cache
+
+	err := authManager.refreshUDKInternal()
+
+	if err != nil {
+		return userDelegationAuthenticationManager{}, err
+	}
+
+	// Start our refresh loop
+	go func() {
+		for {
+			<-time.After(keyRefreshInterval)     // Refresh regularly so the key doesn't expire while we're working with it.
+			_ = authManager.refreshUDKInternal() // We don't need to worry about a retry here.
+		}
+	}()
+
+	return authManager, nil
+}
+
+func (u *userDelegationAuthenticationManager) refreshUDKInternal() error {
+	u.credInfoLock.Lock()
+	defer u.credInfoLock.Unlock()
+
+	// Create a new start/expiry time.
+	// Because SAS tokens are based on UTC, we need to convert our time to UTC.
+	// Thankfully, Golang includes a .UTC() on time.Time.
+	u.startTime = time.Now().UTC()
+	u.expiryTime = u.startTime.Add(u.validityTime)
+	keyInfo := azblob.NewKeyInfo(u.startTime, u.expiryTime)
+
+	if JobsAdmin != nil {
+		JobsAdmin.LogToJobLog("Attempting to refresh the User Delegation Credential for the blob source.", pipeline.LogDebug)
+	}
+
+	var err error
+	u.credential, err = u.serviceURL.GetUserDelegationCredential(steCtx, keyInfo, nil, nil)
+
+	if err != nil {
+		if JobsAdmin != nil {
+			JobsAdmin.LogToJobLog("Failed to obtain a User Delegation Credential for the blob source.", pipeline.LogError)
+		}
+
+		// Clear the user delegation credential-- it is now invalid.
+		u.credential = azblob.UserDelegationCredential{}
+		return err
+	}
+
+	u.sasCache.Clear()
+
+	if JobsAdmin != nil {
+		JobsAdmin.LogToJobLog("Successfully obtained a User Delegation Credential for the blob source.", pipeline.LogDebug)
+	}
+
+	return nil
+}
+
+func (u *userDelegationAuthenticationManager) GetUserDelegationSASForURL(blobURLParts azblob.BlobURLParts) (string, error) {
+	// Go doesn't seem to parse this quite right without the ().
+	if u.credential == (azblob.UserDelegationCredential{}) {
+		// If we don't have creds, we can't return a SAS token anyway.
+		return "", nil
+	}
+
+	// Check if the SAS token is already present. No need to waste time locking the write mutex if it already exists.
+	if sas, ok := u.sasCache.Get(blobURLParts.ContainerName); ok {
+		return sas.(string), nil
+	} else {
+		// if it is not already present, it should be.
+		// so, create it and return whatever it returns.
+		sas, err := u.createUserDelegationSASForURL(blobURLParts.ContainerName)
+		return sas, err
+	}
+}
+
+func (u *userDelegationAuthenticationManager) createUserDelegationSASForURL(containerName string) (string, error) {
+	u.credInfoLock.Lock()
+
+	// If it's not present, we need to generate a SAS query and store it, then return.
+	sasQuery, err := azblob.BlobSASSignatureValues{
+		Protocol:      azblob.SASProtocolHTTPS,
+		StartTime:     u.startTime,
+		ExpiryTime:    u.expiryTime,
+		Permissions:   azblob.ContainerSASPermissions{Read: true, List: true}.String(), // read-only perms, effectively
+		ContainerName: containerName,
+	}.NewSASQueryParameters(u.credential)
+
+	u.credInfoLock.Unlock()
+
+	if err != nil {
+		return "", err
+	}
+
+	// Write the query to the map and then store it.
+	u.sasCache.Add(containerName, sasQuery.Encode())
+
+	if JobsAdmin != nil {
+		JobsAdmin.LogToJobLog("Successfully generated SAS token for source container " + containerName, pipeline.LogDebug)
+	}
+
+	// return the SAS query
+	return sasQuery.Encode(), nil
+}

--- a/ste/userDelegationAuthenticationManager_test.go
+++ b/ste/userDelegationAuthenticationManager_test.go
@@ -1,0 +1,69 @@
+package ste
+
+import (
+	"sync"
+	"time"
+
+	"github.com/Azure/azure-storage-blob-go/azblob"
+	"github.com/golang/groupcache/lru"
+	chk "gopkg.in/check.v1"
+)
+
+type udamTestSuite struct{}
+
+var _ = chk.Suite(&udamTestSuite{})
+
+// MakeUDAMInstance uses fake values in order to create a mostly-dummy instance of UDAM that works, but doesn't produce working tokens.
+func (s *udamTestSuite) MakeUDAMInstance(dummyInstance bool) userDelegationAuthenticationManager {
+	cache := lru.New(10)
+	if dummyInstance {
+		return userDelegationAuthenticationManager{
+			credInfoLock: &sync.Mutex{},
+			sasCache:     cache,
+		}
+	} else {
+		startTime := time.Now()
+		expiryTime := time.Now().Add(time.Hour * 24)
+
+		// this credential and key isn't real, obviously.
+		udc := azblob.NewUserDelegationCredential("dummyAccount", azblob.UserDelegationKey{
+			SignedOid:     "dummyoid",
+			SignedTid:     "dummytid",
+			SignedStart:   startTime,
+			SignedExpiry:  expiryTime,
+			SignedService: "b",
+			SignedVersion: DefaultServiceApiVersion,
+			Value:         "/mzvUcYFlEGeSUSOT6AShSzbruPBueLN2E/1hJ1HV9M=",
+		})
+
+		// create a actual working instance of UDAM, but don't use the normal creation path
+		udam := userDelegationAuthenticationManager{
+			credInfoLock: &sync.Mutex{},
+			credential:   udc,
+			startTime:    startTime,
+			expiryTime:   expiryTime,
+			sasCache:     cache,
+		}
+
+		return udam
+	}
+}
+
+func (s *udamTestSuite) TestGetSASToken(c *chk.C) {
+	// We just want a non-empty UDK
+	udam := s.MakeUDAMInstance(false)
+	var knownSAS string
+
+	// Get an already existing SAS
+	knownSAS, err := udam.createUserDelegationSASForURL("dummyContainer")
+	c.Assert(err, chk.IsNil)
+
+	o, err := udam.GetUserDelegationSASForURL(azblob.BlobURLParts{ContainerName: "dummyContainer"})
+	c.Assert(err, chk.IsNil)
+	c.Assert(o, chk.Equals, knownSAS)
+
+	// Try getting a new SAS
+	newSAS, err := udam.GetUserDelegationSASForURL(azblob.BlobURLParts{ContainerName: ""})
+	c.Assert(err, chk.IsNil)
+	c.Assert(newSAS, chk.Not(chk.Equals), "")
+}


### PR DESCRIPTION
Pasted from the old PR:

Some background:

Previous iterations of this PR have done this creation in the frontend. This would cause problems if a user attempted to resume a transfer of this style, because the SAS has to come in externally in that scenario. Furthermore, this would have caused issues with S2S transfers, as S2S transfers may potentially contain multiple source containers, and UDKs can only create SAS tokens for containers or blobs, not the entire service.

Therefore, I moved it all to the STE. It lives under a single-instance struct named UserDelegationAuthenticationManager, which does two things:

If a UDK was created, it maps container names to SAS tokens.
If a UDK was not created, it creates empty SAS tokens.
Furthermore, rather than just grabbing the URL once from SIP, we grab it every time we make a call to enable refreshing the underlying UDK and user delegated SAS token