### PR TITLE
Retain reportJobPartDoneHandler() for follow-up jobs

### DIFF
--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -514,9 +514,6 @@ func (jm *jobMgr) reportJobPartDoneHandler() {
 		isCancelling := jobStatus == common.EJobStatus.Cancelling()
 		shouldComplete := allKnownPartsDone && (haveFinalPart || isCancelling)
 		if shouldComplete {
-			jobPart0Mgr, _ := jm.jobPartMgrs.Get(0)
-			part0Plan := jobPart0Mgr.Plan() // status of part 0 is status of job as whole.
-
 			partDescription := "all parts of entire Job"
 			if !haveFinalPart {
 				partDescription = "known parts of incomplete Job"


### PR DESCRIPTION
 The thread reportJobPartDoneHandler() was introduced for bookkeeping sometime in 10.5. This thread is responsible to make azcopy exit after completing all the transfers. But, in case of benchmark, after transfers we start another followup-job to delete all the dummy files we uploaded. After the second job completes we should ideally exit the process.  Because reportJobPartDoneHandler() has already exited, the second job would hang indefinitely. The new change will make this thread permanent and will not close it, so that follow-up jobs are serviced as well.