### PR TITLE
Dry Run Mode Sync

### DIFF
--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -277,18 +277,25 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 				} else {
 					if cca.fromTo.From() == common.ELocation.Local() {
 						// formatting from local source
-						return fmt.Sprintf("DRYRUN: copy %v%v to %v%v",
-							common.ToShortPath(cca.source.Value),
-							strings.ReplaceAll(srcRelPath, "/", "\\"),
-							strings.Trim(cca.destination.Value, "/"),
-							dstRelPath)
+						dryrunValue := fmt.Sprintf("DRYRUN: copy %v", common.ToShortPath(cca.source.Value))
+						if runtime.GOOS == "windows" {
+							dryrunValue += strings.ReplaceAll(srcRelPath, "/", "\\")
+						} else { //linux and mac
+							dryrunValue += srcRelPath
+						}
+						dryrunValue += fmt.Sprintf(" to %v%v", strings.Trim(cca.destination.Value, "/"), dstRelPath)
+						return dryrunValue
 					} else if cca.fromTo.To() == common.ELocation.Local() {
 						// formatting to local source
-						return fmt.Sprintf("DRYRUN: copy %v%v to %v%v",
-							strings.Trim(cca.source.Value, "/"),
-							srcRelPath,
-							common.ToShortPath(cca.destination.Value),
-							strings.ReplaceAll(dstRelPath, "/", "\\"))
+						dryrunValue := fmt.Sprintf("DRYRUN: copy %v%v to %v",
+							strings.Trim(cca.source.Value, "/"), srcRelPath,
+							common.ToShortPath(cca.destination.Value))
+						if runtime.GOOS == "windows" {
+							dryrunValue += strings.ReplaceAll(dstRelPath, "/", "\\")
+						} else { //linux and mac
+							dryrunValue += dstRelPath
+						}
+						return dryrunValue
 					} else {
 						return fmt.Sprintf("DRYRUN: copy %v%v to %v%v",
 							cca.source.Value,

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -421,7 +421,9 @@ func (cca *cookedSyncCmdArgs) scanningComplete() bool {
 // if blocking is specified to false, then another goroutine spawns and wait out the job
 func (cca *cookedSyncCmdArgs) waitUntilJobCompletion(blocking bool) {
 	// print initial message to indicate that the job is starting
-	glcm.Init(common.GetStandardInitOutputBuilder(cca.jobID.String(), fmt.Sprintf("%s%s%s.log", azcopyLogPathFolder, common.OS_PATH_SEPARATOR, cca.jobID), false, ""))
+	if !cca.dryrunMode {
+		glcm.Init(common.GetStandardInitOutputBuilder(cca.jobID.String(), fmt.Sprintf("%s%s%s.log", azcopyLogPathFolder, common.OS_PATH_SEPARATOR, cca.jobID), false, ""))
+	}
 
 	// initialize the times necessary to track progress
 	cca.jobStartTime = time.Now()
@@ -432,7 +434,7 @@ func (cca *cookedSyncCmdArgs) waitUntilJobCompletion(blocking bool) {
 	if blocking {
 		glcm.InitiateProgressReporting(cca)
 		glcm.SurrenderControl()
-	} else {
+	} else if !cca.dryrunMode {
 		// non-blocking, return after spawning a go routine to watch the job
 		glcm.InitiateProgressReporting(cca)
 	}
@@ -692,6 +694,9 @@ func init() {
 			if err != nil {
 				glcm.Error("Cannot perform sync due to error: " + err.Error())
 			}
+			if cooked.dryrunMode {
+				glcm.Exit(nil, common.EExitCode.Success())
+			}
 
 			glcm.SurrenderControl()
 		},
@@ -735,6 +740,7 @@ func init() {
 	syncCmd.PersistentFlags().StringVar(&raw.cpkScopeInfo, "cpk-by-name", "", "Client provided key by name let clients making requests against Azure Blob storage an option to provide an encryption key on a per-request basis. Provided key name will be fetched from Azure Key Vault and will be used to encrypt the data")
 	syncCmd.PersistentFlags().BoolVar(&raw.cpkInfo, "cpk-by-value", false, "Client provided key by name let clients making requests against Azure Blob storage an option to provide an encryption key on a per-request basis. Provided key and its hash will be fetched from environment variables")
 	syncCmd.PersistentFlags().BoolVar(&raw.mirrorMode, "mirror-mode", false, "Disable last-modified-time based comparison and overwrites the conflicting files and blobs at the destination if this flag is set to true. Default is false")
+	syncCmd.PersistentFlags().BoolVar(&raw.dryrun, "dry-run", false, "Prints the path of files that would be copied or removed by the sync command. This flag does not copy or remove the actual files.")
 
 	// temp, to assist users with change in param names, by providing a clearer message when these obsolete ones are accidentally used
 	syncCmd.PersistentFlags().StringVar(&raw.legacyInclude, "include", "", "Legacy include param. DO NOT USE")

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -421,9 +421,7 @@ func (cca *cookedSyncCmdArgs) scanningComplete() bool {
 // if blocking is specified to false, then another goroutine spawns and wait out the job
 func (cca *cookedSyncCmdArgs) waitUntilJobCompletion(blocking bool) {
 	// print initial message to indicate that the job is starting
-	if !cca.dryrunMode {
-		glcm.Init(common.GetStandardInitOutputBuilder(cca.jobID.String(), fmt.Sprintf("%s%s%s.log", azcopyLogPathFolder, common.OS_PATH_SEPARATOR, cca.jobID), false, ""))
-	}
+	glcm.Init(common.GetStandardInitOutputBuilder(cca.jobID.String(), fmt.Sprintf("%s%s%s.log", azcopyLogPathFolder, common.OS_PATH_SEPARATOR, cca.jobID), false, ""))
 
 	// initialize the times necessary to track progress
 	cca.jobStartTime = time.Now()
@@ -434,7 +432,7 @@ func (cca *cookedSyncCmdArgs) waitUntilJobCompletion(blocking bool) {
 	if blocking {
 		glcm.InitiateProgressReporting(cca)
 		glcm.SurrenderControl()
-	} else if !cca.dryrunMode {
+	} else {
 		// non-blocking, return after spawning a go routine to watch the job
 		glcm.InitiateProgressReporting(cca)
 	}
@@ -652,7 +650,9 @@ func (cca *cookedSyncCmdArgs) process() (err error) {
 	}
 
 	// trigger the progress reporting
-	cca.waitUntilJobCompletion(false)
+	if !cca.dryrunMode {
+		cca.waitUntilJobCompletion(false)
+	}
 
 	// trigger the enumeration
 	err = enumerator.enumerate()

--- a/cmd/syncEnumerator.go
+++ b/cmd/syncEnumerator.go
@@ -122,7 +122,9 @@ func (cca *cookedSyncCmdArgs) initEnumerator(ctx context.Context) (enumerator *s
 
 	// decide our folder transfer strategy
 	fpo, folderMessage := newFolderPropertyOption(cca.fromTo, cca.recursive, true, filters, cca.preserveSMBInfo, cca.preserveSMBPermissions.IsTruthy()) // sync always acts like stripTopDir=true
-	glcm.Info(folderMessage)
+	if !cca.dryrunMode {
+		glcm.Info(folderMessage)
+	}
 	if ste.JobsAdmin != nil {
 		ste.JobsAdmin.LogToJobLog(folderMessage, pipeline.LogInfo)
 	}

--- a/cmd/zt_sync_blob_blob_test.go
+++ b/cmd/zt_sync_blob_blob_test.go
@@ -902,7 +902,7 @@ func (s *cmdIntegrationSuite) TestDryrunSyncBlobtoBlobJson(c *chk.C) {
 		validateS2SSyncTransfersAreScheduled(c, "", "", []string{}, mockedRPC)
 
 		msg := <-mockedLcm.dryrunLog
-		syncMessage := DeleteTransfer{}
+		syncMessage := common.CopyTransfer{}
 		errMarshal := json.Unmarshal([]byte(msg), &syncMessage)
 		c.Assert(errMarshal, chk.IsNil)
 		c.Check(strings.Contains(syncMessage.Source, blobsToDelete[0]), chk.Equals, true)

--- a/cmd/zt_sync_blob_blob_test.go
+++ b/cmd/zt_sync_blob_blob_test.go
@@ -23,6 +23,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"sort"
 	"strings"
 
@@ -816,5 +817,97 @@ func (s *cmdIntegrationSuite) TestSyncS2SWithIncludeAndExcludeRegexFlag(c *chk.C
 		c.Assert(actualTransfer, chk.DeepEquals, blobsToInclude)
 
 		validateS2SSyncTransfersAreScheduled(c, "", "", blobsToInclude, mockedRPC)
+	})
+}
+
+func (s *cmdIntegrationSuite) TestDryrunSyncBlobtoBlob(c *chk.C) {
+	bsu := getBSU()
+
+	//set up src container
+	srcContainerURL, srcContainerName := createNewContainer(c, bsu)
+	defer deleteContainer(c, srcContainerURL)
+	blobsToInclude := []string{"AzURE2.jpeg", "sub1/aTestOne.txt", "sub1/sub2/testTwo.pdf"}
+	scenarioHelper{}.generateBlobsFromList(c, srcContainerURL, blobsToInclude, blockBlobDefaultData)
+
+	//set up dst container
+	dstContainerURL, dstContainerName := createNewContainer(c, bsu)
+	defer deleteContainer(c, dstContainerURL)
+	blobsToDelete := []string{"testThree.jpeg"}
+	scenarioHelper{}.generateBlobsFromList(c, dstContainerURL, blobsToDelete, blockBlobDefaultData)
+
+	// set up interceptor
+	mockedRPC := interceptor{}
+	Rpc = mockedRPC.intercept
+	mockedLcm := mockedLifecycleManager{dryrunLog: make(chan string, 50)}
+	mockedLcm.SetOutputFormat(common.EOutputFormat.Text())
+	glcm = &mockedLcm
+
+	// construct the raw input to simulate user input
+	srcContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, srcContainerName)
+	dstContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, dstContainerName)
+	raw := getDefaultSyncRawInput(srcContainerURLWithSAS.String(), dstContainerURLWithSAS.String())
+	raw.dryrun = true
+	raw.deleteDestination = "true"
+
+	runSyncAndVerify(c, raw, func(err error) {
+		c.Assert(err, chk.IsNil)
+		validateS2SSyncTransfersAreScheduled(c, "", "", []string{}, mockedRPC)
+
+		msg := mockedLcm.GatherAllLogs(mockedLcm.dryrunLog)
+		sort.Strings(msg)
+		for i := 0; i < len(msg); i++ {
+			if strings.Contains(msg[i], "DRYRUN: remove") {
+				c.Check(strings.Contains(msg[i], blobsToDelete[0]), chk.Equals, true)
+				c.Check(strings.Contains(msg[i], dstContainerURL.String()), chk.Equals, true)
+			} else {
+				c.Check(strings.Contains(msg[i], "DRYRUN: copy"), chk.Equals, true)
+				c.Check(strings.Contains(msg[i], blobsToInclude[i]), chk.Equals, true)
+				c.Check(strings.Contains(msg[i], srcContainerURL.String()), chk.Equals, true)
+				c.Check(strings.Contains(msg[i], dstContainerURL.String()), chk.Equals, true)
+			}
+
+		}
+	})
+}
+
+func (s *cmdIntegrationSuite) TestDryrunSyncBlobtoBlobJson(c *chk.C) {
+	bsu := getBSU()
+
+	//set up src container
+	srcContainerURL, srcContainerName := createNewContainer(c, bsu)
+	defer deleteContainer(c, srcContainerURL)
+
+	//set up dst container
+	dstContainerURL, dstContainerName := createNewContainer(c, bsu)
+	defer deleteContainer(c, dstContainerURL)
+	blobsToDelete := []string{"testThree.jpeg"}
+	scenarioHelper{}.generateBlobsFromList(c, dstContainerURL, blobsToDelete, blockBlobDefaultData)
+
+	// set up interceptor
+	mockedRPC := interceptor{}
+	Rpc = mockedRPC.intercept
+	mockedLcm := mockedLifecycleManager{dryrunLog: make(chan string, 50)}
+	mockedLcm.SetOutputFormat(common.EOutputFormat.Json())
+	glcm = &mockedLcm
+
+	// construct the raw input to simulate user input
+	srcContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, srcContainerName)
+	dstContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, dstContainerName)
+	raw := getDefaultSyncRawInput(srcContainerURLWithSAS.String(), dstContainerURLWithSAS.String())
+	raw.dryrun = true
+	raw.deleteDestination = "true"
+
+	runSyncAndVerify(c, raw, func(err error) {
+		c.Assert(err, chk.IsNil)
+		validateS2SSyncTransfersAreScheduled(c, "", "", []string{}, mockedRPC)
+
+		msg := <-mockedLcm.dryrunLog
+		syncMessage := DeleteTransfer{}
+		errMarshal := json.Unmarshal([]byte(msg), &syncMessage)
+		c.Assert(errMarshal, chk.IsNil)
+		c.Check(strings.Contains(syncMessage.Source, blobsToDelete[0]), chk.Equals, true)
+		c.Check(strings.Compare(syncMessage.EntityType.String(), common.EEntityType.File().String()), chk.Equals, 0)
+		c.Check(strings.Compare(string(syncMessage.BlobType), "BlockBlob"), chk.Equals, 0)
+
 	})
 }

--- a/cmd/zt_sync_file_file_test.go
+++ b/cmd/zt_sync_file_file_test.go
@@ -22,6 +22,7 @@ package cmd
 
 import (
 	"context"
+	"sort"
 	"strings"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
@@ -512,5 +513,55 @@ func (s *cmdIntegrationSuite) TestFileSyncS2SBetweenDirs(c *chk.C) {
 	runSyncAndVerify(c, raw, func(err error) {
 		c.Assert(err, chk.IsNil)
 		validateS2SSyncTransfersAreScheduled(c, "", "", expectedList, mockedRPC)
+	})
+}
+
+func (s *cmdIntegrationSuite) TestDryrunSyncFiletoFile(c *chk.C) {
+	fsu := getFSU()
+
+	//set up src share
+	filesToInclude := []string{"AzURE2.jpeg", "TestOne.txt"}
+	srcShareURL, srcShareName := createNewAzureShare(c, fsu)
+	defer deleteShare(c, srcShareURL)
+	scenarioHelper{}.generateAzureFilesFromList(c, srcShareURL, filesToInclude)
+
+	//set up dst share
+	dstShareURL, dstShareName := createNewAzureShare(c, fsu)
+	defer deleteShare(c, dstShareURL)
+	fileToDelete := []string{"testThree.jpeg"}
+	scenarioHelper{}.generateAzureFilesFromList(c, dstShareURL, fileToDelete)
+
+	// set up interceptor
+	mockedRPC := interceptor{}
+	Rpc = mockedRPC.intercept
+	mockedLcm := mockedLifecycleManager{dryrunLog: make(chan string, 50)}
+	mockedLcm.SetOutputFormat(common.EOutputFormat.Text())
+	glcm = &mockedLcm
+
+	// construct the raw input to simulate user input
+	srcShareURLWithSAS := scenarioHelper{}.getRawShareURLWithSAS(c, srcShareName)
+	dstShareURLWithSAS := scenarioHelper{}.getRawShareURLWithSAS(c, dstShareName)
+	raw := getDefaultSyncRawInput(srcShareURLWithSAS.String(), dstShareURLWithSAS.String())
+	raw.dryrun = true
+	raw.deleteDestination = "true"
+
+	runSyncAndVerify(c, raw, func(err error) {
+		c.Assert(err, chk.IsNil)
+		validateS2SSyncTransfersAreScheduled(c, "", "", []string{}, mockedRPC)
+
+		msg := mockedLcm.GatherAllLogs(mockedLcm.dryrunLog)
+		sort.Strings(msg)
+		for i := 0; i < len(msg); i++ {
+			if strings.Contains(msg[i], "DRYRUN: remove") {
+				c.Check(strings.Contains(msg[i], fileToDelete[0]), chk.Equals, true)
+				c.Check(strings.Contains(msg[i], dstShareURL.String()), chk.Equals, true)
+			} else {
+				c.Check(strings.Contains(msg[i], "DRYRUN: copy"), chk.Equals, true)
+				c.Check(strings.Contains(msg[i], filesToInclude[i]), chk.Equals, true)
+				c.Check(strings.Contains(msg[i], srcShareName), chk.Equals, true)
+				c.Check(strings.Contains(msg[i], dstShareURL.String()), chk.Equals, true)
+			}
+
+		}
 	})
 }

--- a/cmd/zt_sync_local_blob_test.go
+++ b/cmd/zt_sync_local_blob_test.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
@@ -399,5 +400,54 @@ func (s *cmdIntegrationSuite) TestSyncUploadWithMissingDestination(c *chk.C) {
 
 		// validate that the right number of transfers were scheduled
 		c.Assert(len(mockedRPC.transfers), chk.Equals, 0)
+	})
+}
+
+func (s *cmdIntegrationSuite) TestDryrunSyncLocaltoBlob(c *chk.C) {
+	bsu := getBSU()
+
+	//set up local src
+	blobsToInclude := []string{"AzURE2.jpeg", "sub1/aTestOne.txt", "sub1/sub2/testTwo.pdf"}
+	srcDirName := scenarioHelper{}.generateLocalDirectory(c)
+	defer os.RemoveAll(srcDirName)
+	scenarioHelper{}.generateLocalFilesFromList(c, srcDirName, blobsToInclude)
+
+	//set up dst container
+	dstContainerURL, dstContainerName := createNewContainer(c, bsu)
+	defer deleteContainer(c, dstContainerURL)
+	blobsToDelete := []string{"testThree.jpeg"}
+	scenarioHelper{}.generateBlobsFromList(c, dstContainerURL, blobsToDelete, blockBlobDefaultData)
+
+	// set up interceptor
+	mockedRPC := interceptor{}
+	Rpc = mockedRPC.intercept
+	mockedLcm := mockedLifecycleManager{dryrunLog: make(chan string, 50)}
+	mockedLcm.SetOutputFormat(common.EOutputFormat.Text())
+	glcm = &mockedLcm
+
+	// construct the raw input to simulate user input
+	dstContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(c, dstContainerName)
+	raw := getDefaultSyncRawInput(srcDirName, dstContainerURLWithSAS.String())
+	raw.dryrun = true
+	raw.deleteDestination = "true"
+
+	runSyncAndVerify(c, raw, func(err error) {
+		c.Assert(err, chk.IsNil)
+		validateS2SSyncTransfersAreScheduled(c, "", "", []string{}, mockedRPC)
+
+		msg := mockedLcm.GatherAllLogs(mockedLcm.dryrunLog)
+		sort.Strings(msg)
+		for i := 0; i < len(msg); i++ {
+			if strings.Contains(msg[i], "DRYRUN: remove") {
+				c.Check(strings.Contains(msg[i], blobsToDelete[0]), chk.Equals, true)
+				c.Check(strings.Contains(msg[i], dstContainerURL.String()), chk.Equals, true)
+			} else {
+				c.Check(strings.Contains(msg[i], "DRYRUN: copy"), chk.Equals, true)
+				c.Check(strings.Contains(msg[i], blobsToInclude[i]), chk.Equals, true)
+				c.Check(strings.Contains(msg[i], srcDirName), chk.Equals, true)
+				c.Check(strings.Contains(msg[i], dstContainerURL.String()), chk.Equals, true)
+			}
+
+		}
 	})
 }


### PR DESCRIPTION
sync.go -- added dry run flag 
syncProcessor.go -- made DeleteTransfer struct to return for json format and called Dryrun() for remove
zc_processor.go -- added copy for sync to Dryrun() 

sample output for sync:
DRYRUN: copy https://carlotatest.blob.core.windows.net/testcontainertwo/test2/technology.txt to https://carlotatest.blob.core.windows.net/testcontainer/test2/technology.txt
DRYRUN: remove https://carlotatest.blob.core.windows.net/testcontainer/to/excelling.xlsx