### PR TITLE
Include and exclude regex flag 

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -72,8 +72,8 @@ type rawCopyCmdArgs struct {
 	exclude               string
 	includePath           string // NOTE: This gets handled like list-of-files! It may LOOK like a bug, but it is not.
 	excludePath           string
-	includeRegex	   	  string
-	excludeRegex 		  string
+	includeRegex          string
+	excludeRegex          string
 	includeFileAttributes string
 	excludeFileAttributes string
 	includeBefore         string
@@ -984,8 +984,8 @@ type cookedCopyCmdArgs struct {
 	includeAfter          *time.Time
 
 	// include/exclude filters with regular expression (also for sync)
-	includeRegex		  []string
-	excludeRegex		  []string
+	includeRegex []string
+	excludeRegex []string
 
 	// list of version ids
 	listOfVersionIDs chan string

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -72,6 +72,8 @@ type rawCopyCmdArgs struct {
 	exclude               string
 	includePath           string // NOTE: This gets handled like list-of-files! It may LOOK like a bug, but it is not.
 	excludePath           string
+	includeRegex	   	  string
+	excludeRegex 		  string
 	includeFileAttributes string
 	excludeFileAttributes string
 	includeBefore         string
@@ -804,6 +806,9 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 	cooked.includeFileAttributes = raw.parsePatterns(raw.includeFileAttributes)
 	cooked.excludeFileAttributes = raw.parsePatterns(raw.excludeFileAttributes)
 
+	cooked.includeRegex = raw.parsePatterns(raw.includeRegex)
+	cooked.excludeRegex = raw.parsePatterns(raw.excludeRegex)
+
 	return cooked, nil
 }
 
@@ -977,6 +982,10 @@ type cookedCopyCmdArgs struct {
 	excludeFileAttributes []string
 	includeBefore         *time.Time
 	includeAfter          *time.Time
+
+	// include/exclude filters with regular expression (also for sync)
+	includeRegex		  []string
+	excludeRegex		  []string
 
 	// list of version ids
 	listOfVersionIDs chan string
@@ -1755,6 +1764,8 @@ func init() {
 		"This option does not support wildcard characters (*). Checks relative path prefix (For example: myFolder;myFolder/subDirName/file.pdf).")
 	cpCmd.PersistentFlags().StringVar(&raw.excludePath, "exclude-path", "", "Exclude these paths when copying. "+ // Currently, only exclude-path is supported alongside account traversal.
 		"This option does not support wildcard characters (*). Checks relative path prefix(For example: myFolder;myFolder/subDirName/file.pdf). When used in combination with account traversal, paths do not include the container name.")
+	cpCmd.PersistentFlags().StringVar(&raw.includeRegex, "include-regex", "", "Include only the files that align with regular expressions. Separate regular expressions with ';'.")
+	cpCmd.PersistentFlags().StringVar(&raw.excludeRegex, "exclude-regex", "", "Exclude all the files that align with regular expressions. Separate regular expressions with ';'.")
 	// This flag is implemented only for Storage Explorer.
 	cpCmd.PersistentFlags().StringVar(&raw.listOfFilesToCopy, "list-of-files", "", "Defines the location of text file which has the list of only files to be copied.")
 	cpCmd.PersistentFlags().StringVar(&raw.exclude, "exclude-pattern", "", "Exclude these files when copying. This option supports wildcard characters (*)")

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -1764,8 +1764,8 @@ func init() {
 		"This option does not support wildcard characters (*). Checks relative path prefix (For example: myFolder;myFolder/subDirName/file.pdf).")
 	cpCmd.PersistentFlags().StringVar(&raw.excludePath, "exclude-path", "", "Exclude these paths when copying. "+ // Currently, only exclude-path is supported alongside account traversal.
 		"This option does not support wildcard characters (*). Checks relative path prefix(For example: myFolder;myFolder/subDirName/file.pdf). When used in combination with account traversal, paths do not include the container name.")
-	cpCmd.PersistentFlags().StringVar(&raw.includeRegex, "include-regex", "", "Include only the files that align with regular expressions. Separate regular expressions with ';'.")
-	cpCmd.PersistentFlags().StringVar(&raw.excludeRegex, "exclude-regex", "", "Exclude all the files that align with regular expressions. Separate regular expressions with ';'.")
+	cpCmd.PersistentFlags().StringVar(&raw.includeRegex, "include-regex", "", "Include only the relative path of the files that align with regular expressions. Separate regular expressions with ';'.")
+	cpCmd.PersistentFlags().StringVar(&raw.excludeRegex, "exclude-regex", "", "Exclude all the relative path of the files that align with regular expressions. Separate regular expressions with ';'.")
 	// This flag is implemented only for Storage Explorer.
 	cpCmd.PersistentFlags().StringVar(&raw.listOfFilesToCopy, "list-of-files", "", "Defines the location of text file which has the list of only files to be copied.")
 	cpCmd.PersistentFlags().StringVar(&raw.exclude, "exclude-pattern", "", "Exclude these files when copying. This option supports wildcard characters (*)")

--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -334,11 +334,11 @@ func (cca *cookedCopyCmdArgs) initModularFilters() []objectFilter {
 	}
 
 	if len(cca.includeRegex) != 0 {
-		filters = append(filters, &regexFilter{patterns: cca.includeRegex, matchResponse: true})
+		filters = append(filters, &regexFilter{patterns: cca.includeRegex, isIncluded: true})
 	}
 
 	if len(cca.excludeRegex) != 0 {
-		filters = append(filters, &regexFilter{patterns: cca.excludeRegex, matchResponse: false})
+		filters = append(filters, &regexFilter{patterns: cca.excludeRegex, isIncluded: false})
 	}
 
 	if len(cca.excludeBlobType) != 0 {

--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -334,11 +334,11 @@ func (cca *cookedCopyCmdArgs) initModularFilters() []objectFilter {
 	}
 
 	if len(cca.includeRegex) != 0 {
-		filters = append(filters, &includeRegex{patterns: cca.includeRegex})
+		filters = append(filters, &regexFilter{patterns: cca.includeRegex, matchResponse: true})
 	}
 
 	if len(cca.excludeRegex) != 0 {
-		filters = append(filters, &excludeRegex{patterns: cca.excludeRegex})
+		filters = append(filters, &regexFilter{patterns: cca.excludeRegex, matchResponse: false})
 	}
 
 	if len(cca.excludeBlobType) != 0 {

--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -333,6 +333,14 @@ func (cca *cookedCopyCmdArgs) initModularFilters() []objectFilter {
 		}
 	}
 
+	if len(cca.includeRegex) != 0 {
+		filters = append(filters, &includeRegex{patterns: cca.includeRegex})
+	}
+
+	if len(cca.excludeRegex) != 0 {
+		filters = append(filters, &excludeRegex{patterns: cca.excludeRegex})
+	}
+
 	if len(cca.excludeBlobType) != 0 {
 		excludeSet := map[azblob.BlobType]bool{}
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -711,8 +711,8 @@ func init() {
 		"This option does not support wildcard characters (*). Checks relative path prefix(For example: myFolder;myFolder/subDirName/file.pdf).")
 	syncCmd.PersistentFlags().StringVar(&raw.includeFileAttributes, "include-attributes", "", "(Windows only) Include only files whose attributes match the attribute list. For example: A;S;R")
 	syncCmd.PersistentFlags().StringVar(&raw.excludeFileAttributes, "exclude-attributes", "", "(Windows only) Exclude files whose attributes match the attribute list. For example: A;S;R")
-	syncCmd.PersistentFlags().StringVar(&raw.includeRegex, "include-regex", "", "Include files that match with the regular expressions. Separate regular expressions with ';'.")
-	syncCmd.PersistentFlags().StringVar(&raw.excludeRegex, "exclude-regex", "", "Exclude files that match with the regular expressions. Separate regular expressions with ';'.")
+	syncCmd.PersistentFlags().StringVar(&raw.includeRegex, "include-regex", "", "Include the relative path of the files that match with the regular expressions. Separate regular expressions with ';'.")
+	syncCmd.PersistentFlags().StringVar(&raw.excludeRegex, "exclude-regex", "", "Exclude the relative path of the files that match with the regular expressions. Separate regular expressions with ';'.")
 	syncCmd.PersistentFlags().StringVar(&raw.logVerbosity, "log-level", "INFO", "Define the log verbosity for the log file, available levels: INFO(all requests and responses), WARNING(slow responses), ERROR(only failed requests), and NONE(no output logs). (default INFO).")
 	syncCmd.PersistentFlags().StringVar(&raw.deleteDestination, "delete-destination", "false", "Defines whether to delete extra files from the destination that are not present at the source. Could be set to true, false, or prompt. "+
 		"If set to prompt, the user will be asked a question before scheduling files and blobs for deletion. (default 'false').")

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -51,6 +51,8 @@ type rawSyncCmdArgs struct {
 	excludeFileAttributes string
 	legacyInclude         string // for warning messages only
 	legacyExclude         string // for warning messages only
+	includeRegex		  string
+	excludeRegex		  string
 
 	preserveSMBPermissions bool
 	preserveOwner          bool
@@ -295,6 +297,9 @@ func (raw *rawSyncCmdArgs) cook() (cookedSyncCmdArgs, error) {
 
 	cooked.mirrorMode = raw.mirrorMode
 
+	cooked.includeRegex = raw.parsePatterns(raw.includeRegex)
+	cooked.excludeRegex = raw.parsePatterns(raw.excludeRegex)
+
 	return cooked, nil
 }
 
@@ -329,6 +334,8 @@ type cookedSyncCmdArgs struct {
 	excludePaths          []string
 	includeFileAttributes []string
 	excludeFileAttributes []string
+	includeRegex		  []string
+	excludeRegex		  []string
 
 	// options
 	preserveSMBPermissions common.PreservePermissionsOption
@@ -704,6 +711,8 @@ func init() {
 		"This option does not support wildcard characters (*). Checks relative path prefix(For example: myFolder;myFolder/subDirName/file.pdf).")
 	syncCmd.PersistentFlags().StringVar(&raw.includeFileAttributes, "include-attributes", "", "(Windows only) Include only files whose attributes match the attribute list. For example: A;S;R")
 	syncCmd.PersistentFlags().StringVar(&raw.excludeFileAttributes, "exclude-attributes", "", "(Windows only) Exclude files whose attributes match the attribute list. For example: A;S;R")
+	syncCmd.PersistentFlags().StringVar(&raw.includeRegex, "include-regex", "", "Include files that match with the regular expressions. Separate regular expressions with ';'.")
+	syncCmd.PersistentFlags().StringVar(&raw.excludeRegex, "exclude-regex", "", "Exclude files that match with the regular expressions. Separate regular expressions with ';'.")
 	syncCmd.PersistentFlags().StringVar(&raw.logVerbosity, "log-level", "INFO", "Define the log verbosity for the log file, available levels: INFO(all requests and responses), WARNING(slow responses), ERROR(only failed requests), and NONE(no output logs). (default INFO).")
 	syncCmd.PersistentFlags().StringVar(&raw.deleteDestination, "delete-destination", "false", "Defines whether to delete extra files from the destination that are not present at the source. Could be set to true, false, or prompt. "+
 		"If set to prompt, the user will be asked a question before scheduling files and blobs for deletion. (default 'false').")

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -51,8 +51,8 @@ type rawSyncCmdArgs struct {
 	excludeFileAttributes string
 	legacyInclude         string // for warning messages only
 	legacyExclude         string // for warning messages only
-	includeRegex		  string
-	excludeRegex		  string
+	includeRegex          string
+	excludeRegex          string
 
 	preserveSMBPermissions bool
 	preserveOwner          bool
@@ -334,8 +334,8 @@ type cookedSyncCmdArgs struct {
 	excludePaths          []string
 	includeFileAttributes []string
 	excludeFileAttributes []string
-	includeRegex		  []string
-	excludeRegex		  []string
+	includeRegex          []string
+	excludeRegex          []string
 
 	// options
 	preserveSMBPermissions common.PreservePermissionsOption

--- a/cmd/syncEnumerator.go
+++ b/cmd/syncEnumerator.go
@@ -108,6 +108,11 @@ func (cca *cookedSyncCmdArgs) initEnumerator(ctx context.Context) (enumerator *s
 		excludeAttrFilters := buildAttrFilters(cca.excludeFileAttributes, cca.source.ValueLocal(), false)
 		filters = append(filters, excludeAttrFilters...)
 	}
+
+	//includeRegex
+	filters = append(filters, buildIncludeRegexFilters(cca.includeRegex)...)
+	filters = append(filters, buildExcludeRegexFilters(cca.excludeRegex)...)
+
 	// after making all filters, log any search prefix computed from them
 	if ste.JobsAdmin != nil {
 		if prefixFilter := filterSet(filters).GetEnumerationPreFilter(cca.recursive); prefixFilter != "" {

--- a/cmd/syncEnumerator.go
+++ b/cmd/syncEnumerator.go
@@ -110,8 +110,8 @@ func (cca *cookedSyncCmdArgs) initEnumerator(ctx context.Context) (enumerator *s
 	}
 
 	//includeRegex
-	filters = append(filters, buildIncludeRegexFilters(cca.includeRegex)...)
-	filters = append(filters, buildExcludeRegexFilters(cca.excludeRegex)...)
+	filters = append(filters, buildRegexFilters(cca.includeRegex, true)...)
+	filters = append(filters, buildRegexFilters(cca.excludeRegex, false)...)
 
 	// after making all filters, log any search prefix computed from them
 	if ste.JobsAdmin != nil {

--- a/cmd/zt_copy_blob_download_test.go
+++ b/cmd/zt_copy_blob_download_test.go
@@ -469,7 +469,7 @@ func (s *cmdIntegrationSuite) TestDownloadBlobContainerWithRegexInclude(c *chk.C
 	c.Assert(len(blobsToIgnore), chk.Not(chk.Equals), 0)
 
 	// add blobs that we wish to include
-	blobsToInclude := []string{"tessssssssssssst.txt", "subOne/tetingessssss.jpeg", "subOne/subTwo/tessssst.pdf"}
+	blobsToInclude := []string{"tessssssssssssst.txt", "subOne/tetingessssss.jpeg", "subOne/tessssst/hi.pdf"}
 	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobsToInclude, blockBlobDefaultData)
 
 	// set up the destination with an empty folder

--- a/cmd/zt_copy_blob_download_test.go
+++ b/cmd/zt_copy_blob_download_test.go
@@ -455,3 +455,211 @@ func (s *cmdIntegrationSuite) TestDownloadBlobContainerWithPattern(c *chk.C) {
 		c.Assert(strings.Contains(mockedRPC.transfers[0].Source[1:], common.AZCOPY_PATH_SEPARATOR_STRING), chk.Equals, false)
 	})
 }
+
+// test for include with one regular expression
+func (s *cmdIntegrationSuite) TestDownloadBlobContainerWithRegexInclude(c *chk.C) {
+	bsu := getBSU()
+
+	// set up the container with  blobs
+	containerURL, containerName := createNewContainer(c, bsu)
+	blobsToIgnore := scenarioHelper{}.generateCommonRemoteScenarioForBlob(c, containerURL, "")
+	defer deleteContainer(c, containerURL)
+	c.Assert(containerURL, chk.NotNil)
+	c.Assert(len(blobsToIgnore), chk.Not(chk.Equals), 0)
+
+	// add blobs that we wish to include
+	blobsToInclude := []string{"tessssssssssssst.txt", "subOne/tetingessssss.jpeg", "subOne/subTwo/tessssst.pdf"}
+	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobsToInclude, blockBlobDefaultData)
+
+	// set up the destination with an empty folder
+	dstDirName := scenarioHelper{}.generateLocalDirectory(c)
+	defer os.RemoveAll(dstDirName)
+
+	// set up interceptor
+	mockedRPC := interceptor{}
+	Rpc = mockedRPC.intercept
+	mockedRPC.init()
+
+	// construct the raw input to simulate user input
+	rawContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, containerName)
+	rawContainerURLWithSAS.Path = path.Join(rawContainerURLWithSAS.Path, string([]byte{0x00}))
+	containerString := strings.ReplaceAll(rawContainerURLWithSAS.String(), "%00", "*")
+	raw := getDefaultCopyRawInput(containerString, dstDirName)
+	raw.recursive = true
+	raw.includeRegex = "es{4,}"
+
+ 	runCopyAndVerify(c, raw, func(err error) {
+		c.Assert(err, chk.IsNil)
+		// validate that the right number of transfers were scheduled
+		c.Assert(len(mockedRPC.transfers), chk.Equals, len(blobsToInclude))
+		// validate that the right transfers were sent
+		validateDownloadTransfersAreScheduled(c, common.AZCOPY_PATH_SEPARATOR_STRING, common.AZCOPY_PATH_SEPARATOR_STRING,
+			blobsToInclude, mockedRPC)
+	})
+}
+
+//test multiple regular expression with include
+func (s *cmdIntegrationSuite) TestDownloadBlobContainerWithMultRegexInclude(c *chk.C) {
+	bsu := getBSU()
+
+	// set up the container with  blobs
+	containerURL, containerName := createNewContainer(c, bsu)
+	blobsToIgnore := scenarioHelper{}.generateCommonRemoteScenarioForBlob(c, containerURL, "")
+	defer deleteContainer(c, containerURL)
+	c.Assert(containerURL, chk.NotNil)
+	c.Assert(len(blobsToIgnore), chk.Not(chk.Equals), 0)
+
+	// add blobs that we wish to include
+	blobsToInclude := []string{"tessssssssssssst.txt", "zxcfile.txt", "subOne/tetingessssss.jpeg", "subOne/subTwo/tessssst.pdf"}
+	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobsToInclude, blockBlobDefaultData)
+
+	// set up the destination with an empty folder
+	dstDirName := scenarioHelper{}.generateLocalDirectory(c)
+	defer os.RemoveAll(dstDirName)
+
+	// set up interceptor
+	mockedRPC := interceptor{}
+	Rpc = mockedRPC.intercept
+	mockedRPC.init()
+
+	// construct the raw input to simulate user input
+	rawContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, containerName)
+	rawContainerURLWithSAS.Path = path.Join(rawContainerURLWithSAS.Path, string([]byte{0x00}))
+	containerString := strings.ReplaceAll(rawContainerURLWithSAS.String(), "%00", "*")
+	raw := getDefaultCopyRawInput(containerString, dstDirName)
+	raw.recursive = true
+	raw.includeRegex = "es{4,};^zxc"
+
+	runCopyAndVerify(c, raw, func(err error) {
+		c.Assert(err, chk.IsNil)
+		// validate that the right number of transfers were scheduled
+		c.Assert(len(mockedRPC.transfers), chk.Equals, len(blobsToInclude))
+		// validate that the right transfers were sent
+		validateDownloadTransfersAreScheduled(c, common.AZCOPY_PATH_SEPARATOR_STRING, common.AZCOPY_PATH_SEPARATOR_STRING,
+			blobsToInclude, mockedRPC)
+	})
+}
+
+//testing empty expressions for both include and exclude
+func (s *cmdIntegrationSuite) TestDownloadBlobContainerWithEmptyRegex(c *chk.C) {
+	bsu := getBSU()
+
+	// set up the container with  blobs
+	containerURL, containerName := createNewContainer(c, bsu)
+	//test empty regex flag so all blobs will be included since there is no filter
+	blobsToInclude := scenarioHelper{}.generateCommonRemoteScenarioForBlob(c, containerURL, "")
+	defer deleteContainer(c, containerURL)
+	c.Assert(containerURL, chk.NotNil)
+	c.Assert(len(blobsToInclude), chk.Not(chk.Equals), 0)
+
+	// set up the destination with an empty folder
+	dstDirName := scenarioHelper{}.generateLocalDirectory(c)
+	defer os.RemoveAll(dstDirName)
+
+	// set up interceptor
+	mockedRPC := interceptor{}
+	Rpc = mockedRPC.intercept
+	mockedRPC.init()
+
+	// construct the raw input to simulate user input
+	rawContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, containerName)
+	rawContainerURLWithSAS.Path = path.Join(rawContainerURLWithSAS.Path, string([]byte{0x00}))
+	containerString := strings.ReplaceAll(rawContainerURLWithSAS.String(), "%00", "*")
+	raw := getDefaultCopyRawInput(containerString, dstDirName)
+	raw.recursive = true
+	raw.includeRegex = ""
+	raw.excludeRegex = ""
+
+	runCopyAndVerify(c, raw, func(err error) {
+		c.Assert(err, chk.IsNil)
+		// validate that the right number of transfers were scheduled
+		c.Assert(len(mockedRPC.transfers) , chk.Equals, len(blobsToInclude))
+		// validate that the right transfers were sent
+		validateDownloadTransfersAreScheduled(c, common.AZCOPY_PATH_SEPARATOR_STRING, common.AZCOPY_PATH_SEPARATOR_STRING,
+			blobsToInclude, mockedRPC)
+	})
+}
+
+//testing exclude with one regular expression
+func (s *cmdIntegrationSuite) TestDownloadBlobContainerWithRegexExclude(c *chk.C) {
+	bsu := getBSU()
+
+	// set up the container with  blobs
+	containerURL, containerName := createNewContainer(c, bsu)
+	blobsToInclude := scenarioHelper{}.generateCommonRemoteScenarioForBlob(c, containerURL, "")
+	defer deleteContainer(c, containerURL)
+	c.Assert(containerURL, chk.NotNil)
+	c.Assert(len(blobsToInclude), chk.Not(chk.Equals), 0)
+
+	// add blobs that we wish to exclude
+	blobsToIgnore := []string{"tessssssssssssst.txt", "subOne/tetingessssss.jpeg", "subOne/subTwo/tessssst.pdf"}
+	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobsToIgnore, blockBlobDefaultData)
+
+	// set up the destination with an empty folder
+	dstDirName := scenarioHelper{}.generateLocalDirectory(c)
+	defer os.RemoveAll(dstDirName)
+
+	// set up interceptor
+	mockedRPC := interceptor{}
+	Rpc = mockedRPC.intercept
+	mockedRPC.init()
+
+	// construct the raw input to simulate user input
+	rawContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, containerName)
+	rawContainerURLWithSAS.Path = path.Join(rawContainerURLWithSAS.Path, string([]byte{0x00}))
+	containerString := strings.ReplaceAll(rawContainerURLWithSAS.String(), "%00", "*")
+	raw := getDefaultCopyRawInput(containerString, dstDirName)
+	raw.recursive = true
+	raw.excludeRegex = "es{4,}"
+
+	runCopyAndVerify(c, raw, func(err error) {
+		c.Assert(err, chk.IsNil)
+		// validate that only blobsTo
+		c.Assert(len(mockedRPC.transfers), chk.Equals, len(blobsToInclude) )
+		// validate that the right transfers were sent
+		validateDownloadTransfersAreScheduled(c, common.AZCOPY_PATH_SEPARATOR_STRING, common.AZCOPY_PATH_SEPARATOR_STRING,
+			blobsToInclude, mockedRPC)
+	})
+}
+
+//testing exclude with multiple regular expressions
+func (s *cmdIntegrationSuite) TestDownloadBlobContainerWithMultRegexExclude(c *chk.C) {
+	bsu := getBSU()
+
+	// set up the container with  blobs
+	containerURL, containerName := createNewContainer(c, bsu)
+	blobsToInclude := scenarioHelper{}.generateCommonRemoteScenarioForBlob(c, containerURL, "")
+	defer deleteContainer(c, containerURL)
+	c.Assert(containerURL, chk.NotNil)
+	c.Assert(len(blobsToInclude), chk.Not(chk.Equals), 0)
+
+	// add blobs that we wish to exclude
+	blobsToIgnore := []string{"tessssssssssssst.txt", "subOne/dogs.jpeg", "subOne/subTwo/tessssst.pdf"}
+	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobsToIgnore, blockBlobDefaultData)
+
+	// set up the destination with an empty folder
+	dstDirName := scenarioHelper{}.generateLocalDirectory(c)
+	defer os.RemoveAll(dstDirName)
+
+	// set up interceptor
+	mockedRPC := interceptor{}
+	Rpc = mockedRPC.intercept
+	mockedRPC.init()
+
+	// construct the raw input to simulate user input
+	rawContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, containerName)
+	rawContainerURLWithSAS.Path = path.Join(rawContainerURLWithSAS.Path, string([]byte{0x00}))
+	containerString := strings.ReplaceAll(rawContainerURLWithSAS.String(), "%00", "*")
+	raw := getDefaultCopyRawInput(containerString, dstDirName)
+	raw.recursive = true
+	raw.excludeRegex = "es{4,};o(g)"
+
+	runCopyAndVerify(c, raw, func(err error) {
+		c.Assert(err, chk.IsNil)
+		// validate that the right number of transfers were scheduled
+		c.Assert(len(mockedRPC.transfers), chk.Equals, len(blobsToInclude) )
+		// validate that the right transfers were sent
+		validateDownloadTransfersAreScheduled(c, common.AZCOPY_PATH_SEPARATOR_STRING, common.AZCOPY_PATH_SEPARATOR_STRING,
+			blobsToInclude, mockedRPC)
+	})
+}

--- a/cmd/zt_copy_blob_download_test.go
+++ b/cmd/zt_copy_blob_download_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
@@ -488,10 +489,14 @@ func (s *cmdIntegrationSuite) TestDownloadBlobContainerWithRegexInclude(c *chk.C
 	raw.recursive = true
 	raw.includeRegex = "es{4,}"
 
- 	runCopyAndVerify(c, raw, func(err error) {
+	runCopyAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)
 		// validate that the right number of transfers were scheduled
 		c.Assert(len(mockedRPC.transfers), chk.Equals, len(blobsToInclude))
+		//comparing is names of files match
+		for i := 0; i < len(mockedRPC.transfers); i++ {
+			c.Assert(strings.Trim(mockedRPC.transfers[i].Source, "/"), chk.Equals, blobsToInclude[i])
+		}
 		// validate that the right transfers were sent
 		validateDownloadTransfersAreScheduled(c, common.AZCOPY_PATH_SEPARATOR_STRING, common.AZCOPY_PATH_SEPARATOR_STRING,
 			blobsToInclude, mockedRPC)
@@ -535,6 +540,18 @@ func (s *cmdIntegrationSuite) TestDownloadBlobContainerWithMultRegexInclude(c *c
 		// validate that the right number of transfers were scheduled
 		c.Assert(len(mockedRPC.transfers), chk.Equals, len(blobsToInclude))
 		// validate that the right transfers were sent
+
+		//comparing is names of files, since not in order need to sort each string and the compare them
+		actualTransfer := []string{}
+		for i := 0; i < len(mockedRPC.transfers); i++ {
+			actualTransfer = append(actualTransfer, mockedRPC.transfers[i].Source)
+		}
+		sort.Strings(actualTransfer)
+		sort.Strings(blobsToInclude)
+		for i := 0; i < len(mockedRPC.transfers); i++ {
+			c.Assert(strings.Trim(actualTransfer[i], "/"), chk.Equals, blobsToInclude[i])
+		}
+
 		validateDownloadTransfersAreScheduled(c, common.AZCOPY_PATH_SEPARATOR_STRING, common.AZCOPY_PATH_SEPARATOR_STRING,
 			blobsToInclude, mockedRPC)
 	})
@@ -573,7 +590,8 @@ func (s *cmdIntegrationSuite) TestDownloadBlobContainerWithEmptyRegex(c *chk.C) 
 	runCopyAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)
 		// validate that the right number of transfers were scheduled
-		c.Assert(len(mockedRPC.transfers) , chk.Equals, len(blobsToInclude))
+		c.Assert(len(mockedRPC.transfers), chk.Equals, len(blobsToInclude))
+		//do not need to check file names since all files for blobsToInclude are passed bc flags are empty
 		// validate that the right transfers were sent
 		validateDownloadTransfersAreScheduled(c, common.AZCOPY_PATH_SEPARATOR_STRING, common.AZCOPY_PATH_SEPARATOR_STRING,
 			blobsToInclude, mockedRPC)
@@ -615,7 +633,17 @@ func (s *cmdIntegrationSuite) TestDownloadBlobContainerWithRegexExclude(c *chk.C
 	runCopyAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)
 		// validate that only blobsTo
-		c.Assert(len(mockedRPC.transfers), chk.Equals, len(blobsToInclude) )
+		c.Assert(len(mockedRPC.transfers), chk.Equals, len(blobsToInclude))
+		//comparing is names of files, since not in order need to sort each string and the compare them
+		actualTransfer := []string{}
+		for i := 0; i < len(mockedRPC.transfers); i++ {
+			actualTransfer = append(actualTransfer, mockedRPC.transfers[i].Destination)
+		}
+		sort.Strings(actualTransfer)
+		sort.Strings(blobsToInclude)
+		for i := 0; i < len(mockedRPC.transfers); i++ {
+			c.Assert(strings.Trim(actualTransfer[i], "/"), chk.Equals, blobsToInclude[i])
+		}
 		// validate that the right transfers were sent
 		validateDownloadTransfersAreScheduled(c, common.AZCOPY_PATH_SEPARATOR_STRING, common.AZCOPY_PATH_SEPARATOR_STRING,
 			blobsToInclude, mockedRPC)
@@ -657,7 +685,17 @@ func (s *cmdIntegrationSuite) TestDownloadBlobContainerWithMultRegexExclude(c *c
 	runCopyAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)
 		// validate that the right number of transfers were scheduled
-		c.Assert(len(mockedRPC.transfers), chk.Equals, len(blobsToInclude) )
+		c.Assert(len(mockedRPC.transfers), chk.Equals, len(blobsToInclude))
+		//comparing is names of files, since not in order need to sort each string and the compare them
+		actualTransfer := []string{}
+		for i := 0; i < len(mockedRPC.transfers); i++ {
+			actualTransfer = append(actualTransfer, mockedRPC.transfers[i].Destination)
+		}
+		sort.Strings(actualTransfer)
+		sort.Strings(blobsToInclude)
+		for i := 0; i < len(mockedRPC.transfers); i++ {
+			c.Assert(strings.Trim(actualTransfer[i], "/"), chk.Equals, blobsToInclude[i])
+		}
 		// validate that the right transfers were sent
 		validateDownloadTransfersAreScheduled(c, common.AZCOPY_PATH_SEPARATOR_STRING, common.AZCOPY_PATH_SEPARATOR_STRING,
 			blobsToInclude, mockedRPC)

--- a/cmd/zt_copy_blob_download_test.go
+++ b/cmd/zt_copy_blob_download_test.go
@@ -494,9 +494,14 @@ func (s *cmdIntegrationSuite) TestDownloadBlobContainerWithRegexInclude(c *chk.C
 		// validate that the right number of transfers were scheduled
 		c.Assert(len(mockedRPC.transfers), chk.Equals, len(blobsToInclude))
 		//comparing is names of files match
+		actualTransfer := []string{}
 		for i := 0; i < len(mockedRPC.transfers); i++ {
-			c.Assert(strings.Trim(mockedRPC.transfers[i].Source, "/"), chk.Equals, blobsToInclude[i])
+			actualTransfer = append(actualTransfer, strings.Trim(mockedRPC.transfers[i].Source, "/"))
 		}
+		sort.Strings(actualTransfer)
+		sort.Strings(blobsToInclude)
+		c.Assert(actualTransfer, chk.DeepEquals, blobsToInclude)
+
 		// validate that the right transfers were sent
 		validateDownloadTransfersAreScheduled(c, common.AZCOPY_PATH_SEPARATOR_STRING, common.AZCOPY_PATH_SEPARATOR_STRING,
 			blobsToInclude, mockedRPC)
@@ -544,13 +549,11 @@ func (s *cmdIntegrationSuite) TestDownloadBlobContainerWithMultRegexInclude(c *c
 		//comparing is names of files, since not in order need to sort each string and the compare them
 		actualTransfer := []string{}
 		for i := 0; i < len(mockedRPC.transfers); i++ {
-			actualTransfer = append(actualTransfer, mockedRPC.transfers[i].Source)
+			actualTransfer = append(actualTransfer, strings.Trim(mockedRPC.transfers[i].Source, "/"))
 		}
 		sort.Strings(actualTransfer)
 		sort.Strings(blobsToInclude)
-		for i := 0; i < len(mockedRPC.transfers); i++ {
-			c.Assert(strings.Trim(actualTransfer[i], "/"), chk.Equals, blobsToInclude[i])
-		}
+		c.Assert(actualTransfer, chk.DeepEquals, blobsToInclude)
 
 		validateDownloadTransfersAreScheduled(c, common.AZCOPY_PATH_SEPARATOR_STRING, common.AZCOPY_PATH_SEPARATOR_STRING,
 			blobsToInclude, mockedRPC)
@@ -637,13 +640,12 @@ func (s *cmdIntegrationSuite) TestDownloadBlobContainerWithRegexExclude(c *chk.C
 		//comparing is names of files, since not in order need to sort each string and the compare them
 		actualTransfer := []string{}
 		for i := 0; i < len(mockedRPC.transfers); i++ {
-			actualTransfer = append(actualTransfer, mockedRPC.transfers[i].Destination)
+			actualTransfer = append(actualTransfer, strings.Trim(mockedRPC.transfers[i].Destination, "/"))
 		}
 		sort.Strings(actualTransfer)
 		sort.Strings(blobsToInclude)
-		for i := 0; i < len(mockedRPC.transfers); i++ {
-			c.Assert(strings.Trim(actualTransfer[i], "/"), chk.Equals, blobsToInclude[i])
-		}
+		c.Assert(actualTransfer, chk.DeepEquals, blobsToInclude)
+
 		// validate that the right transfers were sent
 		validateDownloadTransfersAreScheduled(c, common.AZCOPY_PATH_SEPARATOR_STRING, common.AZCOPY_PATH_SEPARATOR_STRING,
 			blobsToInclude, mockedRPC)
@@ -689,13 +691,12 @@ func (s *cmdIntegrationSuite) TestDownloadBlobContainerWithMultRegexExclude(c *c
 		//comparing is names of files, since not in order need to sort each string and the compare them
 		actualTransfer := []string{}
 		for i := 0; i < len(mockedRPC.transfers); i++ {
-			actualTransfer = append(actualTransfer, mockedRPC.transfers[i].Destination)
+			actualTransfer = append(actualTransfer, strings.Trim(mockedRPC.transfers[i].Destination, "/"))
 		}
 		sort.Strings(actualTransfer)
 		sort.Strings(blobsToInclude)
-		for i := 0; i < len(mockedRPC.transfers); i++ {
-			c.Assert(strings.Trim(actualTransfer[i], "/"), chk.Equals, blobsToInclude[i])
-		}
+		c.Assert(actualTransfer, chk.DeepEquals, blobsToInclude)
+
 		// validate that the right transfers were sent
 		validateDownloadTransfersAreScheduled(c, common.AZCOPY_PATH_SEPARATOR_STRING, common.AZCOPY_PATH_SEPARATOR_STRING,
 			blobsToInclude, mockedRPC)

--- a/cmd/zt_sync_blob_blob_test.go
+++ b/cmd/zt_sync_blob_blob_test.go
@@ -719,13 +719,12 @@ func (s *cmdIntegrationSuite) TestSyncS2SWithIncludeRegexFlag(c *chk.C) {
 		//comparing is names of files, since not in order need to sort each string and the compare them
 		actualTransfer := []string{}
 		for i := 0; i < len(mockedRPC.transfers); i++ {
-			actualTransfer = append(actualTransfer, mockedRPC.transfers[i].Source)
+			actualTransfer = append(actualTransfer, strings.Trim(mockedRPC.transfers[i].Source, "/"))
 		}
 		sort.Strings(actualTransfer)
 		sort.Strings(blobsToInclude)
-		for i := 0; i < len(mockedRPC.transfers); i++ {
-			c.Assert(strings.Trim(actualTransfer[i], "/"), chk.Equals, blobsToInclude[i])
-		}
+		c.Assert(actualTransfer, chk.DeepEquals, blobsToInclude)
+
 		validateS2SSyncTransfersAreScheduled(c, "", "", blobsToInclude, mockedRPC)
 	})
 }
@@ -810,13 +809,12 @@ func (s *cmdIntegrationSuite) TestSyncS2SWithIncludeAndExcludeRegexFlag(c *chk.C
 		//comparing is names of files, since not in order need to sort each string and the compare them
 		actualTransfer := []string{}
 		for i := 0; i < len(mockedRPC.transfers); i++ {
-			actualTransfer = append(actualTransfer, mockedRPC.transfers[i].Source)
+			actualTransfer = append(actualTransfer, strings.Trim(mockedRPC.transfers[i].Source, "/"))
 		}
 		sort.Strings(actualTransfer)
 		sort.Strings(blobsToInclude)
-		for i := 0; i < len(mockedRPC.transfers); i++ {
-			c.Assert(strings.Trim(actualTransfer[i], "/"), chk.Equals, blobsToInclude[i])
-		}
+		c.Assert(actualTransfer, chk.DeepEquals, blobsToInclude)
+
 		validateS2SSyncTransfersAreScheduled(c, "", "", blobsToInclude, mockedRPC)
 	})
 }

--- a/cmd/zt_sync_blob_blob_test.go
+++ b/cmd/zt_sync_blob_blob_test.go
@@ -23,6 +23,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"sort"
 	"strings"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
@@ -713,6 +714,18 @@ func (s *cmdIntegrationSuite) TestSyncS2SWithIncludeRegexFlag(c *chk.C) {
 	// verify that only the blobs specified by the include flag are synced
 	runSyncAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)
+		// validate that the right number of transfers were scheduled
+		c.Assert(len(mockedRPC.transfers), chk.Equals, len(blobsToInclude))
+		//comparing is names of files, since not in order need to sort each string and the compare them
+		actualTransfer := []string{}
+		for i := 0; i < len(mockedRPC.transfers); i++ {
+			actualTransfer = append(actualTransfer, mockedRPC.transfers[i].Source)
+		}
+		sort.Strings(actualTransfer)
+		sort.Strings(blobsToInclude)
+		for i := 0; i < len(mockedRPC.transfers); i++ {
+			c.Assert(strings.Trim(actualTransfer[i], "/"), chk.Equals, blobsToInclude[i])
+		}
 		validateS2SSyncTransfersAreScheduled(c, "", "", blobsToInclude, mockedRPC)
 	})
 }
@@ -748,6 +761,9 @@ func (s *cmdIntegrationSuite) TestSyncS2SWithExcludeRegexFlag(c *chk.C) {
 	// make sure the list doesn't include the blobs specified by the exclude flag
 	runSyncAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)
+		// validate that the right number of transfers were scheduled
+		c.Assert(len(mockedRPC.transfers), chk.Equals, len(blobList))
+		// all blobs from the blobList are transferred
 		validateS2SSyncTransfersAreScheduled(c, "", "", blobList, mockedRPC)
 	})
 }
@@ -789,6 +805,18 @@ func (s *cmdIntegrationSuite) TestSyncS2SWithIncludeAndExcludeRegexFlag(c *chk.C
 	// verify that only the blobs specified by the include flag are synced
 	runSyncAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)
+		// validate that the right number of transfers were scheduled
+		c.Assert(len(mockedRPC.transfers), chk.Equals, len(blobsToInclude))
+		//comparing is names of files, since not in order need to sort each string and the compare them
+		actualTransfer := []string{}
+		for i := 0; i < len(mockedRPC.transfers); i++ {
+			actualTransfer = append(actualTransfer, mockedRPC.transfers[i].Source)
+		}
+		sort.Strings(actualTransfer)
+		sort.Strings(blobsToInclude)
+		for i := 0; i < len(mockedRPC.transfers); i++ {
+			c.Assert(strings.Trim(actualTransfer[i], "/"), chk.Equals, blobsToInclude[i])
+		}
 		validateS2SSyncTransfersAreScheduled(c, "", "", blobsToInclude, mockedRPC)
 	})
 }


### PR DESCRIPTION
copy.go & sync.go -- added includeRegex and excludeRegex for raw and cook
copyEnumeratorInit.go & syncEnumerator.go -- calls zc_filter.go to append filters
created tests in both zt_sync_blob_blob_test.go & zt_copy_blob_download_test.go 