### PR TITLE
Update #813: Enable the creation of dummy transfers to deliver errors earlier in the process

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -146,6 +146,9 @@ type rawCopyCmdArgs struct {
 
 	// whether to include blobs that have metadata 'hdi_isfolder = true'
 	includeDirectoryStubs bool
+
+	// internal flag
+	internalDisableContainerFailureTransfer bool
 }
 
 func (raw *rawCopyCmdArgs) parsePatterns(pattern string) (cookedPatterns []string) {
@@ -1012,6 +1015,9 @@ type cookedCopyCmdArgs struct {
 
 	// whether to include blobs that have metadata 'hdi_isfolder = true'
 	includeDirectoryStubs bool
+
+	// disable the container transfer failures for tests
+	internalDisableContainerFailureTransfer bool
 }
 
 func (cca *cookedCopyCmdArgs) isRedirection() bool {

--- a/cmd/zc_traverser_blob_account.go
+++ b/cmd/zc_traverser_blob_account.go
@@ -104,7 +104,13 @@ func (t *blobAccountTraverser) traverse(preprocessor objectMorpher, processor ob
 		err = containerTraverser.traverse(preprocessorForThisChild, processor, filters)
 
 		if err != nil {
-			WarnStdoutAndJobLog(fmt.Sprintf("failed to list blobs in container %s: %s", v, err))
+			err = processor(newForcedErrorStoredObject(
+				fmt.Sprintf("failed to list blobs in container %s: %s", v, err),
+				"", "", v))
+			if err != nil {
+				return err
+			}
+
 			continue
 		}
 	}

--- a/cmd/zc_traverser_blobfs_account.go
+++ b/cmd/zc_traverser_blobfs_account.go
@@ -112,7 +112,13 @@ func (t *BlobFSAccountTraverser) traverse(preprocessor objectMorpher, processor 
 		err = fileSystemTraverser.traverse(preprocessorForThisChild, processor, filters)
 
 		if err != nil {
-			WarnStdoutAndJobLog(fmt.Sprintf("failed to list files in filesystem %s: %s", v, err))
+			err = processor(newForcedErrorStoredObject(
+				fmt.Sprintf("failed to list files in filesystem %s: %s", v, err),
+				"", "", v))
+			if err != nil {
+				return err
+			}
+
 			continue
 		}
 	}

--- a/cmd/zc_traverser_file_account.go
+++ b/cmd/zc_traverser_file_account.go
@@ -100,7 +100,13 @@ func (t *fileAccountTraverser) traverse(preprocessor objectMorpher, processor ob
 		err = shareTraverser.traverse(preprocessorForThisChild, processor, filters)
 
 		if err != nil {
-			WarnStdoutAndJobLog(fmt.Sprintf("failed to list files in share %s: %s", v, err))
+			err = processor(newForcedErrorStoredObject(
+				fmt.Sprintf("failed to list files in file share %s: %s", v, err),
+				"", "", v))
+			if err != nil {
+				return err
+			}
+
 			continue
 		}
 	}

--- a/common/fe-ste-models.go
+++ b/common/fe-ste-models.go
@@ -902,6 +902,7 @@ const (
 type CopyTransfer struct {
 	Source           string
 	Destination      string
+	FailureReason    string // embedded failure reason caused by EntityType TransferFailure
 	EntityType       EntityType
 	LastModifiedTime time.Time //represents the last modified time of source which ensures that source hasn't changed while transferring
 	SourceSize       int64     // size of the source entity in bytes.
@@ -1302,6 +1303,9 @@ type EntityType uint8
 
 func (EntityType) File() EntityType   { return EntityType(0) }
 func (EntityType) Folder() EntityType { return EntityType(1) }
+// TransferFailure is intended for pre-STE transfer failures that should still receive the proper "transfer failed" treatment (such as the inability to enumerate a container, the inability to resolve a container name, etc.)
+// this is NOT intended to be a replacement for transfer status. Do not use it as such. It is simply a registration of inability to transfer, from cmd to ste.
+func (EntityType) TransferFailure() EntityType { return EntityType(2) }
 
 func (e EntityType) String() string {
 	return enum.StringInt(e, reflect.TypeOf(e))

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -97,6 +97,7 @@ type TransferInfo struct {
 	EntityType             common.EntityType
 	PreserveSMBPermissions common.PreservePermissionsOption
 	PreserveSMBInfo        bool
+	FailureReason          string
 
 	// Transfer info for S2S copy
 	SrcProperties
@@ -241,7 +242,7 @@ func (jptm *jobPartTransferMgr) Info() TransferInfo {
 	src, dst, _ := plan.TransferSrcDstStrings(jptm.transferIndex)
 	dstBlobData := plan.DstBlobData
 
-	srcHTTPHeaders, srcMetadata, srcBlobType, srcBlobTier, s2sGetPropertiesInBackend, DestLengthValidation, s2sSourceChangeValidation, s2sInvalidMetadataHandleOption, entityType, versionID, blobTags :=
+	failureReason, srcHTTPHeaders, srcMetadata, srcBlobType, srcBlobTier, s2sGetPropertiesInBackend, DestLengthValidation, s2sSourceChangeValidation, s2sInvalidMetadataHandleOption, entityType, versionID, blobTags :=
 		plan.TransferSrcPropertiesAndMetadata(jptm.transferIndex)
 	srcSAS, dstSAS := jptm.jobPartMgr.SAS()
 	// If the length of destination SAS is greater than 0
@@ -330,6 +331,7 @@ func (jptm *jobPartTransferMgr) Info() TransferInfo {
 		Source:                         src,
 		SourceSize:                     sourceSize,
 		Destination:                    dst,
+		FailureReason:                  failureReason,
 		EntityType:                     entityType,
 		PreserveSMBPermissions:         plan.PreserveSMBPermissions,
 		PreserveSMBInfo:                plan.PreserveSMBInfo,


### PR DESCRIPTION
Previously, when we skipped containers due to an inability to resolve the name or traverse the source, it came out via stdout and the job logs as a warning... this wasn't the most "visible" of things, especially in automated transfers.

This now outputs actual transfers with an embedded failure status, so that we have a direct failure listing in the job part plan, and a proper failure output from azcopy. This should be more alarming to users who would not otherwise have known their jobs weren't running completely.