### PR TITLE
[AzCopyV10][StgExp] Add flag to disable automatic decoding of illegal chars on Windows

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -147,6 +147,9 @@ type rawCopyCmdArgs struct {
 	// whether to include blobs that have metadata 'hdi_isfolder = true'
 	includeDirectoryStubs bool
 
+	// whether to disable automatic decoding of illegal chars on Windows
+	disableAutoDecoding bool
+
 	// Optional flag to encrypt user data with user provided key.
 	// Key is provide in the REST request itself
 	// Provided key (EncryptionKey and EncryptionKeySHA256) and its hash will be fetched from environment variables
@@ -510,6 +513,7 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 	cooked.noGuessMimeType = raw.noGuessMimeType
 	cooked.preserveLastModifiedTime = raw.preserveLastModifiedTime
 	cooked.includeDirectoryStubs = raw.includeDirectoryStubs
+	cooked.disableAutoDecoding = raw.disableAutoDecoding
 
 	if cooked.fromTo.To() != common.ELocation.Blob() && raw.blobTags != "" {
 		return cooked, errors.New("blob tags can only be set when transferring to blob storage")
@@ -1053,6 +1057,9 @@ type cookedCopyCmdArgs struct {
 
 	// whether to include blobs that have metadata 'hdi_isfolder = true'
 	includeDirectoryStubs bool
+
+	// whether to disable automatic decoding of illegal chars on Windows
+	disableAutoDecoding bool
 
 	cpkOptions common.CpkOptions
 }
@@ -1755,6 +1762,7 @@ func init() {
 	cpCmd.PersistentFlags().StringVar(&raw.blobTags, "blob-tags", "", "Set tags on blobs to categorize data in your storage account")
 	cpCmd.PersistentFlags().BoolVar(&raw.s2sPreserveBlobTags, "s2s-preserve-blob-tags", false, "Preserve index tags during service to service transfer from one blob storage to another")
 	cpCmd.PersistentFlags().BoolVar(&raw.includeDirectoryStubs, "include-directory-stub", false, "False by default to ignore directory stubs. Directory stubs are blobs with metadata 'hdi_isfolder:true'. Setting value to true will preserve directory stubs during transfers.")
+	cpCmd.PersistentFlags().BoolVar(&raw.disableAutoDecoding, "disable-auto-decoding", false, "False by default to enable automatic decoding of illegal chars on Windows. Can be set to true to disable automatic decoding.")
 	// s2sGetPropertiesInBackend is an optional flag for controlling whether S3 object's or Azure file's full properties are get during enumerating in frontend or
 	// right before transferring in ste(backend).
 	// The traditional behavior of all existing enumerator is to get full properties during enumerating(more specifically listing),

--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -481,7 +481,7 @@ var reverseEncodedChars = map[string]rune{
 	"%2A": '*',
 }
 
-func pathEncodeRules(path string, fromTo common.FromTo, source bool) string {
+func pathEncodeRules(path string, fromTo common.FromTo, disableAutoDecoding bool, source bool) string {
 	loc := common.ELocation.Unknown()
 
 	if source {
@@ -501,8 +501,8 @@ func pathEncodeRules(path string, fromTo common.FromTo, source bool) string {
 			}
 		}
 
-		// If uploading from Windows or downloading from files, decode unsafe chars
-	} else if (!source && fromTo.From() == common.ELocation.Local() && runtime.GOOS == "windows") || (!source && fromTo.From() == common.ELocation.File()) {
+		// If uploading from Windows or downloading from files, decode unsafe chars if user enables decoding
+	} else if ((!source && fromTo.From() == common.ELocation.Local() && runtime.GOOS == "windows") || (!source && fromTo.From() == common.ELocation.File())) && !disableAutoDecoding {
 
 		for encoded, c := range reverseEncodedChars {
 			for k, p := range pathParts {
@@ -548,7 +548,7 @@ func (cca *cookedCopyCmdArgs) makeEscapedRelativePath(source bool, dstIsDir bool
 			}
 		}
 
-		return pathEncodeRules(relativePath, cca.fromTo, source)
+		return pathEncodeRules(relativePath, cca.fromTo, cca.disableAutoDecoding, source)
 	}
 
 	// If it's out here, the object is contained in a folder, or was found via a wildcard, or object.isSourceRootFolder == true
@@ -590,7 +590,7 @@ func (cca *cookedCopyCmdArgs) makeEscapedRelativePath(source bool, dstIsDir bool
 		relativePath = "/" + rootDir + relativePath
 	}
 
-	return pathEncodeRules(relativePath, cca.fromTo, source)
+	return pathEncodeRules(relativePath, cca.fromTo, cca.disableAutoDecoding, source)
 }
 
 // we assume that preserveSmbPermissions and preserveSmbInfo have already been validated, such that they are only true if both resource types support them

--- a/cmd/zc_processor.go
+++ b/cmd/zc_processor.go
@@ -65,8 +65,8 @@ func (s *copyTransferProcessor) scheduleCopyTransfer(storedObject storedObject) 
 
 	// Escape paths on destinations where the characters are invalid
 	// And re-encode them where the characters are valid.
-	srcRelativePath := pathEncodeRules(storedObject.relativePath, s.copyJobTemplate.FromTo, true)
-	dstRelativePath := pathEncodeRules(storedObject.relativePath, s.copyJobTemplate.FromTo, false)
+	srcRelativePath := pathEncodeRules(storedObject.relativePath, s.copyJobTemplate.FromTo, false,true)
+	dstRelativePath := pathEncodeRules(storedObject.relativePath, s.copyJobTemplate.FromTo, false, false)
 
 	copyTransfer, shouldSendToSte := storedObject.ToNewCopyTransfer(
 		false, // sync has no --decompress option

--- a/cmd/zt_copy_blob_upload_test.go
+++ b/cmd/zt_copy_blob_upload_test.go
@@ -547,3 +547,44 @@ func (s *cmdIntegrationSuite) doTestUploadDirectoryToContainerWithIncludeAfter(u
 			common.AZCOPY_PATH_SEPARATOR_STRING+filepath.Base(srcDirPath)+common.AZCOPY_PATH_SEPARATOR_STRING, expectedTransfers, mockedRPC)
 	})
 }
+
+func (s *cmdIntegrationSuite) TestDisableAutoDecoding(c *chk.C) {
+	bsu := getBSU()
+	containerURL, containerName := createNewContainer(c, bsu)
+	defer deleteContainer(c, containerURL)
+
+	// Encoded file name since Windows won't create name with invalid chars
+	srcFileName := `%3C %3E %5C %2F %3A %22 %7C %3F %2A invalidcharsfile`
+
+	// set up the source as a single file
+	srcDirName := scenarioHelper{}.generateLocalDirectory(c)
+	defer os.RemoveAll(srcDirName)
+	_, err := scenarioHelper{}.generateLocalFile(filepath.Join(srcDirName, srcFileName), defaultFileSize)
+	c.Assert(err, chk.IsNil)
+
+	// set up interceptor
+	mockedRPC := interceptor{}
+	Rpc = mockedRPC.intercept
+	mockedRPC.init()
+
+	// clean the RPC for the next test
+	mockedRPC.reset()
+
+	// now target the destination container, the result should be the same
+	rawContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, containerName)
+	raw := getDefaultCopyRawInput(filepath.Join(srcDirName, srcFileName), rawContainerURLWithSAS.String())
+	raw.disableAutoDecoding = true
+
+	// the file was created after the blob, so no sync should happen
+	runCopyAndVerify(c, raw, func(err error) {
+		c.Assert(err, chk.IsNil)
+
+		// verify explicitly since the source and destination names will be different:
+		// the source is "" since the given URL points to the blob itself
+		// the destination should be the source file name, since decoding has been disabled
+		c.Assert(len(mockedRPC.transfers), chk.Equals, 1)
+
+		c.Assert(mockedRPC.transfers[0].Source, chk.Equals, "")
+		c.Assert(mockedRPC.transfers[0].Destination, chk.Equals, common.AZCOPY_PATH_SEPARATOR_STRING+url.PathEscape(srcFileName))
+	})
+}

--- a/ste/xfer-anyToRemote-file.go
+++ b/ste/xfer-anyToRemote-file.go
@@ -168,7 +168,7 @@ func anyToRemote(jptm IJobPartTransferMgr, p pipeline.Pipeline, pacer pacer, sen
 			dstRQ := dstURL.Query()
 
 			// note that query is now all lower case at this point
-			if len(srcRQ["snapshot"]) == 0 && len(srcRQ["versionid"]) == 0 && len(dstRQ["snapshot"]) == 0 && len(dstRQ["versionid"]) == 0 {
+			if len(srcRQ["sharesnapshot"]) == 0 && len(srcRQ["versionid"]) == 0 && len(dstRQ["sharesnapshot"]) == 0 && len(dstRQ["versionid"]) == 0 {
 				jptm.LogSendError(info.Source, info.Destination, "Transfer source and destination are the same, which would cause data loss. Aborting transfer.", 0)
 				jptm.SetStatus(common.ETransferStatus.Failed())
 				jptm.ReportTransferDone()

--- a/ste/xfer-anyToRemote-file.go
+++ b/ste/xfer-anyToRemote-file.go
@@ -168,7 +168,7 @@ func anyToRemote(jptm IJobPartTransferMgr, p pipeline.Pipeline, pacer pacer, sen
 			dstRQ := dstURL.Query()
 
 			// note that query is now all lower case at this point
-			if len(srcRQ["sharesnapshot"]) == 0 && len(srcRQ["versionid"]) == 0 && len(dstRQ["sharesnapshot"]) == 0 && len(dstRQ["versionid"]) == 0 {
+			if len(srcRQ["snapshot"]) == 0 && len(srcRQ["versionid"]) == 0 && len(dstRQ["snapshot"]) == 0 && len(dstRQ["versionid"]) == 0 {
 				jptm.LogSendError(info.Source, info.Destination, "Transfer source and destination are the same, which would cause data loss. Aborting transfer.", 0)
 				jptm.SetStatus(common.ETransferStatus.Failed())
 				jptm.ReportTransferDone()


### PR DESCRIPTION
- Added new copy command variable called **disableAutoDecoding** that is set by the flag **disable-auto-decoding** 
- The **disable-auto-decoding** flag is false by default
- Added **disableAutoDecoding** as a boolean argument for the _pathEncodeRules_ where the bool is used to verify if flag has been set
- Updated usages of _pathEncodeRules_ to have the **disableAutoDecoding**
- Wrote a test that verifies that encoded file names are not decoded when **disableAutoDecoding** is set to false.