### PR TITLE
Dry run mode for remove

### DIFF
--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -81,6 +81,10 @@ func init() {
 				glcm.Error("failed to perform remove command due to error: " + err.Error())
 			}
 
+			if cooked.dryrunMode {
+				glcm.Exit(nil, common.EExitCode.Success())
+			}
+
 			glcm.SurrenderControl()
 		},
 	}
@@ -98,4 +102,5 @@ func init() {
 	deleteCmd.PersistentFlags().StringVar(&raw.listOfFilesToCopy, "list-of-files", "", "Defines the location of a file which contains the list of files and directories to be deleted. The relative paths should be delimited by line breaks, and the paths should NOT be URL-encoded.")
 	deleteCmd.PersistentFlags().StringVar(&raw.deleteSnapshotsOption, "delete-snapshots", "", "By default, the delete operation fails if a blob has snapshots. Specify 'include' to remove the root blob and all its snapshots; alternatively specify 'only' to remove only the snapshots but keep the root blob.")
 	deleteCmd.PersistentFlags().StringVar(&raw.listOfVersionIDs, "list-of-versions", "", "Specifies a file where each version id is listed on a separate line. Ensure that the source must point to a single blob and all the version ids specified in the file using this flag must belong to the source blob only. Specified version ids of the given blob will get deleted from Azure Storage.")
+	deleteCmd.PersistentFlags().BoolVar(&raw.dryrun, "dry-run", false, "Print path files that would be removed by command.")
 }

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -102,5 +102,5 @@ func init() {
 	deleteCmd.PersistentFlags().StringVar(&raw.listOfFilesToCopy, "list-of-files", "", "Defines the location of a file which contains the list of files and directories to be deleted. The relative paths should be delimited by line breaks, and the paths should NOT be URL-encoded.")
 	deleteCmd.PersistentFlags().StringVar(&raw.deleteSnapshotsOption, "delete-snapshots", "", "By default, the delete operation fails if a blob has snapshots. Specify 'include' to remove the root blob and all its snapshots; alternatively specify 'only' to remove only the snapshots but keep the root blob.")
 	deleteCmd.PersistentFlags().StringVar(&raw.listOfVersionIDs, "list-of-versions", "", "Specifies a file where each version id is listed on a separate line. Ensure that the source must point to a single blob and all the version ids specified in the file using this flag must belong to the source blob only. Specified version ids of the given blob will get deleted from Azure Storage.")
-	deleteCmd.PersistentFlags().BoolVar(&raw.dryrun, "dry-run", false, "Print path files that would be removed by command.")
+	deleteCmd.PersistentFlags().BoolVar(&raw.dryrun, "dry-run", false, "Prints the path files that would be removed by the command. This flag does not trigger the removal of the files.")
 }

--- a/cmd/removeEnumerator.go
+++ b/cmd/removeEnumerator.go
@@ -81,11 +81,11 @@ func newRemoveEnumerator(cca *cookedCopyCmdArgs) (enumerator *copyEnumerator, er
 	finalize := func() error {
 		jobInitiated, err := transferScheduler.dispatchFinalPart()
 		if err != nil {
-			if err == NothingScheduledError && !cca.dryrunMode {
+			if cca.dryrunMode {
+				return nil
+			} else if err == NothingScheduledError {
 				// No log file needed. Logging begins as a part of awaiting job completion.
 				return NothingToRemoveError
-			} else if cca.dryrunMode {
-				return nil
 			}
 
 			return err

--- a/cmd/removeProcessor.go
+++ b/cmd/removeProcessor.go
@@ -50,5 +50,5 @@ func newRemoveTransferProcessor(cca *cookedCopyCmdArgs, numOfTransfersPerPart in
 	// note that the source and destination, along with the template are given to the generic processor's constructor
 	// this means that given an object with a relative path, this processor already knows how to schedule the right kind of transfers
 	return newCopyTransferProcessor(copyJobTemplate, numOfTransfersPerPart, cca.source, cca.destination,
-		reportFirstPart, reportFinalPart, false)
+		reportFirstPart, reportFinalPart, false, cca.dryrunMode)
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -83,6 +83,8 @@ type rawSyncCmdArgs struct {
 	// Key is present in AzureKeyVault and Azure KeyVault is linked with storage account.
 	// Provided key name will be fetched from Azure Key Vault and will be used to encrypt the data
 	cpkScopeInfo string
+	// dry run mode bool
+	dryrun bool
 }
 
 func (raw *rawSyncCmdArgs) parsePatterns(pattern string) (cookedPatterns []string) {
@@ -300,6 +302,8 @@ func (raw *rawSyncCmdArgs) cook() (cookedSyncCmdArgs, error) {
 	cooked.includeRegex = raw.parsePatterns(raw.includeRegex)
 	cooked.excludeRegex = raw.parsePatterns(raw.excludeRegex)
 
+	cooked.dryrunMode = raw.dryrun
+
 	return cooked, nil
 }
 
@@ -380,6 +384,8 @@ type cookedSyncCmdArgs struct {
 	cpkOptions common.CpkOptions
 
 	mirrorMode bool
+
+	dryrunMode bool
 }
 
 func (cca *cookedSyncCmdArgs) incrementDeletionCount() {

--- a/cmd/syncProcessor.go
+++ b/cmd/syncProcessor.go
@@ -71,7 +71,7 @@ func newSyncTransferProcessor(cca *cookedSyncCmdArgs, numOfTransfersPerPart int,
 	// note that the source and destination, along with the template are given to the generic processor's constructor
 	// this means that given an object with a relative path, this processor already knows how to schedule the right kind of transfers
 	return newCopyTransferProcessor(copyJobTemplate, numOfTransfersPerPart, cca.source, cca.destination,
-		reportFirstPart, reportFinalPart, cca.preserveAccessTier)
+		reportFirstPart, reportFinalPart, cca.preserveAccessTier, cca.dryrunMode)
 }
 
 // base for delete processors targeting different resources

--- a/cmd/zc_processor.go
+++ b/cmd/zc_processor.go
@@ -90,18 +90,10 @@ func (s *copyTransferProcessor) scheduleCopyTransfer(storedObject storedObject) 
 				common.PanicIfErr(err)
 				return string(jsonOutput)
 			} else {
-				// if remove then To() will equal to common.ELocation.Unknown()
-				if s.copyJobTemplate.FromTo.To() == common.ELocation.Unknown() { //remove
-					return fmt.Sprintf("DRYRUN: remove %v/%v",
-						s.copyJobTemplate.SourceRoot.Value,
-						srcRelativePath)
-				} else { //copy
-					return fmt.Sprintf("DRYRUN: copy %v/%v to %v/%v",
-						s.copyJobTemplate.SourceRoot.Value,
-						srcRelativePath,
-						s.copyJobTemplate.DestinationRoot.Value,
-						dstRelativePath)
-				}
+				// formatting string for remove
+				return fmt.Sprintf("DRYRUN: remove %v/%v",
+					s.copyJobTemplate.SourceRoot.Value,
+					srcRelativePath)
 			}
 		})
 		return nil

--- a/cmd/zt_generic_processor_test.go
+++ b/cmd/zt_generic_processor_test.go
@@ -78,7 +78,7 @@ func (s *genericProcessorSuite) TestCopyTransferProcessorMultipleFiles(c *chk.C)
 	for _, numOfParts := range []int{1, 3} {
 		numOfTransfersPerPart := len(sampleObjects) / numOfParts
 		copyProcessor := newCopyTransferProcessor(processorTestSuiteHelper{}.getCopyJobTemplate(), numOfTransfersPerPart,
-			newRemoteRes(containerURL.String()), newLocalRes(dstDirName), nil, nil, false)
+			newRemoteRes(containerURL.String()), newLocalRes(dstDirName), nil, nil, false, false)
 
 		// go through the objects and make sure they are processed without error
 		for _, storedObject := range sampleObjects {
@@ -125,7 +125,7 @@ func (s *genericProcessorSuite) TestCopyTransferProcessorSingleFile(c *chk.C) {
 	// set up the processor
 	blobURL := containerURL.NewBlockBlobURL(blobList[0]).String()
 	copyProcessor := newCopyTransferProcessor(processorTestSuiteHelper{}.getCopyJobTemplate(), 2,
-		newRemoteRes(blobURL), newLocalRes(filepath.Join(dstDirName, dstFileName)), nil, nil, false)
+		newRemoteRes(blobURL), newLocalRes(filepath.Join(dstDirName, dstFileName)), nil, nil, false, false)
 
 	// exercise the copy transfer processor
 	storedObject := newStoredObject(noPreProccessor, blobList[0], "", common.EEntityType.File(), time.Now(), 0, noContentProps, noBlobProps, noMetdata, "")

--- a/cmd/zt_interceptors_for_test.go
+++ b/cmd/zt_interceptors_for_test.go
@@ -74,10 +74,12 @@ func (i *interceptor) reset() {
 
 // this lifecycle manager substitute does not perform any action
 type mockedLifecycleManager struct {
-	infoLog     chan string
-	errorLog    chan string
-	progressLog chan string
-	exitLog     chan string
+	infoLog      chan string
+	errorLog     chan string
+	progressLog  chan string
+	exitLog      chan string
+	dryrunLog    chan string
+	outputFormat common.OutputFormat
 }
 
 func (m *mockedLifecycleManager) Progress(o common.OutputBuilder) {
@@ -90,6 +92,12 @@ func (*mockedLifecycleManager) Init(common.OutputBuilder) {}
 func (m *mockedLifecycleManager) Info(msg string) {
 	select {
 	case m.infoLog <- msg:
+	default:
+	}
+}
+func (m *mockedLifecycleManager) Dryrun(o common.OutputBuilder) {
+	select {
+	case m.dryrunLog <- o(m.outputFormat):
 	default:
 	}
 }
@@ -122,9 +130,11 @@ func (*mockedLifecycleManager) GetEnvironmentVariable(env common.EnvironmentVari
 	}
 	return value
 }
-func (*mockedLifecycleManager) SetOutputFormat(common.OutputFormat) {}
-func (*mockedLifecycleManager) EnableInputWatcher()                 {}
-func (*mockedLifecycleManager) EnableCancelFromStdIn()              {}
+func (m *mockedLifecycleManager) SetOutputFormat(format common.OutputFormat) {
+	m.outputFormat = format
+}
+func (*mockedLifecycleManager) EnableInputWatcher()    {}
+func (*mockedLifecycleManager) EnableCancelFromStdIn() {}
 func (*mockedLifecycleManager) AddUserAgentPrefix(userAgent string) string {
 	return userAgent
 }

--- a/cmd/zt_remove_blob_test.go
+++ b/cmd/zt_remove_blob_test.go
@@ -22,7 +22,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"fmt"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	chk "gopkg.in/check.v1"
 	"net/url"
@@ -507,7 +506,9 @@ func (s *cmdIntegrationSuite) TestDryrunRemoveSingleBlob(c *chk.C) {
 
 		msg := <-mockedLcm.dryrunLog
 		//comparing message printed for dry run
-		c.Check(strings.Compare(msg, fmt.Sprintf("DRYRUN: remove %v/%v/", containerURL, blobName[0])), chk.Equals, 0)
+		c.Check(strings.Contains(msg, "DRYRUN: remove"), chk.Equals, true)
+		c.Check(strings.Contains(msg, containerURL.String()), chk.Equals, true)
+		c.Check(strings.Contains(msg, blobName[0]), chk.Equals, true)
 	})
 }
 
@@ -517,8 +518,8 @@ func (s *cmdIntegrationSuite) TestDryrunRemoveBlobsUnderContainer(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 
 	// set up the container with a single blob
-	bloblist := []string{"AzURE2021.jpeg", "sub1/dir2/HELLO-4.txt", "sub1/test/testing.txt"}
-	scenarioHelper{}.generateBlobsFromList(c, containerURL, bloblist, blockBlobDefaultData)
+	blobList := []string{"AzURE2021.jpeg", "sub1/dir2/HELLO-4.txt", "sub1/test/testing.txt"}
+	scenarioHelper{}.generateBlobsFromList(c, containerURL, blobList, blockBlobDefaultData)
 	c.Assert(containerURL, chk.NotNil)
 
 	// set up interceptor
@@ -540,8 +541,10 @@ func (s *cmdIntegrationSuite) TestDryrunRemoveBlobsUnderContainer(c *chk.C) {
 		c.Assert(len(mockedRPC.transfers), chk.Equals, 0)
 
 		msg := mockedLcm.GatherAllLogs(mockedLcm.dryrunLog)
-		for i := 0; i < len(bloblist); i++ {
-			c.Check(strings.Compare(msg[i], fmt.Sprintf("DRYRUN: remove %v/%v", containerURL, bloblist[i])), chk.Equals, 0)
+		for i := 0; i < len(blobList); i++ {
+			c.Check(strings.Contains(msg[i], "DRYRUN: remove"), chk.Equals, true)
+			c.Check(strings.Contains(msg[i], containerURL.String()), chk.Equals, true)
+			c.Check(strings.Contains(msg[i], blobList[i]), chk.Equals, true)
 		}
 	})
 }
@@ -580,6 +583,7 @@ func (s *cmdIntegrationSuite) TestDryrunRemoveBlobsUnderContainerJson(c *chk.C) 
 		//comparing some values of deleteTransfer
 		c.Check(strings.Compare(deleteTransfer.Source, blobName[0]), chk.Equals, 0)
 		c.Check(strings.Compare(deleteTransfer.Destination, blobName[0]), chk.Equals, 0)
+		c.Check(strings.Compare(deleteTransfer.EntityType.String(), common.EEntityType.File().String()), chk.Equals, 0)
 		c.Check(strings.Compare(string(deleteTransfer.BlobType), "BlockBlob"), chk.Equals, 0)
 	})
 }

--- a/common/output.go
+++ b/common/output.go
@@ -17,6 +17,7 @@ type outputMessageType uint8
 func (outputMessageType) Init() outputMessageType     { return outputMessageType(0) } // simple print, allowed to float up
 func (outputMessageType) Info() outputMessageType     { return outputMessageType(1) } // simple print, allowed to float up
 func (outputMessageType) Progress() outputMessageType { return outputMessageType(2) } // should be printed on the same line over and over again, not allowed to float up
+func (outputMessageType) Dryrun() outputMessageType   { return outputMessageType(6) } // simple print
 
 // EndOfJob used to be called Exit, but now it's not necessarily an exit, because we may have follow-up jobs
 func (outputMessageType) EndOfJob() outputMessageType { return outputMessageType(3) } // (may) exit after printing


### PR DESCRIPTION
remove.go --added dryrun flag 
lifecyleMgr.go --created dryrun function called in zc_processor.go
zc_processor.go -- added dryrun bool to newCopyTransferProcessor() and updated in removeProcessor.go, syncProcessor.go, and zt_generic_processor_test.go 
zt_interceptors_for_test.go -- updated mockedLifecycleManager
created tests in zt_remove_blob_test.go