### PR TITLE
Improve error if we cannot determine if source is a directory

### DIFF
--- a/cmd/zc_traverser_blob.go
+++ b/cmd/zc_traverser_blob.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
-	"github.com/Azure/azure-storage-azcopy/v10/ste"
 )
 
 // allow us to iterate through a path pointing to the blob endpoint
@@ -85,8 +84,9 @@ func (t *blobTraverser) isDirectory(isSource bool) bool {
 	searchPrefix := strings.TrimSuffix(blobURLParts.BlobName, common.AZCOPY_PATH_SEPARATOR_STRING) + common.AZCOPY_PATH_SEPARATOR_STRING
 	resp, err := containerURL.ListBlobsFlatSegment(t.ctx, azblob.Marker{}, azblob.ListBlobsSegmentOptions{Prefix: searchPrefix, MaxResults: 1})
 	if err != nil {
-		if ste.JobsAdmin != nil {
-			ste.JobsAdmin.LogToJobLog(fmt.Sprintf("Failed to check if the destination is a folder or a file (Azure Files). Assuming the destination is a file: %s", err), pipeline.LogWarning)
+		if azcopyScanningLogger != nil {
+			msg := fmt.Sprintf("Failed to check if the destination is a folder or a file (Azure Files). Assuming the destination is a file: %s", err)
+			azcopyScanningLogger.Log(pipeline.LogError, msg)
 		}
 		return false
 	}

--- a/cmd/zt_sync_blob_blob_test.go
+++ b/cmd/zt_sync_blob_blob_test.go
@@ -480,7 +480,7 @@ func (s *cmdIntegrationSuite) TestSyncS2SContainerAndEmptyVirtualDir(c *chk.C) {
 
 	// construct the raw input to simulate user input
 	srcContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, srcContainerName)
-	dstVirtualDirURLWithSAS := scenarioHelper{}.getRawBlobURLWithSAS(c, dstContainerName, "emptydir")
+	dstVirtualDirURLWithSAS := scenarioHelper{}.getRawBlobURLWithSAS(c, dstContainerName, "emptydir/")
 	raw := getDefaultSyncRawInput(srcContainerURLWithSAS.String(), dstVirtualDirURLWithSAS.String())
 
 	// verify that targeting a virtual directory works fine

--- a/testSuite/scripts/test_blob_sync.py
+++ b/testSuite/scripts/test_blob_sync.py
@@ -116,7 +116,7 @@ class Blob_Sync_User_Scenario(unittest.TestCase):
         content_dir_name = "dir_sync_test"
         content_dir_path = util.create_test_n_files(1024, 10, content_dir_name)
         src_vdir_path = util.get_resource_sas("srcdir")
-        dst_vdir_path = util.get_resource_sas("dstdir")
+        dst_vdir_path = util.get_resource_sas("dstdir/")
 
         # create sub-directory inside directory
         sub_dir_name = os.path.join(content_dir_name, "sub_dir_sync_test")

--- a/testSuite/scripts/test_blob_sync.py
+++ b/testSuite/scripts/test_blob_sync.py
@@ -29,7 +29,8 @@ class Blob_Sync_User_Scenario(unittest.TestCase):
         # the resource local path should be the first argument for the azcopy validator.
         # the resource sas should be the second argument for azcopy validator.
         resource_url = util.get_resource_sas(filename)
-        result = util.Command("testBlob").add_arguments(file_path).add_arguments(resource_url).execute_azcopy_verify()
+        result = util.Command("testBlob").add_arguments(
+            file_path).add_arguments(resource_url).execute_azcopy_verify()
         self.assertTrue(result)
 
         # Sync 1KB file to local using azcopy.
@@ -60,7 +61,8 @@ class Blob_Sync_User_Scenario(unittest.TestCase):
         # upload the directory
         # execute azcopy command
         result = util.Command("copy").add_arguments(dir_path).add_arguments(util.test_container_url). \
-            add_flags("recursive", "true").add_flags("log-level", "info").execute_azcopy_copy_command()
+            add_flags("recursive", "true").add_flags(
+                "log-level", "info").execute_azcopy_copy_command()
         self.assertTrue(result)
 
         # execute the validator.
@@ -71,7 +73,7 @@ class Blob_Sync_User_Scenario(unittest.TestCase):
 
         # sync to local
         src = vdir_sas
-        dst = dir_path
+        dst = dir_path + "/"
         result = util.Command("sync").add_arguments(src).add_arguments(dst).add_flags("log-level", "info")\
             .execute_azcopy_copy_command()
         self.assertTrue(result)
@@ -102,9 +104,11 @@ class Blob_Sync_User_Scenario(unittest.TestCase):
         # verifying the uploaded blobs.
         # the resource local path should be the first argument for the azcopy validator.
         # the resource sas should be the second argument for azcopy validator.
-        result = util.Command("testBlob").add_arguments(content_file_path).add_arguments(src_blob_path).execute_azcopy_verify()
+        result = util.Command("testBlob").add_arguments(
+            content_file_path).add_arguments(src_blob_path).execute_azcopy_verify()
         self.assertTrue(result)
-        result = util.Command("testBlob").add_arguments(content_file_path).add_arguments(dst_blob_path).execute_azcopy_verify()
+        result = util.Command("testBlob").add_arguments(
+            content_file_path).add_arguments(dst_blob_path).execute_azcopy_verify()
         self.assertTrue(result)
 
         # perform the single blob sync using azcopy.
@@ -116,7 +120,7 @@ class Blob_Sync_User_Scenario(unittest.TestCase):
         content_dir_name = "dir_sync_test"
         content_dir_path = util.create_test_n_files(1024, 10, content_dir_name)
         src_vdir_path = util.get_resource_sas("srcdir")
-        dst_vdir_path = util.get_resource_sas("dstdir")
+        dst_vdir_path = util.get_resource_sas("dstdir/")
 
         # create sub-directory inside directory
         sub_dir_name = os.path.join(content_dir_name, "sub_dir_sync_test")
@@ -126,7 +130,8 @@ class Blob_Sync_User_Scenario(unittest.TestCase):
         # upload the directory
         # execute azcopy command
         result = util.Command("copy").add_arguments(content_dir_path).add_arguments(src_vdir_path). \
-            add_flags("recursive", "true").add_flags("log-level", "info").execute_azcopy_copy_command()
+            add_flags("recursive", "true").add_flags(
+                "log-level", "info").execute_azcopy_copy_command()
         self.assertTrue(result)
 
         # execute the validator.

--- a/testSuite/scripts/test_blob_sync.py
+++ b/testSuite/scripts/test_blob_sync.py
@@ -29,8 +29,7 @@ class Blob_Sync_User_Scenario(unittest.TestCase):
         # the resource local path should be the first argument for the azcopy validator.
         # the resource sas should be the second argument for azcopy validator.
         resource_url = util.get_resource_sas(filename)
-        result = util.Command("testBlob").add_arguments(
-            file_path).add_arguments(resource_url).execute_azcopy_verify()
+        result = util.Command("testBlob").add_arguments(file_path).add_arguments(resource_url).execute_azcopy_verify()
         self.assertTrue(result)
 
         # Sync 1KB file to local using azcopy.
@@ -61,8 +60,7 @@ class Blob_Sync_User_Scenario(unittest.TestCase):
         # upload the directory
         # execute azcopy command
         result = util.Command("copy").add_arguments(dir_path).add_arguments(util.test_container_url). \
-            add_flags("recursive", "true").add_flags(
-                "log-level", "info").execute_azcopy_copy_command()
+            add_flags("recursive", "true").add_flags("log-level", "info").execute_azcopy_copy_command()
         self.assertTrue(result)
 
         # execute the validator.
@@ -104,11 +102,9 @@ class Blob_Sync_User_Scenario(unittest.TestCase):
         # verifying the uploaded blobs.
         # the resource local path should be the first argument for the azcopy validator.
         # the resource sas should be the second argument for azcopy validator.
-        result = util.Command("testBlob").add_arguments(
-            content_file_path).add_arguments(src_blob_path).execute_azcopy_verify()
+        result = util.Command("testBlob").add_arguments(content_file_path).add_arguments(src_blob_path).execute_azcopy_verify()
         self.assertTrue(result)
-        result = util.Command("testBlob").add_arguments(
-            content_file_path).add_arguments(dst_blob_path).execute_azcopy_verify()
+        result = util.Command("testBlob").add_arguments(content_file_path).add_arguments(dst_blob_path).execute_azcopy_verify()
         self.assertTrue(result)
 
         # perform the single blob sync using azcopy.
@@ -120,7 +116,7 @@ class Blob_Sync_User_Scenario(unittest.TestCase):
         content_dir_name = "dir_sync_test"
         content_dir_path = util.create_test_n_files(1024, 10, content_dir_name)
         src_vdir_path = util.get_resource_sas("srcdir")
-        dst_vdir_path = util.get_resource_sas("dstdir/")
+        dst_vdir_path = util.get_resource_sas("dstdir")
 
         # create sub-directory inside directory
         sub_dir_name = os.path.join(content_dir_name, "sub_dir_sync_test")
@@ -130,8 +126,7 @@ class Blob_Sync_User_Scenario(unittest.TestCase):
         # upload the directory
         # execute azcopy command
         result = util.Command("copy").add_arguments(content_dir_path).add_arguments(src_vdir_path). \
-            add_flags("recursive", "true").add_flags(
-                "log-level", "info").execute_azcopy_copy_command()
+            add_flags("recursive", "true").add_flags("log-level", "info").execute_azcopy_copy_command()
         self.assertTrue(result)
 
         # execute the validator.


### PR DESCRIPTION
This will replace #1340, which was an overkill.

For a blob traverser, in cases where we cannot determine if a given path is a blob/virtual dir, we assumed it to be a dir and displayed wrong error. This PR will inverse the assumption (ie. if we cannot determine we'll assume it to be a blob). This will make the traverser throw appropriate error (#873). 

This is also in line with assumptions made by ADLS and Filestore traversers.

Previous error
```
[nakulkar@nakulkar-dev:azcopy]$ azcopy copy "https://storenakulkar.blob.core.windows.net/container1/file.pdf?sp=racwdl&st=2021-04-19T06:22:47Z&se=2021-04-19T14:22:47Z&spr=https&sv=2020-02-10&sr=c&sig=-REDACTED-" /dev/null
INFO: Scanning...

failed to perform copy command due to error: cannot use directory as source without --recursive or a trailing wildcard (/*)
```

New Error
```
[nakulkar@nakulkar-dev:azcopy]$ ./azure-storage-azcopy copy "https://storenakulkar.blob.core.windows.net/container1/file.pdf?sp=racwdl&st=2021-04-19T06:22:47Z&se=2021-04-19T14:22:47Z&spr=https&sv=2020-02-10&sr=c&sig=-REDACTED-" /dev/null
INFO: Scanning...
INFO: Any empty folders will not be processed, because source and/or destination doesn't have full folder support

failed to perform copy command due to error: cannot start job due to error: cannot list files due to reason -> github.com/Azure/azure-storage-blob-go/azblob.newStorageError, /home/nakulkar/.go/pkg/mod/github.com/!azure/azure-storage-blob-go@v0.10.1-0.20210407023846-16cf969ec1c3/azblob/zc_storage_error.go:42
===== RESPONSE ERROR (ServiceCode=AuthenticationFailed) =====
Description=Server failed to authenticate the request. Make sure the value of Authorization header is formed correctly including the signature.
RequestId:be3ac33b-f01e-002d-34e6-347f26000000
Time:2021-04-19T06:35:39.5597850Z, Details:
   AuthenticationErrorDetail: Signature fields not well formed.
   Code: AuthenticationFailed
   GET https://storenakulkar.blob.core.windows.net/container1?comp=list&delimiter=%2F&include=metadata&prefix=file.pdf%2F&restype=container&se=2021-04-19t14%3A22%3A47z&sig=-REDACTED-&sp=racwdl&spr=https&sr=c&st=2021-04-19t06%3A22%3A47z&sv=2020-02-10&timeout=901
   User-Agent: [AzCopy/10.10.0 Azure-Storage/0.13 (go1.14.4; linux)]
   X-Ms-Client-Request-Id: [3cc270a8-c02b-4bdb-46db-25c0ca4ee04c]
   X-Ms-Version: [2019-12-12]
```
