### PR TITLE
Dry run mode for copy

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -1824,7 +1824,7 @@ func init() {
 	cpCmd.PersistentFlags().BoolVar(&raw.s2sPreserveBlobTags, "s2s-preserve-blob-tags", false, "Preserve index tags during service to service transfer from one blob storage to another")
 	cpCmd.PersistentFlags().BoolVar(&raw.includeDirectoryStubs, "include-directory-stub", false, "False by default to ignore directory stubs. Directory stubs are blobs with metadata 'hdi_isfolder:true'. Setting value to true will preserve directory stubs during transfers.")
 	cpCmd.PersistentFlags().BoolVar(&raw.disableAutoDecoding, "disable-auto-decoding", false, "False by default to enable automatic decoding of illegal chars on Windows. Can be set to true to disable automatic decoding.")
-	cpCmd.PersistentFlags().BoolVar(&raw.dryrun, "dry-run", false, "Shows a preview of the file paths that would be copied by this command. This flag does not copy the actual files.")
+	cpCmd.PersistentFlags().BoolVar(&raw.dryrun, "dry-run", false, "Prints the file paths that would be copied by this command. This flag does not copy the actual files.")
 	// s2sGetPropertiesInBackend is an optional flag for controlling whether S3 object's or Azure file's full properties are get during enumerating in frontend or
 	// right before transferring in ste(backend).
 	// The traditional behavior of all existing enumerator is to get full properties during enumerating(more specifically listing),

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -1757,6 +1757,10 @@ func init() {
 				glcm.Error("failed to perform copy command due to error: " + err.Error())
 			}
 
+			if cooked.dryrunMode {
+				glcm.Exit(nil, common.EExitCode.Success())
+			}
+
 			glcm.SurrenderControl()
 		},
 	}
@@ -1820,6 +1824,7 @@ func init() {
 	cpCmd.PersistentFlags().BoolVar(&raw.s2sPreserveBlobTags, "s2s-preserve-blob-tags", false, "Preserve index tags during service to service transfer from one blob storage to another")
 	cpCmd.PersistentFlags().BoolVar(&raw.includeDirectoryStubs, "include-directory-stub", false, "False by default to ignore directory stubs. Directory stubs are blobs with metadata 'hdi_isfolder:true'. Setting value to true will preserve directory stubs during transfers.")
 	cpCmd.PersistentFlags().BoolVar(&raw.disableAutoDecoding, "disable-auto-decoding", false, "False by default to enable automatic decoding of illegal chars on Windows. Can be set to true to disable automatic decoding.")
+	cpCmd.PersistentFlags().BoolVar(&raw.dryrun, "dry-run", false, "Shows a preview of the file paths that would be copied by this command. This flag does not copy the actual files.")
 	// s2sGetPropertiesInBackend is an optional flag for controlling whether S3 object's or Azure file's full properties are get during enumerating in frontend or
 	// right before transferring in ste(backend).
 	// The traditional behavior of all existing enumerator is to get full properties during enumerating(more specifically listing),

--- a/cmd/copyEnumeratorHelper.go
+++ b/cmd/copyEnumeratorHelper.go
@@ -74,6 +74,10 @@ func dispatchFinalPart(e *common.CopyJobPartOrderRequest, cca *cookedCopyCmdArgs
 		// Output the log location and such
 		glcm.Init(common.GetStandardInitOutputBuilder(cca.jobID.String(), fmt.Sprintf("%s%s%s.log", azcopyLogPathFolder, common.OS_PATH_SEPARATOR, cca.jobID), cca.isCleanupJob, cca.cleanupJobMessage))
 
+		if cca.dryrunMode {
+			return nil
+		}
+
 		if resp.ErrorMsg == common.ECopyJobPartOrderErrorType.NoTransfersScheduledErr() {
 			return NothingScheduledError
 		}

--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -278,7 +278,7 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 					if cca.fromTo.From() == common.ELocation.Local() {
 						// formatting from local source
 						return fmt.Sprintf("DRYRUN: copy %v%v to %v%v",
-							strings.Trim(cca.source.Value, "\\?"),
+							common.ToShortPath(cca.source.Value),
 							strings.ReplaceAll(srcRelPath, "/", "\\"),
 							strings.Trim(cca.destination.Value, "/"),
 							dstRelPath)
@@ -287,7 +287,7 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 						return fmt.Sprintf("DRYRUN: copy %v%v to %v%v",
 							strings.Trim(cca.source.Value, "/"),
 							srcRelPath,
-							strings.Trim(cca.destination.Value, "\\?"),
+							common.ToShortPath(cca.destination.Value),
 							strings.ReplaceAll(dstRelPath, "/", "\\"))
 					} else {
 						return fmt.Sprintf("DRYRUN: copy %v%v to %v%v",

--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -216,7 +217,9 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 	// decide our folder transfer strategy
 	var message string
 	jobPartOrder.Fpo, message = newFolderPropertyOption(cca.fromTo, cca.recursive, cca.stripTopDir, filters, cca.preserveSMBInfo, cca.preserveSMBPermissions.IsTruthy())
-	glcm.Info(message)
+	if !cca.dryrunMode {
+		glcm.Info(message)
+	}
 	if ste.JobsAdmin != nil {
 		ste.JobsAdmin.LogToJobLog(message, pipeline.LogInfo)
 	}
@@ -263,6 +266,32 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 		)
 		if !cca.s2sPreserveBlobTags {
 			transfer.BlobTags = cca.blobTags
+		}
+
+		if cca.dryrunMode && shouldSendToSte {
+			glcm.Dryrun(func(format common.OutputFormat) string {
+				if format == common.EOutputFormat.Json() {
+					jsonOutput, err := json.Marshal(transfer)
+					common.PanicIfErr(err)
+					return string(jsonOutput)
+				} else {
+					if cca.fromTo.From() == common.ELocation.Local() {
+						//formatting for local source
+						return fmt.Sprintf("DRYRUN: copy %v%v to %v%v",
+							strings.Trim(cca.source.Value, "\\?"),
+							strings.ReplaceAll(srcRelPath, "/", "\\"),
+							cca.destination.Value,
+							dstRelPath)
+					} else {
+						return fmt.Sprintf("DRYRUN: copy %v%v to %v%v",
+							cca.source.Value,
+							srcRelPath,
+							cca.destination.Value,
+							dstRelPath)
+					}
+				}
+			})
+			return nil
 		}
 
 		if shouldSendToSte {

--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -276,12 +276,19 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 					return string(jsonOutput)
 				} else {
 					if cca.fromTo.From() == common.ELocation.Local() {
-						//formatting for local source
+						// formatting from local source
 						return fmt.Sprintf("DRYRUN: copy %v%v to %v%v",
 							strings.Trim(cca.source.Value, "\\?"),
 							strings.ReplaceAll(srcRelPath, "/", "\\"),
-							cca.destination.Value,
+							strings.Trim(cca.destination.Value, "/"),
 							dstRelPath)
+					} else if cca.fromTo.To() == common.ELocation.Local() {
+						// formatting to local source
+						return fmt.Sprintf("DRYRUN: copy %v%v to %v%v",
+							strings.Trim(cca.source.Value, "/"),
+							srcRelPath,
+							strings.Trim(cca.destination.Value, "\\?"),
+							strings.ReplaceAll(dstRelPath, "/", "\\"))
 					} else {
 						return fmt.Sprintf("DRYRUN: copy %v%v to %v%v",
 							cca.source.Value,

--- a/cmd/zt_copy_blob_download_test.go
+++ b/cmd/zt_copy_blob_download_test.go
@@ -21,6 +21,8 @@
 package cmd
 
 import (
+	"encoding/json"
+	"fmt"
 	"github.com/Azure/azure-pipeline-go/pipeline"
 	"os"
 	"path"
@@ -700,5 +702,216 @@ func (s *cmdIntegrationSuite) TestDownloadBlobContainerWithMultRegexExclude(c *c
 		// validate that the right transfers were sent
 		validateDownloadTransfersAreScheduled(c, common.AZCOPY_PATH_SEPARATOR_STRING, common.AZCOPY_PATH_SEPARATOR_STRING,
 			blobsToInclude, mockedRPC)
+	})
+}
+
+func (s *cmdIntegrationSuite) TestDryrunCopyLocalToBlob(c *chk.C) {
+	bsu := getBSU()
+	containerURL, containerName := createNewContainer(c, bsu)
+	defer deleteContainer(c, containerURL)
+
+	// set up the local source
+	blobsToInclude := []string{"AzURE2021.jpeg", "sub1/dir2/HELLO-4.txt", "sub1/test/testing.txt"}
+	srcDirName := scenarioHelper{}.generateLocalDirectory(c)
+	defer os.RemoveAll(srcDirName)
+	scenarioHelper{}.generateLocalFilesFromList(c, srcDirName, blobsToInclude)
+	c.Assert(srcDirName, chk.NotNil)
+
+	// set up the destination container
+	scenarioHelper{}.generateBlobsFromList(c, containerURL, []string{}, blockBlobDefaultData)
+	c.Assert(containerURL, chk.NotNil)
+
+	// set up interceptor
+	mockedRPC := interceptor{}
+	Rpc = mockedRPC.intercept
+	mockedLcm := mockedLifecycleManager{dryrunLog: make(chan string, 50)}
+	mockedLcm.SetOutputFormat(common.EOutputFormat.Text()) //text format
+	glcm = &mockedLcm
+
+	// construct the raw input to simulate user input
+	rawContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, containerName)
+	raw := getDefaultCopyRawInput(srcDirName, rawContainerURLWithSAS.String())
+	raw.dryrun = true
+	raw.recursive = true
+
+	runCopyAndVerify(c, raw, func(err error) {
+		c.Assert(err, chk.IsNil)
+		// validate that none where transferred
+		c.Assert(len(mockedRPC.transfers), chk.Equals, 0)
+
+		msg := mockedLcm.GatherAllLogs(mockedLcm.dryrunLog)
+		folder := strings.Split(srcDirName, "\\")
+		for i := 0; i < len(blobsToInclude); i++ {
+			c.Check(strings.Compare(msg[i], fmt.Sprintf("DRYRUN: copy %v\\%v to %v/%v/%v", srcDirName, strings.ReplaceAll(blobsToInclude[i], "/", "\\"), containerURL, folder[6], blobsToInclude[i])), chk.Equals, 0)
+		}
+	})
+}
+
+func (s *cmdIntegrationSuite) TestDryrunCopyBlobToBlob(c *chk.C) {
+	bsu := getBSU()
+
+	// set up src container
+	srcContainerURL, srcContainerName := createNewContainer(c, bsu)
+	defer deleteContainer(c, srcContainerURL)
+	blobsToInclude := []string{"AzURE2021.jpeg", "sub1/dir2/HELLO-4.txt", "sub1/test/testing.txt"}
+	scenarioHelper{}.generateBlobsFromList(c, srcContainerURL, blobsToInclude, blockBlobDefaultData)
+	c.Assert(srcContainerURL, chk.NotNil)
+
+	// set up the destination
+	dstContainerURL, dstContainerName := createNewContainer(c, bsu)
+	defer deleteContainer(c, dstContainerURL)
+	c.Assert(dstContainerURL, chk.NotNil)
+
+	// set up interceptor
+	mockedRPC := interceptor{}
+	Rpc = mockedRPC.intercept
+	mockedLcm := mockedLifecycleManager{dryrunLog: make(chan string, 50)}
+	mockedLcm.SetOutputFormat(common.EOutputFormat.Text()) //text format
+	glcm = &mockedLcm
+
+	// construct the raw input to simulate user input
+	rawContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, srcContainerName)
+	rawDstContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, dstContainerName)
+	raw := getDefaultCopyRawInput(rawContainerURLWithSAS.String(), rawDstContainerURLWithSAS.String())
+	raw.dryrun = true
+	raw.recursive = true
+
+	runCopyAndVerify(c, raw, func(err error) {
+		c.Assert(err, chk.IsNil)
+		// validate that none where transferred
+		c.Assert(len(mockedRPC.transfers), chk.Equals, 0)
+
+		msg := mockedLcm.GatherAllLogs(mockedLcm.dryrunLog)
+		for i := 0; i < len(blobsToInclude); i++ {
+			c.Check(strings.Compare(msg[i], fmt.Sprintf("DRYRUN: copy %v/%v to %v/%v", srcContainerURL, blobsToInclude[i], dstContainerURL, blobsToInclude[i])), chk.Equals, 0)
+		}
+	})
+}
+
+func (s *cmdIntegrationSuite) TestDryrunCopyBlobToBlobJson(c *chk.C) {
+	bsu := getBSU()
+	// set up src container
+	srcContainerURL, srcContainerName := createNewContainer(c, bsu)
+	defer deleteContainer(c, srcContainerURL)
+	blobsToInclude := []string{"AzURE2021.jpeg"}
+	scenarioHelper{}.generateBlobsFromList(c, srcContainerURL, blobsToInclude, blockBlobDefaultData)
+	c.Assert(srcContainerURL, chk.NotNil)
+
+	// set up the destination
+	dstContainerURL, dstContainerName := createNewContainer(c, bsu)
+	defer deleteContainer(c, dstContainerURL)
+	c.Assert(dstContainerURL, chk.NotNil)
+
+	// set up interceptor
+	mockedRPC := interceptor{}
+	Rpc = mockedRPC.intercept
+	mockedLcm := mockedLifecycleManager{dryrunLog: make(chan string, 50)}
+	mockedLcm.SetOutputFormat(common.EOutputFormat.Json()) //text format
+	glcm = &mockedLcm
+
+	// construct the raw input to simulate user input
+	rawSrcContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, srcContainerName)
+	rawDstContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, dstContainerName)
+	raw := getDefaultCopyRawInput(rawSrcContainerURLWithSAS.String(), rawDstContainerURLWithSAS.String())
+	raw.dryrun = true
+	raw.recursive = true
+
+	runCopyAndVerify(c, raw, func(err error) {
+		c.Assert(err, chk.IsNil)
+		// validate that none where transferred
+		c.Assert(len(mockedRPC.transfers), chk.Equals, 0)
+
+		msg := <-mockedLcm.dryrunLog
+		copyMessage := common.CopyTransfer{}
+		errMarshal := json.Unmarshal([]byte(msg), &copyMessage)
+		c.Assert(errMarshal, chk.IsNil)
+		//comparing some values of deleteTransfer
+		c.Check(strings.Compare(strings.Trim(copyMessage.Source, "/"), blobsToInclude[0]), chk.Equals, 0)
+		c.Check(strings.Compare(strings.Trim(copyMessage.Destination, "/"), blobsToInclude[0]), chk.Equals, 0)
+		c.Check(strings.Compare(string(copyMessage.BlobType), "BlockBlob"), chk.Equals, 0)
+	})
+}
+
+func (s *cmdIntegrationSuite) TestDryrunCopyS3toBlob(c *chk.C) {
+	skipIfS3Disabled(c)
+	s3Client, err := createS3ClientWithMinio(createS3ResOptions{})
+	if err != nil {
+		c.Skip("S3 client credentials not supplied")
+	}
+
+	// set up src s3 bucket
+	bucketName := generateBucketName()
+	createNewBucketWithName(c, s3Client, bucketName, createS3ResOptions{})
+	defer deleteBucket(c, s3Client, bucketName, true)
+	objectList := []string{"AzURE2021.jpeg"}
+	scenarioHelper{}.generateObjects(c, s3Client, bucketName, objectList)
+
+	// initialize dst container
+	dstContainerName := generateContainerName()
+
+	// set up interceptor
+	mockedRPC := interceptor{}
+	Rpc = mockedRPC.intercept
+	mockedLcm := mockedLifecycleManager{dryrunLog: make(chan string, 50)}
+	mockedLcm.SetOutputFormat(common.EOutputFormat.Text()) //text format
+	glcm = &mockedLcm
+
+	// construct the raw input to simulate user input
+	rawSrcS3ObjectURL := scenarioHelper{}.getRawS3ObjectURL(c, "", bucketName, "AzURE2021.jpeg")
+	rawDstContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, dstContainerName)
+	raw := getDefaultRawCopyInput(rawSrcS3ObjectURL.String(), rawDstContainerURLWithSAS.String())
+	raw.dryrun = true
+	raw.recursive = true
+
+	runCopyAndVerify(c, raw, func(err error) {
+		c.Assert(err, chk.IsNil)
+		// validate that none where transferred
+		c.Assert(len(mockedRPC.transfers), chk.Equals, 0)
+
+		msg := mockedLcm.GatherAllLogs(mockedLcm.dryrunLog)
+		dstPath := strings.Split(rawDstContainerURLWithSAS.String(), "?")
+		c.Check(strings.Compare(msg[0], fmt.Sprintf("DRYRUN: copy %v to %v/%v", rawSrcS3ObjectURL.String(), dstPath[0], objectList[0])), chk.Equals, 0)
+	})
+}
+
+func (s *cmdIntegrationSuite) TestDryrunCopyGCPtoBlob(c *chk.C) {
+	//skipIfGCPDisabled(c)
+	gcpClient, err := createGCPClientWithGCSSDK()
+	if err != nil {
+		c.Skip("GCP client credentials not supplied")
+	}
+	// set up src gcp bucket
+	bucketName := generateBucketName()
+	createNewGCPBucketWithName(c, gcpClient, bucketName)
+	defer deleteGCPBucket(c, gcpClient, bucketName, true)
+	blobsToInclude := []string{"AzURE2021.jpeg"}
+	scenarioHelper{}.generateGCPObjects(c, gcpClient, bucketName, blobsToInclude)
+	c.Assert(gcpClient, chk.NotNil)
+
+	// initialiaze dst container
+	dstContainerName := generateContainerName()
+
+	// set up interceptor
+	mockedRPC := interceptor{}
+	Rpc = mockedRPC.intercept
+	mockedLcm := mockedLifecycleManager{dryrunLog: make(chan string, 50)}
+	mockedLcm.SetOutputFormat(common.EOutputFormat.Text()) //text format
+	glcm = &mockedLcm
+
+	// construct the raw input to simulate user input
+	rawSrcGCPObjectURL := scenarioHelper{}.getRawGCPObjectURL(c, bucketName, "AzURE2021.jpeg") // Use default region
+	rawDstContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, dstContainerName)
+	raw := getDefaultRawCopyInput(rawSrcGCPObjectURL.String(), rawDstContainerURLWithSAS.String())
+	raw.dryrun = true
+	raw.recursive = true
+
+	runCopyAndVerify(c, raw, func(err error) {
+		c.Assert(err, chk.IsNil)
+		// validate that none where transferred
+		c.Assert(len(mockedRPC.transfers), chk.Equals, 0)
+
+		msg := mockedLcm.GatherAllLogs(mockedLcm.dryrunLog)
+		dstPath := strings.Split(rawDstContainerURLWithSAS.String(), "?")
+		c.Check(strings.Compare(msg[0], fmt.Sprintf("DRYRUN: copy %v to %v/%v", rawSrcGCPObjectURL.String(), dstPath[0], blobsToInclude[0])), chk.Equals, 0)
 	})
 }

--- a/cmd/zt_copy_blob_download_test.go
+++ b/cmd/zt_copy_blob_download_test.go
@@ -738,7 +738,6 @@ func (s *cmdIntegrationSuite) TestDryrunCopyLocalToBlob(c *chk.C) {
 		c.Assert(len(mockedRPC.transfers), chk.Equals, 0)
 
 		msg := mockedLcm.GatherAllLogs(mockedLcm.dryrunLog)
-		//folder := strings.Split(srcDirName, "\\")
 		for i := 0; i < len(blobsToInclude); i++ {
 			c.Check(strings.Contains(msg[i], "DRYRUN: copy"), chk.Equals, true)
 			c.Check(strings.Contains(msg[i], srcDirName), chk.Equals, true)
@@ -829,7 +828,7 @@ func (s *cmdIntegrationSuite) TestDryrunCopyBlobToBlobJson(c *chk.C) {
 		copyMessage := common.CopyTransfer{}
 		errMarshal := json.Unmarshal([]byte(msg), &copyMessage)
 		c.Assert(errMarshal, chk.IsNil)
-		//comparing some values of deleteTransfer
+		//comparing some values of copyMessage
 		c.Check(strings.Compare(strings.Trim(copyMessage.Source, "/"), blobsToInclude[0]), chk.Equals, 0)
 		c.Check(strings.Compare(strings.Trim(copyMessage.Destination, "/"), blobsToInclude[0]), chk.Equals, 0)
 		c.Check(strings.Compare(copyMessage.EntityType.String(), common.EEntityType.File().String()), chk.Equals, 0)

--- a/cmd/zt_copy_blob_download_test.go
+++ b/cmd/zt_copy_blob_download_test.go
@@ -22,7 +22,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"fmt"
 	"github.com/Azure/azure-pipeline-go/pipeline"
 	"os"
 	"path"
@@ -739,9 +738,12 @@ func (s *cmdIntegrationSuite) TestDryrunCopyLocalToBlob(c *chk.C) {
 		c.Assert(len(mockedRPC.transfers), chk.Equals, 0)
 
 		msg := mockedLcm.GatherAllLogs(mockedLcm.dryrunLog)
-		folder := strings.Split(srcDirName, "\\")
+		//folder := strings.Split(srcDirName, "\\")
 		for i := 0; i < len(blobsToInclude); i++ {
-			c.Check(strings.Compare(msg[i], fmt.Sprintf("DRYRUN: copy %v\\%v to %v/%v/%v", srcDirName, strings.ReplaceAll(blobsToInclude[i], "/", "\\"), dstContainerURL, folder[len(folder)-1], blobsToInclude[i])), chk.Equals, 0)
+			c.Check(strings.Contains(msg[i], "DRYRUN: copy"), chk.Equals, true)
+			c.Check(strings.Contains(msg[i], srcDirName), chk.Equals, true)
+			c.Check(strings.Contains(msg[i], dstContainerURL.String()), chk.Equals, true)
+			c.Check(strings.Contains(msg[i], blobsToInclude[i]), chk.Equals, true)
 		}
 	})
 }
@@ -782,7 +784,10 @@ func (s *cmdIntegrationSuite) TestDryrunCopyBlobToBlob(c *chk.C) {
 
 		msg := mockedLcm.GatherAllLogs(mockedLcm.dryrunLog)
 		for i := 0; i < len(blobsToInclude); i++ {
-			c.Check(strings.Compare(msg[i], fmt.Sprintf("DRYRUN: copy %v/%v to %v/%v", srcContainerURL, blobsToInclude[i], dstContainerURL, blobsToInclude[i])), chk.Equals, 0)
+			c.Check(strings.Contains(msg[i], "DRYRUN: copy"), chk.Equals, true)
+			c.Check(strings.Contains(msg[i], srcContainerURL.String()), chk.Equals, true)
+			c.Check(strings.Contains(msg[i], dstContainerURL.String()), chk.Equals, true)
+			c.Check(strings.Contains(msg[i], blobsToInclude[i]), chk.Equals, true)
 		}
 	})
 }
@@ -869,7 +874,10 @@ func (s *cmdIntegrationSuite) TestDryrunCopyS3toBlob(c *chk.C) {
 
 		msg := mockedLcm.GatherAllLogs(mockedLcm.dryrunLog)
 		dstPath := strings.Split(rawDstContainerURLWithSAS.String(), "?")
-		c.Check(strings.Compare(msg[0], fmt.Sprintf("DRYRUN: copy %v to %v/%v", rawSrcS3ObjectURL.String(), dstPath[0], objectList[0])), chk.Equals, 0)
+		c.Check(strings.Contains(msg[0], "DRYRUN: copy"), chk.Equals, true)
+		c.Check(strings.Contains(msg[0], rawSrcS3ObjectURL.String()), chk.Equals, true)
+		c.Check(strings.Contains(msg[0], dstPath[0]), chk.Equals, true)
+		c.Check(strings.Contains(msg[0], objectList[0]), chk.Equals, true)
 	})
 }
 
@@ -911,6 +919,9 @@ func (s *cmdIntegrationSuite) TestDryrunCopyGCPtoBlob(c *chk.C) {
 
 		msg := mockedLcm.GatherAllLogs(mockedLcm.dryrunLog)
 		dstPath := strings.Split(rawDstContainerURLWithSAS.String(), "?")
-		c.Check(strings.Compare(msg[0], fmt.Sprintf("DRYRUN: copy %v to %v/%v", rawSrcGCPObjectURL.String(), dstPath[0], blobsToInclude[0])), chk.Equals, 0)
+		c.Check(strings.Contains(msg[0], "DRYRUN: copy"), chk.Equals, true)
+		c.Check(strings.Contains(msg[0], rawSrcGCPObjectURL.String()), chk.Equals, true)
+		c.Check(strings.Contains(msg[0], dstPath[0]), chk.Equals, true)
+		c.Check(strings.Contains(msg[0], blobsToInclude[0]), chk.Equals, true)
 	})
 }

--- a/cmd/zt_copy_blob_download_test.go
+++ b/cmd/zt_copy_blob_download_test.go
@@ -810,7 +810,7 @@ func (s *cmdIntegrationSuite) TestDryrunCopyBlobToBlobJson(c *chk.C) {
 	mockedRPC := interceptor{}
 	Rpc = mockedRPC.intercept
 	mockedLcm := mockedLifecycleManager{dryrunLog: make(chan string, 50)}
-	mockedLcm.SetOutputFormat(common.EOutputFormat.Json()) //text format
+	mockedLcm.SetOutputFormat(common.EOutputFormat.Json()) //json format
 	glcm = &mockedLcm
 
 	// construct the raw input to simulate user input
@@ -832,6 +832,7 @@ func (s *cmdIntegrationSuite) TestDryrunCopyBlobToBlobJson(c *chk.C) {
 		//comparing some values of deleteTransfer
 		c.Check(strings.Compare(strings.Trim(copyMessage.Source, "/"), blobsToInclude[0]), chk.Equals, 0)
 		c.Check(strings.Compare(strings.Trim(copyMessage.Destination, "/"), blobsToInclude[0]), chk.Equals, 0)
+		c.Check(strings.Compare(copyMessage.EntityType.String(), common.EEntityType.File().String()), chk.Equals, 0)
 		c.Check(strings.Compare(string(copyMessage.BlobType), "BlockBlob"), chk.Equals, 0)
 	})
 }
@@ -882,7 +883,7 @@ func (s *cmdIntegrationSuite) TestDryrunCopyS3toBlob(c *chk.C) {
 }
 
 func (s *cmdIntegrationSuite) TestDryrunCopyGCPtoBlob(c *chk.C) {
-	//skipIfGCPDisabled(c)
+	skipIfGCPDisabled(c)
 	gcpClient, err := createGCPClientWithGCSSDK()
 	if err != nil {
 		c.Skip("GCP client credentials not supplied")
@@ -895,7 +896,7 @@ func (s *cmdIntegrationSuite) TestDryrunCopyGCPtoBlob(c *chk.C) {
 	scenarioHelper{}.generateGCPObjects(c, gcpClient, bucketName, blobsToInclude)
 	c.Assert(gcpClient, chk.NotNil)
 
-	// initialiaze dst container
+	// initialize dst container
 	dstContainerName := generateContainerName()
 
 	// set up interceptor


### PR DESCRIPTION
copy.go --added flag for dry run
copyEnumeratorInit.go -- call dry run and format for local source
all tests are in zt_copy_blob_download_test.go