### PR TITLE
Fixing Version Check

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -196,7 +196,7 @@ func init() {
 func beginDetectNewVersion() chan struct{} {
 	completionChannel := make(chan struct{})
 	go func() {
-		const versionMetadataUrl = "https://aka.ms/azcopyv10-version-metadata"
+		const versionMetadataUrl = "https://azcopyvnextrelease.blob.core.windows.net/releasemetadata/latest_version.txt"
 
 		// step 0: check the Stderr before checking version
 		_, err := os.Stderr.Stat()


### PR DESCRIPTION
The aka.ms link was sending back the cached request ID rather than the real request ID so the versionMetadataUrl is updated to resolve the issue. 