### PR TITLE
Implement OAuth in the modern test framework

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,6 +101,9 @@ jobs:
         env:
           AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)
           AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
+          AZCOPY_E2E_TENANT_ID: $(OAUTH_TENANT_ID)
+          AZCOPY_E2E_APPLICATION_ID: $(ACTIVE_DIRECTORY_APPLICATION_ID)
+          AZCOPY_E2E_CLIENT_SECRET: $(AZCOPY_SPA_CLIENT_SECRET)
       - script: |
           go build -o test-validator ./testSuite/
           mkdir test-temp

--- a/e2etest/config.go
+++ b/e2etest/config.go
@@ -34,6 +34,18 @@ import (
 // the general guidance is to take in as few parameters as possible
 type GlobalInputManager struct{}
 
+func (GlobalInputManager) GetServicePrincipalAuth() (tenantID string, applicationID string, clientSecret string) {
+	tenantID = os.Getenv("AZCOPY_E2E_TENANT_ID")
+	applicationID = os.Getenv("AZCOPY_E2E_APPLICATION_ID")
+	clientSecret = os.Getenv("AZCOPY_E2E_CLIENT_SECRET")
+
+	if applicationID == "" || clientSecret == "" {
+		panic("Insufficient information was supplied for service principal authentication")
+	}
+
+	return
+}
+
 func (GlobalInputManager) GetAccountAndKey(accountType AccountType) (string, string) {
 	var name, key string
 

--- a/e2etest/declarativeRunner.go
+++ b/e2etest/declarativeRunner.go
@@ -93,6 +93,11 @@ func RunScenarios(t *testing.T,
 	testFromTo TestFromTo,
 	validate Validate, // TODO: do we really want the test author to have to nominate which validation should happen?  Pros: better perf of tests. Cons: they have to tell us, and if they tell us wrong test may not test what they think it tests
 	//_ interface{}, // TODO if we want it??, blockBLobsOnly or specifc/all blob types
+
+	// It would be a pain to list out every combo by hand,
+	// In addition to the fact that not every credential type is sensible.
+	// Thus, the E2E framework takes in a requested set of credential types, and applies them where sensible.
+	// This allows you to make tests use OAuth only, SAS only, etc.
 	requestedCredentialTypes []common.CredentialType,
 	p params,
 	hs *hooks,

--- a/e2etest/factory.go
+++ b/e2etest/factory.go
@@ -34,6 +34,7 @@ import (
 	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/Azure/azure-storage-file-go/azfile"
+	"github.com/google/uuid"
 )
 
 // provide convenient methods to get access to test resources such as accounts, containers/shares, directories
@@ -159,6 +160,7 @@ func (TestResourceFactory) CreateNewContainer(c asserter, accountType AccountTyp
 	container = TestResourceFactory{}.GetBlobServiceURL(accountType).NewContainerURL(name)
 
 	cResp, err := container.Create(context.Background(), nil, azblob.PublicAccessNone)
+
 	c.AssertNoErr(err)
 	c.Assert(cResp.StatusCode(), equals(), 201)
 	return container, name, TestResourceFactory{}.GetContainerURLWithSAS(c, accountType, name).URL()
@@ -250,10 +252,10 @@ func generateName(c asserter, prefix string, maxLen int) string {
 	name := c.CompactScenarioName() // don't want to just use test name here, because each test contains multiple scearios with the declarative runner
 
 	textualPortion := fmt.Sprintf("%s-%s", prefix, strings.ToLower(name))
-	currentTime := time.Now()
-	numericSuffix := fmt.Sprintf("%02d%02d%d", currentTime.Minute(), currentTime.Second(), currentTime.Nanosecond())
+	// GUIDs are less prone to overlap than times.
+	guidSuffix := uuid.New().String()
 	if maxLen > 0 {
-		maxTextLen := maxLen - len(numericSuffix)
+		maxTextLen := maxLen - len(guidSuffix)
 		if maxTextLen < 1 {
 			panic("max len too short")
 		}
@@ -261,7 +263,7 @@ func generateName(c asserter, prefix string, maxLen int) string {
 			textualPortion = textualPortion[:maxTextLen]
 		}
 	}
-	name = textualPortion + numericSuffix
+	name = textualPortion + guidSuffix
 	return name
 }
 

--- a/e2etest/runner.go
+++ b/e2etest/runner.go
@@ -102,12 +102,17 @@ func (t *TestRunner) computeArgs() []string {
 
 // execCommandWithOutput replaces Go's exec.Command().Output, but appends an extra parameter and
 // breaks up the c.Run() call into its component parts. Both changes are to assist debugging
-func (t *TestRunner) execDebuggableWithOutput(name string, args []string, afterStart func() string, chToStdin <-chan string) ([]byte, error) {
+func (t *TestRunner) execDebuggableWithOutput(name string, args []string, env []string, afterStart func() string, chToStdin <-chan string) ([]byte, error) {
 	debug := isLaunchedByDebugger
 	if debug {
 		args = append(args, "--await-continue")
 	}
 	c := exec.Command(name, args...)
+
+	// add environment variables
+	if env != nil {
+		c.Env = env
+	}
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -165,7 +170,7 @@ func (t *TestRunner) execDebuggableWithOutput(name string, args []string, afterS
 	return stdout.Bytes(), runErr
 }
 
-func (t *TestRunner) ExecuteAzCopyCommand(operation Operation, src, dst string, afterStart func() string, chToStdin <-chan string) (CopyOrSyncCommandResult, bool, error) {
+func (t *TestRunner) ExecuteAzCopyCommand(operation Operation, src, dst string, needsOAuth bool, afterStart func() string, chToStdin <-chan string) (CopyOrSyncCommandResult, bool, error) {
 	capLen := func(b []byte) []byte {
 		if len(b) < 1024 {
 			return b
@@ -191,7 +196,27 @@ func (t *TestRunner) ExecuteAzCopyCommand(operation Operation, src, dst string, 
 		args = args[:2]
 	}
 	args = append(args, t.computeArgs()...)
-	out, err := t.execDebuggableWithOutput(GlobalInputManager{}.GetExecutablePath(), args, afterStart, chToStdin)
+
+	// pass along existing environment variables (because $HOME doesn't come along if we just use the OAuth vars, that can be troublesome!)
+	env := make([]string, len(os.Environ()))
+	copy(env, os.Environ())
+
+	// paste in OAuth environment variables
+	if needsOAuth {
+		tenId, appId, clientSecret := GlobalInputManager{}.GetServicePrincipalAuth()
+
+		env = append(env,
+			"AZCOPY_AUTO_LOGIN_TYPE=SPN",
+					"AZCOPY_SPA_APPLICATION_ID=" + appId,
+					"AZCOPY_SPA_CLIENT_SECRET=" + clientSecret,
+			)
+
+		if tenId != "" {
+			env = append(env, "AZCOPY_TENANT_ID=" + tenId)
+		}
+	}
+
+	out, err := t.execDebuggableWithOutput(GlobalInputManager{}.GetExecutablePath(), args, env, afterStart, chToStdin)
 
 	wasClean := true
 	stdErr := make([]byte, 0)

--- a/e2etest/zt_blob_index_tags_test.go
+++ b/e2etest/zt_blob_index_tags_test.go
@@ -33,6 +33,7 @@ func TestTags_SetTagsSingleBlob(t *testing.T) {
 		eOperation.Copy(),
 		eTestFromTo.Other(common.EFromTo.LocalBlob()),
 		eValidate.AutoPlusContent(),
+		allCredentialTypes,
 		params{
 			recursive: true,
 			blobTags:  blobTagsStr,
@@ -52,6 +53,7 @@ func TestTags_SetTagsSpecialCharactersSingleBlob(t *testing.T) {
 		eOperation.Copy(),
 		eTestFromTo.Other(common.EFromTo.LocalBlob()),
 		eValidate.AutoPlusContent(),
+		allCredentialTypes,
 		params{
 			recursive: true,
 			blobTags:  "bla_bla=foo%2b-foo&bla%2fbla%2f2=bar",
@@ -73,6 +75,7 @@ func TestTags_SetTagsMultipleBlobs(t *testing.T) {
 		eOperation.Copy(),
 		eTestFromTo.Other(common.EFromTo.LocalBlob()),
 		eValidate.AutoPlusContent(),
+		allCredentialTypes,
 		params{
 			recursive: true,
 			blobTags:  blobTagsStr,
@@ -96,6 +99,7 @@ func TestTags_PreserveTagsSingleBlob(t *testing.T) {
 		eOperation.Copy(),
 		eTestFromTo.Other(common.EFromTo.BlobBlob()),
 		eValidate.AutoPlusContent(),
+		allCredentialTypes,
 		params{
 			recursive:           true,
 			s2sPreserveBlobTags: true,
@@ -117,6 +121,7 @@ func TestTags_PreserveTagsSpecialCharactersSingleBlob(t *testing.T) {
 		eOperation.Copy(),
 		eTestFromTo.Other(common.EFromTo.BlobBlob()),
 		eValidate.AutoPlusContent(),
+		allCredentialTypes,
 		params{
 			recursive:           true,
 			s2sPreserveBlobTags: true,
@@ -137,6 +142,7 @@ func TestTags_PreserveTagsMultipleBlobs(t *testing.T) {
 		eOperation.Copy(),
 		eTestFromTo.Other(common.EFromTo.BlobBlob()),
 		eValidate.AutoPlusContent(),
+		allCredentialTypes,
 		params{
 			recursive:           true,
 			s2sPreserveBlobTags: true,
@@ -159,6 +165,7 @@ func TestTags_PreserveTagsSpecialCharactersMultipleBlobs(t *testing.T) {
 		eOperation.Copy(),
 		eTestFromTo.Other(common.EFromTo.BlobBlob()),
 		eValidate.AutoPlusContent(),
+		allCredentialTypes,
 		params{
 			recursive:           true,
 			s2sPreserveBlobTags: true,
@@ -182,6 +189,7 @@ func TestTags_PreserveTagsSpecialCharactersDuringSync(t *testing.T) {
 		eOperation.Sync(),
 		eTestFromTo.Other(common.EFromTo.BlobBlob()),
 		eValidate.AutoPlusContent(),
+		allCredentialTypes,
 		params{
 			recursive:           true,
 			s2sPreserveBlobTags: true,

--- a/e2etest/zt_blob_index_tags_test.go
+++ b/e2etest/zt_blob_index_tags_test.go
@@ -34,6 +34,7 @@ func TestTags_SetTagsSingleBlob(t *testing.T) {
 		eTestFromTo.Other(common.EFromTo.LocalBlob()),
 		eValidate.AutoPlusContent(),
 		allCredentialTypes,
+		allCredentialTypes,
 		params{
 			recursive: true,
 			blobTags:  blobTagsStr,
@@ -53,6 +54,7 @@ func TestTags_SetTagsSpecialCharactersSingleBlob(t *testing.T) {
 		eOperation.Copy(),
 		eTestFromTo.Other(common.EFromTo.LocalBlob()),
 		eValidate.AutoPlusContent(),
+		allCredentialTypes,
 		allCredentialTypes,
 		params{
 			recursive: true,
@@ -75,6 +77,7 @@ func TestTags_SetTagsMultipleBlobs(t *testing.T) {
 		eOperation.Copy(),
 		eTestFromTo.Other(common.EFromTo.LocalBlob()),
 		eValidate.AutoPlusContent(),
+		allCredentialTypes,
 		allCredentialTypes,
 		params{
 			recursive: true,
@@ -100,6 +103,7 @@ func TestTags_PreserveTagsSingleBlob(t *testing.T) {
 		eTestFromTo.Other(common.EFromTo.BlobBlob()),
 		eValidate.AutoPlusContent(),
 		allCredentialTypes,
+		allCredentialTypes,
 		params{
 			recursive:           true,
 			s2sPreserveBlobTags: true,
@@ -122,6 +126,7 @@ func TestTags_PreserveTagsSpecialCharactersSingleBlob(t *testing.T) {
 		eTestFromTo.Other(common.EFromTo.BlobBlob()),
 		eValidate.AutoPlusContent(),
 		allCredentialTypes,
+		allCredentialTypes,
 		params{
 			recursive:           true,
 			s2sPreserveBlobTags: true,
@@ -142,6 +147,7 @@ func TestTags_PreserveTagsMultipleBlobs(t *testing.T) {
 		eOperation.Copy(),
 		eTestFromTo.Other(common.EFromTo.BlobBlob()),
 		eValidate.AutoPlusContent(),
+		allCredentialTypes,
 		allCredentialTypes,
 		params{
 			recursive:           true,
@@ -166,6 +172,7 @@ func TestTags_PreserveTagsSpecialCharactersMultipleBlobs(t *testing.T) {
 		eTestFromTo.Other(common.EFromTo.BlobBlob()),
 		eValidate.AutoPlusContent(),
 		allCredentialTypes,
+		allCredentialTypes,
 		params{
 			recursive:           true,
 			s2sPreserveBlobTags: true,
@@ -189,6 +196,7 @@ func TestTags_PreserveTagsSpecialCharactersDuringSync(t *testing.T) {
 		eOperation.Sync(),
 		eTestFromTo.Other(common.EFromTo.BlobBlob()),
 		eValidate.AutoPlusContent(),
+		allCredentialTypes,
 		allCredentialTypes,
 		params{
 			recursive:           true,

--- a/e2etest/zt_change_detection_test.go
+++ b/e2etest/zt_change_detection_test.go
@@ -36,6 +36,7 @@ func TestChange_DetectFileChangedDuringTransfer(t *testing.T) {
 		eOperation.CopyAndSync(),
 		eTestFromTo.AllPairs(),
 		eValidate.Auto(),
+		allCredentialTypes,
 		params{
 			recursive: true,
 		},
@@ -76,6 +77,7 @@ func TestChange_DefaultToNoDetectionForCopyS2S(t *testing.T) {
 		eOperation.Copy(), // this test only applies to Copy, because Sync does always set s2sSourceChangeValidation = true
 		eTestFromTo.AllS2S(),
 		eValidate.Auto(),
+		allCredentialTypes,
 		params{
 			recursive: true,
 		},

--- a/e2etest/zt_change_detection_test.go
+++ b/e2etest/zt_change_detection_test.go
@@ -37,6 +37,7 @@ func TestChange_DetectFileChangedDuringTransfer(t *testing.T) {
 		eTestFromTo.AllPairs(),
 		eValidate.Auto(),
 		allCredentialTypes,
+		allCredentialTypes,
 		params{
 			recursive: true,
 		},
@@ -77,6 +78,7 @@ func TestChange_DefaultToNoDetectionForCopyS2S(t *testing.T) {
 		eOperation.Copy(), // this test only applies to Copy, because Sync does always set s2sSourceChangeValidation = true
 		eTestFromTo.AllS2S(),
 		eValidate.Auto(),
+		allCredentialTypes,
 		allCredentialTypes,
 		params{
 			recursive: true,

--- a/e2etest/zt_content_header_test.go
+++ b/e2etest/zt_content_header_test.go
@@ -29,101 +29,73 @@ var fileExtensions = []string{".exe", ".cpp", ".java", ".py", ".go", ".mp3", ".m
 
 func TestHeader_SourceLocal(t *testing.T) {
 	extensionsMap := GetContentTypeMap(fileExtensions)
-	RunScenarios(
-		t,
-		eOperation.Copy(),
-		eTestFromTo.Other(common.EFromTo.LocalBlob()),
-		eValidate.AutoPlusContent(),
-		params{
-			recursive: true,
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.LocalBlob()), eValidate.AutoPlusContent(), allCredentialTypes, params{
+		recursive: true,
+	}, nil, testFiles{
+		defaultSize: "1M",
+		shouldTransfer: []interface{}{
+			// folder("", ),
+			f("file1.mp3", with{contentType: extensionsMap[".mp3"]}),
+			f("file2.pdf", with{contentType: extensionsMap[".pdf"]}),
+			f("file3.exe", with{contentType: extensionsMap[".exe"]}),
+			f("file4.txt", with{contentType: extensionsMap[".txt"]}),
+			f("file5.mp4", with{contentType: extensionsMap[".mp4"]}),
+			f("file6.xlsx", with{contentType: extensionsMap[".xlsx"]}),
 		},
-		nil,
-		testFiles{
-			defaultSize: "1M",
-			shouldTransfer: []interface{}{
-				//folder("", ),
-				f("file1.mp3", with{contentType: extensionsMap[".mp3"]}),
-				f("file2.pdf", with{contentType: extensionsMap[".pdf"]}),
-				f("file3.exe", with{contentType: extensionsMap[".exe"]}),
-				f("file4.txt", with{contentType: extensionsMap[".txt"]}),
-				f("file5.mp4", with{contentType: extensionsMap[".mp4"]}),
-				f("file6.xlsx", with{contentType: extensionsMap[".xlsx"]}),
-			},
-		})
+	})
 }
 
 func TestHeader_SourceLocalEmptyFiles(t *testing.T) {
 	extensionsMap := GetContentTypeMap(fileExtensions)
-	RunScenarios(
-		t,
-		eOperation.Copy(),
-		eTestFromTo.Other(common.EFromTo.LocalBlob()),
-		eValidate.AutoPlusContent(),
-		params{
-			recursive: true,
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.LocalBlob()), eValidate.AutoPlusContent(), allCredentialTypes, params{
+		recursive: true,
+	}, nil, testFiles{
+		defaultSize: "0K",
+		shouldTransfer: []interface{}{
+			// folder("", ),
+			f("file1.mp3", with{contentType: extensionsMap[".mp3"]}),
+			f("file2.pdf", with{contentType: extensionsMap[".pdf"]}),
+			f("file3.exe", with{contentType: extensionsMap[".exe"]}),
+			f("file4.txt", with{contentType: extensionsMap[".txt"]}),
+			f("file3.mp4", with{contentType: extensionsMap[".mp4"]}),
+			f("file5.xlsx", with{contentType: extensionsMap[".xlsx"]}),
 		},
-		nil,
-		testFiles{
-			defaultSize: "0K",
-			shouldTransfer: []interface{}{
-				//folder("", ),
-				f("file1.mp3", with{contentType: extensionsMap[".mp3"]}),
-				f("file2.pdf", with{contentType: extensionsMap[".pdf"]}),
-				f("file3.exe", with{contentType: extensionsMap[".exe"]}),
-				f("file4.txt", with{contentType: extensionsMap[".txt"]}),
-				f("file3.mp4", with{contentType: extensionsMap[".mp4"]}),
-				f("file5.xlsx", with{contentType: extensionsMap[".xlsx"]}),
-			},
-		})
+	})
 }
 
 func TestHeader_AllS2S(t *testing.T) {
 	extensionsMap := GetContentTypeMap(fileExtensions)
-	RunScenarios(
-		t,
-		eOperation.Copy(),
-		eTestFromTo.AllS2S(),
-		eValidate.Auto(),
-		params{
-			recursive: true,
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.AllS2S(), eValidate.Auto(), allCredentialTypes, params{
+		recursive: true,
+	}, nil, testFiles{
+		defaultSize: "1K",
+		shouldTransfer: []interface{}{
+			// folder("", ),
+			f("file1.mp3", with{contentType: extensionsMap[".mp3"]}),
+			f("file2.pdf", with{contentType: extensionsMap[".pdf"]}),
+			f("file3.exe", with{contentType: extensionsMap[".exe"]}),
+			f("file4.txt", with{contentType: extensionsMap[".txt"]}),
+			f("file3.mp4", with{contentType: extensionsMap[".mp4"]}),
+			f("file5.xlsx", with{contentType: extensionsMap[".xlsx"]}),
 		},
-		nil,
-		testFiles{
-			defaultSize: "1K",
-			shouldTransfer: []interface{}{
-				//folder("", ),
-				f("file1.mp3", with{contentType: extensionsMap[".mp3"]}),
-				f("file2.pdf", with{contentType: extensionsMap[".pdf"]}),
-				f("file3.exe", with{contentType: extensionsMap[".exe"]}),
-				f("file4.txt", with{contentType: extensionsMap[".txt"]}),
-				f("file3.mp4", with{contentType: extensionsMap[".mp4"]}),
-				f("file5.xlsx", with{contentType: extensionsMap[".xlsx"]}),
-			},
-		})
+	})
 }
 
 // TODO: AutoPlusContent is not thread-safe. Look into that.
 func TestHeader_SourceBlobEmptyBlob(t *testing.T) {
 	extensionsMap := GetContentTypeMap(fileExtensions)
-	RunScenarios(
-		t,
-		eOperation.Copy(),
-		eTestFromTo.Other(common.EFromTo.BlobBlob()),
-		eValidate.AutoPlusContent(),
-		params{
-			recursive: true,
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.BlobBlob()), eValidate.AutoPlusContent(), allCredentialTypes, params{
+		recursive: true,
+	}, nil, testFiles{
+		defaultSize: "0K",
+		shouldTransfer: []interface{}{
+			// folder("", ),
+			f("file1.mp3", with{contentType: extensionsMap[".mp3"]}),
+			f("file2.pdf", with{contentType: extensionsMap[".pdf"]}),
+			f("file3.exe", with{contentType: extensionsMap[".exe"]}),
+			f("file4.txt", with{contentType: extensionsMap[".txt"]}),
+			f("file3.mp4", with{contentType: extensionsMap[".mp4"]}),
+			f("file5.xlsx", with{contentType: extensionsMap[".xlsx"]}),
 		},
-		nil,
-		testFiles{
-			defaultSize: "0K",
-			shouldTransfer: []interface{}{
-				//folder("", ),
-				f("file1.mp3", with{contentType: extensionsMap[".mp3"]}),
-				f("file2.pdf", with{contentType: extensionsMap[".pdf"]}),
-				f("file3.exe", with{contentType: extensionsMap[".exe"]}),
-				f("file4.txt", with{contentType: extensionsMap[".txt"]}),
-				f("file3.mp4", with{contentType: extensionsMap[".mp4"]}),
-				f("file5.xlsx", with{contentType: extensionsMap[".xlsx"]}),
-			},
-		})
+	})
 }

--- a/e2etest/zt_content_header_test.go
+++ b/e2etest/zt_content_header_test.go
@@ -29,7 +29,7 @@ var fileExtensions = []string{".exe", ".cpp", ".java", ".py", ".go", ".mp3", ".m
 
 func TestHeader_SourceLocal(t *testing.T) {
 	extensionsMap := GetContentTypeMap(fileExtensions)
-	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.LocalBlob()), eValidate.AutoPlusContent(), allCredentialTypes, params{
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.LocalBlob()), eValidate.AutoPlusContent(), allCredentialTypes, allCredentialTypes, params{
 		recursive: true,
 	}, nil, testFiles{
 		defaultSize: "1M",
@@ -47,7 +47,7 @@ func TestHeader_SourceLocal(t *testing.T) {
 
 func TestHeader_SourceLocalEmptyFiles(t *testing.T) {
 	extensionsMap := GetContentTypeMap(fileExtensions)
-	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.LocalBlob()), eValidate.AutoPlusContent(), allCredentialTypes, params{
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.LocalBlob()), eValidate.AutoPlusContent(), allCredentialTypes, allCredentialTypes, params{
 		recursive: true,
 	}, nil, testFiles{
 		defaultSize: "0K",
@@ -65,7 +65,7 @@ func TestHeader_SourceLocalEmptyFiles(t *testing.T) {
 
 func TestHeader_AllS2S(t *testing.T) {
 	extensionsMap := GetContentTypeMap(fileExtensions)
-	RunScenarios(t, eOperation.Copy(), eTestFromTo.AllS2S(), eValidate.Auto(), allCredentialTypes, params{
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.AllS2S(), eValidate.Auto(), allCredentialTypes, allCredentialTypes, params{
 		recursive: true,
 	}, nil, testFiles{
 		defaultSize: "1K",
@@ -84,7 +84,7 @@ func TestHeader_AllS2S(t *testing.T) {
 // TODO: AutoPlusContent is not thread-safe. Look into that.
 func TestHeader_SourceBlobEmptyBlob(t *testing.T) {
 	extensionsMap := GetContentTypeMap(fileExtensions)
-	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.BlobBlob()), eValidate.AutoPlusContent(), allCredentialTypes, params{
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.BlobBlob()), eValidate.AutoPlusContent(), allCredentialTypes, allCredentialTypes, params{
 		recursive: true,
 	}, nil, testFiles{
 		defaultSize: "0K",

--- a/e2etest/zt_copy_file_smb_test.go
+++ b/e2etest/zt_copy_file_smb_test.go
@@ -6,28 +6,21 @@ import (
 )
 
 func TestSMB_FromShareSnapshot(t *testing.T) {
-	RunScenarios(
-		t,
-		eOperation.Copy(),
-		eTestFromTo.Other(common.EFromTo.FileFile()),
-		eValidate.AutoPlusContent(),
-		params{
-			recursive:              true,
-			preserveSMBInfo:        true,
-			preserveSMBPermissions: true,
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.FileFile()), eValidate.AutoPlusContent(), allCredentialTypes, params{
+		recursive:              true,
+		preserveSMBInfo:        true,
+		preserveSMBPermissions: true,
+	}, &hooks{
+		// create a snapshot for the source share
+		beforeRunJob: func(h hookHelper) {
+			h.CreateSourceSnapshot()
 		},
-		&hooks{
-			// create a snapshot for the source share
-			beforeRunJob: func(h hookHelper) {
-				h.CreateSourceSnapshot()
-			},
+	}, testFiles{
+		defaultSize: "4M",
+		shouldTransfer: []interface{}{
+			folder(""), // root folder
+			folder("folder1"),
+			f("folder1/filea"),
 		},
-		testFiles{
-			defaultSize: "4M",
-			shouldTransfer: []interface{}{
-				folder(""), // root folder
-				folder("folder1"),
-				f("folder1/filea"),
-			},
-		})
+	})
 }

--- a/e2etest/zt_copy_file_smb_test.go
+++ b/e2etest/zt_copy_file_smb_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestSMB_FromShareSnapshot(t *testing.T) {
-	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.FileFile()), eValidate.AutoPlusContent(), allCredentialTypes, params{
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.FileFile()), eValidate.AutoPlusContent(), allCredentialTypes, allCredentialTypes, params{
 		recursive:              true,
 		preserveSMBInfo:        true,
 		preserveSMBPermissions: true,

--- a/e2etest/zt_enumeration_filter_test.go
+++ b/e2etest/zt_enumeration_filter_test.go
@@ -43,7 +43,7 @@ func TestFilter_IncludePath(t *testing.T) {
 	// instead of just eOperation.Copy(), then for the first three listed above, RunTests would have run Sync as well, making
 	// it 8 scenarios in total. But include-path does not apply to Sync, so we did not specify that here)
 
-	RunScenarios(t, eOperation.Copy(), eTestFromTo.AllSourcesToOneDest(), eValidate.Auto(), allCredentialTypes, params{ // Pass flag values that the test requires. The params struct is a superset of Copy and Sync params
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.AllSourcesToOneDest(), eValidate.Auto(), allCredentialTypes, allCredentialTypes, params{ // Pass flag values that the test requires. The params struct is a superset of Copy and Sync params
 		recursive:   true,
 		includePath: "sub/subsub;wantedfile",
 	}, nil, testFiles{ // Source files specifies details of the files to test on
@@ -76,7 +76,7 @@ func TestFilter_IncludePath(t *testing.T) {
 
 // TestFilter_IncludeAfter test the include-after parameter
 func TestFilter_IncludeAfter(t *testing.T) {
-	RunScenarios(t, eOperation.Copy(), eTestFromTo.AllSourcesToOneDest(), eValidate.Auto(), allCredentialTypes, params{
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.AllSourcesToOneDest(), eValidate.Auto(), allCredentialTypes, allCredentialTypes, params{
 		recursive: true,
 	}, &hooks{
 		beforeRunJob: func(h hookHelper) {
@@ -109,7 +109,7 @@ func TestFilter_IncludeAfter(t *testing.T) {
 
 func TestFilter_IncludePattern(t *testing.T) {
 
-	RunScenarios(t, eOperation.Copy(), eTestFromTo.AllSourcesToOneDest(), eValidate.Auto(), allCredentialTypes, params{
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.AllSourcesToOneDest(), eValidate.Auto(), allCredentialTypes, allCredentialTypes, params{
 		recursive:      true,
 		includePattern: "*.txt;2020*;*mid*;file8", // *pre*in*post*",
 	}, nil, testFiles{
@@ -133,7 +133,7 @@ func TestFilter_IncludePattern(t *testing.T) {
 
 func TestFilter_RemoveFile(t *testing.T) {
 
-	RunScenarios(t, eOperation.Remove(), eTestFromTo.AllRemove(), eValidate.Auto(), allCredentialTypes, params{
+	RunScenarios(t, eOperation.Remove(), eTestFromTo.AllRemove(), eValidate.Auto(), allCredentialTypes, allCredentialTypes, params{
 		relativeSourcePath: "file2.txt",
 	}, nil, testFiles{
 		defaultSize: "1K",
@@ -148,7 +148,7 @@ func TestFilter_RemoveFile(t *testing.T) {
 
 func TestFilter_RemoveFolder(t *testing.T) {
 
-	RunScenarios(t, eOperation.Remove(), eTestFromTo.AllRemove(), eValidate.Auto(), allCredentialTypes, params{
+	RunScenarios(t, eOperation.Remove(), eTestFromTo.AllRemove(), eValidate.Auto(), allCredentialTypes, allCredentialTypes, params{
 		recursive:          true,
 		relativeSourcePath: "folder2/",
 	}, nil, testFiles{
@@ -167,7 +167,7 @@ func TestFilter_RemoveFolder(t *testing.T) {
 
 func TestFilter_RemoveContainer(t *testing.T) {
 
-	RunScenarios(t, eOperation.Remove(), eTestFromTo.AllRemove(), eValidate.Auto(), allCredentialTypes, params{
+	RunScenarios(t, eOperation.Remove(), eTestFromTo.AllRemove(), eValidate.Auto(), allCredentialTypes, allCredentialTypes, params{
 		recursive:          true,
 		relativeSourcePath: "",
 	}, nil, testFiles{
@@ -182,7 +182,7 @@ func TestFilter_RemoveContainer(t *testing.T) {
 
 func TestFilter_ExcludePath(t *testing.T) {
 
-	RunScenarios(t, eOperation.Copy(), eTestFromTo.AllSourcesToOneDest(), eValidate.Auto(), allCredentialTypes, params{
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.AllSourcesToOneDest(), eValidate.Auto(), allCredentialTypes, allCredentialTypes, params{
 		recursive:   true,
 		excludePath: "subL1/subL2;excludeFile",
 	}, nil, testFiles{
@@ -209,7 +209,7 @@ func TestFilter_ExcludePath(t *testing.T) {
 
 func TestFilter_ExcludePattern(t *testing.T) {
 
-	RunScenarios(t, eOperation.Copy(), eTestFromTo.AllSourcesToOneDest(), eValidate.Auto(), allCredentialTypes, params{
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.AllSourcesToOneDest(), eValidate.Auto(), allCredentialTypes, allCredentialTypes, params{
 		recursive:      true,
 		excludePattern: "*.log;2020*;*mid*;excludeFile",
 	}, nil, testFiles{
@@ -235,7 +235,7 @@ func TestFilter_ExcludePattern(t *testing.T) {
 // include-path with other filters didn't work properly. This test should give us some protection against that.
 // In particular, this tests asserts how the various path and pattern related filters should combine with each other.
 func TestFilter_CombineCommonFilters(t *testing.T) {
-	RunScenarios(t, eOperation.Copy(), eTestFromTo.AllSourcesToOneDest(), eValidate.Auto(), allCredentialTypes, params{
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.AllSourcesToOneDest(), eValidate.Auto(), allCredentialTypes, allCredentialTypes, params{
 		recursive:      true,
 		includePath:    "dog;donkey/seal;ferret.txt;frog.txt;goat.txt", // mix of directories and files, all relative to the root
 		excludePath:    "dog/seal;donkey/seal/frog.txt",                // mix of directories and files, all relative to the root

--- a/e2etest/zt_enumeration_filter_test.go
+++ b/e2etest/zt_enumeration_filter_test.go
@@ -43,333 +43,269 @@ func TestFilter_IncludePath(t *testing.T) {
 	// instead of just eOperation.Copy(), then for the first three listed above, RunTests would have run Sync as well, making
 	// it 8 scenarios in total. But include-path does not apply to Sync, so we did not specify that here)
 
-	RunScenarios( // This is the method that does all the work.  We pass it params to define that test that should be run
-		t,                                 // Pass in the test context
-		eOperation.Copy(),                 // Should the test be run for copy only, sync only, or both?
-		eTestFromTo.AllSourcesToOneDest(), // What range of source/dest pairs should this test be run on
-		eValidate.Auto(),                  // What to validate (in this case, we don't validate content. We just validate that the desired transfers were scheduled
-		params{ // Pass flag values that the test requires. The params struct is a superset of Copy and Sync params
-			recursive:   true,
-			includePath: "sub/subsub;wantedfile",
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.AllSourcesToOneDest(), eValidate.Auto(), allCredentialTypes, params{ // Pass flag values that the test requires. The params struct is a superset of Copy and Sync params
+		recursive:   true,
+		includePath: "sub/subsub;wantedfile",
+	}, nil, testFiles{ // Source files specifies details of the files to test on
+		defaultSize: "1K", // An indication of what size of files should be created
+		shouldIgnore: []interface{}{ // A list of files which should be created, but which are expected to be ignored by the job
+			folder(""), // root folder (i.e. the folder that normally gets copied when source doesn't end in /*.  But it doesn't get copied in this case, because it doesn't match the include-path)
+			"filea",
+			"fileb",
+			"filec",
+			"wantedfileabc", // include-path only works with whole filenames, so this won't match wantedfile
+			"sub/filea",
+			"sub/fileb",
+			"sub/filec",
+			folder("sub/subsubsub"),          // include-path only works with _whole_ directories (i.e. not prefix match)
+			"sub/somethingelse/subsub/filey", // should not be included because sub/subsub is not contiguous here
+			"othersub/sub/subsub/filey",      // should not be included because sub/subsub is not at root here
+			"othersub/wantedfile",            // should not be included because, although wantedfile is in the includepath, include path always starts from the root
 		},
-		nil, // For advanced usage, can pass a hooks struct here, to hook funcs into different stage of the testing process to customize it
-		testFiles{ // Source files specifies details of the files to test on
-			defaultSize: "1K", // An indication of what size of files should be created
-			shouldIgnore: []interface{}{ // A list of files which should be created, but which are expected to be ignored by the job
-				folder(""), // root folder (i.e. the folder that normally gets copied when source doesn't end in /*.  But it doesn't get copied in this case, because it doesn't match the include-path)
-				"filea",
-				"fileb",
-				"filec",
-				"wantedfileabc", // include-path only works with whole filenames, so this won't match wantedfile
-				"sub/filea",
-				"sub/fileb",
-				"sub/filec",
-				folder("sub/subsubsub"),          // include-path only works with _whole_ directories (i.e. not prefix match)
-				"sub/somethingelse/subsub/filey", // should not be included because sub/subsub is not contiguous here
-				"othersub/sub/subsub/filey",      // should not be included because sub/subsub is not at root here
-				"othersub/wantedfile",            // should not be included because, although wantedfile is in the includepath, include path always starts from the root
-			},
-			shouldTransfer: []interface{}{ // A list of files which should be created an which should indeed be transferred
-				// Include folders as a line that ends in /. Test framework will automatically ignore them when
-				// not transferring between folder-aware locations
-				"wantedfile",
-				folder("sub/subsub"),
-				"sub/subsub/filea",
-				"sub/subsub/fileb",
-				"sub/subsub/filec",
-			},
+		shouldTransfer: []interface{}{ // A list of files which should be created an which should indeed be transferred
+			// Include folders as a line that ends in /. Test framework will automatically ignore them when
+			// not transferring between folder-aware locations
+			"wantedfile",
+			folder("sub/subsub"),
+			"sub/subsub/filea",
+			"sub/subsub/fileb",
+			"sub/subsub/filec",
 		},
-	)
+	})
 }
 
 // TestFilter_IncludeAfter test the include-after parameter
 func TestFilter_IncludeAfter(t *testing.T) {
-	RunScenarios(
-		t,
-		eOperation.Copy(), // IncludeAfter is not applicable for sync
-		eTestFromTo.AllSourcesToOneDest(),
-		eValidate.Auto(),
-		params{
-			recursive: true,
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.AllSourcesToOneDest(), eValidate.Auto(), allCredentialTypes, params{
+		recursive: true,
+	}, &hooks{
+		beforeRunJob: func(h hookHelper) {
+			// let LMTs of existing file age a little (so they are definitely older than our include-after)
+			time.Sleep(4 * time.Second)
+
+			// set includeAfter to "now"
+			scenarioParams := h.GetModifiableParameters()
+			scenarioParams.includeAfter = time.Now().Format(time.RFC3339)
+
+			// wait a moment, so that LMTs of the files we are about to create will be definitely >= our include-after
+			// (without this, we had a bug, presumably due to a small clock skew error between client machine and blob storage,
+			// in which the LMTs of the re-created files ended up before the include-after time).
+			time.Sleep(4 * time.Second)
+
+			// re-create the "shouldTransfer" files, after our includeAfter time.
+			fs := h.GetTestFiles().cloneShouldTransfers()
+			h.CreateFiles(fs, true)
 		},
-		&hooks{
-			beforeRunJob: func(h hookHelper) {
-				// let LMTs of existing file age a little (so they are definitely older than our include-after)
-				time.Sleep(4 * time.Second)
-
-				// set includeAfter to "now"
-				scenarioParams := h.GetModifiableParameters()
-				scenarioParams.includeAfter = time.Now().Format(time.RFC3339)
-
-				// wait a moment, so that LMTs of the files we are about to create will be definitely >= our include-after
-				// (without this, we had a bug, presumably due to a small clock skew error between client machine and blob storage,
-				// in which the LMTs of the re-created files ended up before the include-after time).
-				time.Sleep(4 * time.Second)
-
-				// re-create the "shouldTransfer" files, after our includeAfter time.
-				fs := h.GetTestFiles().cloneShouldTransfers()
-				h.CreateFiles(fs, true)
-			},
+	}, testFiles{
+		defaultSize: "1K",
+		shouldIgnore: []interface{}{
+			"filea",
 		},
-		testFiles{
-			defaultSize: "1K",
-			shouldIgnore: []interface{}{
-				"filea",
-			},
-			shouldTransfer: []interface{}{
-				"fileb",
-			},
-		})
+		shouldTransfer: []interface{}{
+			"fileb",
+		},
+	})
 }
 
 func TestFilter_IncludePattern(t *testing.T) {
 
-	RunScenarios(
-		t,
-		eOperation.Copy(),
-		eTestFromTo.AllSourcesToOneDest(),
-		eValidate.Auto(),
-		params{
-			recursive:      true,
-			includePattern: "*.txt;2020*;*mid*;file8", //*pre*in*post*",
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.AllSourcesToOneDest(), eValidate.Auto(), allCredentialTypes, params{
+		recursive:      true,
+		includePattern: "*.txt;2020*;*mid*;file8", // *pre*in*post*",
+	}, nil, testFiles{
+		defaultSize: "1K",
+		shouldIgnore: []interface{}{
+			"A2020log",
+			"A2020log.txte",
 		},
-		nil,
-		testFiles{
-			defaultSize: "1K",
-			shouldIgnore: []interface{}{
-				"A2020log",
-				"A2020log.txte",
-			},
-			shouldTransfer: []interface{}{
-				folder("subdir"),
-				"2020_file1",
-				"file2.txt",
-				"file3_mid_txt",
-				"subdir/2020_file5", //because recursive=true and patterns are matched in subdirectories as well.
-				"subdir/file6.txt",
-				"subdir/file7_A_mid_B",
-				"file8", //Exact match
-			},
-		})
+		shouldTransfer: []interface{}{
+			folder("subdir"),
+			"2020_file1",
+			"file2.txt",
+			"file3_mid_txt",
+			"subdir/2020_file5", // because recursive=true and patterns are matched in subdirectories as well.
+			"subdir/file6.txt",
+			"subdir/file7_A_mid_B",
+			"file8", // Exact match
+		},
+	})
 }
 
 func TestFilter_RemoveFile(t *testing.T) {
 
-	RunScenarios(
-		t,
-		eOperation.Remove(),
-		eTestFromTo.AllRemove(),
-		eValidate.Auto(),
-		params{
-			relativeSourcePath: "file2.txt",
+	RunScenarios(t, eOperation.Remove(), eTestFromTo.AllRemove(), eValidate.Auto(), allCredentialTypes, params{
+		relativeSourcePath: "file2.txt",
+	}, nil, testFiles{
+		defaultSize: "1K",
+		shouldTransfer: []interface{}{
+			"file1.txt",
 		},
-		nil,
-		testFiles{
-			defaultSize: "1K",
-			shouldTransfer: []interface{}{
-				"file1.txt",
-			},
-			shouldIgnore: []interface{}{
-				"file2.txt",
-			},
-		})
+		shouldIgnore: []interface{}{
+			"file2.txt",
+		},
+	})
 }
 
 func TestFilter_RemoveFolder(t *testing.T) {
 
-	RunScenarios(
-		t,
-		eOperation.Remove(),
-		eTestFromTo.AllRemove(),
-		eValidate.Auto(),
-		params{
-			recursive:          true,
-			relativeSourcePath: "folder2/",
+	RunScenarios(t, eOperation.Remove(), eTestFromTo.AllRemove(), eValidate.Auto(), allCredentialTypes, params{
+		recursive:          true,
+		relativeSourcePath: "folder2/",
+	}, nil, testFiles{
+		defaultSize: "1K",
+		shouldTransfer: []interface{}{
+			"file1.txt",
+			"folder1/file11.txt",
+			"folder1/file12.txt",
 		},
-		nil,
-		testFiles{
-			defaultSize: "1K",
-			shouldTransfer: []interface{}{
-				"file1.txt",
-				"folder1/file11.txt",
-				"folder1/file12.txt",
-			},
-			shouldIgnore: []interface{}{
-				"folder2/file21.txt",
-				"folder2/file22.txt",
-			},
-		})
+		shouldIgnore: []interface{}{
+			"folder2/file21.txt",
+			"folder2/file22.txt",
+		},
+	})
 }
 
 func TestFilter_RemoveContainer(t *testing.T) {
 
-	RunScenarios(
-		t,
-		eOperation.Remove(),
-		eTestFromTo.AllRemove(),
-		eValidate.Auto(),
-		params{
-			recursive:          true,
-			relativeSourcePath: "",
+	RunScenarios(t, eOperation.Remove(), eTestFromTo.AllRemove(), eValidate.Auto(), allCredentialTypes, params{
+		recursive:          true,
+		relativeSourcePath: "",
+	}, nil, testFiles{
+		defaultSize: "1K",
+		shouldTransfer: []interface{}{
+			"file1.txt",
+			"folder1/file11.txt",
+			"folder1/file12.txt",
 		},
-		nil,
-		testFiles{
-			defaultSize: "1K",
-			shouldTransfer: []interface{}{
-				"file1.txt",
-				"folder1/file11.txt",
-				"folder1/file12.txt",
-			},
-		})
+	})
 }
 
 func TestFilter_ExcludePath(t *testing.T) {
 
-	RunScenarios(
-		t,
-		eOperation.Copy(),
-		eTestFromTo.AllSourcesToOneDest(),
-		eValidate.Auto(),
-		params{
-			recursive:   true,
-			excludePath: "subL1/subL2;excludeFile",
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.AllSourcesToOneDest(), eValidate.Auto(), allCredentialTypes, params{
+		recursive:   true,
+		excludePath: "subL1/subL2;excludeFile",
+	}, nil, testFiles{
+		defaultSize: "1K",
+		shouldIgnore: []interface{}{
+			"excludeFile",
+			folder("subL1/subL2"),
+			"subL1/subL2/file1",
 		},
-		nil,
-		testFiles{
-			defaultSize: "1K",
-			shouldIgnore: []interface{}{
-				"excludeFile",
-				folder("subL1/subL2"),
-				"subL1/subL2/file1",
-			},
-			shouldTransfer: []interface{}{
-				folder(""),
-				folder("subL1"),
-				folder("sub"),
-				folder("subL1/sub"),
-				folder("sub/subL1"),
-				folder("subL1/sub/subL2"),
-				folder("sub/subL1/subL2"),
-				"sub/excludeFile",       // exclude path starts at root
-				"subL1/sub/subL2/fileA", //exclude path should be contiguous
-				"sub/subL1/subL2/fileB",
-			},
-		})
+		shouldTransfer: []interface{}{
+			folder(""),
+			folder("subL1"),
+			folder("sub"),
+			folder("subL1/sub"),
+			folder("sub/subL1"),
+			folder("subL1/sub/subL2"),
+			folder("sub/subL1/subL2"),
+			"sub/excludeFile",       // exclude path starts at root
+			"subL1/sub/subL2/fileA", // exclude path should be contiguous
+			"sub/subL1/subL2/fileB",
+		},
+	})
 }
 
 func TestFilter_ExcludePattern(t *testing.T) {
 
-	RunScenarios(
-		t,
-		eOperation.Copy(),
-		eTestFromTo.AllSourcesToOneDest(),
-		eValidate.Auto(),
-		params{
-			recursive:      true,
-			excludePattern: "*.log;2020*;*mid*;excludeFile",
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.AllSourcesToOneDest(), eValidate.Auto(), allCredentialTypes, params{
+		recursive:      true,
+		excludePattern: "*.log;2020*;*mid*;excludeFile",
+	}, nil, testFiles{
+		defaultSize: "1K",
+		shouldIgnore: []interface{}{
+			"A2020.log",
+			"2020log.txt",
+			"A2020_mid_file",
+			"excludeFile",
+			"subdir/A2020.log", // We'll match patterns as sub-directories if recursive=true
+			"subdir/2020log.txt",
+			"subdir/A2020_mid_file",
 		},
-		nil,
-		testFiles{
-			defaultSize: "1K",
-			shouldIgnore: []interface{}{
-				"A2020.log",
-				"2020log.txt",
-				"A2020_mid_file",
-				"excludeFile",
-				"subdir/A2020.log", //We'll match patterns as sub-directories if recursive=true
-				"subdir/2020log.txt",
-				"subdir/A2020_mid_file",
-			},
-			shouldTransfer: []interface{}{
-				folder("subdir"),
-				"sample.txt",
-				"subdir/sample.txt",
-			},
-		})
+		shouldTransfer: []interface{}{
+			folder("subdir"),
+			"sample.txt",
+			"subdir/sample.txt",
+		},
+	})
 }
 
 // Generally, each filter test should target one filter.  We did once have a bug though, where combining
 // include-path with other filters didn't work properly. This test should give us some protection against that.
 // In particular, this tests asserts how the various path and pattern related filters should combine with each other.
 func TestFilter_CombineCommonFilters(t *testing.T) {
-	RunScenarios(
-		t,
-		eOperation.Copy(), // for Sync, include-path doesn't make sense and isn't supported
-		eTestFromTo.AllSourcesToOneDest(),
-		eValidate.Auto(),
-		params{
-			recursive:      true,
-			includePath:    "dog;donkey/seal;ferret.txt;frog.txt;goat.txt", // mix of directories and files, all relative to the root
-			excludePath:    "dog/seal;donkey/seal/frog.txt",                // mix of directories and files, all relative to the root
-			includePattern: "f*",
-			excludePattern: "ferret*",
-			// Include path includes a whole subdir, from which the include pattern includes only the f*s.
-			// The exclude path excludes a specific frog.txt in a specific directory,
-			// and the exclude pattern excludes the all ferret files.
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.AllSourcesToOneDest(), eValidate.Auto(), allCredentialTypes, params{
+		recursive:      true,
+		includePath:    "dog;donkey/seal;ferret.txt;frog.txt;goat.txt", // mix of directories and files, all relative to the root
+		excludePath:    "dog/seal;donkey/seal/frog.txt",                // mix of directories and files, all relative to the root
+		includePattern: "f*",
+		excludePattern: "ferret*",
+		// Include path includes a whole subdir, from which the include pattern includes only the f*s.
+		// The exclude path excludes a specific frog.txt in a specific directory,
+		// and the exclude pattern excludes the all ferret files.
+	}, nil, testFiles{
+		defaultSize: "1K",
+		shouldIgnore: []interface{}{
+			// since this is such a long list, and it has a repetitive structure, the "shouldTransfer" files are included,
+			// (just as comments) in the shouldIgnore list, so that the structure can be seen. We don't normally need (or want)
+			// to do that. But it seemed useful here.
+			// All folders are excluded, because the params include file-only filters.
+			// Naming convention in this test: d* = directory; s* = subdirectory; f* (and one g*) = file
+			folder(""),
+			"ferret.txt",
+			"fox.txt",
+			// "frog.txt", in shouldTransfer
+			"goat.txt",
+			folder("dog"),
+			"dog/ferret.txt",
+			// "dog/fox.txt", in shouldTransfer
+			// "dog/frog.txt", in shouldTransfer
+			"dog/goat.txt",
+			folder("dog/seal"),
+			"dog/seal/ferret.txt",
+			"dog/seal/fox.txt",
+			"dog/seal/frog.txt",
+			"dog/seal/goat.txt",
+			folder("dog/skunk"),
+			"dog/skunk/ferret.txt",
+			// "dog/skunk/fox.txt", in shouldTransfer
+			// "dog/skunk/frog.txt", in shouldTransfer
+			"dog/skunk/goat.txt",
+			folder("dog/snail"),
+			"dog/snail/ferret.txt",
+			// "dog/snail/fox.txt", in shouldTransfer
+			// "dog/snail/frog.txt", in shouldTransfer
+			"dog/snail/goat.txt",
+			"donkey/ferret.txt",
+			"donkey/fox.txt",
+			"donkey/frog.txt",
+			"donkey/goat.txt",
+			folder("donkey/seal"),
+			"donkey/seal/ferret.txt",
+			// "donkey/seal/fox.txt", in shouldTransfer
+			"donkey/seal/frog.txt",
+			"donkey/seal/goat.txt",
+			folder("donkey/skunk"),
+			"donkey/skunk/ferret.txt",
+			"donkey/skunk/fox.txt",
+			"donkey/skunk/frog.txt",
+			"donkey/skunk/goat.txt",
+			folder("donkey/snail"),
+			"donkey/snail/ferret.txt",
+			"donkey/snail/fox.txt",
+			"donkey/snail/frog.txt",
+			"donkey/snail/goat.txt",
 		},
-		nil,
-		testFiles{
-			defaultSize: "1K",
-			shouldIgnore: []interface{}{
-				// since this is such a long list, and it has a repetitive structure, the "shouldTransfer" files are included,
-				// (just as comments) in the shouldIgnore list, so that the structure can be seen. We don't normally need (or want)
-				// to do that. But it seemed useful here.
-				// All folders are excluded, because the params include file-only filters.
-				// Naming convention in this test: d* = directory; s* = subdirectory; f* (and one g*) = file
-				folder(""),
-				"ferret.txt",
-				"fox.txt",
-				//"frog.txt", in shouldTransfer
-				"goat.txt",
-				folder("dog"),
-				"dog/ferret.txt",
-				//"dog/fox.txt", in shouldTransfer
-				//"dog/frog.txt", in shouldTransfer
-				"dog/goat.txt",
-				folder("dog/seal"),
-				"dog/seal/ferret.txt",
-				"dog/seal/fox.txt",
-				"dog/seal/frog.txt",
-				"dog/seal/goat.txt",
-				folder("dog/skunk"),
-				"dog/skunk/ferret.txt",
-				//"dog/skunk/fox.txt", in shouldTransfer
-				//"dog/skunk/frog.txt", in shouldTransfer
-				"dog/skunk/goat.txt",
-				folder("dog/snail"),
-				"dog/snail/ferret.txt",
-				//"dog/snail/fox.txt", in shouldTransfer
-				//"dog/snail/frog.txt", in shouldTransfer
-				"dog/snail/goat.txt",
-				"donkey/ferret.txt",
-				"donkey/fox.txt",
-				"donkey/frog.txt",
-				"donkey/goat.txt",
-				folder("donkey/seal"),
-				"donkey/seal/ferret.txt",
-				//"donkey/seal/fox.txt", in shouldTransfer
-				"donkey/seal/frog.txt",
-				"donkey/seal/goat.txt",
-				folder("donkey/skunk"),
-				"donkey/skunk/ferret.txt",
-				"donkey/skunk/fox.txt",
-				"donkey/skunk/frog.txt",
-				"donkey/skunk/goat.txt",
-				folder("donkey/snail"),
-				"donkey/snail/ferret.txt",
-				"donkey/snail/fox.txt",
-				"donkey/snail/frog.txt",
-				"donkey/snail/goat.txt",
-			},
-			shouldTransfer: []interface{}{
-				"dog/fox.txt",
-				"dog/frog.txt",
-				"dog/skunk/fox.txt",
-				"dog/skunk/frog.txt",
-				"dog/snail/fox.txt",
-				"dog/snail/frog.txt",
-				"donkey/seal/fox.txt",
-				"frog.txt",
-			},
-		})
+		shouldTransfer: []interface{}{
+			"dog/fox.txt",
+			"dog/frog.txt",
+			"dog/skunk/fox.txt",
+			"dog/skunk/frog.txt",
+			"dog/snail/fox.txt",
+			"dog/snail/frog.txt",
+			"donkey/seal/fox.txt",
+			"frog.txt",
+		},
+	})
 }

--- a/e2etest/zt_enumeration_other_test.go
+++ b/e2etest/zt_enumeration_other_test.go
@@ -28,24 +28,17 @@ import (
 // Purpose: Other tests for enumeration of sources, NOT including filtering
 
 func TestEnumeration_DirectoryStubsAreNotDownloaded(t *testing.T) {
-	RunScenarios(
-		t,
-		eOperation.CopyAndSync(),
-		eTestFromTo.Other(common.EFromTo.BlobLocal()), // TODO: does this apply to any additional cases?
-		eValidate.Auto(),
-		params{
-			recursive: true,
+	RunScenarios(t, eOperation.CopyAndSync(), eTestFromTo.Other(common.EFromTo.BlobLocal()), eValidate.Auto(), allCredentialTypes, params{
+		recursive: true,
+	}, nil, testFiles{
+		defaultSize: "1K",
+		shouldIgnore: []interface{}{
+			f("dir", withDirStubMetadata{}),
 		},
-		nil,
-		testFiles{
-			defaultSize: "1K",
-			shouldIgnore: []interface{}{
-				f("dir", withDirStubMetadata{}),
-			},
-			shouldTransfer: []interface{}{
-				"filea",
-				folder("dir"),
-				"dir/fileb",
-			},
-		})
+		shouldTransfer: []interface{}{
+			"filea",
+			folder("dir"),
+			"dir/fileb",
+		},
+	})
 }

--- a/e2etest/zt_enumeration_other_test.go
+++ b/e2etest/zt_enumeration_other_test.go
@@ -28,7 +28,7 @@ import (
 // Purpose: Other tests for enumeration of sources, NOT including filtering
 
 func TestEnumeration_DirectoryStubsAreNotDownloaded(t *testing.T) {
-	RunScenarios(t, eOperation.CopyAndSync(), eTestFromTo.Other(common.EFromTo.BlobLocal()), eValidate.Auto(), allCredentialTypes, params{
+	RunScenarios(t, eOperation.CopyAndSync(), eTestFromTo.Other(common.EFromTo.BlobLocal()), eValidate.Auto(), allCredentialTypes, allCredentialTypes, params{
 		recursive: true,
 	}, nil, testFiles{
 		defaultSize: "1K",

--- a/e2etest/zt_naming_file_and_folder_test.go
+++ b/e2etest/zt_naming_file_and_folder_test.go
@@ -37,17 +37,10 @@ func TestNaming_ShareFileFoldersSpecialChar(t *testing.T) {
 			transfers = append(transfers, f(folders[i]+"/"+files[j]))
 		}
 	}
-	RunScenarios(
-		t,
-		eOperation.CopyAndSync(),
-		eTestFromTo.Other(common.EFromTo.FileFile(), common.EFromTo.FileLocal(), common.EFromTo.LocalFile()),
-		eValidate.Auto(),
-		params{
-			recursive: true,
-		},
-		nil,
-		testFiles{
-			defaultSize:    "1K",
-			shouldTransfer: transfers,
-		})
+	RunScenarios(t, eOperation.CopyAndSync(), eTestFromTo.Other(common.EFromTo.FileFile(), common.EFromTo.FileLocal(), common.EFromTo.LocalFile()), eValidate.Auto(), allCredentialTypes, params{
+		recursive: true,
+	}, nil, testFiles{
+		defaultSize:    "1K",
+		shouldTransfer: transfers,
+	})
 }

--- a/e2etest/zt_naming_file_and_folder_test.go
+++ b/e2etest/zt_naming_file_and_folder_test.go
@@ -37,7 +37,7 @@ func TestNaming_ShareFileFoldersSpecialChar(t *testing.T) {
 			transfers = append(transfers, f(folders[i]+"/"+files[j]))
 		}
 	}
-	RunScenarios(t, eOperation.CopyAndSync(), eTestFromTo.Other(common.EFromTo.FileFile(), common.EFromTo.FileLocal(), common.EFromTo.LocalFile()), eValidate.Auto(), allCredentialTypes, params{
+	RunScenarios(t, eOperation.CopyAndSync(), eTestFromTo.Other(common.EFromTo.FileFile(), common.EFromTo.FileLocal(), common.EFromTo.LocalFile()), eValidate.Auto(), allCredentialTypes, allCredentialTypes, params{
 		recursive: true,
 	}, nil, testFiles{
 		defaultSize:    "1K",

--- a/e2etest/zt_preserve_content_test.go
+++ b/e2etest/zt_preserve_content_test.go
@@ -32,7 +32,7 @@ import (
 
 func TestContent_AtBlobStorage(t *testing.T) {
 
-	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.LocalBlob()), eValidate.AutoPlusContent(), allCredentialTypes, params{
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.LocalBlob()), eValidate.AutoPlusContent(), allCredentialTypes, allCredentialTypes, params{
 		recursive: true,
 	}, nil, testFiles{
 		defaultSize: "4M",
@@ -44,7 +44,7 @@ func TestContent_AtBlobStorage(t *testing.T) {
 }
 
 func TestContent_AtFileShare(t *testing.T) {
-	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.LocalFile()), eValidate.AutoPlusContent(), allCredentialTypes, params{
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.LocalFile()), eValidate.AutoPlusContent(), allCredentialTypes, allCredentialTypes, params{
 		recursive: true,
 	}, nil, testFiles{
 		defaultSize: "4M",
@@ -57,7 +57,7 @@ func TestContent_AtFileShare(t *testing.T) {
 }
 
 func TestContent_BlobToBlob(t *testing.T) {
-	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.BlobBlob()), eValidate.AutoPlusContent(), allCredentialTypes, params{
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.BlobBlob()), eValidate.AutoPlusContent(), allCredentialTypes, allCredentialTypes, params{
 		recursive: true,
 	}, nil, testFiles{
 		defaultSize: "8M",

--- a/e2etest/zt_preserve_content_test.go
+++ b/e2etest/zt_preserve_content_test.go
@@ -32,62 +32,40 @@ import (
 
 func TestContent_AtBlobStorage(t *testing.T) {
 
-	RunScenarios(
-		t,
-		eOperation.Copy(), // Sync doesn't support the command-line metadata flag
-		eTestFromTo.Other(common.EFromTo.LocalBlob()),
-		eValidate.AutoPlusContent(),
-		params{
-			recursive: true,
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.LocalBlob()), eValidate.AutoPlusContent(), allCredentialTypes, params{
+		recursive: true,
+	}, nil, testFiles{
+		defaultSize: "4M",
+		shouldTransfer: []interface{}{
+			folder(""), // root folder
+			f("filea"),
 		},
-		nil,
-		testFiles{
-			defaultSize: "4M",
-			shouldTransfer: []interface{}{
-				folder(""), // root folder
-				f("filea"),
-			},
-		})
+	})
 }
 
 func TestContent_AtFileShare(t *testing.T) {
-	RunScenarios(
-		t,
-		eOperation.Copy(), // Sync doesn't support the command-line metadata flag
-		eTestFromTo.Other(common.EFromTo.LocalFile()),
-		eValidate.AutoPlusContent(),
-		params{
-			recursive: true,
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.LocalFile()), eValidate.AutoPlusContent(), allCredentialTypes, params{
+		recursive: true,
+	}, nil, testFiles{
+		defaultSize: "4M",
+		shouldTransfer: []interface{}{
+			folder(""), // root folder
+			folder("folder1"),
+			f("folder1/filea"),
 		},
-		nil,
-		testFiles{
-			defaultSize: "4M",
-			shouldTransfer: []interface{}{
-				folder(""), // root folder
-				folder("folder1"),
-				f("folder1/filea"),
-			},
-		})
+	})
 }
 
 func TestContent_BlobToBlob(t *testing.T) {
-	RunScenarios(
-		t,
-		eOperation.Copy(), // Sync doesn't support the command-line metadata flag
-		// eTestFromTo.Other(common.EFromTo.BlobBlob()),
-		eTestFromTo.Other(common.EFromTo.BlobBlob()),
-		eValidate.AutoPlusContent(),
-		params{
-			recursive: true,
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.BlobBlob()), eValidate.AutoPlusContent(), allCredentialTypes, params{
+		recursive: true,
+	}, nil, testFiles{
+		defaultSize: "8M",
+		shouldTransfer: []interface{}{
+			folder(""), // root folder
+			f("filea"),
 		},
-		nil,
-		testFiles{
-			defaultSize: "8M",
-			shouldTransfer: []interface{}{
-				folder(""), // root folder
-				f("filea"),
-			},
-		})
+	})
 }
 
 //func TestChange_ValidateFileContentAtRemote(t *testing.T) {

--- a/e2etest/zt_preserve_properties_test.go
+++ b/e2etest/zt_preserve_properties_test.go
@@ -28,44 +28,30 @@ import (
 //   and those specified on the command line
 
 func TestProperties_NameValueMetadataIsPreservedS2S(t *testing.T) {
-	RunScenarios(
-		t,
-		eOperation.CopyAndSync(),
-		eTestFromTo.AllS2S(),
-		eValidate.Auto(),
-		params{
-			recursive: true,
+	RunScenarios(t, eOperation.CopyAndSync(), eTestFromTo.AllS2S(), eValidate.Auto(), allCredentialTypes, params{
+		recursive: true,
+	}, nil, testFiles{
+		defaultSize: "1K",
+		shouldTransfer: []interface{}{
+			f("filea", with{nameValueMetadata: map[string]string{"foo": "abc", "bar": "def"}}),
+			folder("fold1", with{nameValueMetadata: map[string]string{"other": "xyz"}}),
 		},
-		nil,
-		testFiles{
-			defaultSize: "1K",
-			shouldTransfer: []interface{}{
-				f("filea", with{nameValueMetadata: map[string]string{"foo": "abc", "bar": "def"}}),
-				folder("fold1", with{nameValueMetadata: map[string]string{"other": "xyz"}}),
-			},
-		})
+	})
 }
 
 func TestProperties_NameValueMetadataCanBeUploaded(t *testing.T) {
 	expectedMap := map[string]string{"foo": "abc", "bar": "def"}
 
-	RunScenarios(
-		t,
-		eOperation.Copy(),        // Sync doesn't support the command-line metadata flag
-		eTestFromTo.AllUploads(), // TODO: Metadata copy not supported while performing S2S transfers
-		eValidate.Auto(),
-		params{
-			recursive: true,
-			metadata:  "foo=abc;bar=def",
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.AllUploads(), eValidate.Auto(), allCredentialTypes, params{
+		recursive: true,
+		metadata:  "foo=abc;bar=def",
+	}, nil, testFiles{
+		defaultSize: "1K",
+		shouldTransfer: []interface{}{
+			folder("", verifyOnly{with{nameValueMetadata: expectedMap}}), // root folder
+			f("filea", verifyOnly{with{nameValueMetadata: expectedMap}}),
 		},
-		nil,
-		testFiles{
-			defaultSize: "1K",
-			shouldTransfer: []interface{}{
-				folder("", verifyOnly{with{nameValueMetadata: expectedMap}}), // root folder
-				f("filea", verifyOnly{with{nameValueMetadata: expectedMap}}),
-			},
-		})
+	})
 }
 
 //func TestProperties_SMBPermissionsSDDLPreserved(t *testing.T) {

--- a/e2etest/zt_preserve_properties_test.go
+++ b/e2etest/zt_preserve_properties_test.go
@@ -28,7 +28,7 @@ import (
 //   and those specified on the command line
 
 func TestProperties_NameValueMetadataIsPreservedS2S(t *testing.T) {
-	RunScenarios(t, eOperation.CopyAndSync(), eTestFromTo.AllS2S(), eValidate.Auto(), allCredentialTypes, params{
+	RunScenarios(t, eOperation.CopyAndSync(), eTestFromTo.AllS2S(), eValidate.Auto(), allCredentialTypes, allCredentialTypes, params{
 		recursive: true,
 	}, nil, testFiles{
 		defaultSize: "1K",
@@ -42,7 +42,7 @@ func TestProperties_NameValueMetadataIsPreservedS2S(t *testing.T) {
 func TestProperties_NameValueMetadataCanBeUploaded(t *testing.T) {
 	expectedMap := map[string]string{"foo": "abc", "bar": "def"}
 
-	RunScenarios(t, eOperation.Copy(), eTestFromTo.AllUploads(), eValidate.Auto(), allCredentialTypes, params{
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.AllUploads(), eValidate.Auto(), allCredentialTypes, allCredentialTypes, params{
 		recursive: true,
 		metadata:  "foo=abc;bar=def",
 	}, nil, testFiles{

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/danieljoos/wincred v1.0.1
 	github.com/go-ini/ini v1.41.0 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
+	github.com/google/uuid v1.1.1
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jiacfan/keychain v0.0.0-20180920053336-f2c902a3d807
 	github.com/jiacfan/keyctl v0.3.1


### PR DESCRIPTION
Makes use of SPN and One-Shot login to enable OAuth in the modern OAuth test framework.

This works by generating valid credential type combos with a requested source and destination set of credentials.