### PR TITLE
Update AzCopy Pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -166,17 +166,6 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: $(ciGCSServiceAccountKey.secureFilePath)
           GOOGLE_CLOUD_PROJECT: $(GOOGLE_CLOUD_PROJECT)
       - script: |
-          set -e
-          GOARCH=amd64 GOOS=linux go build -o azcopy_linux_amd64
-          export AZCOPY_E2E_EXECUTABLE_PATH=$(pwd)/azcopy_linux_amd64
-          go test -timeout 20m -race -short -cover ./e2etest         
-        name: 'Run_e2e_tests'
-        env:
-          AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)
-          AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
-          CPK_ENCRYPTION_KEY: $(CPK_ENCRYPTION_KEY)
-          CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
-      - script: |
           go build -o test-validator ./testSuite/
           mkdir test-temp
           export AZCOPY_EXECUTABLE_PATH=$(pwd)/azcopy_linux_amd64

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,70 +61,70 @@ jobs:
         condition: succeededOrFailed()
 
   - job: Running_E2E
-      timeoutInMinutes: 360
-      # Creating strategies for GOOS: Windows Server 2019 /macOS X Mojave 10.15/Ubuntu 20.04
-      strategy:
-        matrix:
-          Ubuntu-20:
-            imageName: 'ubuntu-20.04'
-            type: 'linux'
-          Windows:
-            imageName: 'windows-2019'
-            type: 'windows'
-          MacOS:
-            imageName: 'macOS-10.15'
-            type: 'mac-os'
-      pool:
-        vmImage: $(imageName)
+    timeoutInMinutes: 360
+    # Creating strategies for GOOS: Windows Server 2019 /macOS X Mojave 10.15/Ubuntu 20.04
+    strategy:
+      matrix:
+        Ubuntu-20:
+          imageName: 'ubuntu-20.04'
+          type: 'linux'
+        Windows:
+          imageName: 'windows-2019'
+          type: 'windows'
+        MacOS:
+          imageName: 'macOS-10.15'
+          type: 'mac-os'
+    pool:
+      vmImage: $(imageName)
 
-      steps:
-        - task: GoTool@0
-          inputs:
-            version: '1.15'
+    steps:
+      - task: GoTool@0
+        inputs:
+          version: '1.15'
 
-        # Running E2E Tests on Linux
-        - script: |
-            set -e
-            go build -o azcopy_linux_amd64
-            go build -tags "se_integration" -o azcopy_linux_se_amd64
-            echo 'starting E2E tests on linux'
-            go test -timeout 30m -race -cover -v ./e2etest
-          env:
-            AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)
-            AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
-            CPK_ENCRYPTION_KEY: $(CPK_ENCRYPTION_KEY)
-            CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
-            AZCOPY_E2E_EXECUTABLE_PATH: $(Build.ArtifactStagingDirectory)/azcopy_linux_amd64
-          displayName: 'E2E Test Linux'
-          condition: eq(variables.type, 'linux')
-        # Running E2E Tests on Windows
-        - script: |
-            go build -o azcopy_windows_amd64.exe
-            go build -o azcopy_windows_386.exe
-            echo 'starting E2E tests on windows'
-            go test -timeout 30m -race -cover -v ./e2etest
-          env:
-            AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)
-            AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
-            CPK_ENCRYPTION_KEY: $(CPK_ENCRYPTION_KEY)
-            CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
-            AZCOPY_E2E_EXECUTABLE_PATH: $(Build.ArtifactStagingDirectory)/azcopy_windows_amd64.exe
-          displayName: 'E2E Test Windows'
-          condition: eq(variables.type, 'windows')
-        # Running E2E Tests on Mac
-        - script: |
-            set -e
-            go build -o azcopy_darwin_amd64
-            echo 'starting E2E tests on mac-os'
-            go test -timeout 30m -race -cover -v ./e2etest
-          env:
-            AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)
-            AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
-            CPK_ENCRYPTION_KEY: $(CPK_ENCRYPTION_KEY)
-            CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
-            AZCOPY_E2E_EXECUTABLE_PATH: $(Build.ArtifactStagingDirectory)/azcopy_darwin_amd64
-          displayName: 'E2E Test MacOs'
-          condition: eq(variables.type, 'mac-os')
+      # Running E2E Tests on Linux
+      - script: |
+          set -e
+          go build -o azcopy_linux_amd64
+          go build -tags "se_integration" -o azcopy_linux_se_amd64
+          echo 'starting E2E tests on linux'
+          go test -timeout 30m -race -cover -v ./e2etest
+        env:
+          AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)
+          AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
+          CPK_ENCRYPTION_KEY: $(CPK_ENCRYPTION_KEY)
+          CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
+          AZCOPY_E2E_EXECUTABLE_PATH: $(Build.ArtifactStagingDirectory)/azcopy_linux_amd64
+        displayName: 'E2E Test Linux'
+        condition: eq(variables.type, 'linux')
+      # Running E2E Tests on Windows
+      - script: |
+          go build -o azcopy_windows_amd64.exe
+          go build -o azcopy_windows_386.exe
+          echo 'starting E2E tests on windows'
+          go test -timeout 30m -race -cover -v ./e2etest
+        env:
+          AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)
+          AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
+          CPK_ENCRYPTION_KEY: $(CPK_ENCRYPTION_KEY)
+          CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
+          AZCOPY_E2E_EXECUTABLE_PATH: $(Build.ArtifactStagingDirectory)/azcopy_windows_amd64.exe
+        displayName: 'E2E Test Windows'
+        condition: eq(variables.type, 'windows')
+      # Running E2E Tests on Mac
+      - script: |
+          set -e
+          go build -o azcopy_darwin_amd64
+          echo 'starting E2E tests on mac-os'
+          go test -timeout 30m -race -cover -v ./e2etest
+        env:
+          AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)
+          AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
+          CPK_ENCRYPTION_KEY: $(CPK_ENCRYPTION_KEY)
+          CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
+          AZCOPY_E2E_EXECUTABLE_PATH: $(Build.ArtifactStagingDirectory)/azcopy_darwin_amd64
+        displayName: 'E2E Test MacOs'
+        condition: eq(variables.type, 'mac-os')
 
   - job: Test_On_Ubuntu
     variables:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,8 +91,8 @@ jobs:
 
       # Running E2E Tests on Windows
       - script: |
-          go build -o azcopy_windows_amd64.exe
-          go build -o azcopy_windows_386.exe
+          go build -o $(System.DefaultWorkingDirectory)/azcopy_windows_amd64.exe
+          go build -o $(System.DefaultWorkingDirectory)/azcopy_windows_386.exe
           echo 'starting E2E tests on windows'
           go test -timeout 30m -race -cover -v ./e2etest
         env:
@@ -100,6 +100,7 @@ jobs:
           AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
           CPK_ENCRYPTION_KEY: $(CPK_ENCRYPTION_KEY)
           CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
+          AZCOPY_E2E_EXECUTABLE_PATH: $(System.DefaultWorkingDirectory)/azcopy_windows_amd64.exe
         displayName: 'E2E Test Windows'
         condition: eq(variables.type, 'windows')
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,12 +88,12 @@ jobs:
           CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
         displayName: 'E2E Test Linux'
         condition: eq(variables.type, 'linux')
+
       # Running E2E Tests on Windows
       - script: |
           go build -o azcopy_windows_amd64.exe
           go build -o azcopy_windows_386.exe
           echo 'starting E2E tests on windows'
-          set AZCOPY_E2E_EXECUTABLE_PATH=$(pwd)/azcopy_windows_amd64.exe
           go test -timeout 30m -race -cover -v ./e2etest
         env:
           AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)
@@ -102,6 +102,7 @@ jobs:
           CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
         displayName: 'E2E Test Windows'
         condition: eq(variables.type, 'windows')
+
       # Running E2E Tests on Mac
       - script: |
           set -e
@@ -123,7 +124,7 @@ jobs:
     # allow maximum build time, in case we have build congestion
     timeoutInMinutes: 360
     pool:
-      vmImage: 'ubuntu-16.04'
+      vmImage: 'ubuntu-20.04'
     steps:
       - task: UsePythonVersion@0
         name: 'Set_up_Python'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,9 +11,9 @@ pr:
       - master
 
 jobs:
-  - job: Linux_and_Windows_Builds
+  - job: Linux_Build
     pool:
-      vmImage: 'ubuntu-16.04'
+      vmImage: 'ubuntu-20.04'
     steps:
       - task: GoTool@0
         inputs:
@@ -21,29 +21,110 @@ jobs:
       - script: |
           GOARCH=amd64 GOOS=linux go build -o "$(Build.ArtifactStagingDirectory)/azcopy_linux_amd64"
           GOARCH=amd64 GOOS=linux go build -tags "se_integration" -o "$(Build.ArtifactStagingDirectory)/azcopy_linux_se_amd64"
-          GOARCH=amd64 GOOS=windows go build -o "$(Build.ArtifactStagingDirectory)/azcopy_windows_amd64.exe"
-          GOARCH=386 GOOS=windows go build -o "$(Build.ArtifactStagingDirectory)/azcopy_windows_386.exe"
           cp NOTICE.txt $(Build.ArtifactStagingDirectory)
-        displayName: 'Generate builds'
+        displayName: 'Generate Linux Build'
 
       - task: PublishBuildArtifacts@1
         displayName: 'Publish Artifacts'
         condition: succeededOrFailed()
 
+  - job: Windows_Build
+      pool:
+        vmImage: 'windows-2019'
+      steps:
+        - task: GoTool@0
+          inputs:
+            version: '1.15'
+        - script: |
+            GOARCH=amd64 GOOS=windows go build -o "$(Build.ArtifactStagingDirectory)/azcopy_windows_amd64.exe"
+            GOARCH=386 GOOS=windows go build -o "$(Build.ArtifactStagingDirectory)/azcopy_windows_386.exe"
+            cp NOTICE.txt $(Build.ArtifactStagingDirectory)
+          displayName: 'Generate Windows Build'
+
+        - task: PublishBuildArtifacts@1
+          displayName: 'Publish Artifacts'
+          condition: succeededOrFailed()
+
   - job: MacOS_Build
     pool:
-      vmImage: 'macOS-10.14'
+      vmImage: 'macOS-10.15'
     steps:
       - task: GoTool@0
         inputs:
           version: '1.15'
       - script: |
           go build -o "$(Build.ArtifactStagingDirectory)/azcopy_darwin_amd64"
-        displayName: 'Generate builds'
+        displayName: 'Generate MacOS Build'
 
       - task: PublishBuildArtifacts@1
         displayName: 'Publish Artifacts'
         condition: succeededOrFailed()
+
+  - job: Running_E2E
+      timeoutInMinutes: 360
+      # Creating strategies for GOOS: Windows Server 2019 /macOS X Mojave 10.15/Ubuntu 20.04
+      strategy:
+        matrix:
+          Ubuntu-20:
+            imageName: 'ubuntu-20.04'
+            type: 'linux'
+          Windows:
+            imageName: 'windows-2019'
+            type: 'windows'
+          MacOS:
+            imageName: 'macOS-10.15'
+            type: 'mac-os'
+      pool:
+        vmImage: $(imageName)
+
+      steps:
+        - task: GoTool@0
+          inputs:
+            version: '1.15'
+
+        # Running E2E Tests on Linux
+        - script: |
+            set -e
+            go build -o azcopy_linux_amd64
+            go build -tags "se_integration" -o azcopy_linux_se_amd64
+            echo 'starting E2E tests on linux'
+            go test -timeout 30m -race -cover -v ./e2etest
+          env:
+            AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)
+            AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
+            CPK_ENCRYPTION_KEY: $(CPK_ENCRYPTION_KEY)
+            CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
+            AZCOPY_E2E_EXECUTABLE_PATH: $(Build.ArtifactStagingDirectory)/azcopy_linux_amd64
+          displayName: 'E2E Test Linux'
+          condition: eq(variables.type, 'linux')
+        # Running E2E Tests on Windows
+        - script: |
+            go build -o azcopy_windows_amd64.exe
+            go build -o azcopy_windows_386.exe
+            echo 'starting E2E tests on windows'
+            go test -timeout 30m -race -cover -v ./e2etest
+          env:
+            AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)
+            AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
+            CPK_ENCRYPTION_KEY: $(CPK_ENCRYPTION_KEY)
+            CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
+            AZCOPY_E2E_EXECUTABLE_PATH: $(Build.ArtifactStagingDirectory)/azcopy_windows_amd64.exe
+          displayName: 'E2E Test Windows'
+          condition: eq(variables.type, 'windows')
+        # Running E2E Tests on Mac
+        - script: |
+            set -e
+            go build -o azcopy_darwin_amd64
+            echo 'starting E2E tests on mac-os'
+            go test -timeout 30m -race -cover -v ./e2etest
+          env:
+            AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)
+            AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
+            CPK_ENCRYPTION_KEY: $(CPK_ENCRYPTION_KEY)
+            CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
+            AZCOPY_E2E_EXECUTABLE_PATH: $(Build.ArtifactStagingDirectory)/azcopy_darwin_amd64
+          displayName: 'E2E Test MacOs'
+          condition: eq(variables.type, 'mac-os')
 
   - job: Test_On_Ubuntu
     variables:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,13 +93,13 @@ jobs:
           go build -o azcopy_windows_amd64.exe
           go build -o azcopy_windows_386.exe
           echo 'starting E2E tests on windows'
+          set AZCOPY_E2E_EXECUTABLE_PATH=$(pwd)/azcopy_windows_amd64.exe
           go test -timeout 30m -race -cover -v ./e2etest
         env:
           AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)
           AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
           CPK_ENCRYPTION_KEY: $(CPK_ENCRYPTION_KEY)
           CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
-          AZCOPY_E2E_EXECUTABLE_PATH: $(pwd)/azcopy_windows_amd64.exe
         displayName: 'E2E Test Windows'
         condition: eq(variables.type, 'windows')
       # Running E2E Tests on Mac
@@ -107,7 +107,7 @@ jobs:
           set -e
           go build -o azcopy_darwin_amd64
           echo 'starting E2E tests on mac-os'
-          export AZCOPY_E2E_EXECUTABLE_PATH=$(pwd)/azcopy_linux_amd64
+          export AZCOPY_E2E_EXECUTABLE_PATH=$(pwd)/azcopy_darwin_amd64
           go test -timeout 30m -race -cover -v ./e2etest
         env:
           AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,70 +54,70 @@ jobs:
         condition: succeededOrFailed()
 
   - job: E2E_Test
-      timeoutInMinutes: 360
-      # Creating strategies for GOOS: Windows Server 2019 /macOS X Mojave 10.15/Ubuntu 20.04
-      strategy:
-        matrix:
-          Ubuntu-20:
-            imageName: 'ubuntu-20.04'
-            type: 'linux'
-          Windows:
-            imageName: 'windows-2019'
-            type: 'windows'
-          MacOS:
-            imageName: 'macOS-10.15'
-            type: 'mac-os'
-      pool:
-        vmImage: $(imageName)
+    timeoutInMinutes: 360
+    # Creating strategies for GOOS: Windows Server 2019 /macOS X Mojave 10.15/Ubuntu 20.04
+    strategy:
+      matrix:
+        Ubuntu-20:
+          imageName: 'ubuntu-20.04'
+          type: 'linux'
+        Windows:
+          imageName: 'windows-2019'
+          type: 'windows'
+        MacOS:
+          imageName: 'macOS-10.15'
+          type: 'mac-os'
+    pool:
+      vmImage: $(imageName)
 
-      steps:
-        - task: GoTool@0
-          inputs:
-            version: '1.15'
+    steps:
+      - task: GoTool@0
+        inputs:
+          version: '1.15'
 
-        # Running E2E Tests on Linux
-        - script: |
-            set -e
-            go build -o azcopy_linux_amd64
-            go build -tags "se_integration" -o azcopy_linux_se_amd64
-            echo 'starting E2E tests on linux'
-            go test -timeout 30m -race -cover -v ./e2etest
-          env:
-            AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)
-            AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
-            CPK_ENCRYPTION_KEY: $(CPK_ENCRYPTION_KEY)
-            CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
-            AZCOPY_E2E_EXECUTABLE_PATH: $(Build.ArtifactStagingDirectory)/azcopy_linux_amd64
-          displayName: 'E2E Test Linux'
-          condition: eq(variables.type, 'linux')
-        # Running E2E Tests on Windows
-        - script: |
-            go build -o azcopy_windows_amd64.exe
-            go build -o azcopy_windows_386.exe
-            echo 'starting E2E tests on windows'
-            go test -timeout 30m -race -cover -v ./e2etest
-          env:
-            AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)
-            AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
-            CPK_ENCRYPTION_KEY: $(CPK_ENCRYPTION_KEY)
-            CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
-            AZCOPY_E2E_EXECUTABLE_PATH: $(Build.ArtifactStagingDirectory)/azcopy_windows_amd64.exe
-          displayName: 'E2E Test Windows'
-          condition: eq(variables.type, 'windows')
-        # Running E2E Tests on Mac
-        - script: |
-            set -e
-            go build -o azcopy_darwin_amd64
-            echo 'starting E2E tests on mac-os'
-            go test -timeout 30m -race -cover -v ./e2etest
-          env:
-            AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)
-            AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
-            CPK_ENCRYPTION_KEY: $(CPK_ENCRYPTION_KEY)
-            CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
-            AZCOPY_E2E_EXECUTABLE_PATH: $(Build.ArtifactStagingDirectory)/azcopy_darwin_amd64
-          displayName: 'E2E Test MacOs'
-          condition: eq(variables.type, 'mac-os')
+      # Running E2E Tests on Linux
+      - script: |
+          set -e
+          go build -o azcopy_linux_amd64
+          go build -tags "se_integration" -o azcopy_linux_se_amd64
+          echo 'starting E2E tests on linux'
+          go test -timeout 30m -race -cover -v ./e2etest
+        env:
+          AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)
+          AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
+          CPK_ENCRYPTION_KEY: $(CPK_ENCRYPTION_KEY)
+          CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
+          AZCOPY_E2E_EXECUTABLE_PATH: $(Build.ArtifactStagingDirectory)/azcopy_linux_amd64
+        displayName: 'E2E Test Linux'
+        condition: eq(variables.type, 'linux')
+      # Running E2E Tests on Windows
+      - script: |
+          go build -o azcopy_windows_amd64.exe
+          go build -o azcopy_windows_386.exe
+          echo 'starting E2E tests on windows'
+          go test -timeout 30m -race -cover -v ./e2etest
+        env:
+          AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)
+          AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
+          CPK_ENCRYPTION_KEY: $(CPK_ENCRYPTION_KEY)
+          CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
+          AZCOPY_E2E_EXECUTABLE_PATH: $(Build.ArtifactStagingDirectory)/azcopy_windows_amd64.exe
+        displayName: 'E2E Test Windows'
+        condition: eq(variables.type, 'windows')
+      # Running E2E Tests on Mac
+      - script: |
+          set -e
+          go build -o azcopy_darwin_amd64
+          echo 'starting E2E tests on mac-os'
+          go test -timeout 30m -race -cover -v ./e2etest
+        env:
+          AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)
+          AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
+          CPK_ENCRYPTION_KEY: $(CPK_ENCRYPTION_KEY)
+          CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
+          AZCOPY_E2E_EXECUTABLE_PATH: $(Build.ArtifactStagingDirectory)/azcopy_darwin_amd64
+        displayName: 'E2E Test MacOs'
+        condition: eq(variables.type, 'mac-os')
 
   - job: Test_On_Ubuntu
     variables:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,9 +18,6 @@ jobs:
         Ubuntu-20:
           imageName: 'ubuntu-20.04'
           type: 'linux'
-        Windows:
-          imageName: 'windows-2019'
-          type: 'windows'
         MacOS:
           imageName: 'macOS-10.15'
           type: 'mac-os'
@@ -33,16 +30,11 @@ jobs:
       - script: |
           GOARCH=amd64 GOOS=linux go build -o "$(Build.ArtifactStagingDirectory)/azcopy_linux_amd64"
           GOARCH=amd64 GOOS=linux go build -tags "se_integration" -o "$(Build.ArtifactStagingDirectory)/azcopy_linux_se_amd64"
-          cp NOTICE.txt $(Build.ArtifactStagingDirectory)
-        displayName: 'Generate Linux Build'
-        condition: eq(variables.type, 'linux')
-
-      - script: |
           GOARCH=amd64 GOOS=windows go build -o "$(Build.ArtifactStagingDirectory)/azcopy_windows_amd64.exe"
           GOARCH=386 GOOS=windows go build -o "$(Build.ArtifactStagingDirectory)/azcopy_windows_386.exe"
           cp NOTICE.txt $(Build.ArtifactStagingDirectory)
-        displayName: 'Generate Windows Build'
-        condition: eq(variables.type, 'windows')
+        displayName: 'Generate Linux And Windows Build'
+        condition: eq(variables.type, 'linux')
 
       - script: |
           go build -o "$(Build.ArtifactStagingDirectory)/azcopy_darwin_amd64"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,13 +2,13 @@ trigger:
   branches:
     include:
       - dev
-      - master
+      - main
 
 pr:
   branches:
     include:
       - dev
-      - master
+      - main
 
 jobs:
   - job: Build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,58 +11,8 @@ pr:
       - master
 
 jobs:
-  - job: Linux_Build
-    pool:
-      vmImage: 'ubuntu-20.04'
-    steps:
-      - task: GoTool@0
-        inputs:
-          version: '1.15'
-      - script: |
-          GOARCH=amd64 GOOS=linux go build -o "$(Build.ArtifactStagingDirectory)/azcopy_linux_amd64"
-          GOARCH=amd64 GOOS=linux go build -tags "se_integration" -o "$(Build.ArtifactStagingDirectory)/azcopy_linux_se_amd64"
-          cp NOTICE.txt $(Build.ArtifactStagingDirectory)
-        displayName: 'Generate Linux Build'
-
-      - task: PublishBuildArtifacts@1
-        displayName: 'Publish Artifacts'
-        condition: succeededOrFailed()
-
-  - job: Windows_Build
-    pool:
-      vmImage: 'windows-2019'
-    steps:
-      - task: GoTool@0
-        inputs:
-          version: '1.15'
-      - script: |
-          GOARCH=amd64 GOOS=windows go build -o "$(Build.ArtifactStagingDirectory)/azcopy_windows_amd64.exe"
-          GOARCH=386 GOOS=windows go build -o "$(Build.ArtifactStagingDirectory)/azcopy_windows_386.exe"
-          cp NOTICE.txt $(Build.ArtifactStagingDirectory)
-        displayName: 'Generate Windows Build'
-
-      - task: PublishBuildArtifacts@1
-        displayName: 'Publish Artifacts'
-        condition: succeededOrFailed()
-
-  - job: MacOS_Build
-    pool:
-      vmImage: 'macOS-10.15'
-    steps:
-      - task: GoTool@0
-        inputs:
-          version: '1.15'
-      - script: |
-          go build -o "$(Build.ArtifactStagingDirectory)/azcopy_darwin_amd64"
-        displayName: 'Generate MacOS Build'
-
-      - task: PublishBuildArtifacts@1
-        displayName: 'Publish Artifacts'
-        condition: succeededOrFailed()
-
-  - job: Running_E2E
+  - job: Build
     timeoutInMinutes: 360
-    # Creating strategies for GOOS: Windows Server 2019 /macOS X Mojave 10.15/Ubuntu 20.04
     strategy:
       matrix:
         Ubuntu-20:
@@ -76,55 +26,98 @@ jobs:
           type: 'mac-os'
     pool:
       vmImage: $(imageName)
-
     steps:
       - task: GoTool@0
         inputs:
           version: '1.15'
-
-      # Running E2E Tests on Linux
       - script: |
-          set -e
-          go build -o azcopy_linux_amd64
-          go build -tags "se_integration" -o azcopy_linux_se_amd64
-          echo 'starting E2E tests on linux'
-          go test -timeout 30m -race -cover -v ./e2etest
-        env:
-          AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)
-          AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
-          CPK_ENCRYPTION_KEY: $(CPK_ENCRYPTION_KEY)
-          CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
-          AZCOPY_E2E_EXECUTABLE_PATH: $(Build.ArtifactStagingDirectory)/azcopy_linux_amd64
-        displayName: 'E2E Test Linux'
+          GOARCH=amd64 GOOS=linux go build -o "$(Build.ArtifactStagingDirectory)/azcopy_linux_amd64"
+          GOARCH=amd64 GOOS=linux go build -tags "se_integration" -o "$(Build.ArtifactStagingDirectory)/azcopy_linux_se_amd64"
+          cp NOTICE.txt $(Build.ArtifactStagingDirectory)
+        displayName: 'Generate Linux Build'
         condition: eq(variables.type, 'linux')
-      # Running E2E Tests on Windows
+
       - script: |
-          go build -o azcopy_windows_amd64.exe
-          go build -o azcopy_windows_386.exe
-          echo 'starting E2E tests on windows'
-          go test -timeout 30m -race -cover -v ./e2etest
-        env:
-          AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)
-          AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
-          CPK_ENCRYPTION_KEY: $(CPK_ENCRYPTION_KEY)
-          CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
-          AZCOPY_E2E_EXECUTABLE_PATH: $(Build.ArtifactStagingDirectory)/azcopy_windows_amd64.exe
-        displayName: 'E2E Test Windows'
+          GOARCH=amd64 GOOS=windows go build -o "$(Build.ArtifactStagingDirectory)/azcopy_windows_amd64.exe"
+          GOARCH=386 GOOS=windows go build -o "$(Build.ArtifactStagingDirectory)/azcopy_windows_386.exe"
+          cp NOTICE.txt $(Build.ArtifactStagingDirectory)
+        displayName: 'Generate Windows Build'
         condition: eq(variables.type, 'windows')
-      # Running E2E Tests on Mac
+
       - script: |
-          set -e
-          go build -o azcopy_darwin_amd64
-          echo 'starting E2E tests on mac-os'
-          go test -timeout 30m -race -cover -v ./e2etest
-        env:
-          AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)
-          AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
-          CPK_ENCRYPTION_KEY: $(CPK_ENCRYPTION_KEY)
-          CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
-          AZCOPY_E2E_EXECUTABLE_PATH: $(Build.ArtifactStagingDirectory)/azcopy_darwin_amd64
-        displayName: 'E2E Test MacOs'
+          go build -o "$(Build.ArtifactStagingDirectory)/azcopy_darwin_amd64"
+        displayName: 'Generate MacOS Build'
         condition: eq(variables.type, 'mac-os')
+
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish Artifacts'
+        condition: succeededOrFailed()
+
+  - job: E2E_Test
+      timeoutInMinutes: 360
+      # Creating strategies for GOOS: Windows Server 2019 /macOS X Mojave 10.15/Ubuntu 20.04
+      strategy:
+        matrix:
+          Ubuntu-20:
+            imageName: 'ubuntu-20.04'
+            type: 'linux'
+          Windows:
+            imageName: 'windows-2019'
+            type: 'windows'
+          MacOS:
+            imageName: 'macOS-10.15'
+            type: 'mac-os'
+      pool:
+        vmImage: $(imageName)
+
+      steps:
+        - task: GoTool@0
+          inputs:
+            version: '1.15'
+
+        # Running E2E Tests on Linux
+        - script: |
+            set -e
+            go build -o azcopy_linux_amd64
+            go build -tags "se_integration" -o azcopy_linux_se_amd64
+            echo 'starting E2E tests on linux'
+            go test -timeout 30m -race -cover -v ./e2etest
+          env:
+            AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)
+            AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
+            CPK_ENCRYPTION_KEY: $(CPK_ENCRYPTION_KEY)
+            CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
+            AZCOPY_E2E_EXECUTABLE_PATH: $(Build.ArtifactStagingDirectory)/azcopy_linux_amd64
+          displayName: 'E2E Test Linux'
+          condition: eq(variables.type, 'linux')
+        # Running E2E Tests on Windows
+        - script: |
+            go build -o azcopy_windows_amd64.exe
+            go build -o azcopy_windows_386.exe
+            echo 'starting E2E tests on windows'
+            go test -timeout 30m -race -cover -v ./e2etest
+          env:
+            AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)
+            AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
+            CPK_ENCRYPTION_KEY: $(CPK_ENCRYPTION_KEY)
+            CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
+            AZCOPY_E2E_EXECUTABLE_PATH: $(Build.ArtifactStagingDirectory)/azcopy_windows_amd64.exe
+          displayName: 'E2E Test Windows'
+          condition: eq(variables.type, 'windows')
+        # Running E2E Tests on Mac
+        - script: |
+            set -e
+            go build -o azcopy_darwin_amd64
+            echo 'starting E2E tests on mac-os'
+            go test -timeout 30m -race -cover -v ./e2etest
+          env:
+            AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)
+            AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
+            CPK_ENCRYPTION_KEY: $(CPK_ENCRYPTION_KEY)
+            CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
+            AZCOPY_E2E_EXECUTABLE_PATH: $(Build.ArtifactStagingDirectory)/azcopy_darwin_amd64
+          displayName: 'E2E Test MacOs'
+          condition: eq(variables.type, 'mac-os')
 
   - job: Test_On_Ubuntu
     variables:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,21 +29,21 @@ jobs:
         condition: succeededOrFailed()
 
   - job: Windows_Build
-      pool:
-        vmImage: 'windows-2019'
-      steps:
-        - task: GoTool@0
-          inputs:
-            version: '1.15'
-        - script: |
-            GOARCH=amd64 GOOS=windows go build -o "$(Build.ArtifactStagingDirectory)/azcopy_windows_amd64.exe"
-            GOARCH=386 GOOS=windows go build -o "$(Build.ArtifactStagingDirectory)/azcopy_windows_386.exe"
-            cp NOTICE.txt $(Build.ArtifactStagingDirectory)
-          displayName: 'Generate Windows Build'
+    pool:
+      vmImage: 'windows-2019'
+    steps:
+      - task: GoTool@0
+        inputs:
+          version: '1.15'
+      - script: |
+          GOARCH=amd64 GOOS=windows go build -o "$(Build.ArtifactStagingDirectory)/azcopy_windows_amd64.exe"
+          GOARCH=386 GOOS=windows go build -o "$(Build.ArtifactStagingDirectory)/azcopy_windows_386.exe"
+          cp NOTICE.txt $(Build.ArtifactStagingDirectory)
+        displayName: 'Generate Windows Build'
 
-        - task: PublishBuildArtifacts@1
-          displayName: 'Publish Artifacts'
-          condition: succeededOrFailed()
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish Artifacts'
+        condition: succeededOrFailed()
 
   - job: MacOS_Build
     pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,16 +78,14 @@ jobs:
       # Running E2E Tests on Linux
       - script: |
           set -e
-          go build -o azcopy_linux_amd64
-          go build -tags "se_integration" -o azcopy_linux_se_amd64
-          echo 'starting E2E tests on linux'
-          go test -timeout 30m -race -cover -v ./e2etest
+          GOARCH=amd64 GOOS=linux go build -o azcopy_linux_amd64
+          export AZCOPY_E2E_EXECUTABLE_PATH=$(pwd)/azcopy_linux_amd64
+          go test -timeout 20m -race -short -cover ./e2etest
         env:
           AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)
           AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
           CPK_ENCRYPTION_KEY: $(CPK_ENCRYPTION_KEY)
           CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
-          AZCOPY_E2E_EXECUTABLE_PATH: $(Build.ArtifactStagingDirectory)/azcopy_linux_amd64
         displayName: 'E2E Test Linux'
         condition: eq(variables.type, 'linux')
       # Running E2E Tests on Windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,7 +99,7 @@ jobs:
           AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
           CPK_ENCRYPTION_KEY: $(CPK_ENCRYPTION_KEY)
           CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
-          AZCOPY_E2E_EXECUTABLE_PATH: $(Build.ArtifactStagingDirectory)/azcopy_windows_amd64.exe
+          AZCOPY_E2E_EXECUTABLE_PATH: $(pwd)/azcopy_windows_amd64.exe
         displayName: 'E2E Test Windows'
         condition: eq(variables.type, 'windows')
       # Running E2E Tests on Mac
@@ -107,13 +107,13 @@ jobs:
           set -e
           go build -o azcopy_darwin_amd64
           echo 'starting E2E tests on mac-os'
+          export AZCOPY_E2E_EXECUTABLE_PATH=$(pwd)/azcopy_linux_amd64
           go test -timeout 30m -race -cover -v ./e2etest
         env:
           AZCOPY_E2E_ACCOUNT_KEY: $(AZCOPY_E2E_ACCOUNT_KEY)
           AZCOPY_E2E_ACCOUNT_NAME: $(AZCOPY_E2E_ACCOUNT_NAME)
           CPK_ENCRYPTION_KEY: $(CPK_ENCRYPTION_KEY)
           CPK_ENCRYPTION_KEY_SHA256: $(CPK_ENCRYPTION_KEY_SHA256)
-          AZCOPY_E2E_EXECUTABLE_PATH: $(Build.ArtifactStagingDirectory)/azcopy_darwin_amd64
         displayName: 'E2E Test MacOs'
         condition: eq(variables.type, 'mac-os')
 


### PR DESCRIPTION
Extracted E2E tests outside the smoke tests which will reduce running time by at least 10 mins.

Started E2E testing for Windows Server 2019 /macOS X Mojave 10.15/Ubuntu 20.04. Also updated versions of hosted agents to latest. Since these tests will run in parallel on all these abovementioned platforms, it won't affect the performance and give better performance insight.

Checkout the pipeline for more information.