### PR TITLE
Exported APIs required to create custom Enumerator.

### DIFF
--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -97,11 +97,11 @@ func ParseSizeString(s string, name string) (int64, error) {
 // raw benchmark args cook into copyArgs, because the actual work
 // of a benchmark job is doing a copy. Benchmark just doesn't offer so many
 // choices in its raw args
-func (raw rawBenchmarkCmdArgs) cook() (cookedCopyCmdArgs, error) {
+func (raw rawBenchmarkCmdArgs) cook() (CookedCopyCmdArgs, error) {
 
 	glcm.Info(common.BenchmarkPreviewNotice)
 
-	dummyCooked := cookedCopyCmdArgs{}
+	dummyCooked := CookedCopyCmdArgs{}
 	virtualDir := "benchmark-" + azcopyCurrentJobID.String() // create unique directory name, so we won't overwrite anything
 
 	if raw.fileCount <= 0 {
@@ -161,14 +161,14 @@ func (raw rawBenchmarkCmdArgs) cook() (cookedCopyCmdArgs, error) {
 	}
 
 	if downloadMode {
-		glcm.Info(fmt.Sprintf("Benchmarking downloads from %s.", cooked.source.Value))
+		glcm.Info(fmt.Sprintf("Benchmarking downloads from %s.", cooked.Source.Value))
 	} else {
-		glcm.Info(fmt.Sprintf("Benchmarking uploads to %s.", cooked.destination.Value))
+		glcm.Info(fmt.Sprintf("Benchmarking uploads to %s.", cooked.Destination.Value))
 	}
 
 	if !downloadMode && raw.deleteTestData {
 		// set up automatic cleanup
-		cooked.followupJobArgs, err = raw.createCleanupJobArgs(cooked.destination, raw.logVerbosity)
+		cooked.followupJobArgs, err = raw.createCleanupJobArgs(cooked.Destination, raw.logVerbosity)
 		if err != nil {
 			return dummyCooked, err
 		}
@@ -186,7 +186,7 @@ func (raw rawBenchmarkCmdArgs) appendVirtualDir(target, virtualDir string) (stri
 
 	var result url.URL
 
-	switch inferArgumentLocation(target) {
+	switch InferArgumentLocation(target) {
 	case common.ELocation.Blob():
 		p := azblob.NewBlobURLParts(*u)
 		if p.ContainerName == "" || p.BlobName != "" {
@@ -218,7 +218,7 @@ func (raw rawBenchmarkCmdArgs) appendVirtualDir(target, virtualDir string) (stri
 }
 
 // define a cleanup job
-func (raw rawBenchmarkCmdArgs) createCleanupJobArgs(benchmarkDest common.ResourceString, logVerbosity string) (*cookedCopyCmdArgs, error) {
+func (raw rawBenchmarkCmdArgs) createCleanupJobArgs(benchmarkDest common.ResourceString, logVerbosity string) (*CookedCopyCmdArgs, error) {
 
 	rc := rawCopyCmdArgs{}
 
@@ -227,7 +227,7 @@ func (raw rawBenchmarkCmdArgs) createCleanupJobArgs(benchmarkDest common.Resourc
 	rc.recursive = true
 	rc.logVerbosity = logVerbosity
 
-	switch inferArgumentLocation(rc.src) {
+	switch InferArgumentLocation(rc.src) {
 	case common.ELocation.Blob():
 		rc.fromTo = common.EFromTo.BlobTrash().String()
 	case common.ELocation.File():
@@ -315,7 +315,7 @@ func init() {
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			var cooked cookedCopyCmdArgs // benchmark args cook into copy args
+			var cooked CookedCopyCmdArgs // benchmark args cook into copy args
 			cooked, err := raw.cook()
 			if err != nil {
 				glcm.Error("failed to parse user input due to error: " + err.Error())

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -241,25 +241,25 @@ func (raw rawCopyCmdArgs) stripTrailingWildcardOnRemoteSource(location common.Lo
 	return
 }
 
-func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
-	cooked := cookedCopyCmdArgs{
+func (raw rawCopyCmdArgs) cook() (CookedCopyCmdArgs, error) {
+	cooked := CookedCopyCmdArgs{
 		jobID: azcopyCurrentJobID,
 	}
 
-	err := cooked.logVerbosity.Parse(raw.logVerbosity)
+	err := cooked.LogVerbosity.Parse(raw.logVerbosity)
 	if err != nil {
 		return cooked, err
 	}
 
 	// set up the front end scanning logger
-	azcopyScanningLogger = common.NewJobLogger(azcopyCurrentJobID, cooked.logVerbosity, azcopyLogPathFolder, "-scanning")
+	azcopyScanningLogger = common.NewJobLogger(azcopyCurrentJobID, cooked.LogVerbosity, azcopyLogPathFolder, "-scanning")
 	azcopyScanningLogger.OpenLog()
 	glcm.RegisterCloseFunc(func() {
 		azcopyScanningLogger.CloseLog()
 	})
 
 	/* We support DFS by using blob end-point of the account. We replace dfs by blob in src and dst */
-	if src, dst := inferArgumentLocation(raw.src), inferArgumentLocation(raw.dst); src == common.ELocation.BlobFS() || dst == common.ELocation.BlobFS() {
+	if src, dst := InferArgumentLocation(raw.src), InferArgumentLocation(raw.dst); src == common.ELocation.BlobFS() || dst == common.ELocation.BlobFS() {
 		if src == common.ELocation.BlobFS() && dst != common.ELocation.Local() {
 			raw.src = strings.Replace(raw.src, ".dfs", ".blob", 1)
 			glcm.Info("Switching to use blob endpoint on source account.")
@@ -271,7 +271,7 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 		}
 	}
 
-	fromTo, err := validateFromTo(raw.src, raw.dst, raw.fromTo) // TODO: src/dst
+	fromTo, err := ValidateFromTo(raw.src, raw.dst, raw.fromTo) // TODO: src/dst
 	if err != nil {
 		return cooked, err
 	}
@@ -285,7 +285,7 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 
 	// Check if source has a trailing wildcard on a URL
 	if fromTo.From().IsRemote() {
-		tempSrc, cooked.stripTopDir, err = raw.stripTrailingWildcardOnRemoteSource(fromTo.From())
+		tempSrc, cooked.StripTopDir, err = raw.stripTrailingWildcardOnRemoteSource(fromTo.From())
 
 		if err != nil {
 			return cooked, err
@@ -294,32 +294,32 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 		tempSrc = raw.src
 	}
 	if raw.internalOverrideStripTopDir {
-		cooked.stripTopDir = true
+		cooked.StripTopDir = true
 	}
 
 	// Strip the SAS from the source and destination whenever there is SAS exists in URL.
 	// Note: SAS could exists in source of S2S copy, even if the credential type is OAuth for destination.
 
-	cooked.source, err = SplitResourceString(tempSrc, fromTo.From())
+	cooked.Source, err = SplitResourceString(tempSrc, fromTo.From())
 	if err != nil {
 		return cooked, err
 	}
 
-	cooked.destination, err = SplitResourceString(tempDest, fromTo.To())
+	cooked.Destination, err = SplitResourceString(tempDest, fromTo.To())
 	if err != nil {
 		return cooked, err
 	}
 
-	cooked.fromTo = fromTo
-	cooked.recursive = raw.recursive
-	cooked.followSymlinks = raw.followSymlinks
-	cooked.forceIfReadOnly = raw.forceIfReadOnly
-	if err = validateForceIfReadOnly(cooked.forceIfReadOnly, cooked.fromTo); err != nil {
+	cooked.FromTo = fromTo
+	cooked.Recursive = raw.recursive
+	cooked.FollowSymlinks = raw.followSymlinks
+	cooked.ForceIfReadOnly = raw.forceIfReadOnly
+	if err = validateForceIfReadOnly(cooked.ForceIfReadOnly, cooked.FromTo); err != nil {
 		return cooked, err
 	}
 
 	// copy&transform flags to type-safety
-	err = cooked.forceWrite.Parse(raw.forceWrite)
+	err = cooked.ForceWrite.Parse(raw.forceWrite)
 	if err != nil {
 		return cooked, err
 	}
@@ -329,11 +329,11 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 	}
 	cooked.autoDecompress = raw.autoDecompress
 
-	// cooked.stripTopDir is effectively a workaround for the lack of wildcards in remote sources.
+	// cooked.StripTopDir is effectively a workaround for the lack of wildcards in remote sources.
 	// Local, however, still supports wildcards, and thus needs its top directory stripped whenever a wildcard is used.
-	// Thus, we check for wildcards and instruct the processor to strip the top dir later instead of repeatedly checking cca.source for wildcards.
-	if fromTo.From() == common.ELocation.Local() && strings.Contains(cooked.source.ValueLocal(), "*") {
-		cooked.stripTopDir = true
+	// Thus, we check for wildcards and instruct the processor to strip the top dir later instead of repeatedly checking cca.Source for wildcards.
+	if fromTo.From() == common.ELocation.Local() && strings.Contains(cooked.Source.ValueLocal(), "*") {
+		cooked.StripTopDir = true
 	}
 
 	cooked.blockSize, err = blockSizeInBytes(raw.blockSizeMB)
@@ -371,7 +371,7 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 		return cooked, fmt.Errorf("the include and exclude parameters have been replaced by include-pattern; include-path; exclude-pattern and exclude-path. For info, run: azcopy copy help")
 	}
 
-	if (len(raw.include) > 0 || len(raw.exclude) > 0) && cooked.fromTo == common.EFromTo.BlobFSTrash() {
+	if (len(raw.include) > 0 || len(raw.exclude) > 0) && cooked.FromTo == common.EFromTo.BlobFSTrash() {
 		return cooked, fmt.Errorf("include/exclude flags are not supported for this destination")
 		// note there's another, more rigorous check, in removeBfsResources()
 	}
@@ -458,27 +458,27 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 	}
 
 	if raw.listOfFilesToCopy != "" || raw.includePath != "" {
-		cooked.listOfFilesChannel = listChan
+		cooked.ListOfFilesChannel = listChan
 	}
 
 	if raw.includeBefore != "" {
 		// must set chooseEarliest = false, so that if there's an ambiguous local date, the latest will be returned
 		// (since that's safest for includeBefore.  Better to choose the later time and do more work, than the earlier one and fail to pick up a changed file
-		parsedIncludeBefore, err := includeBeforeDateFilter{}.ParseISO8601(raw.includeBefore, false)
+		parsedIncludeBefore, err := IncludeBeforeDateFilter{}.ParseISO8601(raw.includeBefore, false)
 		if err != nil {
 			return cooked, err
 		}
-		cooked.includeBefore = &parsedIncludeBefore
+		cooked.IncludeBefore = &parsedIncludeBefore
 	}
 
 	if raw.includeAfter != "" {
 		// must set chooseEarliest = true, so that if there's an ambiguous local date, the earliest will be returned
 		// (since that's safest for includeAfter.  Better to choose the earlier time and do more work, than the later one and fail to pick up a changed file
-		parsedIncludeAfter, err := includeAfterDateFilter{}.ParseISO8601(raw.includeAfter, true)
+		parsedIncludeAfter, err := IncludeAfterDateFilter{}.ParseISO8601(raw.includeAfter, true)
 		if err != nil {
 			return cooked, err
 		}
-		cooked.includeAfter = &parsedIncludeAfter
+		cooked.IncludeAfter = &parsedIncludeAfter
 	}
 
 	versionsChan := make(chan string)
@@ -517,7 +517,7 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 	}()
 
 	if raw.listOfVersionIDs != "" {
-		cooked.listOfVersionIDs = versionsChan
+		cooked.ListOfVersionIDs = versionsChan
 	}
 
 	cooked.metadata = raw.metadata
@@ -528,10 +528,10 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 	cooked.cacheControl = raw.cacheControl
 	cooked.noGuessMimeType = raw.noGuessMimeType
 	cooked.preserveLastModifiedTime = raw.preserveLastModifiedTime
-	cooked.includeDirectoryStubs = raw.includeDirectoryStubs
+	cooked.IncludeDirectoryStubs = raw.includeDirectoryStubs
 	cooked.disableAutoDecoding = raw.disableAutoDecoding
 
-	if cooked.fromTo.To() != common.ELocation.Blob() && raw.blobTags != "" {
+	if cooked.FromTo.To() != common.ELocation.Blob() && raw.blobTags != "" {
 		return cooked, errors.New("blob tags can only be set when transferring to blob storage")
 	}
 	blobTags := common.ToCommonBlobTagsMap(raw.blobTags)
@@ -545,12 +545,12 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 	// 1. Both source and destination must be blob storages.
 	// 2. `blob-tags` is not present as they create conflicting scenario of whether to preserve blob tags from the source or set user defined tags on the destination
 	if raw.s2sPreserveBlobTags {
-		if cooked.fromTo.From() != common.ELocation.Blob() || cooked.fromTo.To() != common.ELocation.Blob() {
+		if cooked.FromTo.From() != common.ELocation.Blob() || cooked.FromTo.To() != common.ELocation.Blob() {
 			return cooked, errors.New("either source or destination is not a blob storage. blob index tags is a property of blobs only therefore both source and destination must be blob storage")
 		} else if raw.blobTags != "" {
 			return cooked, errors.New("both s2s-preserve-blob-tags and blob-tags flags cannot be used in conjunction")
 		} else {
-			cooked.s2sPreserveBlobTags = raw.s2sPreserveBlobTags
+			cooked.S2sPreserveBlobTags = raw.s2sPreserveBlobTags
 		}
 	}
 
@@ -571,7 +571,7 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 	if cpkOptions.CpkScopeInfo != "" || cpkOptions.CpkInfo {
 		// We only support transfer from source encrypted by user key when user wishes to download.
 		// Due to service limitation, S2S transfer is not supported for source encrypted by user key.
-		if cooked.fromTo.IsDownload() {
+		if cooked.FromTo.IsDownload() {
 			glcm.Info("Client Provided Key (CPK) for encryption/decryption is provided for download scenario. " +
 				"Assuming source is encrypted.")
 			cpkOptions.IsSourceEncrypted = true
@@ -584,7 +584,7 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 		}
 	}
 
-	cooked.cpkOptions = cpkOptions
+	cooked.CpkOptions = cpkOptions
 
 	// Make sure the given input is the one of the enums given by the blob SDK
 	err = cooked.deleteSnapshotsOption.Parse(raw.deleteSnapshotsOption)
@@ -605,7 +605,7 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 
 	cooked.CheckLength = raw.CheckLength
 	// length of devnull will be 0, thus this will always fail unless downloading an empty file
-	if cooked.destination.Value == common.Dev_Null {
+	if cooked.Destination.Value == common.Dev_Null {
 		cooked.CheckLength = false
 	}
 
@@ -614,13 +614,13 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 		glcm.SetOutputFormat(common.EOutputFormat.None())
 	}
 
-	cooked.preserveSMBInfo = areBothLocationsSMBAware(cooked.fromTo)
+	cooked.preserveSMBInfo = areBothLocationsSMBAware(cooked.FromTo)
 	// If user has explicitly specified not to copy SMB Information, set cooked.preserveSMBInfo to false
 	if !raw.preserveSMBInfo {
 		cooked.preserveSMBInfo = false
 	}
 
-	if err = validatePreserveSMBPropertyOption(cooked.preserveSMBInfo, cooked.fromTo, &cooked.forceWrite, "preserve-smb-info"); err != nil {
+	if err = validatePreserveSMBPropertyOption(cooked.preserveSMBInfo, cooked.FromTo, &cooked.ForceWrite, "preserve-smb-info"); err != nil {
 		return cooked, err
 	}
 
@@ -628,27 +628,27 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 		glcm.Info("Please note: the preserve-smb-permissions flag is set to false, thus AzCopy will not copy SMB ACLs between the source and destination.")
 	}
 
-	if err = validatePreserveSMBPropertyOption(raw.preserveSMBPermissions, cooked.fromTo, &cooked.forceWrite, "preserve-smb-permissions"); err != nil {
+	if err = validatePreserveSMBPropertyOption(raw.preserveSMBPermissions, cooked.FromTo, &cooked.ForceWrite, "preserve-smb-permissions"); err != nil {
 		return cooked, err
 	}
-	if err = validatePreserveOwner(raw.preserveOwner, cooked.fromTo); err != nil {
+	if err = validatePreserveOwner(raw.preserveOwner, cooked.FromTo); err != nil {
 		return cooked, err
 	}
-	cooked.preserveSMBPermissions = common.NewPreservePermissionsOption(raw.preserveSMBPermissions, raw.preserveOwner, cooked.fromTo)
+	cooked.preserveSMBPermissions = common.NewPreservePermissionsOption(raw.preserveSMBPermissions, raw.preserveOwner, cooked.FromTo)
 
-	if err = crossValidateSymlinksAndPermissions(cooked.followSymlinks, cooked.preserveSMBPermissions.IsTruthy()); err != nil {
+	if err = crossValidateSymlinksAndPermissions(cooked.FollowSymlinks, cooked.preserveSMBPermissions.IsTruthy()); err != nil {
 		return cooked, err
 	}
 
 	cooked.backupMode = raw.backupMode
-	if err = validateBackupMode(cooked.backupMode, cooked.fromTo); err != nil {
+	if err = validateBackupMode(cooked.backupMode, cooked.FromTo); err != nil {
 		return cooked, err
 	}
 
 	// check for the flag value relative to fromTo location type
 	// Example1: for Local to Blob, preserve-last-modified-time flag should not be set to true
 	// Example2: for Blob to Local, follow-symlinks, blob-tier flags should not be provided with values.
-	switch cooked.fromTo {
+	switch cooked.FromTo {
 	case common.EFromTo.LocalBlobFS():
 		if cooked.blobType != common.EBlobType.Detect() {
 			return cooked, fmt.Errorf("blob-type is not supported on ADLS Gen 2")
@@ -717,7 +717,7 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 	case common.EFromTo.BlobLocal(),
 		common.EFromTo.FileLocal(),
 		common.EFromTo.BlobFSLocal():
-		if cooked.followSymlinks {
+		if cooked.FollowSymlinks {
 			return cooked, fmt.Errorf("follow-symlinks flag is not supported while downloading")
 		}
 		if cooked.blockBlobTier != common.EBlockBlobTier.None() ||
@@ -751,18 +751,18 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 		if cooked.preserveLastModifiedTime {
 			return cooked, fmt.Errorf("preserve-last-modified-time is not supported while copying from service to service")
 		}
-		if cooked.followSymlinks {
+		if cooked.FollowSymlinks {
 			return cooked, fmt.Errorf("follow-symlinks flag is not supported while copying from service to service")
 		}
 		// blob type is not supported if destination is not blob
-		if cooked.blobType != common.EBlobType.Detect() && cooked.fromTo.To() != common.ELocation.Blob() {
-			return cooked, fmt.Errorf("blob-type is not supported for the scenario (%s)", cooked.fromTo.String())
+		if cooked.blobType != common.EBlobType.Detect() && cooked.FromTo.To() != common.ELocation.Blob() {
+			return cooked, fmt.Errorf("blob-type is not supported for the scenario (%s)", cooked.FromTo.String())
 		}
 
 		// Setting blob tier is supported only when destination is a blob storage. Disabling it for all the other transfer scenarios.
 		if (cooked.blockBlobTier != common.EBlockBlobTier.None() || cooked.pageBlobTier != common.EPageBlobTier.None()) &&
-			cooked.fromTo.To() != common.ELocation.Blob() {
-			return cooked, fmt.Errorf("blob-tier is not supported for the scenario (%s)", cooked.fromTo.String())
+			cooked.FromTo.To() != common.ELocation.Blob() {
+			return cooked, fmt.Errorf("blob-tier is not supported for the scenario (%s)", cooked.FromTo.String())
 		}
 		if cooked.noGuessMimeType {
 			return cooked, fmt.Errorf("no-guess-mime-type is not supported while copying from service to service")
@@ -771,10 +771,10 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 			return cooked, fmt.Errorf("content-type, content-encoding, content-language, content-disposition, cache-control, or metadata is not supported while copying from service to service")
 		}
 	}
-	if err = validatePutMd5(cooked.putMd5, cooked.fromTo); err != nil {
+	if err = validatePutMd5(cooked.putMd5, cooked.FromTo); err != nil {
 		return cooked, err
 	}
-	if err = validateMd5Option(cooked.md5ValidationOption, cooked.fromTo); err != nil {
+	if err = validateMd5Option(cooked.md5ValidationOption, cooked.FromTo); err != nil {
 		return cooked, err
 	}
 
@@ -805,15 +805,15 @@ func (raw rawCopyCmdArgs) cook() (cookedCopyCmdArgs, error) {
 	}
 
 	// parse the filter patterns
-	cooked.includePatterns = raw.parsePatterns(raw.include)
-	cooked.excludePatterns = raw.parsePatterns(raw.exclude)
-	cooked.excludePathPatterns = raw.parsePatterns(raw.excludePath)
+	cooked.IncludePatterns = raw.parsePatterns(raw.include)
+	cooked.ExcludePatterns = raw.parsePatterns(raw.exclude)
+	cooked.ExcludePathPatterns = raw.parsePatterns(raw.excludePath)
 
 	if (raw.includeFileAttributes != "" || raw.excludeFileAttributes != "") && fromTo.From() != common.ELocation.Local() {
 		return cooked, errors.New("cannot check file attributes on remote objects")
 	}
-	cooked.includeFileAttributes = raw.parsePatterns(raw.includeFileAttributes)
-	cooked.excludeFileAttributes = raw.parsePatterns(raw.excludeFileAttributes)
+	cooked.IncludeFileAttributes = raw.parsePatterns(raw.includeFileAttributes)
+	cooked.ExcludeFileAttributes = raw.parsePatterns(raw.excludeFileAttributes)
 
 	cooked.includeRegex = raw.parsePatterns(raw.includeRegex)
 	cooked.excludeRegex = raw.parsePatterns(raw.excludeRegex)
@@ -991,36 +991,36 @@ func validateBlobTagsKeyValue(bt common.BlobTags) error {
 }
 
 // represents the processed copy command input from the user
-type cookedCopyCmdArgs struct {
+type CookedCopyCmdArgs struct {
 	// from arguments
-	source      common.ResourceString
-	destination common.ResourceString
-	fromTo      common.FromTo
+	Source      common.ResourceString
+	Destination common.ResourceString
+	FromTo      common.FromTo
 
 	// new include/exclude only apply to file names
 	// implemented for remove (and sync) only
 	// includePathPatterns are handled like a list-of-files. Do not panic. This is not a bug that it is not present here.
-	includePatterns       []string
-	excludePatterns       []string
-	excludePathPatterns   []string
-	includeFileAttributes []string
-	excludeFileAttributes []string
-	includeBefore         *time.Time
-	includeAfter          *time.Time
+	IncludePatterns       []string
+	ExcludePatterns       []string
+	ExcludePathPatterns   []string
+	IncludeFileAttributes []string
+	ExcludeFileAttributes []string
+	IncludeBefore         *time.Time
+	IncludeAfter          *time.Time
 
 	// include/exclude filters with regular expression (also for sync)
 	includeRegex []string
 	excludeRegex []string
 
 	// list of version ids
-	listOfVersionIDs chan string
+	ListOfVersionIDs chan string
 	// filters from flags
-	listOfFilesChannel chan string // Channels are nullable.
-	recursive          bool
-	stripTopDir        bool
-	followSymlinks     bool
-	forceWrite         common.OverwriteOption // says whether we should try to overwrite
-	forceIfReadOnly    bool                   // says whether we should _force_ any overwrites (triggered by forceWrite) to work on Azure Files objects that are set to read-only
+	ListOfFilesChannel chan string // Channels are nullable.
+	Recursive          bool
+	StripTopDir        bool
+	FollowSymlinks     bool
+	ForceWrite         common.OverwriteOption // says whether we should try to overwrite
+	ForceIfReadOnly    bool                   // says whether we should _force_ any overwrites (triggered by forceWrite) to work on Azure Files objects that are set to read-only
 	autoDecompress     bool
 
 	// options from flags
@@ -1045,7 +1045,7 @@ type cookedCopyCmdArgs struct {
 	putMd5                   bool
 	md5ValidationOption      common.HashValidationOption
 	CheckLength              bool
-	logVerbosity             common.LogLevel
+	LogVerbosity             common.LogLevel
 	// commandString hold the user given command which is logged to the Job log file
 	commandString string
 
@@ -1092,19 +1092,19 @@ type cookedCopyCmdArgs struct {
 	// For S2S copy, as source is a remote resource, validating whether source has changed need additional request costs.
 	s2sSourceChangeValidation bool
 	// To specify whether user wants to preserve the blob index tags during service to service transfer.
-	s2sPreserveBlobTags bool
+	S2sPreserveBlobTags bool
 	// specify how user wants to handle invalid metadata.
 	s2sInvalidMetadataHandleOption common.InvalidMetadataHandleOption
 
 	// followup/cleanup properties are NOT available on resume, and so should not be used for jobs that may be resumed
 	// TODO: consider find a way to enforce that, or else to allow them to be preserved. Initially, they are just for benchmark jobs, so not a problem immediately because those jobs can't be resumed, by design.
-	followupJobArgs   *cookedCopyCmdArgs
+	followupJobArgs   *CookedCopyCmdArgs
 	priorJobExitCode  *common.ExitCode
 	isCleanupJob      bool // triggers abbreviated status reporting, since we don't want full reporting for cleanup jobs
 	cleanupJobMessage string
 
 	// whether to include blobs that have metadata 'hdi_isfolder = true'
-	includeDirectoryStubs bool
+	IncludeDirectoryStubs bool
 
 	// whether to disable automatic decoding of illegal chars on Windows
 	disableAutoDecoding bool
@@ -1112,11 +1112,11 @@ type cookedCopyCmdArgs struct {
 	// specify if dry run mode on
 	dryrunMode bool
 
-	cpkOptions common.CpkOptions
+	CpkOptions common.CpkOptions
 }
 
-func (cca *cookedCopyCmdArgs) isRedirection() bool {
-	switch cca.fromTo {
+func (cca *CookedCopyCmdArgs) isRedirection() bool {
+	switch cca.FromTo {
 	case common.EFromTo.BlobPipe():
 		fallthrough
 	case common.EFromTo.PipeBlob():
@@ -1126,9 +1126,9 @@ func (cca *cookedCopyCmdArgs) isRedirection() bool {
 	}
 }
 
-func (cca *cookedCopyCmdArgs) process() error {
+func (cca *CookedCopyCmdArgs) process() error {
 
-	err := common.SetBackupMode(cca.backupMode, cca.fromTo)
+	err := common.SetBackupMode(cca.backupMode, cca.FromTo)
 	if err != nil {
 		return err
 	}
@@ -1147,17 +1147,17 @@ func (cca *cookedCopyCmdArgs) process() error {
 }
 
 // TODO discuss with Jeff what features should be supported by redirection, such as metadata, content-type, etc.
-func (cca *cookedCopyCmdArgs) processRedirectionCopy() error {
-	if cca.fromTo == common.EFromTo.PipeBlob() {
-		return cca.processRedirectionUpload(cca.destination, cca.blockSize)
-	} else if cca.fromTo == common.EFromTo.BlobPipe() {
-		return cca.processRedirectionDownload(cca.source)
+func (cca *CookedCopyCmdArgs) processRedirectionCopy() error {
+	if cca.FromTo == common.EFromTo.PipeBlob() {
+		return cca.processRedirectionUpload(cca.Destination, cca.blockSize)
+	} else if cca.FromTo == common.EFromTo.BlobPipe() {
+		return cca.processRedirectionDownload(cca.Source)
 	}
 
-	return fmt.Errorf("unsupported redirection type: %s", cca.fromTo)
+	return fmt.Errorf("unsupported redirection type: %s", cca.FromTo)
 }
 
-func (cca *cookedCopyCmdArgs) processRedirectionDownload(blobResource common.ResourceString) error {
+func (cca *CookedCopyCmdArgs) processRedirectionDownload(blobResource common.ResourceString) error {
 
 	ctx := context.WithValue(context.TODO(), ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
 
@@ -1169,8 +1169,8 @@ func (cca *cookedCopyCmdArgs) processRedirectionDownload(blobResource common.Res
 
 	// The isPublic flag is useful in S2S transfers but doesn't much matter for download. Fortunately, no S2S happens here.
 	// This means that if there's auth, there's auth. We're happy and can move on.
-	// getCredentialInfoForLocation also populates oauth token fields... so, it's very easy.
-	credInfo, _, err := getCredentialInfoForLocation(ctx, common.ELocation.Blob(), blobResource.Value, blobResource.SAS, true, cca.cpkOptions)
+	// GetCredentialInfoForLocation also populates oauth token fields... so, it's very easy.
+	credInfo, _, err := GetCredentialInfoForLocation(ctx, common.ELocation.Blob(), blobResource.Value, blobResource.SAS, true, cca.CpkOptions)
 
 	if err != nil {
 		return fmt.Errorf("fatal: cannot find auth on source blob URL: %s", err.Error())
@@ -1191,8 +1191,8 @@ func (cca *cookedCopyCmdArgs) processRedirectionDownload(blobResource common.Res
 	// step 3: start download
 	blobURL := azblob.NewBlobURL(*u, p)
 	clientProvidedKey := azblob.ClientProvidedKeyOptions{}
-	if cca.cpkOptions.IsSourceEncrypted {
-		clientProvidedKey = common.GetClientProvidedKey(cca.cpkOptions)
+	if cca.CpkOptions.IsSourceEncrypted {
+		clientProvidedKey = common.GetClientProvidedKey(cca.CpkOptions)
 	}
 	blobStream, err := blobURL.Download(ctx, 0, azblob.CountToEnd, azblob.BlobAccessConditions{}, false, clientProvidedKey)
 	if err != nil {
@@ -1211,7 +1211,7 @@ func (cca *cookedCopyCmdArgs) processRedirectionDownload(blobResource common.Res
 	return nil
 }
 
-func (cca *cookedCopyCmdArgs) processRedirectionUpload(blobResource common.ResourceString, blockSize int64) error {
+func (cca *CookedCopyCmdArgs) processRedirectionUpload(blobResource common.ResourceString, blockSize int64) error {
 	ctx := context.WithValue(context.TODO(), ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
 
 	// if no block size is set, then use default value
@@ -1219,8 +1219,8 @@ func (cca *cookedCopyCmdArgs) processRedirectionUpload(blobResource common.Resou
 		blockSize = pipingDefaultBlockSize
 	}
 
-	// getCredentialInfoForLocation populates oauth token fields... so, it's very easy.
-	credInfo, _, err := getCredentialInfoForLocation(ctx, common.ELocation.Blob(), blobResource.Value, blobResource.SAS, false, cca.cpkOptions)
+	// GetCredentialInfoForLocation populates oauth token fields... so, it's very easy.
+	credInfo, _, err := GetCredentialInfoForLocation(ctx, common.ELocation.Blob(), blobResource.Value, blobResource.SAS, false, cca.CpkOptions)
 
 	if err != nil {
 		return fmt.Errorf("fatal: cannot find auth on source blob URL: %s", err.Error())
@@ -1266,7 +1266,7 @@ func (cca *cookedCopyCmdArgs) processRedirectionUpload(blobResource common.Resou
 			CacheControl:       cca.cacheControl,
 		},
 		BlobAccessTier:           bbAccessTier,
-		ClientProvidedKeyOptions: common.GetClientProvidedKey(cca.cpkOptions),
+		ClientProvidedKeyOptions: common.GetClientProvidedKey(cca.CpkOptions),
 	})
 
 	return err
@@ -1274,7 +1274,7 @@ func (cca *cookedCopyCmdArgs) processRedirectionUpload(blobResource common.Resou
 
 // handles the copy command
 // dispatches the job order (in parts) to the storage engine
-func (cca *cookedCopyCmdArgs) processCopyJobPartOrders() (err error) {
+func (cca *CookedCopyCmdArgs) processCopyJobPartOrders() (err error) {
 	ctx := context.WithValue(context.TODO(), ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
 
 	// Note: credential info here is only used by remove at the moment.
@@ -1285,12 +1285,12 @@ func (cca *cookedCopyCmdArgs) processCopyJobPartOrders() (err error) {
 	// For upload&download, only one side need credential.
 	// For S2S copy, as azcopy-v10 use Put*FromUrl, only one credential is needed for destination.
 	if cca.credentialInfo.CredentialType, err = getCredentialType(ctx, rawFromToInfo{
-		fromTo:         cca.fromTo,
-		source:         cca.source.Value,
-		destination:    cca.destination.Value,
-		sourceSAS:      cca.source.SAS,
-		destinationSAS: cca.destination.SAS,
-	}, cca.cpkOptions); err != nil {
+		fromTo:         cca.FromTo,
+		source:         cca.Source.Value,
+		destination:    cca.Destination.Value,
+		sourceSAS:      cca.Source.SAS,
+		destinationSAS: cca.Destination.SAS,
+	}, cca.CpkOptions); err != nil {
 		return err
 	}
 
@@ -1310,12 +1310,12 @@ func (cca *cookedCopyCmdArgs) processCopyJobPartOrders() (err error) {
 	// and for which we have sufficient info now to set them
 	jobPartOrder := common.CopyJobPartOrderRequest{
 		JobID:           cca.jobID,
-		FromTo:          cca.fromTo,
-		ForceWrite:      cca.forceWrite,
-		ForceIfReadOnly: cca.forceIfReadOnly,
+		FromTo:          cca.FromTo,
+		ForceWrite:      cca.ForceWrite,
+		ForceIfReadOnly: cca.ForceIfReadOnly,
 		AutoDecompress:  cca.autoDecompress,
 		Priority:        common.EJobPriority.Normal(),
-		LogLevel:        cca.logVerbosity,
+		LogLevel:        cca.LogVerbosity,
 		ExcludeBlobType: cca.excludeBlobType,
 		BlobAttributes: common.BlobTransferAttributes{
 			BlobType:                 cca.blobType,
@@ -1340,29 +1340,29 @@ func (cca *cookedCopyCmdArgs) processCopyJobPartOrders() (err error) {
 		CredentialInfo: cca.credentialInfo,
 	}
 
-	from := cca.fromTo.From()
+	from := cca.FromTo.From()
 
-	jobPartOrder.DestinationRoot = cca.destination
+	jobPartOrder.DestinationRoot = cca.Destination
 
-	jobPartOrder.SourceRoot = cca.source
-	jobPartOrder.SourceRoot.Value, err = GetResourceRoot(cca.source.Value, from)
+	jobPartOrder.SourceRoot = cca.Source
+	jobPartOrder.SourceRoot.Value, err = GetResourceRoot(cca.Source.Value, from)
 	if err != nil {
 		return err
 	}
 
 	// Stripping the trailing /* for local occurs much later than stripping the trailing /* for remote resources.
 	// TODO: Move these into the same place for maintainability.
-	if diff := strings.TrimPrefix(cca.source.Value, jobPartOrder.SourceRoot.Value); cca.fromTo.From().IsLocal() &&
+	if diff := strings.TrimPrefix(cca.Source.Value, jobPartOrder.SourceRoot.Value); cca.FromTo.From().IsLocal() &&
 		diff == "*" || diff == common.OS_PATH_SEPARATOR+"*" || diff == common.AZCOPY_PATH_SEPARATOR_STRING+"*" {
 		// trim the /*
-		cca.source.Value = jobPartOrder.SourceRoot.Value
+		cca.Source.Value = jobPartOrder.SourceRoot.Value
 		// set stripTopDir to true so that --list-of-files/--include-path play nice
-		cca.stripTopDir = true
+		cca.StripTopDir = true
 	}
 
 	// depending on the source and destination type, we process the cp command differently
 	// Create enumerator and do enumerating
-	switch cca.fromTo {
+	switch cca.FromTo {
 	case common.EFromTo.LocalBlob(),
 		common.EFromTo.LocalBlobFS(),
 		common.EFromTo.LocalFile(),
@@ -1379,7 +1379,7 @@ func (cca *cookedCopyCmdArgs) processCopyJobPartOrders() (err error) {
 		common.EFromTo.BenchmarkBlobFS(),
 		common.EFromTo.BenchmarkFile():
 
-		var e *copyEnumerator
+		var e *CopyEnumerator
 		e, err = cca.initEnumerator(jobPartOrder, ctx)
 		if err != nil {
 			return err
@@ -1403,7 +1403,7 @@ func (cca *cookedCopyCmdArgs) processCopyJobPartOrders() (err error) {
 	// 	e := copyFileToNEnumerator(jobPartOrder)
 	// 	err = e.enumerate(cca)
 	default:
-		return fmt.Errorf("copy direction %v is not supported\n", cca.fromTo)
+		return fmt.Errorf("copy direction %v is not supported\n", cca.FromTo)
 	}
 
 	if err != nil {
@@ -1420,7 +1420,7 @@ func (cca *cookedCopyCmdArgs) processCopyJobPartOrders() (err error) {
 // wraps call to lifecycle manager to wait for the job to complete
 // if blocking is specified to true, then this method will never return
 // if blocking is specified to false, then another goroutine spawns and wait out the job
-func (cca *cookedCopyCmdArgs) waitUntilJobCompletion(blocking bool) {
+func (cca *CookedCopyCmdArgs) waitUntilJobCompletion(blocking bool) {
 	// print initial message to indicate that the job is starting
 	// if on dry run mode do not want to print message since no  job is being done
 	if !cca.dryrunMode {
@@ -1448,7 +1448,7 @@ func (cca *cookedCopyCmdArgs) waitUntilJobCompletion(blocking bool) {
 	}
 }
 
-func (cca *cookedCopyCmdArgs) Cancel(lcm common.LifecycleMgr) {
+func (cca *CookedCopyCmdArgs) Cancel(lcm common.LifecycleMgr) {
 	// prompt for confirmation, except when enumeration is complete
 	if !cca.isEnumerationComplete {
 		answer := lcm.Prompt("The source enumeration is not complete, "+
@@ -1473,11 +1473,11 @@ func (cca *cookedCopyCmdArgs) Cancel(lcm common.LifecycleMgr) {
 	}
 }
 
-func (cca *cookedCopyCmdArgs) hasFollowup() bool {
+func (cca *CookedCopyCmdArgs) hasFollowup() bool {
 	return cca.followupJobArgs != nil
 }
 
-func (cca *cookedCopyCmdArgs) launchFollowup(priorJobExitCode common.ExitCode) {
+func (cca *CookedCopyCmdArgs) launchFollowup(priorJobExitCode common.ExitCode) {
 	go func() {
 		glcm.AllowReinitiateProgressReporting()
 		cca.followupJobArgs.priorJobExitCode = &priorJobExitCode
@@ -1492,7 +1492,7 @@ func (cca *cookedCopyCmdArgs) launchFollowup(priorJobExitCode common.ExitCode) {
 	}()
 }
 
-func (cca *cookedCopyCmdArgs) getSuccessExitCode() common.ExitCode {
+func (cca *CookedCopyCmdArgs) getSuccessExitCode() common.ExitCode {
 	if cca.priorJobExitCode != nil {
 		return *cca.priorJobExitCode // in a chain of jobs our best case outcome is whatever the predecessor(s) finished with
 	} else {
@@ -1500,7 +1500,7 @@ func (cca *cookedCopyCmdArgs) getSuccessExitCode() common.ExitCode {
 	}
 }
 
-func (cca *cookedCopyCmdArgs) ReportProgressOrExit(lcm common.LifecycleMgr) (totalKnownCount uint32) {
+func (cca *CookedCopyCmdArgs) ReportProgressOrExit(lcm common.LifecycleMgr) (totalKnownCount uint32) {
 	// fetch a job status
 	var summary common.ListJobSummaryResponse
 	Rpc(common.ERpcCmd.ListJobSummary(), &cca.jobID, &summary)
@@ -1528,7 +1528,7 @@ func (cca *cookedCopyCmdArgs) ReportProgressOrExit(lcm common.LifecycleMgr) (tot
 				common.PanicIfErr(err)
 				return string(jsonOutput)
 			} else {
-				screenStats, logStats := formatExtraStats(cca.fromTo, summary.AverageIOPS, summary.AverageE2EMilliseconds, summary.NetworkErrorPercentage, summary.ServerBusyPercentage)
+				screenStats, logStats := formatExtraStats(cca.FromTo, summary.AverageIOPS, summary.AverageE2EMilliseconds, summary.NetworkErrorPercentage, summary.ServerBusyPercentage)
 
 				output := fmt.Sprintf(
 					`
@@ -1618,7 +1618,7 @@ Final Job Status: %v%s%s
 			}
 
 			// indicate whether constrained by disk or not
-			isBenchmark := cca.fromTo.From() == common.ELocation.Benchmark()
+			isBenchmark := cca.FromTo.From() == common.ELocation.Benchmark()
 			perfString, diskString := getPerfDisplayText(summary.PerfStrings, summary.PerfConstraint, duration, isBenchmark)
 
 			return fmt.Sprintf("%.1f %%, %v Done, %v Failed, %v Pending, %v Skipped, %v Total%s, %s%s%s",

--- a/cmd/copyEnumeratorHelper.go
+++ b/cmd/copyEnumeratorHelper.go
@@ -10,11 +10,11 @@ import (
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
-var enumerationParallelism = 1
-var enumerationParallelStatFiles = false
+var EnumerationParallelism = 1
+var EnumerationParallelStatFiles = false
 
 // addTransfer accepts a new transfer, if the threshold is reached, dispatch a job part order.
-func addTransfer(e *common.CopyJobPartOrderRequest, transfer common.CopyTransfer, cca *cookedCopyCmdArgs) error {
+func addTransfer(e *common.CopyJobPartOrderRequest, transfer common.CopyTransfer, cca *CookedCopyCmdArgs) error {
 	// Remove the source and destination roots from the path to save space in the plan files
 	transfer.Source = strings.TrimPrefix(transfer.Source, e.SourceRoot.Value)
 	transfer.Destination = strings.TrimPrefix(transfer.Destination, e.DestinationRoot.Value)
@@ -64,7 +64,7 @@ func shuffleTransfers(transfers []common.CopyTransfer) {
 
 // we need to send a last part with isFinalPart set to true, along with whatever transfers that still haven't been sent
 // dispatchFinalPart sends a last part with isFinalPart set to true, along with whatever transfers that still haven't been sent.
-func dispatchFinalPart(e *common.CopyJobPartOrderRequest, cca *cookedCopyCmdArgs) error {
+func dispatchFinalPart(e *common.CopyJobPartOrderRequest, cca *CookedCopyCmdArgs) error {
 	shuffleTransfers(e.Transfers.List)
 	e.IsFinalPart = true
 	var resp common.CopyJobPartOrderResponse

--- a/cmd/copyEnumeratorHelper_test.go
+++ b/cmd/copyEnumeratorHelper_test.go
@@ -54,7 +54,7 @@ func (s *copyEnumeratorHelperTestSuite) TestAddTransferPathRootsTrimmed(c *chk.C
 	}
 
 	// execute
-	err := addTransfer(&request, transfer, &cookedCopyCmdArgs{})
+	err := addTransfer(&request, transfer, &CookedCopyCmdArgs{})
 
 	// assert
 	c.Assert(err, chk.IsNil)

--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -27,11 +27,11 @@ type BucketToContainerNameResolver interface {
 	ResolveName(bucketName string) (string, error)
 }
 
-func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrderRequest, ctx context.Context) (*copyEnumerator, error) {
-	var traverser resourceTraverser
+func (cca *CookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrderRequest, ctx context.Context) (*CopyEnumerator, error) {
+	var traverser ResourceTraverser
 
 	// Warn about GCP -> Blob being in preview. Also, we do not support GCP as destination.
-	if cca.fromTo.From() == common.ELocation.GCP() {
+	if cca.FromTo.From() == common.ELocation.GCP() {
 		glcm.Info("Google Cloud Storage to Azure Blob copy is currently in preview. Validate the copy operation carefully before removing your data at source.")
 	}
 
@@ -39,17 +39,17 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 	var isPublic bool
 	var err error
 
-	if srcCredInfo, isPublic, err = getCredentialInfoForLocation(ctx, cca.fromTo.From(), cca.source.Value, cca.source.SAS, true, cca.cpkOptions); err != nil {
+	if srcCredInfo, isPublic, err = GetCredentialInfoForLocation(ctx, cca.FromTo.From(), cca.Source.Value, cca.Source.SAS, true, cca.CpkOptions); err != nil {
 		return nil, err
 		// If S2S and source takes OAuthToken as its cred type (OR) source takes anonymous as its cred type, but it's not public and there's no SAS
-	} else if cca.fromTo.From().IsRemote() && cca.fromTo.To().IsRemote() &&
+	} else if cca.FromTo.From().IsRemote() && cca.FromTo.To().IsRemote() &&
 		(srcCredInfo.CredentialType == common.ECredentialType.OAuthToken() ||
-			(srcCredInfo.CredentialType == common.ECredentialType.Anonymous() && !isPublic && cca.source.SAS == "")) {
+			(srcCredInfo.CredentialType == common.ECredentialType.Anonymous() && !isPublic && cca.Source.SAS == "")) {
 		// TODO: Generate a SAS token if it's blob -> *
 		return nil, errors.New("a SAS token (or S3 access key) is required as a part of the source in S2S transfers, unless the source is a public resource")
 	}
 
-	jobPartOrder.CpkOptions = cca.cpkOptions
+	jobPartOrder.CpkOptions = cca.CpkOptions
 	jobPartOrder.PreserveSMBPermissions = cca.preserveSMBPermissions
 	jobPartOrder.PreserveSMBInfo = cca.preserveSMBInfo
 
@@ -57,43 +57,43 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 	// On S2S transfers the following rules apply:
 	// If preserve properties is enabled, but get properties in backend is disabled, turn it on
 	// If source change validation is enabled on files to remote, turn it on (consider a separate flag entirely?)
-	getRemoteProperties := cca.forceWrite == common.EOverwriteOption.IfSourceNewer() ||
-		(cca.fromTo.From() == common.ELocation.File() && !cca.fromTo.To().IsRemote()) || // If download, we still need LMT and MD5 from files.
-		(cca.fromTo.From() == common.ELocation.File() && cca.fromTo.To().IsRemote() && (cca.s2sSourceChangeValidation || cca.includeAfter != nil)) || // If S2S from File to *, and sourceChangeValidation is enabled, we get properties so that we have LMTs. Likewise if we are using includeAfter, which requires LMTs.
-		(cca.fromTo.From().IsRemote() && cca.fromTo.To().IsRemote() && cca.s2sPreserveProperties && !cca.s2sGetPropertiesInBackend) // If S2S and preserve properties AND get properties in backend is on, turn this off, as properties will be obtained in the backend.
+	getRemoteProperties := cca.ForceWrite == common.EOverwriteOption.IfSourceNewer() ||
+		(cca.FromTo.From() == common.ELocation.File() && !cca.FromTo.To().IsRemote()) || // If download, we still need LMT and MD5 from files.
+		(cca.FromTo.From() == common.ELocation.File() && cca.FromTo.To().IsRemote() && (cca.s2sSourceChangeValidation || cca.IncludeAfter != nil)) || // If S2S from File to *, and sourceChangeValidation is enabled, we get properties so that we have LMTs. Likewise if we are using includeAfter, which requires LMTs.
+		(cca.FromTo.From().IsRemote() && cca.FromTo.To().IsRemote() && cca.s2sPreserveProperties && !cca.s2sGetPropertiesInBackend) // If S2S and preserve properties AND get properties in backend is on, turn this off, as properties will be obtained in the backend.
 	jobPartOrder.S2SGetPropertiesInBackend = cca.s2sPreserveProperties && !getRemoteProperties && cca.s2sGetPropertiesInBackend // Infer GetProperties if GetPropertiesInBackend is enabled.
 	jobPartOrder.S2SSourceChangeValidation = cca.s2sSourceChangeValidation
 	jobPartOrder.DestLengthValidation = cca.CheckLength
 	jobPartOrder.S2SInvalidMetadataHandleOption = cca.s2sInvalidMetadataHandleOption
-	jobPartOrder.S2SPreserveBlobTags = cca.s2sPreserveBlobTags
+	jobPartOrder.S2SPreserveBlobTags = cca.S2sPreserveBlobTags
 
-	traverser, err = initResourceTraverser(cca.source, cca.fromTo.From(), &ctx, &srcCredInfo,
-		&cca.followSymlinks, cca.listOfFilesChannel, cca.recursive, getRemoteProperties,
-		cca.includeDirectoryStubs, func(common.EntityType) {}, cca.listOfVersionIDs,
-		cca.s2sPreserveBlobTags, cca.logVerbosity.ToPipelineLogLevel(), cca.cpkOptions)
+	traverser, err = InitResourceTraverser(cca.Source, cca.FromTo.From(), &ctx, &srcCredInfo,
+		&cca.FollowSymlinks, cca.ListOfFilesChannel, cca.Recursive, getRemoteProperties,
+		cca.IncludeDirectoryStubs, func(common.EntityType) {}, cca.ListOfVersionIDs,
+		cca.S2sPreserveBlobTags, cca.LogVerbosity.ToPipelineLogLevel(), cca.CpkOptions)
 
 	if err != nil {
 		return nil, err
 	}
 
 	// Ensure we're only copying from a directory with a trailing wildcard or recursive.
-	isSourceDir := traverser.isDirectory(true)
-	if isSourceDir && !cca.recursive && !cca.stripTopDir {
+	isSourceDir := traverser.IsDirectory(true)
+	if isSourceDir && !cca.Recursive && !cca.StripTopDir {
 		return nil, errors.New("cannot use directory as source without --recursive or a trailing wildcard (/*)")
 	}
 
 	// Check if the destination is a directory so we can correctly decide where our files land
-	isDestDir := cca.isDestDirectory(cca.destination, &ctx)
-	if cca.listOfVersionIDs != nil && (!(cca.fromTo == common.EFromTo.BlobLocal() || cca.fromTo == common.EFromTo.BlobTrash()) || isSourceDir || !isDestDir) {
+	isDestDir := cca.isDestDirectory(cca.Destination, &ctx)
+	if cca.ListOfVersionIDs != nil && (!(cca.FromTo == common.EFromTo.BlobLocal() || cca.FromTo == common.EFromTo.BlobTrash()) || isSourceDir || !isDestDir) {
 		log.Fatalf("Either source is not a blob or destination is not a local folder")
 	}
-	srcLevel, err := determineLocationLevel(cca.source.Value, cca.fromTo.From(), true)
+	srcLevel, err := DetermineLocationLevel(cca.Source.Value, cca.FromTo.From(), true)
 
 	if err != nil {
 		return nil, err
 	}
 
-	dstLevel, err := determineLocationLevel(cca.destination.Value, cca.fromTo.To(), false)
+	dstLevel, err := DetermineLocationLevel(cca.Destination.Value, cca.FromTo.To(), false)
 
 	if err != nil {
 		return nil, err
@@ -105,24 +105,24 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 	//       1) Account name doesn't get trimmed from the path
 	//       2) List-of-files is not considered an account traverser; therefore containers don't get made.
 	//       Resolve these two issues and service-level list-of-files/include-path will work
-	if cca.listOfFilesChannel != nil && srcLevel == ELocationLevel.Service() {
+	if cca.ListOfFilesChannel != nil && srcLevel == ELocationLevel.Service() {
 		return nil, errors.New("cannot combine list-of-files or include-path with account traversal")
 	}
 
-	if (srcLevel == ELocationLevel.Object() || cca.fromTo.From().IsLocal()) && dstLevel == ELocationLevel.Service() {
+	if (srcLevel == ELocationLevel.Object() || cca.FromTo.From().IsLocal()) && dstLevel == ELocationLevel.Service() {
 		return nil, errors.New("cannot transfer individual files/folders to the root of a service. Add a container or directory to the destination URL")
 	}
 
 	// When copying a container directly to a container, strip the top directory
-	if srcLevel == ELocationLevel.Container() && dstLevel == ELocationLevel.Container() && cca.fromTo.From().IsRemote() && cca.fromTo.To().IsRemote() {
-		cca.stripTopDir = true
+	if srcLevel == ELocationLevel.Container() && dstLevel == ELocationLevel.Container() && cca.FromTo.From().IsRemote() && cca.FromTo.To().IsRemote() {
+		cca.StripTopDir = true
 	}
 
 	// Create a Remote resource resolver
 	// Giving it nothing to work with as new names will be added as we traverse.
 	var containerResolver BucketToContainerNameResolver
 	containerResolver = NewS3BucketNameToAzureResourcesResolver(nil)
-	if cca.fromTo == common.EFromTo.GCPBlob() {
+	if cca.FromTo == common.EFromTo.GCPBlob() {
 		containerResolver = NewGCPBucketNameToAzureResourcesResolver(nil)
 	}
 	existingContainers := make(map[string]bool)
@@ -131,17 +131,17 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 
 	dstContainerName := ""
 	// Extract the existing destination container name
-	if cca.fromTo.To().IsRemote() {
-		dstContainerName, err = GetContainerName(cca.destination.Value, cca.fromTo.To())
+	if cca.FromTo.To().IsRemote() {
+		dstContainerName, err = GetContainerName(cca.Destination.Value, cca.FromTo.To())
 
 		if err != nil {
 			return nil, err
 		}
 
 		// only create the destination container in S2S scenarios
-		if cca.fromTo.From().IsRemote() && dstContainerName != "" { // if the destination has a explicit container name
+		if cca.FromTo.From().IsRemote() && dstContainerName != "" { // if the destination has a explicit container name
 			// Attempt to create the container. If we fail, fail silently.
-			err = cca.createDstContainer(dstContainerName, cca.destination, ctx, existingContainers, cca.logVerbosity)
+			err = cca.createDstContainer(dstContainerName, cca.Destination, ctx, existingContainers, cca.LogVerbosity)
 
 			// check against seenFailedContainers so we don't spam the job log with initialization failed errors
 			if _, ok := seenFailedContainers[dstContainerName]; err != nil && ste.JobsAdmin != nil && !ok {
@@ -151,8 +151,8 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 				ste.JobsAdmin.LogToJobLog(fmt.Sprintf("failed to initialize destination container %s; the transfer will continue (but be wary it may fail): %s", dstContainerName, err), pipeline.LogWarning)
 				seenFailedContainers[dstContainerName] = true
 			}
-		} else if cca.fromTo.From().IsRemote() { // if the destination has implicit container names
-			if acctTraverser, ok := traverser.(accountTraverser); ok && dstLevel == ELocationLevel.Service() {
+		} else if cca.FromTo.From().IsRemote() { // if the destination has implicit container names
+			if acctTraverser, ok := traverser.(AccountTraverser); ok && dstLevel == ELocationLevel.Service() {
 				containers, err := acctTraverser.listContainers()
 
 				if err != nil {
@@ -161,9 +161,9 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 
 				// Resolve all container names up front.
 				// If we were to resolve on-the-fly, then name order would affect the results inconsistently.
-				if cca.fromTo == common.EFromTo.S3Blob() {
+				if cca.FromTo == common.EFromTo.S3Blob() {
 					containerResolver = NewS3BucketNameToAzureResourcesResolver(containers)
-				} else if cca.fromTo == common.EFromTo.GCPBlob() {
+				} else if cca.FromTo == common.EFromTo.GCPBlob() {
 					containerResolver = NewGCPBucketNameToAzureResourcesResolver(containers)
 				}
 
@@ -175,7 +175,7 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 						continue
 					}
 
-					err = cca.createDstContainer(bucketName, cca.destination, ctx, existingContainers, cca.logVerbosity)
+					err = cca.createDstContainer(bucketName, cca.Destination, ctx, existingContainers, cca.LogVerbosity)
 
 					// if JobsAdmin is nil, we're probably in testing mode.
 					// As a result, container creation failures are expected as we don't give the SAS tokens adequate permissions.
@@ -189,7 +189,7 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 					}
 				}
 			} else {
-				cName, err := GetContainerName(cca.source.Value, cca.fromTo.From())
+				cName, err := GetContainerName(cca.Source.Value, cca.FromTo.From())
 
 				if err != nil || cName == "" {
 					// this will probably never be reached
@@ -198,7 +198,7 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 				resName, err := containerResolver.ResolveName(cName)
 
 				if err == nil {
-					err = cca.createDstContainer(resName, cca.destination, ctx, existingContainers, cca.logVerbosity)
+					err = cca.createDstContainer(resName, cca.Destination, ctx, existingContainers, cca.LogVerbosity)
 
 					if _, ok := seenFailedContainers[dstContainerName]; err != nil && ste.JobsAdmin != nil && !ok {
 						logDstContainerCreateFailureOnce.Do(func() {
@@ -212,11 +212,11 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 		}
 	}
 
-	filters := cca.initModularFilters()
+	filters := cca.InitModularFilters()
 
 	// decide our folder transfer strategy
 	var message string
-	jobPartOrder.Fpo, message = newFolderPropertyOption(cca.fromTo, cca.recursive, cca.stripTopDir, filters, cca.preserveSMBInfo, cca.preserveSMBPermissions.IsTruthy())
+	jobPartOrder.Fpo, message = newFolderPropertyOption(cca.FromTo, cca.Recursive, cca.StripTopDir, filters, cca.preserveSMBInfo, cca.preserveSMBPermissions.IsTruthy())
 	if !cca.dryrunMode {
 		glcm.Info(message)
 	}
@@ -224,47 +224,47 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 		ste.JobsAdmin.LogToJobLog(message, pipeline.LogInfo)
 	}
 
-	processor := func(object storedObject) error {
+	processor := func(object StoredObject) error {
 		// Start by resolving the name and creating the container
-		if object.containerName != "" {
+		if object.ContainerName != "" {
 			// set up the destination container name.
 			cName := dstContainerName
 			// if a destination container name is not specified OR copying service to container/folder, append the src container name.
 			if cName == "" || (srcLevel == ELocationLevel.Service() && dstLevel > ELocationLevel.Service()) {
-				cName, err = containerResolver.ResolveName(object.containerName)
+				cName, err = containerResolver.ResolveName(object.ContainerName)
 
 				if err != nil {
-					if _, ok := seenFailedContainers[object.containerName]; !ok {
-						WarnStdoutAndScanningLog(fmt.Sprintf("failed to add transfers from container %s as it has an invalid name. Please manually transfer from this container to one with a valid name.", object.containerName))
-						seenFailedContainers[object.containerName] = true
+					if _, ok := seenFailedContainers[object.ContainerName]; !ok {
+						WarnStdoutAndScanningLog(fmt.Sprintf("failed to add transfers from container %s as it has an invalid name. Please manually transfer from this container to one with a valid name.", object.ContainerName))
+						seenFailedContainers[object.ContainerName] = true
 					}
 					return nil
 				}
 
-				object.dstContainerName = cName
+				object.DstContainerName = cName
 			}
 		}
 
 		// If above the service level, we already know the container name and don't need to supply it to makeEscapedRelativePath
 		if srcLevel != ELocationLevel.Service() {
-			object.containerName = ""
+			object.ContainerName = ""
 
 			// When copying directly TO a container or object from a container, don't drop under a sub directory
 			if dstLevel >= ELocationLevel.Container() {
-				object.dstContainerName = ""
+				object.DstContainerName = ""
 			}
 		}
 
-		srcRelPath := cca.makeEscapedRelativePath(true, isDestDir, object)
-		dstRelPath := cca.makeEscapedRelativePath(false, isDestDir, object)
+		srcRelPath := cca.MakeEscapedRelativePath(true, isDestDir, object)
+		dstRelPath := cca.MakeEscapedRelativePath(false, isDestDir, object)
 
 		transfer, shouldSendToSte := object.ToNewCopyTransfer(
-			cca.autoDecompress && cca.fromTo.IsDownload(),
+			cca.autoDecompress && cca.FromTo.IsDownload(),
 			srcRelPath, dstRelPath,
 			cca.s2sPreserveAccessTier,
 			jobPartOrder.Fpo,
 		)
-		if !cca.s2sPreserveBlobTags {
+		if !cca.S2sPreserveBlobTags {
 			transfer.BlobTags = cca.blobTags
 		}
 
@@ -275,21 +275,21 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 					common.PanicIfErr(err)
 					return string(jsonOutput)
 				} else {
-					if cca.fromTo.From() == common.ELocation.Local() {
+					if cca.FromTo.From() == common.ELocation.Local() {
 						// formatting from local source
-						dryrunValue := fmt.Sprintf("DRYRUN: copy %v", common.ToShortPath(cca.source.Value))
+						dryrunValue := fmt.Sprintf("DRYRUN: copy %v", common.ToShortPath(cca.Source.Value))
 						if runtime.GOOS == "windows" {
 							dryrunValue += strings.ReplaceAll(srcRelPath, "/", "\\")
 						} else { //linux and mac
 							dryrunValue += srcRelPath
 						}
-						dryrunValue += fmt.Sprintf(" to %v%v", strings.Trim(cca.destination.Value, "/"), dstRelPath)
+						dryrunValue += fmt.Sprintf(" to %v%v", strings.Trim(cca.Destination.Value, "/"), dstRelPath)
 						return dryrunValue
-					} else if cca.fromTo.To() == common.ELocation.Local() {
+					} else if cca.FromTo.To() == common.ELocation.Local() {
 						// formatting to local source
 						dryrunValue := fmt.Sprintf("DRYRUN: copy %v%v to %v",
-							strings.Trim(cca.source.Value, "/"), srcRelPath,
-							common.ToShortPath(cca.destination.Value))
+							strings.Trim(cca.Source.Value, "/"), srcRelPath,
+							common.ToShortPath(cca.Destination.Value))
 						if runtime.GOOS == "windows" {
 							dryrunValue += strings.ReplaceAll(dstRelPath, "/", "\\")
 						} else { //linux and mac
@@ -298,9 +298,9 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 						return dryrunValue
 					} else {
 						return fmt.Sprintf("DRYRUN: copy %v%v to %v%v",
-							cca.source.Value,
+							cca.Source.Value,
 							srcRelPath,
-							cca.destination.Value,
+							cca.Destination.Value,
 							dstRelPath)
 					}
 				}
@@ -317,12 +317,12 @@ func (cca *cookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 		return dispatchFinalPart(&jobPartOrder, cca)
 	}
 
-	return newCopyEnumerator(traverser, filters, processor, finalizer), nil
+	return NewCopyEnumerator(traverser, filters, processor, finalizer), nil
 }
 
 // This is condensed down into an individual function as we don't end up re-using the destination traverser at all.
 // This is just for the directory check.
-func (cca *cookedCopyCmdArgs) isDestDirectory(dst common.ResourceString, ctx *context.Context) bool {
+func (cca *CookedCopyCmdArgs) isDestDirectory(dst common.ResourceString, ctx *context.Context) bool {
 	var err error
 	dstCredInfo := common.CredentialInfo{}
 
@@ -330,39 +330,39 @@ func (cca *cookedCopyCmdArgs) isDestDirectory(dst common.ResourceString, ctx *co
 		return false
 	}
 
-	if dstCredInfo, _, err = getCredentialInfoForLocation(*ctx, cca.fromTo.To(), cca.destination.Value, cca.destination.SAS, false, cca.cpkOptions); err != nil {
+	if dstCredInfo, _, err = GetCredentialInfoForLocation(*ctx, cca.FromTo.To(), cca.Destination.Value, cca.Destination.SAS, false, cca.CpkOptions); err != nil {
 		return false
 	}
 
-	rt, err := initResourceTraverser(dst, cca.fromTo.To(), ctx, &dstCredInfo, nil,
+	rt, err := InitResourceTraverser(dst, cca.FromTo.To(), ctx, &dstCredInfo, nil,
 		nil, false, false, false,
-		func(common.EntityType) {}, cca.listOfVersionIDs, false, pipeline.LogNone, cca.cpkOptions)
+		func(common.EntityType) {}, cca.ListOfVersionIDs, false, pipeline.LogNone, cca.CpkOptions)
 
 	if err != nil {
 		return false
 	}
 
-	return rt.isDirectory(false)
+	return rt.IsDirectory(false)
 }
 
 // Initialize the modular filters outside of copy to increase readability.
-func (cca *cookedCopyCmdArgs) initModularFilters() []objectFilter {
-	filters := make([]objectFilter, 0) // same as []objectFilter{} under the hood
+func (cca *CookedCopyCmdArgs) InitModularFilters() []ObjectFilter {
+	filters := make([]ObjectFilter, 0) // same as []ObjectFilter{} under the hood
 
-	if cca.includeBefore != nil {
-		filters = append(filters, &includeBeforeDateFilter{threshold: *cca.includeBefore})
+	if cca.IncludeBefore != nil {
+		filters = append(filters, &IncludeBeforeDateFilter{Threshold: *cca.IncludeBefore})
 	}
 
-	if cca.includeAfter != nil {
-		filters = append(filters, &includeAfterDateFilter{threshold: *cca.includeAfter})
+	if cca.IncludeAfter != nil {
+		filters = append(filters, &IncludeAfterDateFilter{Threshold: *cca.IncludeAfter})
 	}
 
-	if len(cca.includePatterns) != 0 {
-		filters = append(filters, &includeFilter{patterns: cca.includePatterns}) // TODO should this call buildIncludeFilters?
+	if len(cca.IncludePatterns) != 0 {
+		filters = append(filters, &IncludeFilter{patterns: cca.IncludePatterns}) // TODO should this call buildIncludeFilters?
 	}
 
-	if len(cca.excludePatterns) != 0 {
-		for _, v := range cca.excludePatterns {
+	if len(cca.ExcludePatterns) != 0 {
+		for _, v := range cca.ExcludePatterns {
 			filters = append(filters, &excludeFilter{pattern: v})
 		}
 	}
@@ -370,8 +370,8 @@ func (cca *cookedCopyCmdArgs) initModularFilters() []objectFilter {
 	// include-path is not a filter, therefore it does not get handled here.
 	// Check up in cook() around the list-of-files implementation as include-path gets included in the same way.
 
-	if len(cca.excludePathPatterns) != 0 {
-		for _, v := range cca.excludePathPatterns {
+	if len(cca.ExcludePathPatterns) != 0 {
+		for _, v := range cca.ExcludePathPatterns {
 			filters = append(filters, &excludeFilter{pattern: v, targetsPath: true})
 		}
 	}
@@ -394,17 +394,17 @@ func (cca *cookedCopyCmdArgs) initModularFilters() []objectFilter {
 		filters = append(filters, &excludeBlobTypeFilter{blobTypes: excludeSet})
 	}
 
-	if len(cca.includeFileAttributes) != 0 {
-		filters = append(filters, buildAttrFilters(cca.includeFileAttributes, cca.source.ValueLocal(), true)...)
+	if len(cca.IncludeFileAttributes) != 0 {
+		filters = append(filters, buildAttrFilters(cca.IncludeFileAttributes, cca.Source.ValueLocal(), true)...)
 	}
 
-	if len(cca.excludeFileAttributes) != 0 {
-		filters = append(filters, buildAttrFilters(cca.excludeFileAttributes, cca.source.ValueLocal(), false)...)
+	if len(cca.ExcludeFileAttributes) != 0 {
+		filters = append(filters, buildAttrFilters(cca.ExcludeFileAttributes, cca.Source.ValueLocal(), false)...)
 	}
 
 	// finally, log any search prefix computed from these
 	if ste.JobsAdmin != nil {
-		if prefixFilter := filterSet(filters).GetEnumerationPreFilter(cca.recursive); prefixFilter != "" {
+		if prefixFilter := FilterSet(filters).GetEnumerationPreFilter(cca.Recursive); prefixFilter != "" {
 			ste.JobsAdmin.LogToJobLog("Search prefix, which may be used to optimize scanning, is: "+prefixFilter, pipeline.LogInfo) // "May be used" because we don't know here which enumerators will use it
 		}
 	}
@@ -412,7 +412,7 @@ func (cca *cookedCopyCmdArgs) initModularFilters() []objectFilter {
 	return filters
 }
 
-func (cca *cookedCopyCmdArgs) createDstContainer(containerName string, dstWithSAS common.ResourceString, parentCtx context.Context, existingContainers map[string]bool, logLevel common.LogLevel) (err error) {
+func (cca *CookedCopyCmdArgs) createDstContainer(containerName string, dstWithSAS common.ResourceString, parentCtx context.Context, existingContainers map[string]bool, logLevel common.LogLevel) (err error) {
 	if _, ok := existingContainers[containerName]; ok {
 		return
 	}
@@ -422,11 +422,11 @@ func (cca *cookedCopyCmdArgs) createDstContainer(containerName string, dstWithSA
 
 	// 3minutes is enough time to list properties of a container, and create new if it does not exist.
 	ctx, _ := context.WithTimeout(parentCtx, time.Minute*3)
-	if dstCredInfo, _, err = getCredentialInfoForLocation(ctx, cca.fromTo.To(), cca.destination.Value, cca.destination.SAS, false, cca.cpkOptions); err != nil {
+	if dstCredInfo, _, err = GetCredentialInfoForLocation(ctx, cca.FromTo.To(), cca.Destination.Value, cca.Destination.SAS, false, cca.CpkOptions); err != nil {
 		return err
 	}
 
-	dstPipeline, err := initPipeline(ctx, cca.fromTo.To(), dstCredInfo, logLevel.ToPipelineLogLevel())
+	dstPipeline, err := InitPipeline(ctx, cca.FromTo.To(), dstCredInfo, logLevel.ToPipelineLogLevel())
 	if err != nil {
 		return
 	}
@@ -434,11 +434,11 @@ func (cca *cookedCopyCmdArgs) createDstContainer(containerName string, dstWithSA
 	// Because the only use-cases for createDstContainer will be on service-level S2S and service-level download
 	// We only need to create "containers" on local and blob.
 	// TODO: Reduce code dupe somehow
-	switch cca.fromTo.To() {
+	switch cca.FromTo.To() {
 	case common.ELocation.Local():
-		err = os.MkdirAll(common.GenerateFullPath(cca.destination.ValueLocal(), containerName), os.ModeDir|os.ModePerm)
+		err = os.MkdirAll(common.GenerateFullPath(cca.Destination.ValueLocal(), containerName), os.ModeDir|os.ModePerm)
 	case common.ELocation.Blob():
-		accountRoot, err := GetAccountRoot(dstWithSAS, cca.fromTo.To())
+		accountRoot, err := GetAccountRoot(dstWithSAS, cca.FromTo.To())
 
 		if err != nil {
 			return err
@@ -469,7 +469,7 @@ func (cca *cookedCopyCmdArgs) createDstContainer(containerName string, dstWithSA
 		}
 	case common.ELocation.File():
 		// Grab the account root and parse it as a URL
-		accountRoot, err := GetAccountRoot(dstWithSAS, cca.fromTo.To())
+		accountRoot, err := GetAccountRoot(dstWithSAS, cca.FromTo.To())
 
 		if err != nil {
 			return err
@@ -501,7 +501,7 @@ func (cca *cookedCopyCmdArgs) createDstContainer(containerName string, dstWithSA
 			return err
 		}
 	default:
-		panic(fmt.Sprintf("cannot create a destination container at location %s.", cca.fromTo.To()))
+		panic(fmt.Sprintf("cannot create a destination container at location %s.", cca.FromTo.To()))
 	}
 
 	return
@@ -572,9 +572,9 @@ func pathEncodeRules(path string, fromTo common.FromTo, disableAutoDecoding bool
 	return path
 }
 
-func (cca *cookedCopyCmdArgs) makeEscapedRelativePath(source bool, dstIsDir bool, object storedObject) (relativePath string) {
+func (cca *CookedCopyCmdArgs) MakeEscapedRelativePath(source bool, dstIsDir bool, object StoredObject) (relativePath string) {
 	// write straight to /dev/null, do not determine a indirect path
-	if !source && cca.destination.Value == common.Dev_Null {
+	if !source && cca.Destination.Value == common.Dev_Null {
 		return "" // ignore path encode rules
 	}
 
@@ -599,7 +599,7 @@ func (cca *cookedCopyCmdArgs) makeEscapedRelativePath(source bool, dstIsDir bool
 			}
 		}
 
-		return pathEncodeRules(relativePath, cca.fromTo, cca.disableAutoDecoding, source)
+		return pathEncodeRules(relativePath, cca.FromTo, cca.disableAutoDecoding, source)
 	}
 
 	// If it's out here, the object is contained in a folder, or was found via a wildcard, or object.isSourceRootFolder == true
@@ -610,13 +610,13 @@ func (cca *cookedCopyCmdArgs) makeEscapedRelativePath(source bool, dstIsDir bool
 		relativePath = "/" + strings.Replace(object.relativePath, common.OS_PATH_SEPARATOR, common.AZCOPY_PATH_SEPARATOR_STRING, -1)
 	}
 
-	if common.IffString(source, object.containerName, object.dstContainerName) != "" {
-		relativePath = `/` + common.IffString(source, object.containerName, object.dstContainerName) + relativePath
-	} else if !source && !cca.stripTopDir {
+	if common.IffString(source, object.ContainerName, object.DstContainerName) != "" {
+		relativePath = `/` + common.IffString(source, object.ContainerName, object.DstContainerName) + relativePath
+	} else if !source && !cca.StripTopDir {
 		// We ONLY need to do this adjustment to the destination.
 		// The source SAS has already been removed. No need to convert it to a URL or whatever.
 		// Save to a directory
-		rootDir := filepath.Base(cca.source.Value)
+		rootDir := filepath.Base(cca.Source.Value)
 
 		/* In windows, when a user tries to copy whole volume (eg. D:\),  the upload destination
 		will contains "//"" in the files/directories names because of rootDir = "\" prefix.
@@ -624,10 +624,10 @@ func (cca *cookedCopyCmdArgs) makeEscapedRelativePath(source bool, dstIsDir bool
 		Following code will get volume name from source and add volume name as prefix in rootDir
 		*/
 		if runtime.GOOS == "windows" && rootDir == `\` {
-			rootDir = filepath.VolumeName(common.ToShortPath(cca.source.Value))
+			rootDir = filepath.VolumeName(common.ToShortPath(cca.Source.Value))
 		}
 
-		if cca.fromTo.From().IsRemote() {
+		if cca.FromTo.From().IsRemote() {
 			ueRootDir, err := url.PathUnescape(rootDir)
 
 			// Realistically, err should never not be nil here.
@@ -641,11 +641,11 @@ func (cca *cookedCopyCmdArgs) makeEscapedRelativePath(source bool, dstIsDir bool
 		relativePath = "/" + rootDir + relativePath
 	}
 
-	return pathEncodeRules(relativePath, cca.fromTo, cca.disableAutoDecoding, source)
+	return pathEncodeRules(relativePath, cca.FromTo, cca.disableAutoDecoding, source)
 }
 
 // we assume that preserveSmbPermissions and preserveSmbInfo have already been validated, such that they are only true if both resource types support them
-func newFolderPropertyOption(fromTo common.FromTo, recursive bool, stripTopDir bool, filters []objectFilter, preserveSmbInfo, preserveSmbPermissions bool) (common.FolderPropertyOption, string) {
+func newFolderPropertyOption(fromTo common.FromTo, recursive bool, stripTopDir bool, filters []ObjectFilter, preserveSmbInfo, preserveSmbPermissions bool) (common.FolderPropertyOption, string) {
 
 	getSuffix := func(willProcess bool) string {
 		willProcessString := common.IffString(willProcess, "will be processed", "will not be processed")
@@ -677,7 +677,7 @@ func newFolderPropertyOption(fromTo common.FromTo, recursive bool, stripTopDir b
 		// at the destination.
 		filtersOK := true
 		for _, f := range filters {
-			if f.appliesOnlyToFiles() {
+			if f.AppliesOnlyToFiles() {
 				filtersOK = false // we have a least one filter that doesn't apply to folders
 			}
 		}

--- a/cmd/credentialUtil.go
+++ b/cmd/credentialUtil.go
@@ -533,7 +533,7 @@ func doGetCredentialTypeForLocation(ctx context.Context, location common.Locatio
 	return
 }
 
-func getCredentialInfoForLocation(ctx context.Context, location common.Location, resource, resourceSAS string, isSource bool, cpkOptions common.CpkOptions) (credInfo common.CredentialInfo, isPublic bool, err error) {
+func GetCredentialInfoForLocation(ctx context.Context, location common.Location, resource, resourceSAS string, isSource bool, cpkOptions common.CpkOptions) (credInfo common.CredentialInfo, isPublic bool, err error) {
 
 	// get the type
 	credInfo.CredentialType, isPublic, err = getCredentialTypeForLocation(ctx, location, resource, resourceSAS, isSource, cpkOptions)

--- a/cmd/make.go
+++ b/cmd/make.go
@@ -57,7 +57,7 @@ func (raw rawMakeCmdArgs) cook() (cookedMakeCmdArgs, error) {
 	// resourceLocation could be unknown at this stage, it will be handled by the caller
 	return cookedMakeCmdArgs{
 		resourceURL:      *parsedURL,
-		resourceLocation: inferArgumentLocation(raw.resourceToCreate),
+		resourceLocation: InferArgumentLocation(raw.resourceToCreate),
 		quota:            int32(raw.quota),
 	}, nil
 }
@@ -77,7 +77,7 @@ func (cookedArgs cookedMakeCmdArgs) process() (err error) {
 		return err
 	}
 
-	credentialInfo, _, err := getCredentialInfoForLocation(ctx, cookedArgs.resourceLocation, resourceStringParts.Value, resourceStringParts.SAS, false, common.CpkOptions{})
+	credentialInfo, _, err := GetCredentialInfoForLocation(ctx, cookedArgs.resourceLocation, resourceStringParts.Value, resourceStringParts.SAS, false, common.CpkOptions{})
 	if err != nil {
 		return err
 	}

--- a/cmd/pathUtils.go
+++ b/cmd/pathUtils.go
@@ -24,7 +24,7 @@ func (LocationLevel) Object() LocationLevel    { return 2 } // An Object can be 
 
 // Uses syntax to assume the "level" of a location.
 // This is typically used to
-func determineLocationLevel(location string, locationType common.Location, source bool) (LocationLevel, error) {
+func DetermineLocationLevel(location string, locationType common.Location, source bool) (LocationLevel, error) {
 	switch locationType {
 	// In local, there's no such thing as a service.
 	// As such, we'll treat folders as containers, and files as objects.

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -45,7 +45,7 @@ func init() {
 			// the resource to delete is set as the source
 			raw.src = args[0]
 
-			srcLocationType := inferArgumentLocation(raw.src)
+			srcLocationType := InferArgumentLocation(raw.src)
 			if raw.fromTo == "" {
 				switch srcLocationType {
 				case common.ELocation.Blob():

--- a/cmd/removeEnumerator.go
+++ b/cmd/removeEnumerator.go
@@ -40,25 +40,25 @@ var NothingToRemoveError = errors.New("nothing found to remove")
 // and schedule delete transfers to remove them
 // TODO: Make this merge into the other copy refactor code
 // TODO: initEnumerator is significantly more verbose at this point, evaluate the impact of switching over
-func newRemoveEnumerator(cca *cookedCopyCmdArgs) (enumerator *copyEnumerator, err error) {
-	var sourceTraverser resourceTraverser
+func newRemoveEnumerator(cca *CookedCopyCmdArgs) (enumerator *CopyEnumerator, err error) {
+	var sourceTraverser ResourceTraverser
 
 	ctx := context.WithValue(context.TODO(), ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
 
 	// Include-path is handled by ListOfFilesChannel.
-	sourceTraverser, err = initResourceTraverser(cca.source, cca.fromTo.From(), &ctx, &cca.credentialInfo,
-		nil, cca.listOfFilesChannel, cca.recursive, false, cca.includeDirectoryStubs,
-		func(common.EntityType) {}, cca.listOfVersionIDs, false,
-		cca.logVerbosity.ToPipelineLogLevel(), cca.cpkOptions)
+	sourceTraverser, err = InitResourceTraverser(cca.Source, cca.FromTo.From(), &ctx, &cca.credentialInfo,
+		nil, cca.ListOfFilesChannel, cca.Recursive, false, cca.IncludeDirectoryStubs,
+		func(common.EntityType) {}, cca.ListOfVersionIDs, false,
+		cca.LogVerbosity.ToPipelineLogLevel(), cca.CpkOptions)
 
 	// report failure to create traverser
 	if err != nil {
 		return nil, err
 	}
 
-	includeFilters := buildIncludeFilters(cca.includePatterns)
-	excludeFilters := buildExcludeFilters(cca.excludePatterns, false)
-	excludePathFilters := buildExcludeFilters(cca.excludePathPatterns, true)
+	includeFilters := buildIncludeFilters(cca.IncludePatterns)
+	excludeFilters := buildExcludeFilters(cca.ExcludePatterns, false)
+	excludePathFilters := buildExcludeFilters(cca.ExcludePathPatterns, true)
 
 	// set up the filters in the right order
 	filters := append(includeFilters, excludeFilters...)
@@ -67,7 +67,7 @@ func newRemoveEnumerator(cca *cookedCopyCmdArgs) (enumerator *copyEnumerator, er
 	// decide our folder transfer strategy
 	// (Must enumerate folders when deleting from a folder-aware location. Can't do folder deletion just based on file
 	// deletion, because that would not handle folders that were empty at the start of the job).
-	fpo, message := newFolderPropertyOption(cca.fromTo, cca.recursive, cca.stripTopDir, filters, false, false)
+	fpo, message := newFolderPropertyOption(cca.FromTo, cca.Recursive, cca.StripTopDir, filters, false, false)
 	// do not print Info message if in dry run mode
 	if !cca.dryrunMode {
 		glcm.Info(message)
@@ -103,34 +103,34 @@ func newRemoveEnumerator(cca *cookedCopyCmdArgs) (enumerator *copyEnumerator, er
 		return nil
 	}
 
-	return newCopyEnumerator(sourceTraverser, filters, transferScheduler.scheduleCopyTransfer, finalize), nil
+	return NewCopyEnumerator(sourceTraverser, filters, transferScheduler.scheduleCopyTransfer, finalize), nil
 }
 
 // TODO move after ADLS/Blob interop goes public
 // TODO this simple remove command is only here to support the scenario temporarily
 // Ultimately, this code can be merged into the newRemoveEnumerator
-func removeBfsResources(cca *cookedCopyCmdArgs) (err error) {
+func removeBfsResources(cca *CookedCopyCmdArgs) (err error) {
 	ctx := context.Background()
 
 	// return an error if the unsupported options are passed in
-	if len(cca.initModularFilters()) > 0 {
+	if len(cca.InitModularFilters()) > 0 {
 		return errors.New("filter options, such as include/exclude, are not supported for this destination")
 		// because we just ignore them and delete the root
 	}
 
 	// patterns are not supported
-	if strings.Contains(cca.source.Value, "*") {
+	if strings.Contains(cca.Source.Value, "*") {
 		return errors.New("pattern matches are not supported in this command")
 	}
 
 	// create bfs pipeline
-	p, err := createBlobFSPipeline(ctx, cca.credentialInfo, cca.logVerbosity.ToPipelineLogLevel())
+	p, err := createBlobFSPipeline(ctx, cca.credentialInfo, cca.LogVerbosity.ToPipelineLogLevel())
 	if err != nil {
 		return err
 	}
 
 	// attempt to parse the source url
-	sourceURL, err := cca.source.FullURL()
+	sourceURL, err := cca.Source.FullURL()
 	if err != nil {
 		return errors.New("cannot parse source URL")
 	}
@@ -138,8 +138,8 @@ func removeBfsResources(cca *cookedCopyCmdArgs) (err error) {
 	// parse the given source URL into parts, which separates the filesystem name and directory/file path
 	urlParts := azbfs.NewBfsURLParts(*sourceURL)
 
-	if cca.listOfFilesChannel == nil {
-		successMsg, err := removeSingleBfsResource(urlParts, p, ctx, cca.recursive)
+	if cca.ListOfFilesChannel == nil {
+		successMsg, err := removeSingleBfsResource(urlParts, p, ctx, cca.Recursive)
 		if err != nil {
 			return err
 		}
@@ -171,11 +171,11 @@ func removeBfsResources(cca *cookedCopyCmdArgs) (err error) {
 	failedTransfers := make([]common.TransferDetail, 0)
 
 	// read from the list of files channel to find out what needs to be deleted.
-	childPath, ok := <-cca.listOfFilesChannel
-	for ; ok; childPath, ok = <-cca.listOfFilesChannel {
+	childPath, ok := <-cca.ListOfFilesChannel
+	for ; ok; childPath, ok = <-cca.ListOfFilesChannel {
 		// remove the child path
 		urlParts.DirectoryOrFilePath = common.GenerateFullPath(parentPath, childPath)
-		successMessage, err := removeSingleBfsResource(urlParts, p, ctx, cca.recursive)
+		successMessage, err := removeSingleBfsResource(urlParts, p, ctx, cca.Recursive)
 		if err != nil {
 			// the specific error is not included in the details, since it doesn't have a field for full error message
 			failedTransfers = append(failedTransfers, common.TransferDetail{Src: childPath, TransferStatus: common.ETransferStatus.Failed()})

--- a/cmd/removeProcessor.go
+++ b/cmd/removeProcessor.go
@@ -25,18 +25,18 @@ import (
 )
 
 // extract the right info from cooked arguments and instantiate a generic copy transfer processor from it
-func newRemoveTransferProcessor(cca *cookedCopyCmdArgs, numOfTransfersPerPart int, fpo common.FolderPropertyOption) *copyTransferProcessor {
+func newRemoveTransferProcessor(cca *CookedCopyCmdArgs, numOfTransfersPerPart int, fpo common.FolderPropertyOption) *copyTransferProcessor {
 	copyJobTemplate := &common.CopyJobPartOrderRequest{
 		JobID:           cca.jobID,
 		CommandString:   cca.commandString,
-		FromTo:          cca.fromTo,
+		FromTo:          cca.FromTo,
 		Fpo:             fpo,
-		SourceRoot:      cca.source.CloneWithConsolidatedSeparators(), // TODO: why do we consolidate here, but not in "copy"? Is it needed in both places or neither? Or is copy just covering the same need differently?
+		SourceRoot:      cca.Source.CloneWithConsolidatedSeparators(), // TODO: why do we consolidate here, but not in "copy"? Is it needed in both places or neither? Or is copy just covering the same need differently?
 		CredentialInfo:  cca.credentialInfo,
-		ForceIfReadOnly: cca.forceIfReadOnly,
+		ForceIfReadOnly: cca.ForceIfReadOnly,
 
 		// flags
-		LogLevel:       cca.logVerbosity,
+		LogLevel:       cca.LogVerbosity,
 		BlobAttributes: common.BlobTransferAttributes{DeleteSnapshotsOption: cca.deleteSnapshotsOption},
 	}
 
@@ -49,6 +49,6 @@ func newRemoveTransferProcessor(cca *cookedCopyCmdArgs, numOfTransfersPerPart in
 
 	// note that the source and destination, along with the template are given to the generic processor's constructor
 	// this means that given an object with a relative path, this processor already knows how to schedule the right kind of transfers
-	return newCopyTransferProcessor(copyJobTemplate, numOfTransfersPerPart, cca.source, cca.destination,
+	return newCopyTransferProcessor(copyJobTemplate, numOfTransfersPerPart, cca.Source, cca.Destination,
 		reportFirstPart, reportFinalPart, false, cca.dryrunMode)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -111,8 +111,8 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		enumerationParallelism = concurrencySettings.EnumerationPoolSize.Value
-		enumerationParallelStatFiles = concurrencySettings.ParallelStatFiles.Value
+	        EnumerationParallelism = concurrencySettings.EnumerationPoolSize.Value
+		EnumerationParallelStatFiles = concurrencySettings.ParallelStatFiles.Value
 
 		// Log a clear ISO 8601-formatted start time, so it can be read and use in the --include-after parameter
 		// Subtract a few seconds, to ensure that this date DEFINITELY falls before the LMT of any file changed while this
@@ -120,8 +120,8 @@ var rootCmd = &cobra.Command{
 		// or after this job
 		adjustedTime := timeAtPrestart.Add(-5 * time.Second)
 		startTimeMessage := fmt.Sprintf("ISO 8601 START TIME: to copy files that changed before or after this job started, use the parameter --%s=%s or --%s=%s",
-			common.IncludeBeforeFlagName, includeBeforeDateFilter{}.FormatAsUTC(adjustedTime),
-			common.IncludeAfterFlagName, includeAfterDateFilter{}.FormatAsUTC(adjustedTime))
+			common.IncludeBeforeFlagName, IncludeBeforeDateFilter{}.FormatAsUTC(adjustedTime),
+			common.IncludeAfterFlagName, IncludeAfterDateFilter{}.FormatAsUTC(adjustedTime))
 		ste.JobsAdmin.LogToJobLog(startTimeMessage, pipeline.LogInfo)
 
 		// spawn a routine to fetch and compare the local application's version against the latest version available

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -103,7 +103,7 @@ func (raw *rawSyncCmdArgs) parsePatterns(pattern string) (cookedPatterns []strin
 
 // it is assume that the given url has the SAS stripped, and safe to print
 func (raw *rawSyncCmdArgs) validateURLIsNotServiceLevel(url string, location common.Location) error {
-	srcLevel, err := determineLocationLevel(url, location, true)
+	srcLevel, err := DetermineLocationLevel(url, location, true)
 	if err != nil {
 		return err
 	}
@@ -136,12 +136,12 @@ func (raw *rawSyncCmdArgs) cook() (cookedSyncCmdArgs, error) {
 	// TODO: if expand the set of source/dest combos supported by sync, update this method the declarative test framework:
 
 	/* We support DFS by using blob end-point of the account. We replace dfs by blob in src and dst */
-	if loc := inferArgumentLocation(raw.src); loc == common.ELocation.BlobFS() {
+	if loc := InferArgumentLocation(raw.src); loc == common.ELocation.BlobFS() {
 		raw.src = strings.Replace(raw.src, ".dfs", ".blob", 1)
 		glcm.Info("Sync operates only on blob endpoint. Switching to use blob endpoint on source account.")
 	}
 
-	if loc := inferArgumentLocation(raw.dst); loc == common.ELocation.BlobFS() {
+	if loc := InferArgumentLocation(raw.dst); loc == common.ELocation.BlobFS() {
 		raw.dst = strings.Replace(raw.dst, ".dfs", ".blob", 1)
 		glcm.Info("Sync operates only on blob endpoint. Switching to use blob endpoint on destination account.")
 	}
@@ -336,7 +336,7 @@ type cookedSyncCmdArgs struct {
 
 	source         common.ResourceString
 	destination    common.ResourceString
-	fromTo         common.FromTo
+        fromTo         common.FromTo
 	credentialInfo common.CredentialInfo
 
 	// filters
@@ -624,13 +624,13 @@ func (cca *cookedSyncCmdArgs) process() (err error) {
 
 	// Verifies credential type and initializes credential info.
 	// Note that this is for the destination.
-	cca.credentialInfo, _, err = getCredentialInfoForLocation(ctx, cca.fromTo.To(), cca.destination.Value, cca.destination.SAS, false, cca.cpkOptions)
+	cca.credentialInfo, _, err = GetCredentialInfoForLocation(ctx, cca.fromTo.To(), cca.destination.Value, cca.destination.SAS, false, cca.cpkOptions)
 
 	if err != nil {
 		return err
 	}
 
-	srcCredInfo, _, err := getCredentialInfoForLocation(ctx, cca.fromTo.From(), cca.source.Value, cca.source.SAS, true, cca.cpkOptions)
+	srcCredInfo, _, err := GetCredentialInfoForLocation(ctx, cca.fromTo.From(), cca.source.Value, cca.source.SAS, true, cca.cpkOptions)
 
 	if err != nil {
 		return err

--- a/cmd/syncComparator.go
+++ b/cmd/syncComparator.go
@@ -47,7 +47,7 @@ func newSyncDestinationComparator(i *objectIndexer, copyScheduler, cleaner objec
 // ex: we already know what the source contains, now we are looking at objects at the destination
 // if file x from the destination exists at the source, then we'd only transfer it if it is considered stale compared to its counterpart at the source
 // if file x does not exist at the source, then it is considered extra, and will be deleted
-func (f *syncDestinationComparator) processIfNecessary(destinationObject storedObject) error {
+func (f *syncDestinationComparator) processIfNecessary(destinationObject StoredObject) error {
 	sourceObjectInMap, present := f.sourceIndex.indexMap[destinationObject.relativePath]
 	if !present && f.sourceIndex.isDestinationCaseInsensitive {
 		lcRelativePath := strings.ToLower(destinationObject.relativePath)
@@ -92,9 +92,9 @@ func newSyncSourceComparator(i *objectIndexer, copyScheduler objectProcessor, di
 // it will only transfer source items that are:
 //	1. not present in the map
 //  2. present but is more recent than the entry in the map
-// note: we remove the storedObject if it is present so that when we have finished
+// note: we remove the StoredObject if it is present so that when we have finished
 // the index will contain all objects which exist at the destination but were NOT seen at the source
-func (f *syncSourceComparator) processIfNecessary(sourceObject storedObject) error {
+func (f *syncSourceComparator) processIfNecessary(sourceObject StoredObject) error {
 	destinationObjectInMap, present := f.destinationIndex.indexMap[sourceObject.relativePath]
 	if !present && f.destinationIndex.isDestinationCaseInsensitive {
 		lcRelativePath := strings.ToLower(sourceObject.relativePath)

--- a/cmd/syncEnumerator.go
+++ b/cmd/syncEnumerator.go
@@ -36,7 +36,7 @@ import (
 
 func (cca *cookedSyncCmdArgs) initEnumerator(ctx context.Context) (enumerator *syncEnumerator, err error) {
 
-	srcCredInfo, srcIsPublic, err := getCredentialInfoForLocation(ctx, cca.fromTo.From(), cca.source.Value, cca.source.SAS, true, cca.cpkOptions)
+	srcCredInfo, srcIsPublic, err := GetCredentialInfoForLocation(ctx, cca.fromTo.From(), cca.source.Value, cca.source.SAS, true, cca.cpkOptions)
 
 	if err != nil {
 		return nil, err
@@ -56,7 +56,7 @@ func (cca *cookedSyncCmdArgs) initEnumerator(ctx context.Context) (enumerator *s
 	// TODO: enable symlink support in a future release after evaluating the implications
 	// GetProperties is enabled by default as sync supports both upload and download.
 	// This property only supports Files and S3 at the moment, but provided that Files sync is coming soon, enable to avoid stepping on Files sync work
-	sourceTraverser, err := initResourceTraverser(cca.source, cca.fromTo.From(), &ctx, &srcCredInfo, nil,
+	sourceTraverser, err := InitResourceTraverser(cca.source, cca.fromTo.From(), &ctx, &srcCredInfo, nil,
 		nil, cca.recursive, true, false, func(entityType common.EntityType) {
 			if entityType == common.EEntityType.File() {
 				atomic.AddUint64(&cca.atomicSourceFilesScanned, 1)
@@ -68,7 +68,7 @@ func (cca *cookedSyncCmdArgs) initEnumerator(ctx context.Context) (enumerator *s
 	}
 
 	// Because we can't trust cca.credinfo, given that it's for the overall job, not the individual traversers, we get cred info again here.
-	dstCredInfo, _, err := getCredentialInfoForLocation(ctx, cca.fromTo.To(), cca.destination.Value,
+	dstCredInfo, _, err := GetCredentialInfoForLocation(ctx, cca.fromTo.To(), cca.destination.Value,
 		cca.destination.SAS, false, cca.cpkOptions)
 
 	if err != nil {
@@ -78,7 +78,7 @@ func (cca *cookedSyncCmdArgs) initEnumerator(ctx context.Context) (enumerator *s
 	// TODO: enable symlink support in a future release after evaluating the implications
 	// GetProperties is enabled by default as sync supports both upload and download.
 	// This property only supports Files and S3 at the moment, but provided that Files sync is coming soon, enable to avoid stepping on Files sync work
-	destinationTraverser, err := initResourceTraverser(cca.destination, cca.fromTo.To(), &ctx, &dstCredInfo, nil, nil, cca.recursive, true, false, func(entityType common.EntityType) {
+	destinationTraverser, err := InitResourceTraverser(cca.destination, cca.fromTo.To(), &ctx, &dstCredInfo, nil, nil, cca.recursive, true, false, func(entityType common.EntityType) {
 		if entityType == common.EEntityType.File() {
 			atomic.AddUint64(&cca.atomicDestinationFilesScanned, 1)
 		}
@@ -88,7 +88,7 @@ func (cca *cookedSyncCmdArgs) initEnumerator(ctx context.Context) (enumerator *s
 	}
 
 	// verify that the traversers are targeting the same type of resources
-	if sourceTraverser.isDirectory(true) != destinationTraverser.isDirectory(true) {
+	if sourceTraverser.IsDirectory(true) != destinationTraverser.IsDirectory(true) {
 		return nil, errors.New("sync must happen between source and destination of the same type," +
 			" e.g. either file <-> file, or directory/container <-> directory/container")
 	}
@@ -116,7 +116,7 @@ func (cca *cookedSyncCmdArgs) initEnumerator(ctx context.Context) (enumerator *s
 
 	// after making all filters, log any search prefix computed from them
 	if ste.JobsAdmin != nil {
-		if prefixFilter := filterSet(filters).GetEnumerationPreFilter(cca.recursive); prefixFilter != "" {
+		if prefixFilter := FilterSet(filters).GetEnumerationPreFilter(cca.recursive); prefixFilter != "" {
 			ste.JobsAdmin.LogToJobLog("Search prefix, which may be used to optimize scanning, is: "+prefixFilter, pipeline.LogInfo) // "May be used" because we don't know here which enumerators will use it
 		}
 	}

--- a/cmd/syncIndexer.go
+++ b/cmd/syncIndexer.go
@@ -26,10 +26,10 @@ import (
 
 // the objectIndexer is essential for the generic sync enumerator to work
 // it can serve as a:
-// 		1. objectProcessor: accumulate a lookup map with given storedObjects
+// 		1. objectProcessor: accumulate a lookup map with given StoredObjects
 //		2. resourceTraverser: go through the entities in the map like a traverser
 type objectIndexer struct {
-	indexMap map[string]storedObject
+	indexMap map[string]StoredObject
 	counter  int
 
 	// isDestinationCaseInsensitive is true when the destination is case-insensitive
@@ -40,15 +40,15 @@ type objectIndexer struct {
 }
 
 func newObjectIndexer() *objectIndexer {
-	return &objectIndexer{indexMap: make(map[string]storedObject)}
+	return &objectIndexer{indexMap: make(map[string]StoredObject)}
 }
 
 // process the given stored object by indexing it using its relative path
-func (i *objectIndexer) store(storedObject storedObject) (err error) {
+func (i *objectIndexer) store(storedObject StoredObject) (err error) {
 	// TODO we might buffer too much data in memory, figure out whether we should limit the max number of files
 	// TODO previously we used 10M as the max, but it was proven to be too small for some users
 
-	// It is safe to index all storedObjects just by relative path, regardless of their entity type, because
+	// It is safe to index all StoredObjects just by relative path, regardless of their entity type, because
 	// no filesystem allows a file and a folder to have the exact same full path.  This is true of
 	// Linux file systems, Windows, Azure Files and ADLS Gen 2 (and logically should be true of all file systems).
 	if i.isDestinationCaseInsensitive {
@@ -62,7 +62,7 @@ func (i *objectIndexer) store(storedObject storedObject) (err error) {
 }
 
 // go through the remaining stored objects in the map to process them
-func (i *objectIndexer) traverse(processor objectProcessor, filters []objectFilter) (err error) {
+func (i *objectIndexer) traverse(processor objectProcessor, filters []ObjectFilter) (err error) {
 	for _, value := range i.indexMap {
 		err = processIfPassedFilters(filters, value, processor)
 		_, err = getProcessingError(err)

--- a/cmd/syncProcessor.go
+++ b/cmd/syncProcessor.go
@@ -101,7 +101,7 @@ type interactiveDeleteProcessor struct {
 	dryrunMode bool
 }
 
-func newDeleteTransfer(object storedObject) (newDeleteTransfer common.CopyTransfer) {
+func newDeleteTransfer(object StoredObject) (newDeleteTransfer common.CopyTransfer) {
 	return common.CopyTransfer{
 		Source:             object.relativePath,
 		EntityType:         object.entityType,
@@ -119,7 +119,7 @@ func newDeleteTransfer(object storedObject) (newDeleteTransfer common.CopyTransf
 	}
 }
 
-func (d *interactiveDeleteProcessor) removeImmediately(object storedObject) (err error) {
+func (d *interactiveDeleteProcessor) removeImmediately(object StoredObject) (err error) {
 	if d.shouldPromptUser {
 		d.shouldDelete, d.shouldPromptUser = d.promptForConfirmation(object) // note down the user's decision
 	}
@@ -163,7 +163,7 @@ func (d *interactiveDeleteProcessor) removeImmediately(object storedObject) (err
 	return
 }
 
-func (d *interactiveDeleteProcessor) promptForConfirmation(object storedObject) (shouldDelete bool, keepPrompting bool) {
+func (d *interactiveDeleteProcessor) promptForConfirmation(object StoredObject) (shouldDelete bool, keepPrompting bool) {
 	answer := glcm.Prompt(fmt.Sprintf("The %s '%s' does not exist at the source. "+
 		"Do you wish to delete it from the destination(%s)?",
 		d.objectTypeToDisplay, object.relativePath, d.objectLocationToDisplay),
@@ -236,7 +236,7 @@ func shouldSyncRemoveFolders() bool {
 	return false
 }
 
-func (l *localFileDeleter) deleteFile(object storedObject) error {
+func (l *localFileDeleter) deleteFile(object StoredObject) error {
 	if object.entityType == common.EEntityType.File() {
 		glcm.Info("Deleting extra file: " + object.relativePath)
 		return os.Remove(common.GenerateFullPath(l.rootPath, object.relativePath))
@@ -255,7 +255,7 @@ func newSyncDeleteProcessor(cca *cookedSyncCmdArgs) (*interactiveDeleteProcessor
 
 	ctx := context.WithValue(context.TODO(), ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
 
-	p, err := initPipeline(ctx, cca.fromTo.To(), cca.credentialInfo, cca.logVerbosity.ToPipelineLogLevel())
+	p, err := InitPipeline(ctx, cca.fromTo.To(), cca.credentialInfo, cca.logVerbosity.ToPipelineLogLevel())
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +280,7 @@ func newRemoteResourceDeleter(rawRootURL *url.URL, p pipeline.Pipeline, ctx cont
 	}
 }
 
-func (b *remoteResourceDeleter) delete(object storedObject) error {
+func (b *remoteResourceDeleter) delete(object StoredObject) error {
 	if object.entityType == common.EEntityType.File() {
 		// TODO: use b.targetLocation.String() in the next line, instead of "object", if we can make it come out as string
 		glcm.Info("Deleting extra object: " + object.relativePath)

--- a/cmd/validators.go
+++ b/cmd/validators.go
@@ -29,7 +29,7 @@ import (
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
-func validateFromTo(src, dst string, userSpecifiedFromTo string) (common.FromTo, error) {
+func ValidateFromTo(src, dst string, userSpecifiedFromTo string) (common.FromTo, error) {
 	if userSpecifiedFromTo == "" {
 		inferredFromTo := inferFromTo(src, dst)
 
@@ -57,7 +57,7 @@ const fromToHelpText = "Valid values are two-word phases of the form BlobLocal, 
 
 func inferFromTo(src, dst string) common.FromTo {
 	// Try to infer the 1st argument
-	srcLocation := inferArgumentLocation(src)
+	srcLocation := InferArgumentLocation(src)
 	if srcLocation == srcLocation.Unknown() {
 		glcm.Info("Cannot infer source location of " +
 			common.URLStringExtension(src).RedactSecretQueryParamForLogging() +
@@ -65,7 +65,7 @@ func inferFromTo(src, dst string) common.FromTo {
 		return common.EFromTo.Unknown()
 	}
 
-	dstLocation := inferArgumentLocation(dst)
+	dstLocation := InferArgumentLocation(dst)
 	if dstLocation == dstLocation.Unknown() {
 		glcm.Info("Cannot infer destination location of " +
 			common.URLStringExtension(dst).RedactSecretQueryParamForLogging() +
@@ -122,7 +122,7 @@ func inferFromTo(src, dst string) common.FromTo {
 
 var IPv4Regex = regexp.MustCompile(`\d+\.\d+\.\d+\.\d+`) // simple regex
 
-func inferArgumentLocation(arg string) common.Location {
+func InferArgumentLocation(arg string) common.Location {
 	if arg == pipeLocation {
 		return common.ELocation.Pipe()
 	}

--- a/cmd/zc_attr_filter_notwin.go
+++ b/cmd/zc_attr_filter_notwin.go
@@ -24,24 +24,24 @@ package cmd
 
 type attrFilter struct{}
 
-func (f *attrFilter) doesSupportThisOS() (msg string, supported bool) {
+func (f *attrFilter) DoesSupportThisOS() (msg string, supported bool) {
 	msg = "'include-attributes' and 'exclude-attributes' are not supported on this OS. Abort."
 	supported = false
 	return
 }
 
-func (f *attrFilter) appliesOnlyToFiles() bool {
+func (f *attrFilter) AppliesOnlyToFiles() bool {
 	return true
 }
 
-func (f *attrFilter) doesPass(storedObject storedObject) bool {
+func (f *attrFilter) DoesPass(storedObject StoredObject) bool {
 	// ignore this option on Unix systems
 	return true
 }
 
-func buildAttrFilters(attributes []string, fullPath string, resultIfMatch bool) []objectFilter {
+func buildAttrFilters(attributes []string, fullPath string, resultIfMatch bool) []ObjectFilter {
 	// ignore this option on Unix systems
-	filters := make([]objectFilter, 0)
+	filters := make([]ObjectFilter, 0)
 	if len(attributes) > 0 {
 		filters = append(filters, &attrFilter{})
 	}

--- a/cmd/zc_attr_filter_windows.go
+++ b/cmd/zc_attr_filter_windows.go
@@ -34,17 +34,17 @@ type attrFilter struct {
 	isIncludeFilter bool
 }
 
-func (f *attrFilter) doesSupportThisOS() (msg string, supported bool) {
+func (f *attrFilter) DoesSupportThisOS() (msg string, supported bool) {
 	msg = ""
 	supported = true
 	return
 }
 
-func (f *attrFilter) appliesOnlyToFiles() bool {
+func (f *attrFilter) AppliesOnlyToFiles() bool {
 	return true // keep this filter consistent with include-pattern
 }
 
-func (f *attrFilter) doesPass(storedObject storedObject) bool {
+func (f *attrFilter) DoesPass(storedObject StoredObject) bool {
 	fileName := ""
 	if strings.Index(f.filePath, "*") == -1 {
 		fileName = common.GenerateFullPath(f.filePath, storedObject.relativePath)
@@ -74,9 +74,9 @@ func (f *attrFilter) doesPass(storedObject storedObject) bool {
 	return !f.isIncludeFilter
 }
 
-func buildAttrFilters(attributes []string, fullPath string, isIncludeFilter bool) []objectFilter {
+func buildAttrFilters(attributes []string, fullPath string, isIncludeFilter bool) []ObjectFilter {
 	var fileAttributes uint32
-	filters := make([]objectFilter, 0)
+	filters := make([]ObjectFilter, 0)
 	// Available attributes (SMB) include:
 	// R = Read-only files
 	// A = Files ready for archiving

--- a/cmd/zc_enumerator.go
+++ b/cmd/zc_enumerator.go
@@ -46,7 +46,7 @@ import (
 // represent a local or remote resource object (ex: local file, blob, etc.)
 // we can add more properties if needed, as this is easily extensible
 // ** DO NOT instantiate directly, always use newStoredObject ** (to make sure its fully populated and any preprocessor method runs)
-type storedObject struct {
+type StoredObject struct {
 	name             string
 	entityType       common.EntityType
 	lastModifiedTime time.Time
@@ -67,14 +67,14 @@ type storedObject struct {
 	// example: rootDir=/var/a/b/c/d/e/f.pdf fullPath=/var/a/b/c/d/e/f.pdf => relativePath=""
 	// in this case, since rootDir already points to the file, relatively speaking the path is nothing.
 	// In this case isSingleSourceFile returns true.
-	// Note 2: The other unusual case is the storedObject representing the folder properties of the root dir
+	// Note 2: The other unusual case is the StoredObject representing the folder properties of the root dir
 	// (if the source is folder-aware). In this case relativePath is also empty.
 	// In this case isSourceRootFolder returns true.
 	relativePath string
 	// container source, only included by account traversers.
-	containerName string
+	ContainerName string
 	// destination container name. Included in the processor after resolving container names.
-	dstContainerName string
+	DstContainerName string
 	// access tier, only included by blob traverser.
 	blobAccessTier azblob.AccessTierType
 	// metadata, included in S2S transfers
@@ -88,15 +88,15 @@ type storedObject struct {
 	leaseDuration azblob.LeaseDurationType
 }
 
-func (s *storedObject) isMoreRecentThan(storedObject2 storedObject) bool {
+func (s *StoredObject) isMoreRecentThan(storedObject2 StoredObject) bool {
 	return s.lastModifiedTime.After(storedObject2.lastModifiedTime)
 }
 
-func (s *storedObject) isSingleSourceFile() bool {
+func (s *StoredObject) isSingleSourceFile() bool {
 	return s.relativePath == "" && s.entityType == common.EEntityType.File()
 }
 
-func (s *storedObject) isSourceRootFolder() bool {
+func (s *StoredObject) isSourceRootFolder() bool {
 	return s.relativePath == "" && s.entityType == common.EEntityType.Folder()
 }
 
@@ -106,7 +106,7 @@ func (s *storedObject) isSourceRootFolder() bool {
 // We can't just implement this filtering in ToNewCopyTransfer, because delete transfers (from sync)
 // do not pass through that routine.  So we need to make the filtering available in a separate function
 // so that the sync deletion code path(s) can access it.
-func (s *storedObject) isCompatibleWithFpo(fpo common.FolderPropertyOption) bool {
+func (s *StoredObject) isCompatibleWithFpo(fpo common.FolderPropertyOption) bool {
 	if s.entityType == common.EEntityType.File() {
 		return true
 	} else if s.entityType == common.EEntityType.Folder() {
@@ -125,10 +125,10 @@ func (s *storedObject) isCompatibleWithFpo(fpo common.FolderPropertyOption) bool
 	}
 }
 
-// Returns a func that only calls inner if storedObject isCompatibleWithFpo
+// Returns a func that only calls inner if StoredObject isCompatibleWithFpo
 // We use this, so that we can easily test for compatibility in the sync deletion code (which expects an objectProcessor)
 func newFpoAwareProcessor(fpo common.FolderPropertyOption, inner objectProcessor) objectProcessor {
-	return func(s storedObject) error {
+	return func(s StoredObject) error {
 		if s.isCompatibleWithFpo(fpo) {
 			return inner(s)
 		} else {
@@ -137,7 +137,7 @@ func newFpoAwareProcessor(fpo common.FolderPropertyOption, inner objectProcessor
 	}
 }
 
-func (s *storedObject) ToNewCopyTransfer(
+func (s *StoredObject) ToNewCopyTransfer(
 	steWillAutoDecompress bool,
 	Source string,
 	Destination string,
@@ -196,7 +196,7 @@ func stripCompressionExtension(dest string, contentEncoding string) string {
 	return dest
 }
 
-// interfaces for standard properties of storedObjects
+// interfaces for standard properties of StoredObjects
 type contentPropsProvider interface {
 	CacheControl() string
 	ContentDisposition() string
@@ -213,10 +213,10 @@ type blobPropsProvider interface {
 	LeaseState() azblob.LeaseStateType
 }
 
-// a constructor is used so that in case the storedObject has to change, the callers would get a compilation error
+// a constructor is used so that in case the StoredObject has to change, the callers would get a compilation error
 // and it forces all necessary properties to be always supplied and not forgotten
-func newStoredObject(morpher objectMorpher, name string, relativePath string, entityType common.EntityType, lmt time.Time, size int64, props contentPropsProvider, blobProps blobPropsProvider, meta common.Metadata, containerName string) storedObject {
-	obj := storedObject{
+func newStoredObject(morpher objectMorpher, name string, relativePath string, entityType common.EntityType, lmt time.Time, size int64, props contentPropsProvider, blobProps blobPropsProvider, meta common.Metadata, containerName string) StoredObject {
+	obj := StoredObject{
 		name:               name,
 		relativePath:       relativePath,
 		entityType:         entityType,
@@ -231,14 +231,14 @@ func newStoredObject(morpher objectMorpher, name string, relativePath string, en
 		blobType:           blobProps.BlobType(),
 		blobAccessTier:     blobProps.AccessTier(),
 		Metadata:           meta,
-		containerName:      containerName,
+		ContainerName:      containerName,
 		// Additional lease properties. To be used in listing
 		leaseStatus:   blobProps.LeaseStatus(),
 		leaseState:    blobProps.LeaseState(),
 		leaseDuration: blobProps.LeaseDuration(),
 	}
 
-	// Folders don't have size, and root ones shouldn't have names in the storedObject. Ensure those rules are consistently followed
+	// Folders don't have size, and root ones shouldn't have names in the StoredObject. Ensure those rules are consistently followed
 	if entityType == common.EEntityType.Folder() {
 		obj.size = 0
 		if obj.isSourceRootFolder() {
@@ -255,18 +255,18 @@ func newStoredObject(morpher objectMorpher, name string, relativePath string, en
 }
 
 // capable of traversing a structured resource like container or local directory
-// pass each storedObject to the given objectProcessor if it passes all the filters
-type resourceTraverser interface {
-	traverse(preprocessor objectMorpher, processor objectProcessor, filters []objectFilter) error
-	isDirectory(isSource bool) bool
+// pass each StoredObject to the given objectProcessor if it passes all the filters
+type ResourceTraverser interface {
+	Traverse(preprocessor objectMorpher, processor objectProcessor, filters []ObjectFilter) error
+	IsDirectory(isSource bool) bool
 	// isDirectory has an isSource flag for a single exception to blob.
 	// Blob should ONLY check remote if it's a source.
 	// On destinations, because blobs and virtual directories can share names, we should support placing in both ways.
 	// Thus, we only check the directory syntax on blob destinations. On sources, we check both syntax and remote, if syntax isn't a directory.
 }
 
-type accountTraverser interface {
-	resourceTraverser
+type AccountTraverser interface {
+	ResourceTraverser
 	listContainers() ([]string, error)
 }
 
@@ -275,10 +275,10 @@ func containerNameMatchesPattern(containerName, pattern string) (bool, error) {
 	return filepath.Match(pattern, containerName)
 }
 
-// newContainerDecorator constructs an objectMorpher that adds the given container name to storedObjects
+// newContainerDecorator constructs an objectMorpher that adds the given container name to StoredObjects
 func newContainerDecorator(containerName string) objectMorpher {
-	return func(object *storedObject) {
-		object.containerName = containerName
+	return func(object *StoredObject) {
+		object.ContainerName = containerName
 	}
 }
 
@@ -302,11 +302,11 @@ type enumerationCounterFunc func(entityType common.EntityType)
 // followSymlinks is only required for local resources (defaults to false)
 // errorOnDirWOutRecursive is used by copy.
 
-func initResourceTraverser(resource common.ResourceString, location common.Location, ctx *context.Context,
-	credential *common.CredentialInfo, followSymlinks *bool, listOfFilesChannel chan string, recursive, getProperties,
+func InitResourceTraverser(resource common.ResourceString, location common.Location, ctx *context.Context,
+	credential *common.CredentialInfo, followSymlinks *bool,listOfFilesChannel chan string, recursive, getProperties,
 	includeDirectoryStubs bool, incrementEnumerationCounter enumerationCounterFunc, listOfVersionIds chan string,
-	s2sPreserveBlobTags bool, logLevel pipeline.LogLevel, cpkOptions common.CpkOptions) (resourceTraverser, error) {
-	var output resourceTraverser
+	s2sPreserveBlobTags bool, logLevel pipeline.LogLevel, cpkOptions common.CpkOptions) (ResourceTraverser, error) {
+	var output ResourceTraverser
 	var p *pipeline.Pipeline
 
 	// Clean up the resource if it's a local path
@@ -316,7 +316,7 @@ func initResourceTraverser(resource common.ResourceString, location common.Locat
 
 	// Initialize the pipeline if creds and ctx is provided
 	if ctx != nil && credential != nil {
-		tmppipe, err := initPipeline(*ctx, location, *credential, logLevel)
+		tmppipe, err := InitPipeline(*ctx, location, *credential, logLevel)
 
 		if err != nil {
 			return nil, err
@@ -343,7 +343,7 @@ func initResourceTraverser(resource common.ResourceString, location common.Locat
 		}
 
 		output = newListTraverser(resource, location, credential, ctx, recursive, toFollow, getProperties,
-			listOfFilesChannel, includeDirectoryStubs, incrementEnumerationCounter, s2sPreserveBlobTags, logLevel, cpkOptions)
+		listOfFilesChannel, includeDirectoryStubs, incrementEnumerationCounter, s2sPreserveBlobTags, logLevel, cpkOptions)
 		return output, nil
 	}
 
@@ -538,13 +538,13 @@ func initResourceTraverser(resource common.ResourceString, location common.Locat
 	return output, nil
 }
 
-// given a storedObject, process it accordingly. Used for the "real work" of, say, creating a copyTransfer from the object
-type objectProcessor func(storedObject storedObject) error
+// given a StoredObject, process it accordingly. Used for the "real work" of, say, creating a copyTransfer from the object
+type objectProcessor func(storedObject StoredObject) error
 
 // TODO: consider making objectMorpher an interface, not a func, and having newStoredObject take an array of them, instead of just one
 //   Might be easier to debug
-// modifies a storedObject, but does NOT process it.  Used for modifications, such as pre-pending a parent path
-type objectMorpher func(storedObject *storedObject)
+// modifies a StoredObject, but does NOT process it.  Used for modifications, such as pre-pending a parent path
+type objectMorpher func(storedObject *StoredObject)
 
 // FollowedBy returns a new objectMorpher, which performs the action of existing followed by the action of additional.
 // Use this so that we always chain pre-processors, never replace them (this is so we avoid making any assumptions about
@@ -556,7 +556,7 @@ func (existing objectMorpher) FollowedBy(additional objectMorpher) objectMorpher
 	case additional == nil:
 		return existing
 	default:
-		return func(obj *storedObject) {
+		return func(obj *StoredObject) {
 			existing(obj)
 			additional(obj)
 		}
@@ -568,12 +568,12 @@ func (existing objectMorpher) FollowedBy(additional objectMorpher) objectMorpher
 // add their morphers with FollowedBy()
 var noPreProccessor objectMorpher = nil
 
-// given a storedObject, verify if it satisfies the defined conditions
+// given a StoredObject, verify if it satisfies the defined conditions
 // if yes, return true
-type objectFilter interface {
-	doesSupportThisOS() (msg string, supported bool)
-	doesPass(storedObject storedObject) bool
-	appliesOnlyToFiles() bool
+type ObjectFilter interface {
+	DoesSupportThisOS() (msg string, supported bool)
+	DoesPass(storedObject StoredObject) bool
+	AppliesOnlyToFiles() bool
 }
 
 type preFilterProvider interface {
@@ -587,14 +587,14 @@ type preFilterProvider interface {
 type syncEnumerator struct {
 	// these allow us to go through the source and destination
 	// there is flexibility in which side we scan first, it could be either the source or the destination
-	primaryTraverser   resourceTraverser
-	secondaryTraverser resourceTraverser
+	primaryTraverser   ResourceTraverser
+	secondaryTraverser ResourceTraverser
 
 	// the results from the primary traverser would be stored here
 	objectIndexer *objectIndexer
 
 	// general filters apply to both the primary and secondary traverser
-	filters []objectFilter
+	filters []ObjectFilter
 
 	// the processor that apply only to the secondary traverser
 	// it processes objects as scanning happens
@@ -605,8 +605,8 @@ type syncEnumerator struct {
 	finalize func() error
 }
 
-func newSyncEnumerator(primaryTraverser, secondaryTraverser resourceTraverser, indexer *objectIndexer,
-	filters []objectFilter, comparator objectProcessor, finalize func() error) *syncEnumerator {
+func newSyncEnumerator(primaryTraverser, secondaryTraverser ResourceTraverser, indexer *objectIndexer,
+	filters []ObjectFilter, comparator objectProcessor, finalize func() error) *syncEnumerator {
 	return &syncEnumerator{
 		primaryTraverser:   primaryTraverser,
 		secondaryTraverser: secondaryTraverser,
@@ -619,7 +619,7 @@ func newSyncEnumerator(primaryTraverser, secondaryTraverser resourceTraverser, i
 
 func (e *syncEnumerator) enumerate() (err error) {
 	// enumerate the primary resource and build lookup map
-	err = e.primaryTraverser.traverse(noPreProccessor, e.objectIndexer.store, e.filters)
+	err = e.primaryTraverser.Traverse(noPreProccessor, e.objectIndexer.store, e.filters)
 	if err != nil {
 		return
 	}
@@ -628,7 +628,7 @@ func (e *syncEnumerator) enumerate() (err error) {
 	// they will be passed to the object comparator
 	// which can process given objects based on what's already indexed
 	// note: transferring can start while scanning is ongoing
-	err = e.secondaryTraverser.traverse(noPreProccessor, e.objectComparator, e.filters)
+	err = e.secondaryTraverser.Traverse(noPreProccessor, e.objectComparator, e.filters)
 	if err != nil {
 		return
 	}
@@ -642,25 +642,25 @@ func (e *syncEnumerator) enumerate() (err error) {
 	return
 }
 
-type copyEnumerator struct {
-	traverser resourceTraverser
+type CopyEnumerator struct {
+	Traverser ResourceTraverser
 
 	// general filters apply to the objects returned by the traverser
-	filters []objectFilter
+	Filters []ObjectFilter
 
 	// receive objects from the traverser and dispatch them for transferring
-	objectDispatcher objectProcessor
+	ObjectDispatcher objectProcessor
 
 	// a finalizer that is always called if the enumeration finishes properly
-	finalize func() error
+	Finalize func() error
 }
 
-func newCopyEnumerator(traverser resourceTraverser, filters []objectFilter, objectDispatcher objectProcessor, finalizer func() error) *copyEnumerator {
-	return &copyEnumerator{
-		traverser:        traverser,
-		filters:          filters,
-		objectDispatcher: objectDispatcher,
-		finalize:         finalizer,
+func NewCopyEnumerator(traverser ResourceTraverser, filters []ObjectFilter, objectDispatcher objectProcessor, finalizer func() error) *CopyEnumerator {
+	return &CopyEnumerator{
+		Traverser:        traverser,
+		Filters:          filters,
+		ObjectDispatcher: objectDispatcher,
+		Finalize:         finalizer,
 	}
 }
 
@@ -672,28 +672,28 @@ func WarnStdoutAndScanningLog(toLog string) {
 	}
 }
 
-func (e *copyEnumerator) enumerate() (err error) {
-	err = e.traverser.traverse(noPreProccessor, e.objectDispatcher, e.filters)
+func (e *CopyEnumerator) enumerate() (err error) {
+	err = e.Traverser.Traverse(noPreProccessor, e.ObjectDispatcher, e.Filters)
 	if err != nil {
 		return
 	}
 
 	// execute the finalize func which may perform useful clean up steps
-	return e.finalize()
+	return e.Finalize()
 }
 
 // -------------------------------------- Helper Funcs -------------------------------------- \\
 
-func passedFilters(filters []objectFilter, storedObject storedObject) bool {
+func passedFilters(filters []ObjectFilter, storedObject StoredObject) bool {
 	if filters != nil && len(filters) > 0 {
 		// loop through the filters, if any of them fail, then return false
 		for _, filter := range filters {
-			msg, supported := filter.doesSupportThisOS()
+			msg, supported := filter.DoesSupportThisOS()
 			if !supported {
 				glcm.Error(msg)
 			}
 
-			if filter.appliesOnlyToFiles() && storedObject.entityType != common.EEntityType.File() {
+			if filter.AppliesOnlyToFiles() && storedObject.entityType != common.EEntityType.File() {
 				// don't pass folders to filters that only know how to deal with files
 				// As at Feb 2020, we have separate logic to weed out folder properties (and not even send them)
 				// if any filter applies only to files... but that logic runs after this point, so we need this
@@ -701,7 +701,7 @@ func passedFilters(filters []objectFilter, storedObject storedObject) bool {
 				continue
 			}
 
-			if !filter.doesPass(storedObject) {
+			if !filter.DoesPass(storedObject) {
 				return false
 			}
 		}
@@ -723,7 +723,7 @@ func getProcessingError(errin error) (ignored bool, err error) {
 	return false, err
 }
 
-func processIfPassedFilters(filters []objectFilter, storedObject storedObject, processor objectProcessor) (err error) {
+func processIfPassedFilters(filters []ObjectFilter, storedObject StoredObject, processor objectProcessor) (err error) {
 	if passedFilters(filters, storedObject) {
 		err = processor(storedObject)
 	} else {
@@ -733,13 +733,13 @@ func processIfPassedFilters(filters []objectFilter, storedObject storedObject, p
 	return
 }
 
-// storedObject names are useful for filters
+// StoredObject names are useful for filters
 func getObjectNameOnly(fullPath string) (nameOnly string) {
 	lastPathSeparator := strings.LastIndex(fullPath, common.AZCOPY_PATH_SEPARATOR_STRING)
 
 	// if there is a path separator and it is not the last character
 	if lastPathSeparator > 0 && lastPathSeparator != len(fullPath)-1 {
-		// then we separate out the name of the storedObject
+		// then we separate out the name of the StoredObject
 		nameOnly = fullPath[lastPathSeparator+1:]
 	} else {
 		nameOnly = fullPath

--- a/cmd/zc_pipeline_init.go
+++ b/cmd/zc_pipeline_init.go
@@ -9,7 +9,7 @@ import (
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
-func initPipeline(ctx context.Context, location common.Location, credential common.CredentialInfo, logLevel pipeline.LogLevel) (p pipeline.Pipeline, err error) {
+func InitPipeline(ctx context.Context, location common.Location, credential common.CredentialInfo, logLevel pipeline.LogLevel) (p pipeline.Pipeline, err error) {
 	switch location {
 	case common.ELocation.Local(),
 		common.ELocation.Benchmark():

--- a/cmd/zc_processor.go
+++ b/cmd/zc_processor.go
@@ -66,7 +66,7 @@ func newCopyTransferProcessor(copyJobTemplate *common.CopyJobPartOrderRequest, n
 	}
 }
 
-func (s *copyTransferProcessor) scheduleCopyTransfer(storedObject storedObject) (err error) {
+func (s *copyTransferProcessor) scheduleCopyTransfer(storedObject StoredObject) (err error) {
 
 	// Escape paths on destinations where the characters are invalid
 	// And re-encode them where the characters are valid.

--- a/cmd/zc_traverser_benchmark.go
+++ b/cmd/zc_traverser_benchmark.go
@@ -45,7 +45,7 @@ func newBenchmarkTraverser(source string, incrementEnumerationCounter enumeratio
 		nil
 }
 
-func (t *benchmarkTraverser) isDirectory(bool) bool {
+func (t *benchmarkTraverser) IsDirectory(bool) bool {
 	return true
 }
 
@@ -61,7 +61,7 @@ func (_ *benchmarkTraverser) toReversedString(i uint) string {
 	return string(r)
 }
 
-func (t *benchmarkTraverser) traverse(preprocessor objectMorpher, processor objectProcessor, filters []objectFilter) (err error) {
+func (t *benchmarkTraverser) Traverse(preprocessor objectMorpher, processor objectProcessor, filters []ObjectFilter) (err error) {
 	if len(filters) > 0 {
 		panic("filters not expected or supported in benchmark traverser") // but we still call processIfPassedFilters below, for consistency with other traversers
 	}

--- a/cmd/zc_traverser_blob.go
+++ b/cmd/zc_traverser_blob.go
@@ -56,7 +56,7 @@ type blobTraverser struct {
 	cpkOptions common.CpkOptions
 }
 
-func (t *blobTraverser) isDirectory(isSource bool) bool {
+func (t *blobTraverser) IsDirectory(isSource bool) bool {
 	isDirDirect := copyHandlerUtil{}.urlIsContainerOrVirtualDirectory(t.rawURL)
 
 	// Skip the single blob check if we're checking a destination.
@@ -121,7 +121,7 @@ func (t *blobTraverser) getBlobTags() (common.BlobTags, error) {
 	return blobTagsMap, nil
 }
 
-func (t *blobTraverser) traverse(preprocessor objectMorpher, processor objectProcessor, filters []objectFilter) (err error) {
+func (t *blobTraverser) Traverse(preprocessor objectMorpher, processor objectProcessor, filters []ObjectFilter) (err error) {
 	blobUrlParts := azblob.NewBlobURLParts(*t.rawURL)
 
 	// check if the url points to a single blob
@@ -203,7 +203,7 @@ func (t *blobTraverser) traverse(preprocessor objectMorpher, processor objectPro
 	}
 
 	// as a performance optimization, get an extra prefix to do pre-filtering. It's typically the start portion of a blob name.
-	extraSearchPrefix := filterSet(filters).GetEnumerationPreFilter(t.recursive)
+	extraSearchPrefix := FilterSet(filters).GetEnumerationPreFilter(t.recursive)
 
 	if t.parallelListing {
 		return t.parallelList(containerURL, blobUrlParts.ContainerName, searchPrefix, extraSearchPrefix, preprocessor, processor, filters)
@@ -213,7 +213,7 @@ func (t *blobTraverser) traverse(preprocessor objectMorpher, processor objectPro
 }
 
 func (t *blobTraverser) parallelList(containerURL azblob.ContainerURL, containerName string, searchPrefix string,
-	extraSearchPrefix string, preprocessor objectMorpher, processor objectProcessor, filters []objectFilter) error {
+	extraSearchPrefix string, preprocessor objectMorpher, processor objectProcessor, filters []ObjectFilter) error {
 	// Define how to enumerate its contents
 	// This func must be thread safe/goroutine safe
 	enumerateOneDir := func(dir parallel.Directory, enqueueDir func(parallel.Directory), enqueueOutput func(parallel.DirectoryEntry, error)) error {
@@ -280,7 +280,7 @@ func (t *blobTraverser) parallelList(containerURL azblob.ContainerURL, container
 
 	// initiate parallel scanning, starting at the root path
 	workerContext, cancelWorkers := context.WithCancel(t.ctx)
-	cCrawled := parallel.Crawl(workerContext, searchPrefix+extraSearchPrefix, enumerateOneDir, enumerationParallelism)
+	cCrawled := parallel.Crawl(workerContext, searchPrefix+extraSearchPrefix, enumerateOneDir, EnumerationParallelism)
 
 	for x := range cCrawled {
 		item, workerError := x.Item()
@@ -293,7 +293,7 @@ func (t *blobTraverser) parallelList(containerURL azblob.ContainerURL, container
 			t.incrementEnumerationCounter(common.EEntityType.File())
 		}
 
-		object := item.(storedObject)
+		object := item.(StoredObject)
 		processErr := processIfPassedFilters(filters, object, processor)
 		_, processErr = getProcessingError(processErr)
 		if processErr != nil {
@@ -305,7 +305,7 @@ func (t *blobTraverser) parallelList(containerURL azblob.ContainerURL, container
 	return nil
 }
 
-func (t *blobTraverser) createStoredObjectForBlob(preprocessor objectMorpher, blobInfo azblob.BlobItemInternal, relativePath string, containerName string) storedObject {
+func (t *blobTraverser) createStoredObjectForBlob(preprocessor objectMorpher, blobInfo azblob.BlobItemInternal, relativePath string, containerName string) StoredObject {
 	adapter := blobPropertiesAdapter{blobInfo.Properties}
 	return newStoredObject(
 		preprocessor,
@@ -327,7 +327,7 @@ func (t *blobTraverser) doesBlobRepresentAFolder(metadata azblob.Metadata) bool 
 }
 
 func (t *blobTraverser) serialList(containerURL azblob.ContainerURL, containerName string, searchPrefix string,
-	extraSearchPrefix string, preprocessor objectMorpher, processor objectProcessor, filters []objectFilter) error {
+	extraSearchPrefix string, preprocessor objectMorpher, processor objectProcessor, filters []ObjectFilter) error {
 
 	for marker := (azblob.Marker{}); marker.NotDone(); {
 		// see the TO DO in GetEnumerationPreFilter if/when we make this more directory-aware

--- a/cmd/zc_traverser_blob_account.go
+++ b/cmd/zc_traverser_blob_account.go
@@ -47,7 +47,7 @@ type blobAccountTraverser struct {
 	cpkOptions common.CpkOptions
 }
 
-func (t *blobAccountTraverser) isDirectory(_ bool) bool {
+func (t *blobAccountTraverser) IsDirectory(_ bool) bool {
 	return true // Returns true as account traversal is inherently folder-oriented and recursive.
 }
 
@@ -90,7 +90,7 @@ func (t *blobAccountTraverser) listContainers() ([]string, error) {
 	}
 }
 
-func (t *blobAccountTraverser) traverse(preprocessor objectMorpher, processor objectProcessor, filters []objectFilter) error {
+func (t *blobAccountTraverser) Traverse(preprocessor objectMorpher, processor objectProcessor, filters []ObjectFilter) error {
 	// listContainers will return the cached container list if containers have already been listed by this traverser.
 	cList, err := t.listContainers()
 
@@ -105,7 +105,7 @@ func (t *blobAccountTraverser) traverse(preprocessor objectMorpher, processor ob
 
 		preprocessorForThisChild := preprocessor.FollowedBy(newContainerDecorator(v))
 
-		err = containerTraverser.traverse(preprocessorForThisChild, processor, filters)
+		err = containerTraverser.Traverse(preprocessorForThisChild, processor, filters)
 
 		if err != nil {
 			WarnStdoutAndScanningLog(fmt.Sprintf("failed to list blobs in container %s: %s", v, err))

--- a/cmd/zc_traverser_blob_versions.go
+++ b/cmd/zc_traverser_blob_versions.go
@@ -40,7 +40,7 @@ type blobVersionsTraverser struct {
 	cpkOptions                  common.CpkOptions
 }
 
-func (t *blobVersionsTraverser) isDirectory(isSource bool) bool {
+func (t *blobVersionsTraverser) IsDirectory(isSource bool) bool {
 	isDirDirect := copyHandlerUtil{}.urlIsContainerOrVirtualDirectory(t.rawURL)
 
 	// Skip the single blob check if we're checking a destination.
@@ -69,7 +69,7 @@ func (t *blobVersionsTraverser) getBlobProperties(versionID string) (props *azbl
 	return props, err
 }
 
-func (t *blobVersionsTraverser) traverse(preprocessor objectMorpher, processor objectProcessor, filters []objectFilter) (err error) {
+func (t *blobVersionsTraverser) Traverse(preprocessor objectMorpher, processor objectProcessor, filters []ObjectFilter) (err error) {
 	blobURLParts := azblob.NewBlobURLParts(*t.rawURL)
 
 	versionID, ok := <-t.listOfVersionIds

--- a/cmd/zc_traverser_blobfs.go
+++ b/cmd/zc_traverser_blobfs.go
@@ -54,7 +54,7 @@ func newBlobFSTraverser(rawURL *url.URL, p pipeline.Pipeline, ctx context.Contex
 	return
 }
 
-func (t *blobFSTraverser) isDirectory(bool) bool {
+func (t *blobFSTraverser) IsDirectory(bool) bool {
 	return copyHandlerUtil{}.urlIsBFSFileSystemOrDirectory(t.ctx, t.rawURL, t.p) // This gets all the fanciness done for us.
 }
 
@@ -87,7 +87,7 @@ func (t *blobFSTraverser) getFolderProps() (p contentPropsProvider, size int64) 
 	return noContentProps, 0
 }
 
-func (t *blobFSTraverser) traverse(preprocessor objectMorpher, processor objectProcessor, filters []objectFilter) (err error) {
+func (t *blobFSTraverser) Traverse(preprocessor objectMorpher, processor objectProcessor, filters []ObjectFilter) (err error) {
 	bfsURLParts := azbfs.NewBfsURLParts(*t.rawURL)
 
 	pathProperties, isFile, _ := t.getPropertiesIfSingleFile()
@@ -180,7 +180,7 @@ func (t *blobFSTraverser) traverse(preprocessor objectMorpher, processor objectP
 			}
 
 			// TODO: if we need to get full properties and metadata, then add call here to
-			//     dirUrl.NewFileURL(storedObject.relativePath).GetProperties(t.ctx)
+			//     dirUrl.NewFileURL(StoredObject.relativePath).GetProperties(t.ctx)
 			//     AND consider also supporting alternate mechanism to get the props in the backend
 			//     using s2sGetPropertiesInBackend
 			storedObject := newStoredObject(

--- a/cmd/zc_traverser_blobfs_account.go
+++ b/cmd/zc_traverser_blobfs_account.go
@@ -44,7 +44,7 @@ type BlobFSAccountTraverser struct {
 	incrementEnumerationCounter enumerationCounterFunc
 }
 
-func (t *BlobFSAccountTraverser) isDirectory(isSource bool) bool {
+func (t *BlobFSAccountTraverser) IsDirectory(isSource bool) bool {
 	return true // Returns true as account traversal is inherently folder-oriented and recursive.
 }
 
@@ -99,7 +99,7 @@ func (t *BlobFSAccountTraverser) listContainers() ([]string, error) {
 	}
 }
 
-func (t *BlobFSAccountTraverser) traverse(preprocessor objectMorpher, processor objectProcessor, filters []objectFilter) error {
+func (t *BlobFSAccountTraverser) Traverse(preprocessor objectMorpher, processor objectProcessor, filters []ObjectFilter) error {
 	// listContainers will return the cached filesystem list if filesystems have already been listed by this traverser.
 	fsList, err := t.listContainers()
 
@@ -109,7 +109,7 @@ func (t *BlobFSAccountTraverser) traverse(preprocessor objectMorpher, processor 
 
 		preprocessorForThisChild := preprocessor.FollowedBy(newContainerDecorator(v))
 
-		err = fileSystemTraverser.traverse(preprocessorForThisChild, processor, filters)
+		err = fileSystemTraverser.Traverse(preprocessorForThisChild, processor, filters)
 
 		if err != nil {
 			WarnStdoutAndScanningLog(fmt.Sprintf("failed to list files in filesystem %s: %s", v, err))

--- a/cmd/zc_traverser_file.go
+++ b/cmd/zc_traverser_file.go
@@ -46,7 +46,7 @@ type fileTraverser struct {
 	incrementEnumerationCounter enumerationCounterFunc
 }
 
-func (t *fileTraverser) isDirectory(bool) bool {
+func (t *fileTraverser) IsDirectory(bool) bool {
 	return copyHandlerUtil{}.urlIsAzureFileDirectory(t.ctx, t.rawURL, t.p) // This handles all of the fanciness for us.
 }
 
@@ -62,7 +62,7 @@ func (t *fileTraverser) getPropertiesIfSingleFile() (*azfile.FileGetPropertiesRe
 	return nil, false
 }
 
-func (t *fileTraverser) traverse(preprocessor objectMorpher, processor objectProcessor, filters []objectFilter) (err error) {
+func (t *fileTraverser) Traverse(preprocessor objectMorpher, processor objectProcessor, filters []ObjectFilter) (err error) {
 	targetURLParts := azfile.NewFileURLParts(*t.rawURL)
 
 	// if not pointing to a share, check if we are pointing to a single file
@@ -119,7 +119,7 @@ func (t *fileTraverser) traverse(preprocessor objectMorpher, processor objectPro
 			var fullProperties azfilePropertiesAdapter
 			fullProperties, err = f.propertyGetter(t.ctx)
 			if err != nil {
-				return storedObject{
+				return StoredObject{
 					relativePath: relativePath,
 				}, err
 			}
@@ -149,7 +149,7 @@ func (t *fileTraverser) traverse(preprocessor objectMorpher, processor objectPro
 		), nil
 	}
 
-	processStoredObject := func(s storedObject) error {
+	processStoredObject := func(s StoredObject) error {
 		if t.incrementEnumerationCounter != nil {
 			t.incrementEnumerationCounter(s.entityType)
 		}
@@ -169,7 +169,7 @@ func (t *fileTraverser) traverse(preprocessor objectMorpher, processor objectPro
 		if err != nil {
 			return err
 		}
-		err = processStoredObject(s.(storedObject))
+		err = processStoredObject(s.(StoredObject))
 		if err != nil {
 			return err
 		}
@@ -225,7 +225,7 @@ func (t *fileTraverser) traverse(preprocessor objectMorpher, processor objectPro
 	// run the actual enumeration.
 	// First part is a parallel directory crawl
 	// Second part is parallel conversion of the directories and files to stored objects. This is necessary because the conversion to stored object may hit the network and therefore be slow if not parallelized
-	parallelism := enumerationParallelism // for Azure Files we'll run two pools of this size, one for crawl and one for transform
+	parallelism := EnumerationParallelism // for Azure Files we'll run two pools of this size, one for crawl and one for transform
 
 	workerContext, cancelWorkers := context.WithCancel(t.ctx)
 
@@ -238,7 +238,7 @@ func (t *fileTraverser) traverse(preprocessor objectMorpher, processor objectPro
 		if workerError != nil {
 			relativePath := ""
 			if item != nil {
-				relativePath = item.(storedObject).relativePath
+				relativePath = item.(StoredObject).relativePath
 			}
 			glcm.Info("Failed to scan directory/file " + relativePath + ". Logging errors in scanning logs.")
 			if azcopyScanningLogger != nil {
@@ -246,7 +246,7 @@ func (t *fileTraverser) traverse(preprocessor objectMorpher, processor objectPro
 			}
 			continue
 		}
-		processErr := processStoredObject(item.(storedObject))
+		processErr := processStoredObject(item.(StoredObject))
 		if processErr != nil {
 			cancelWorkers()
 			return processErr

--- a/cmd/zc_traverser_file_account.go
+++ b/cmd/zc_traverser_file_account.go
@@ -42,7 +42,7 @@ type fileAccountTraverser struct {
 	incrementEnumerationCounter enumerationCounterFunc
 }
 
-func (t *fileAccountTraverser) isDirectory(isSource bool) bool {
+func (t *fileAccountTraverser) IsDirectory(isSource bool) bool {
 	return true // Returns true as account traversal is inherently folder-oriented and recursive.
 }
 
@@ -83,7 +83,7 @@ func (t *fileAccountTraverser) listContainers() ([]string, error) {
 	}
 }
 
-func (t *fileAccountTraverser) traverse(preprocessor objectMorpher, processor objectProcessor, filters []objectFilter) error {
+func (t *fileAccountTraverser) Traverse(preprocessor objectMorpher, processor objectProcessor, filters []ObjectFilter) error {
 	// listContainers will return the cached share list if shares have already been listed by this traverser.
 	shareList, err := t.listContainers()
 
@@ -97,7 +97,7 @@ func (t *fileAccountTraverser) traverse(preprocessor objectMorpher, processor ob
 
 		preprocessorForThisChild := preprocessor.FollowedBy(newContainerDecorator(v))
 
-		err = shareTraverser.traverse(preprocessorForThisChild, processor, filters)
+		err = shareTraverser.Traverse(preprocessorForThisChild, processor, filters)
 
 		if err != nil {
 			WarnStdoutAndScanningLog(fmt.Sprintf("failed to list files in share %s: %s", v, err))

--- a/cmd/zc_traverser_gcp.go
+++ b/cmd/zc_traverser_gcp.go
@@ -23,7 +23,7 @@ type gcpTraverser struct {
 	incrementEnumerationCounter enumerationCounterFunc
 }
 
-func (t *gcpTraverser) isDirectory(isSource bool) bool {
+func (t *gcpTraverser) IsDirectory(isSource bool) bool {
 	//Identify whether directory or not syntactically
 	isDirDirect := !t.gcpURLParts.IsObjectSyntactically() && (t.gcpURLParts.IsDirectorySyntactically() || t.gcpURLParts.IsBucketSyntactically())
 	if !isSource {
@@ -39,7 +39,7 @@ func (t *gcpTraverser) isDirectory(isSource bool) bool {
 	return false
 }
 
-func (t *gcpTraverser) traverse(preprocessor objectMorpher, processor objectProcessor, filters []objectFilter) error {
+func (t *gcpTraverser) Traverse(preprocessor objectMorpher, processor objectProcessor, filters []ObjectFilter) error {
 	//Syntactically ensure whether single object or not
 	if t.gcpURLParts.IsObjectSyntactically() && !t.gcpURLParts.IsDirectorySyntactically() && !t.gcpURLParts.IsBucketSyntactically() {
 		objectPath := strings.Split(t.gcpURLParts.ObjectKey, "/")

--- a/cmd/zc_traverser_gcp_service.go
+++ b/cmd/zc_traverser_gcp_service.go
@@ -24,7 +24,7 @@ type gcpServiceTraverser struct {
 
 var projectID = ""
 
-func (t *gcpServiceTraverser) isDirectory(isSource bool) bool {
+func (t *gcpServiceTraverser) IsDirectory(isSource bool) bool {
 	return true //Account traversals are inherently folder based
 }
 
@@ -60,7 +60,7 @@ func (t *gcpServiceTraverser) listContainers() ([]string, error) {
 	}
 }
 
-func (t *gcpServiceTraverser) traverse(preprocessor objectMorpher, processor objectProcessor, filters []objectFilter) error {
+func (t *gcpServiceTraverser) Traverse(preprocessor objectMorpher, processor objectProcessor, filters []ObjectFilter) error {
 	bucketList, err := t.listContainers()
 
 	if err != nil {
@@ -78,7 +78,7 @@ func (t *gcpServiceTraverser) traverse(preprocessor objectMorpher, processor obj
 		}
 		preprocessorForThisChild := preprocessor.FollowedBy(newContainerDecorator(v))
 
-		err = bucketTraverser.traverse(preprocessorForThisChild, processor, filters)
+		err = bucketTraverser.Traverse(preprocessorForThisChild, processor, filters)
 
 		if err != nil {
 			if strings.Contains(err.Error(), "cannot list objects, The specified bucket does not exist") {

--- a/cmd/zc_traverser_list.go
+++ b/cmd/zc_traverser_list.go
@@ -37,16 +37,16 @@ type listTraverser struct {
 	childTraverserGenerator childTraverserGenerator
 }
 
-type childTraverserGenerator func(childPath string) (resourceTraverser, error)
+type childTraverserGenerator func(childPath string) (ResourceTraverser, error)
 
 // There is no impact to a list traverser returning false because a list traverser points directly to relative paths.
-func (l *listTraverser) isDirectory(bool) bool {
+func (l *listTraverser) IsDirectory(bool) bool {
 	return false
 }
 
 // To kill the traverser, close() the channel under it.
 // Behavior demonstrated: https://play.golang.org/p/OYdvLmNWgwO
-func (l *listTraverser) traverse(preprocessor objectMorpher, processor objectProcessor, filters []objectFilter) (err error) {
+func (l *listTraverser) Traverse(preprocessor objectMorpher, processor objectProcessor, filters []ObjectFilter) (err error) {
 	// read a channel until it closes to get a list of objects
 	childPath, ok := <-l.listReader
 	for ; ok; childPath, ok = <-l.listReader {
@@ -61,7 +61,7 @@ func (l *listTraverser) traverse(preprocessor objectMorpher, processor objectPro
 		}
 
 		// listTraverser will only ever execute on the source
-		if !l.recursive && childTraverser.isDirectory(true) {
+		if !l.recursive && childTraverser.IsDirectory(true) {
 			continue // skip over directories
 		}
 
@@ -74,12 +74,12 @@ func (l *listTraverser) traverse(preprocessor objectMorpher, processor objectPro
 		// case 2: child2 is a directory, and it has items under it such as child2/grandchild1
 		//         the relative path returned by the child traverser would be "grandchild1"
 		//         it should be "child2/grandchild1" instead
-		childPreProcessor := func(object *storedObject) {
+		childPreProcessor := func(object *StoredObject) {
 			object.relativePath = common.GenerateFullPath(childPath, object.relativePath)
 		}
 		preProcessorForThisChild := preprocessor.FollowedBy(childPreProcessor)
 
-		err = childTraverser.traverse(preProcessorForThisChild, processor, filters)
+		err = childTraverser.Traverse(preProcessorForThisChild, processor, filters)
 		if err != nil {
 			glcm.Info(fmt.Sprintf("Skipping %s as it cannot be scanned due to error: %s", childPath, err))
 		}
@@ -91,10 +91,10 @@ func (l *listTraverser) traverse(preprocessor objectMorpher, processor objectPro
 func newListTraverser(parent common.ResourceString, parentType common.Location, credential *common.CredentialInfo,
 	ctx *context.Context, recursive, followSymlinks, getProperties bool, listChan chan string,
 	includeDirectoryStubs bool, incrementEnumerationCounter enumerationCounterFunc, s2sPreserveBlobTags bool,
-	logLevel pipeline.LogLevel, cpkOptions common.CpkOptions) resourceTraverser {
+	logLevel pipeline.LogLevel, cpkOptions common.CpkOptions) ResourceTraverser {
 	var traverserGenerator childTraverserGenerator
 
-	traverserGenerator = func(relativeChildPath string) (resourceTraverser, error) {
+	traverserGenerator = func(relativeChildPath string) (ResourceTraverser, error) {
 		source := parent.Clone()
 		if parentType != common.ELocation.Local() {
 			// assume child path is not URL-encoded yet, this is consistent with the behavior of previous implementation
@@ -107,7 +107,7 @@ func newListTraverser(parent common.ResourceString, parentType common.Location, 
 		}
 
 		// Construct a traverser that goes through the child
-		traverser, err := initResourceTraverser(source, parentType, ctx, credential, &followSymlinks,
+		traverser, err := InitResourceTraverser(source, parentType, ctx, credential, &followSymlinks,
 			nil, recursive, getProperties, includeDirectoryStubs, incrementEnumerationCounter,
 			nil, s2sPreserveBlobTags, logLevel, cpkOptions)
 		if err != nil {

--- a/cmd/zc_traverser_local.go
+++ b/cmd/zc_traverser_local.go
@@ -41,7 +41,7 @@ type localTraverser struct {
 	incrementEnumerationCounter enumerationCounterFunc
 }
 
-func (t *localTraverser) isDirectory(bool) bool {
+func (t *localTraverser) IsDirectory(bool) bool {
 	if strings.HasSuffix(t.fullPath, "/") {
 		return true
 	}
@@ -164,7 +164,6 @@ func WalkWithSymlinks(fullPath string, walkFunc filepath.WalkFunc, followSymlink
 	}
 
 	fullPath, err = filepath.Abs(fullPath)
-
 	if err != nil {
 		return err
 	}
@@ -181,15 +180,13 @@ func WalkWithSymlinks(fullPath string, walkFunc filepath.WalkFunc, followSymlink
 	for len(walkQueue) > 0 {
 		queueItem := walkQueue[0]
 		walkQueue = walkQueue[1:]
-
 		// walk contents of this queueItem in parallel
 		// (for simplicity of coding, we don't parallelize across multiple queueItems)
-		parallel.Walk(queueItem.fullPath, enumerationParallelism, enumerationParallelStatFiles, func(filePath string, fileInfo os.FileInfo, fileError error) error {
+		parallel.Walk(queueItem.fullPath, EnumerationParallelism, EnumerationParallelStatFiles, func(filePath string, fileInfo os.FileInfo, fileError error) error {
 			if fileError != nil {
 				WarnStdoutAndScanningLog(fmt.Sprintf("Accessing '%s' failed with error: %s", filePath, fileError))
 				return nil
 			}
-
 			computedRelativePath := strings.TrimPrefix(cleanLocalPath(filePath), cleanLocalPath(queueItem.fullPath))
 			computedRelativePath = cleanLocalPath(common.GenerateFullPath(queueItem.relativeBase, computedRelativePath))
 			computedRelativePath = strings.TrimPrefix(computedRelativePath, common.AZCOPY_PATH_SEPARATOR_STRING)
@@ -299,7 +296,7 @@ func WalkWithSymlinks(fullPath string, walkFunc filepath.WalkFunc, followSymlink
 	return
 }
 
-func (t *localTraverser) traverse(preprocessor objectMorpher, processor objectProcessor, filters []objectFilter) (err error) {
+func (t *localTraverser) Traverse(preprocessor objectMorpher, processor objectProcessor, filters []ObjectFilter) (err error) {
 	singleFileInfo, isSingleFile, err := t.getInfoIfSingleFile()
 
 	if err != nil {
@@ -371,7 +368,7 @@ func (t *localTraverser) traverse(preprocessor objectMorpher, processor objectPr
 					processor)
 			}
 
-			// note: Walk includes root, so no need here to separately create storedObject for root (as we do for other folder-aware sources)
+			// note: Walk includes root, so no need here to separately create StoredObject for root (as we do for other folder-aware sources)
 			return WalkWithSymlinks(t.fullPath, processFile, t.followSymlinks)
 		} else {
 			// if recursive is off, we only need to scan the files immediately under the fullPath

--- a/cmd/zc_traverser_s3.go
+++ b/cmd/zc_traverser_s3.go
@@ -45,7 +45,7 @@ type s3Traverser struct {
 	incrementEnumerationCounter enumerationCounterFunc
 }
 
-func (t *s3Traverser) isDirectory(isSource bool) bool {
+func (t *s3Traverser) IsDirectory(isSource bool) bool {
 	// Do a basic syntax check
 	isDirDirect := !t.s3URLParts.IsObjectSyntactically() && (t.s3URLParts.IsDirectorySyntactically() || t.s3URLParts.IsBucketSyntactically())
 
@@ -63,7 +63,7 @@ func (t *s3Traverser) isDirectory(isSource bool) bool {
 	return false
 }
 
-func (t *s3Traverser) traverse(preprocessor objectMorpher, processor objectProcessor, filters []objectFilter) (err error) {
+func (t *s3Traverser) Traverse(preprocessor objectMorpher, processor objectProcessor, filters []ObjectFilter) (err error) {
 	invalidAzureBlobName := func (objectKey string) bool {
 		/* S3 object name is invalid if it ends with period or
 		   one of virtual directories in path ends with period.

--- a/cmd/zc_traverser_s3_service.go
+++ b/cmd/zc_traverser_s3_service.go
@@ -32,7 +32,7 @@ import (
 )
 
 // As we discussed, the general architecture is that this is going to search a list of buckets and spawn s3Traversers for each bucket.
-// This will modify the storedObject format a slight bit to add a "container" parameter.
+// This will modify the StoredObject format a slight bit to add a "container" parameter.
 
 // Enumerates an entire S3 account, looking into each matching bucket as it goes
 type s3ServiceTraverser struct {
@@ -48,7 +48,7 @@ type s3ServiceTraverser struct {
 	incrementEnumerationCounter enumerationCounterFunc
 }
 
-func (t *s3ServiceTraverser) isDirectory(isSource bool) bool {
+func (t *s3ServiceTraverser) IsDirectory(isSource bool) bool {
 	return true // Returns true as account traversal is inherently folder-oriented and recursive.
 }
 
@@ -82,7 +82,7 @@ func (t *s3ServiceTraverser) listContainers() ([]string, error) {
 	}
 }
 
-func (t *s3ServiceTraverser) traverse(preprocessor objectMorpher, processor objectProcessor, filters []objectFilter) error {
+func (t *s3ServiceTraverser) Traverse(preprocessor objectMorpher, processor objectProcessor, filters []ObjectFilter) error {
 	bucketList, err := t.listContainers()
 
 	if err != nil {
@@ -102,7 +102,7 @@ func (t *s3ServiceTraverser) traverse(preprocessor objectMorpher, processor obje
 
 		preprocessorForThisChild := preprocessor.FollowedBy(newContainerDecorator(v))
 
-		err = bucketTraverser.traverse(preprocessorForThisChild, processor, filters)
+		err = bucketTraverser.Traverse(preprocessorForThisChild, processor, filters)
 
 		if err != nil {
 			if strings.Contains(err.Error(), "301 response missing Location header") {

--- a/cmd/zt_copy_blob_download_test.go
+++ b/cmd/zt_copy_blob_download_test.go
@@ -75,7 +75,7 @@ func (s *cmdIntegrationSuite) TestInferredStripTopDirDownload(c *chk.C) {
 	// Test inference of striptopdir
 	cooked, err := raw.cook()
 	c.Assert(err, chk.IsNil)
-	c.Assert(cooked.stripTopDir, chk.Equals, false)
+	c.Assert(cooked.StripTopDir, chk.Equals, false)
 
 	// Test and ensure only one file is being downloaded
 	runCopyAndVerify(c, raw, func(err error) {
@@ -102,7 +102,7 @@ func (s *cmdIntegrationSuite) TestInferredStripTopDirDownload(c *chk.C) {
 	// Test inference of striptopdir
 	cooked, err = raw.cook()
 	c.Assert(err, chk.IsNil)
-	c.Assert(cooked.stripTopDir, chk.Equals, true)
+	c.Assert(cooked.StripTopDir, chk.Equals, true)
 
 	// Test and ensure only 3 files get scheduled, nothing under the sub-directory
 	runCopyAndVerify(c, raw, func(err error) {
@@ -151,7 +151,7 @@ func (s *cmdIntegrationSuite) TestInferredStripTopDirDownload(c *chk.C) {
 	// test cook
 	cooked, err = raw.cook()
 	c.Assert(err, chk.IsNil)
-	c.Assert(cooked.stripTopDir, chk.Equals, true)
+	c.Assert(cooked.StripTopDir, chk.Equals, true)
 
 	// Test and ensure only one file got scheduled
 	runCopyAndVerify(c, raw, func(err error) {
@@ -165,7 +165,7 @@ func (s *cmdIntegrationSuite) TestInferredStripTopDirDownload(c *chk.C) {
 func (s *cmdIntegrationSuite) TestDownloadAccount(c *chk.C) {
 	bsu := getBSU()
 	rawBSU := scenarioHelper{}.getRawBlobServiceURLWithSAS(c)
-	p, err := initPipeline(ctx, common.ELocation.Blob(), common.CredentialInfo{CredentialType: common.ECredentialType.Anonymous()}, pipeline.LogNone)
+	p, err := InitPipeline(ctx, common.ELocation.Blob(), common.CredentialInfo{CredentialType: common.ECredentialType.Anonymous()}, pipeline.LogNone)
 	c.Assert(err, chk.IsNil)
 
 	// Just in case there are no existing containers...
@@ -175,13 +175,13 @@ func (s *cmdIntegrationSuite) TestDownloadAccount(c *chk.C) {
 	// Traverse the account ahead of time and determine the relative paths for testing.
 	relPaths := make([]string, 0) // Use a map for easy lookup
 	blobTraverser := newBlobAccountTraverser(&rawBSU, p, ctx, false, func(common.EntityType) {}, false, common.CpkOptions{})
-	processor := func(object storedObject) error {
+	processor := func(object StoredObject) error {
 		// Append the container name to the relative path
-		relPath := "/" + object.containerName + "/" + object.relativePath
+		relPath := "/" + object.ContainerName + "/" + object.relativePath
 		relPaths = append(relPaths, relPath)
 		return nil
 	}
-	err = blobTraverser.traverse(noPreProccessor, processor, []objectFilter{})
+	err = blobTraverser.Traverse(noPreProccessor, processor, []ObjectFilter{})
 	c.Assert(err, chk.IsNil)
 
 	// set up a destination
@@ -207,7 +207,7 @@ func (s *cmdIntegrationSuite) TestDownloadAccount(c *chk.C) {
 func (s *cmdIntegrationSuite) TestDownloadAccountWildcard(c *chk.C) {
 	bsu := getBSU()
 	rawBSU := scenarioHelper{}.getRawBlobServiceURLWithSAS(c)
-	p, err := initPipeline(ctx, common.ELocation.Blob(), common.CredentialInfo{CredentialType: common.ECredentialType.Anonymous()}, pipeline.LogNone)
+	p, err := InitPipeline(ctx, common.ELocation.Blob(), common.CredentialInfo{CredentialType: common.ECredentialType.Anonymous()}, pipeline.LogNone)
 	c.Assert(err, chk.IsNil)
 
 	// Create a unique container to be targeted.
@@ -223,13 +223,13 @@ func (s *cmdIntegrationSuite) TestDownloadAccountWildcard(c *chk.C) {
 	// Traverse the account ahead of time and determine the relative paths for testing.
 	relPaths := make([]string, 0) // Use a map for easy lookup
 	blobTraverser := newBlobAccountTraverser(&rawBSU, p, ctx, false, func(common.EntityType) {}, false, common.CpkOptions{})
-	processor := func(object storedObject) error {
+	processor := func(object StoredObject) error {
 		// Append the container name to the relative path
-		relPath := "/" + object.containerName + "/" + object.relativePath
+		relPath := "/" + object.ContainerName + "/" + object.relativePath
 		relPaths = append(relPaths, relPath)
 		return nil
 	}
-	err = blobTraverser.traverse(noPreProccessor, processor, []objectFilter{})
+	err = blobTraverser.Traverse(noPreProccessor, processor, []ObjectFilter{})
 	c.Assert(err, chk.IsNil)
 
 	// set up a destination

--- a/cmd/zt_generic_filter_test.go
+++ b/cmd/zt_generic_filter_test.go
@@ -41,14 +41,14 @@ func (s *genericFilterSuite) TestIncludeFilter(c *chk.C) {
 	// test the positive cases
 	filesToPass := []string{"bla.pdf", "fancy.jpeg", "socool.jpeg.pdf", "exactName"}
 	for _, file := range filesToPass {
-		passed := includeFilter.doesPass(storedObject{name: file})
+		passed := includeFilter.DoesPass(StoredObject{name: file})
 		c.Assert(passed, chk.Equals, true)
 	}
 
 	// test the negative cases
 	filesNotToPass := []string{"bla.pdff", "fancyjpeg", "socool.jpeg.pdf.wut", "eexactName"}
 	for _, file := range filesNotToPass {
-		passed := includeFilter.doesPass(storedObject{name: file})
+		passed := includeFilter.DoesPass(StoredObject{name: file})
 		c.Assert(passed, chk.Equals, false)
 	}
 }
@@ -63,7 +63,7 @@ func (s *genericFilterSuite) TestExcludeFilter(c *chk.C) {
 	filesToPass := []string{"bla.pdfe", "fancy.jjpeg", "socool.png", "eexactName"}
 	for _, file := range filesToPass {
 		dummyProcessor := &dummyProcessor{}
-		err := processIfPassedFilters(excludeFilterList, storedObject{name: file}, dummyProcessor.process)
+		err := processIfPassedFilters(excludeFilterList, StoredObject{name: file}, dummyProcessor.process)
 		c.Assert(err, chk.IsNil)
 		c.Assert(len(dummyProcessor.record), chk.Equals, 1)
 	}
@@ -72,7 +72,7 @@ func (s *genericFilterSuite) TestExcludeFilter(c *chk.C) {
 	filesToNotPass := []string{"bla.pdf", "fancy.jpeg", "socool.jpeg.pdf", "exactName"}
 	for _, file := range filesToNotPass {
 		dummyProcessor := &dummyProcessor{}
-		err := processIfPassedFilters(excludeFilterList, storedObject{name: file}, dummyProcessor.process)
+		err := processIfPassedFilters(excludeFilterList, StoredObject{name: file}, dummyProcessor.process)
 		c.Assert(err, chk.Equals, ignoredError)
 		c.Assert(len(dummyProcessor.record), chk.Equals, 0)
 	}
@@ -107,7 +107,7 @@ func (s *genericFilterSuite) TestDateParsingForIncludeAfter(c *chk.C) {
 	loc, _ := time.LoadLocation("Local")
 
 	for _, x := range examples {
-		t, err := includeAfterDateFilter{}.ParseISO8601(x.input, true)
+		t, err := IncludeAfterDateFilter{}.ParseISO8601(x.input, true)
 		if x.expectedErrorContents == "" {
 			c.Assert(err, chk.IsNil, chk.Commentf(x.input))
 			//fmt.Printf("%v -> %v\n", x.input, t)
@@ -147,14 +147,14 @@ func (s *genericFilterSuite) TestDateParsingForIncludeAfter_IsSafeAtDaylightSavi
 	fmt.Println("Testing end of daylight saving at " + dateString + " local time")
 
 	// ask for the earliest of the two ambiguous times
-	parsed, err := includeAfterDateFilter{}.ParseISO8601(dateString, true) // we use chooseEarliest=true for includeAfter
+	parsed, err := IncludeAfterDateFilter{}.ParseISO8601(dateString, true) // we use chooseEarliest=true for includeAfter
 	c.Assert(err, chk.IsNil)
 	fmt.Printf("For chooseEarliest = true, the times are parsed %v, utcEarly %v, utcLate %v \n", parsed, utcEarlyVersion, utcLateVersion)
 	c.Assert(parsed.Equal(utcEarlyVersion), chk.Equals, true)
 	c.Assert(parsed.Equal(utcLateVersion), chk.Equals, false)
 
 	// ask for the latest of the two ambiguous times
-	parsed, err = includeAfterDateFilter{}.ParseISO8601(dateString, false) // we test the false case in this test too, just for completeness
+	parsed, err = IncludeAfterDateFilter{}.ParseISO8601(dateString, false) // we test the false case in this test too, just for completeness
 	c.Assert(err, chk.IsNil)
 	fmt.Printf("For chooseEarliest = false, the times are parsed %v, utcEarly %v, utcLate %v \n", parsed, utcEarlyVersion, utcLateVersion)
 	c.Assert(parsed.UTC().Equal(utcEarlyVersion), chk.Equals, false)

--- a/cmd/zt_generic_processor_test.go
+++ b/cmd/zt_generic_processor_test.go
@@ -35,8 +35,8 @@ var _ = chk.Suite(&genericProcessorSuite{})
 type processorTestSuiteHelper struct{}
 
 // return a list of sample entities
-func (processorTestSuiteHelper) getSampleObjectList() []storedObject {
-	return []storedObject{
+func (processorTestSuiteHelper) getSampleObjectList() []StoredObject {
+	return []StoredObject{
 		{name: "file1", relativePath: "file1", lastModifiedTime: time.Now()},
 		{name: "file2", relativePath: "file2", lastModifiedTime: time.Now()},
 		{name: "file3", relativePath: "sub1/file3", lastModifiedTime: time.Now()},
@@ -47,7 +47,7 @@ func (processorTestSuiteHelper) getSampleObjectList() []storedObject {
 }
 
 // given a list of entities, return the relative paths in a list, to help with validations
-func (processorTestSuiteHelper) getExpectedTransferFromStoredObjectList(storedObjectList []storedObject) []string {
+func (processorTestSuiteHelper) getExpectedTransferFromStoredObjectList(storedObjectList []StoredObject) []string {
 	expectedTransfers := make([]string, 0)
 	for _, storedObject := range storedObjectList {
 		expectedTransfers = append(expectedTransfers, storedObject.relativePath)

--- a/cmd/zt_generic_service_traverser_test.go
+++ b/cmd/zt_generic_service_traverser_test.go
@@ -60,7 +60,7 @@ func (s *genericTraverserSuite) TestBlobFSServiceTraverserWithManyObjects(c *chk
 
 	// Invoke the traversal with an indexer so the results are indexed for easy validation
 	localIndexer := newObjectIndexer()
-	err := localTraverser.traverse(noPreProccessor, localIndexer.store, nil)
+	err := localTraverser.Traverse(noPreProccessor, localIndexer.store, nil)
 	c.Assert(err, chk.IsNil)
 
 	// construct a blob account traverser
@@ -70,14 +70,14 @@ func (s *genericTraverserSuite) TestBlobFSServiceTraverserWithManyObjects(c *chk
 
 	// invoke the blob account traversal with a dummy processor
 	blobDummyProcessor := dummyProcessor{}
-	err = blobAccountTraverser.traverse(noPreProccessor, blobDummyProcessor.process, nil)
+	err = blobAccountTraverser.Traverse(noPreProccessor, blobDummyProcessor.process, nil)
 	c.Assert(err, chk.IsNil)
 
 	c.Assert(len(blobDummyProcessor.record), chk.Equals, len(localIndexer.indexMap)*len(containerList))
 
 	for _, storedObject := range blobDummyProcessor.record {
 		correspondingLocalFile, present := localIndexer.indexMap[storedObject.relativePath]
-		_, cnamePresent := cnames[storedObject.containerName]
+		_, cnamePresent := cnames[storedObject.ContainerName]
 
 		c.Assert(present, chk.Equals, true)
 		c.Assert(cnamePresent, chk.Equals, true)
@@ -176,7 +176,7 @@ func (s *genericTraverserSuite) TestServiceTraverserWithManyObjects(c *chk.C) {
 
 	// Invoke the traversal with an indexer so the results are indexed for easy validation
 	localIndexer := newObjectIndexer()
-	err = localTraverser.traverse(noPreProccessor, localIndexer.store, nil)
+	err = localTraverser.Traverse(noPreProccessor, localIndexer.store, nil)
 	c.Assert(err, chk.IsNil)
 
 	// construct a blob account traverser
@@ -187,7 +187,7 @@ func (s *genericTraverserSuite) TestServiceTraverserWithManyObjects(c *chk.C) {
 
 	// invoke the blob account traversal with a dummy processor
 	blobDummyProcessor := dummyProcessor{}
-	err = blobAccountTraverser.traverse(noPreProccessor, blobDummyProcessor.process, nil)
+	err = blobAccountTraverser.Traverse(noPreProccessor, blobDummyProcessor.process, nil)
 	c.Assert(err, chk.IsNil)
 
 	// construct a file account traverser
@@ -197,7 +197,7 @@ func (s *genericTraverserSuite) TestServiceTraverserWithManyObjects(c *chk.C) {
 
 	// invoke the file account traversal with a dummy processor
 	fileDummyProcessor := dummyProcessor{}
-	err = fileAccountTraverser.traverse(noPreProccessor, fileDummyProcessor.process, nil)
+	err = fileAccountTraverser.Traverse(noPreProccessor, fileDummyProcessor.process, nil)
 	c.Assert(err, chk.IsNil)
 
 	var s3DummyProcessor dummyProcessor
@@ -210,7 +210,7 @@ func (s *genericTraverserSuite) TestServiceTraverserWithManyObjects(c *chk.C) {
 
 		// invoke the s3 service traversal with a dummy processor
 		s3DummyProcessor = dummyProcessor{}
-		err = s3ServiceTraverser.traverse(noPreProccessor, s3DummyProcessor.process, nil)
+		err = s3ServiceTraverser.Traverse(noPreProccessor, s3DummyProcessor.process, nil)
 		c.Assert(err, chk.IsNil)
 	}
 
@@ -221,7 +221,7 @@ func (s *genericTraverserSuite) TestServiceTraverserWithManyObjects(c *chk.C) {
 		c.Assert(err, chk.IsNil)
 
 		gcpDummyProcessor = dummyProcessor{}
-		err = gcpServiceTraverser.traverse(noPreProccessor, gcpDummyProcessor.process, nil)
+		err = gcpServiceTraverser.Traverse(noPreProccessor, gcpDummyProcessor.process, nil)
 		c.Assert(err, chk.IsNil)
 	}
 
@@ -247,7 +247,7 @@ func (s *genericTraverserSuite) TestServiceTraverserWithManyObjects(c *chk.C) {
 
 	for _, storedObject := range records {
 		correspondingLocalFile, present := localIndexer.indexMap[storedObject.relativePath]
-		_, cnamePresent := cnames[storedObject.containerName]
+		_, cnamePresent := cnames[storedObject.ContainerName]
 
 		c.Assert(present, chk.Equals, true)
 		c.Assert(cnamePresent, chk.Equals, true)
@@ -361,7 +361,7 @@ func (s *genericTraverserSuite) TestServiceTraverserWithWildcards(c *chk.C) {
 
 	// Invoke the traversal with an indexer so the results are indexed for easy validation
 	localIndexer := newObjectIndexer()
-	err = localTraverser.traverse(noPreProccessor, localIndexer.store, nil)
+	err = localTraverser.Traverse(noPreProccessor, localIndexer.store, nil)
 	c.Assert(err, chk.IsNil)
 
 	// construct a blob account traverser
@@ -373,7 +373,7 @@ func (s *genericTraverserSuite) TestServiceTraverserWithWildcards(c *chk.C) {
 
 	// invoke the blob account traversal with a dummy processor
 	blobDummyProcessor := dummyProcessor{}
-	err = blobAccountTraverser.traverse(noPreProccessor, blobDummyProcessor.process, nil)
+	err = blobAccountTraverser.Traverse(noPreProccessor, blobDummyProcessor.process, nil)
 	c.Assert(err, chk.IsNil)
 
 	// construct a file account traverser
@@ -384,7 +384,7 @@ func (s *genericTraverserSuite) TestServiceTraverserWithWildcards(c *chk.C) {
 
 	// invoke the file account traversal with a dummy processor
 	fileDummyProcessor := dummyProcessor{}
-	err = fileAccountTraverser.traverse(noPreProccessor, fileDummyProcessor.process, nil)
+	err = fileAccountTraverser.Traverse(noPreProccessor, fileDummyProcessor.process, nil)
 	c.Assert(err, chk.IsNil)
 
 	// construct a ADLS account traverser
@@ -395,7 +395,7 @@ func (s *genericTraverserSuite) TestServiceTraverserWithWildcards(c *chk.C) {
 
 	// invoke the blobFS account traversal with a dummy processor
 	bfsDummyProcessor := dummyProcessor{}
-	err = bfsAccountTraverser.traverse(noPreProccessor, bfsDummyProcessor.process, nil)
+	err = bfsAccountTraverser.Traverse(noPreProccessor, bfsDummyProcessor.process, nil)
 
 	var s3DummyProcessor dummyProcessor
 	var gcpDummyProcessor dummyProcessor
@@ -411,7 +411,7 @@ func (s *genericTraverserSuite) TestServiceTraverserWithWildcards(c *chk.C) {
 
 		// invoke the s3 service traversal with a dummy processor
 		s3DummyProcessor = dummyProcessor{}
-		err = s3ServiceTraverser.traverse(noPreProccessor, s3DummyProcessor.process, nil)
+		err = s3ServiceTraverser.Traverse(noPreProccessor, s3DummyProcessor.process, nil)
 		c.Assert(err, chk.IsNil)
 	}
 	if testGCP {
@@ -423,7 +423,7 @@ func (s *genericTraverserSuite) TestServiceTraverserWithWildcards(c *chk.C) {
 		c.Assert(err, chk.IsNil)
 
 		gcpDummyProcessor = dummyProcessor{}
-		err = gcpServiceTraverser.traverse(noPreProccessor, gcpDummyProcessor.process, nil)
+		err = gcpServiceTraverser.Traverse(noPreProccessor, gcpDummyProcessor.process, nil)
 		c.Assert(err, chk.IsNil)
 	}
 
@@ -451,7 +451,7 @@ func (s *genericTraverserSuite) TestServiceTraverserWithWildcards(c *chk.C) {
 
 	for _, storedObject := range records {
 		correspondingLocalFile, present := localIndexer.indexMap[storedObject.relativePath]
-		_, cnamePresent := cnames[storedObject.containerName]
+		_, cnamePresent := cnames[storedObject.ContainerName]
 
 		c.Assert(present, chk.Equals, true)
 		c.Assert(cnamePresent, chk.Equals, true)
@@ -462,7 +462,7 @@ func (s *genericTraverserSuite) TestServiceTraverserWithWildcards(c *chk.C) {
 	c.Assert(len(bfsDummyProcessor.record), chk.Equals, len(localIndexer.indexMap)*2)
 	for _, storedObject := range bfsDummyProcessor.record {
 		correspondingLocalFile, present := localIndexer.indexMap[storedObject.relativePath]
-		_, cnamePresent := bfscnames[storedObject.containerName]
+		_, cnamePresent := bfscnames[storedObject.ContainerName]
 
 		c.Assert(present, chk.Equals, true)
 		c.Assert(cnamePresent, chk.Equals, true)

--- a/cmd/zt_generic_traverser_test.go
+++ b/cmd/zt_generic_traverser_test.go
@@ -82,7 +82,7 @@ func (s *genericTraverserSuite) TestFilesGetProperties(c *chk.C) {
 
 	// embed the check into the processor for ease of use
 	seenContentType := false
-	processor := func(object storedObject) error {
+	processor := func(object StoredObject) error {
 		if object.entityType == common.EEntityType.File() {
 			// test all attributes (but only for files, since folders don't have them)
 			c.Assert(object.contentType, chk.Equals, headers.ContentType)
@@ -95,7 +95,7 @@ func (s *genericTraverserSuite) TestFilesGetProperties(c *chk.C) {
 		return nil
 	}
 
-	err = traverser.traverse(noPreProccessor, processor, nil)
+	err = traverser.Traverse(noPreProccessor, processor, nil)
 	c.Assert(err, chk.IsNil)
 	c.Assert(seenContentType, chk.Equals, true)
 
@@ -104,7 +104,7 @@ func (s *genericTraverserSuite) TestFilesGetProperties(c *chk.C) {
 	fileURL := scenarioHelper{}.getRawFileURLWithSAS(c, shareName, fileName)
 	traverser = newFileTraverser(&fileURL, pipeline, ctx, false, true, func(common.EntityType) {})
 
-	err = traverser.traverse(noPreProccessor, processor, nil)
+	err = traverser.Traverse(noPreProccessor, processor, nil)
 	c.Assert(err, chk.IsNil)
 	c.Assert(seenContentType, chk.Equals, true)
 }
@@ -147,7 +147,7 @@ func (s *genericTraverserSuite) TestS3GetProperties(c *chk.C) {
 
 	// Embed the check into the processor for ease of use
 	seenContentType := false
-	processor := func(object storedObject) error {
+	processor := func(object StoredObject) error {
 		// test all attributes
 		c.Assert(object.contentType, chk.Equals, headers.ContentType)
 		c.Assert(object.contentEncoding, chk.Equals, headers.ContentEncoding)
@@ -158,7 +158,7 @@ func (s *genericTraverserSuite) TestS3GetProperties(c *chk.C) {
 		return nil
 	}
 
-	err = traverser.traverse(noPreProccessor, processor, nil)
+	err = traverser.Traverse(noPreProccessor, processor, nil)
 	c.Assert(err, chk.IsNil)
 	c.Assert(seenContentType, chk.Equals, true)
 
@@ -169,7 +169,7 @@ func (s *genericTraverserSuite) TestS3GetProperties(c *chk.C) {
 	traverser, err = newS3Traverser(credentialInfo.CredentialType, &s3ObjectURL, ctx, false, true, func(common.EntityType) {})
 	c.Assert(err, chk.IsNil)
 
-	err = traverser.traverse(noPreProccessor, processor, nil)
+	err = traverser.Traverse(noPreProccessor, processor, nil)
 	c.Assert(err, chk.IsNil)
 	c.Assert(seenContentType, chk.Equals, true)
 }
@@ -217,7 +217,7 @@ func (s *genericTraverserSuite) TestGCPGetProperties(c *chk.C) {
 
 	// Embed the check into the processor for ease of use
 	seenContentType := false
-	processor := func(object storedObject) error {
+	processor := func(object StoredObject) error {
 		// test all attributes
 		c.Assert(object.contentType, chk.Equals, headers.ContentType)
 		c.Assert(object.contentEncoding, chk.Equals, headers.ContentEncoding)
@@ -228,7 +228,7 @@ func (s *genericTraverserSuite) TestGCPGetProperties(c *chk.C) {
 		return nil
 	}
 
-	err = traverser.traverse(noPreProccessor, processor, nil)
+	err = traverser.Traverse(noPreProccessor, processor, nil)
 	c.Assert(err, chk.IsNil)
 	c.Assert(seenContentType, chk.Equals, true)
 
@@ -238,7 +238,7 @@ func (s *genericTraverserSuite) TestGCPGetProperties(c *chk.C) {
 	traverser, err = newGCPTraverser(&gcpObjectURL, ctx, false, true, func(common.EntityType) {})
 	c.Assert(err, chk.IsNil)
 
-	err = traverser.traverse(noPreProccessor, processor, nil)
+	err = traverser.Traverse(noPreProccessor, processor, nil)
 	c.Assert(err, chk.IsNil)
 	c.Assert(seenContentType, chk.Equals, true)
 }
@@ -492,7 +492,7 @@ func (s *genericTraverserSuite) TestTraverserWithSingleObject(c *chk.C) {
 
 		// invoke the local traversal with a dummy processor
 		localDummyProcessor := dummyProcessor{}
-		err := localTraverser.traverse(noPreProccessor, localDummyProcessor.process, nil)
+		err := localTraverser.Traverse(noPreProccessor, localDummyProcessor.process, nil)
 		c.Assert(err, chk.IsNil)
 		c.Assert(len(localDummyProcessor.record), chk.Equals, 1)
 
@@ -505,7 +505,7 @@ func (s *genericTraverserSuite) TestTraverserWithSingleObject(c *chk.C) {
 
 		// invoke the blob traversal with a dummy processor
 		blobDummyProcessor := dummyProcessor{}
-		err = blobTraverser.traverse(noPreProccessor, blobDummyProcessor.process, nil)
+		err = blobTraverser.Traverse(noPreProccessor, blobDummyProcessor.process, nil)
 		c.Assert(err, chk.IsNil)
 		c.Assert(len(blobDummyProcessor.record), chk.Equals, 1)
 
@@ -529,7 +529,7 @@ func (s *genericTraverserSuite) TestTraverserWithSingleObject(c *chk.C) {
 
 			// invoke the file traversal with a dummy processor
 			fileDummyProcessor := dummyProcessor{}
-			err = azureFileTraverser.traverse(noPreProccessor, fileDummyProcessor.process, nil)
+			err = azureFileTraverser.Traverse(noPreProccessor, fileDummyProcessor.process, nil)
 			c.Assert(err, chk.IsNil)
 			c.Assert(len(fileDummyProcessor.record), chk.Equals, 1)
 
@@ -549,7 +549,7 @@ func (s *genericTraverserSuite) TestTraverserWithSingleObject(c *chk.C) {
 
 		// Construct and run a dummy processor for bfs
 		bfsDummyProcessor := dummyProcessor{}
-		err = bfsTraverser.traverse(noPreProccessor, bfsDummyProcessor.process, nil)
+		err = bfsTraverser.Traverse(noPreProccessor, bfsDummyProcessor.process, nil)
 		c.Assert(err, chk.IsNil)
 		c.Assert(len(bfsDummyProcessor.record), chk.Equals, 1)
 
@@ -568,7 +568,7 @@ func (s *genericTraverserSuite) TestTraverserWithSingleObject(c *chk.C) {
 			S3Traverser, err := newS3Traverser(credentialInfo.CredentialType, &url, ctx, false, false, func(common.EntityType) {})
 			c.Assert(err, chk.IsNil)
 
-			err = S3Traverser.traverse(noPreProccessor, s3DummyProcessor.process, nil)
+			err = S3Traverser.Traverse(noPreProccessor, s3DummyProcessor.process, nil)
 			c.Assert(err, chk.IsNil)
 			c.Assert(len(s3DummyProcessor.record), chk.Equals, 1)
 
@@ -584,7 +584,7 @@ func (s *genericTraverserSuite) TestTraverserWithSingleObject(c *chk.C) {
 			GCPTraverser, err := newGCPTraverser(&gcpURL, ctx, false, false, func(entityType common.EntityType) {})
 			c.Assert(err, chk.IsNil)
 
-			err = GCPTraverser.traverse(noPreProccessor, gcpDummyProcessor.process, nil)
+			err = GCPTraverser.Traverse(noPreProccessor, gcpDummyProcessor.process, nil)
 			c.Assert(err, chk.IsNil)
 			c.Assert(len(gcpDummyProcessor.record), chk.Equals, 1)
 
@@ -654,7 +654,7 @@ func (s *genericTraverserSuite) TestTraverserContainerAndLocalDirectory(c *chk.C
 		// invoke the local traversal with an indexer
 		// so that the results are indexed for easy validation
 		localIndexer := newObjectIndexer()
-		err := localTraverser.traverse(noPreProccessor, localIndexer.store, nil)
+		err := localTraverser.Traverse(noPreProccessor, localIndexer.store, nil)
 		c.Assert(err, chk.IsNil)
 
 		// construct a blob traverser
@@ -666,7 +666,7 @@ func (s *genericTraverserSuite) TestTraverserContainerAndLocalDirectory(c *chk.C
 
 		// invoke the local traversal with a dummy processor
 		blobDummyProcessor := dummyProcessor{}
-		err = blobTraverser.traverse(noPreProccessor, blobDummyProcessor.process, nil)
+		err = blobTraverser.Traverse(noPreProccessor, blobDummyProcessor.process, nil)
 		c.Assert(err, chk.IsNil)
 
 		// construct an Azure File traverser
@@ -676,7 +676,7 @@ func (s *genericTraverserSuite) TestTraverserContainerAndLocalDirectory(c *chk.C
 
 		// invoke the file traversal with a dummy processor
 		fileDummyProcessor := dummyProcessor{}
-		err = azureFileTraverser.traverse(noPreProccessor, fileDummyProcessor.process, nil)
+		err = azureFileTraverser.Traverse(noPreProccessor, fileDummyProcessor.process, nil)
 		c.Assert(err, chk.IsNil)
 
 		// construct a directory URL and pipeline
@@ -687,7 +687,7 @@ func (s *genericTraverserSuite) TestTraverserContainerAndLocalDirectory(c *chk.C
 		// construct and run a FS traverser
 		bfsTraverser := newBlobFSTraverser(&rawFilesystemURL, bfsPipeline, ctx, isRecursiveOn, func(common.EntityType) {})
 		bfsDummyProcessor := dummyProcessor{}
-		err = bfsTraverser.traverse(noPreProccessor, bfsDummyProcessor.process, nil)
+		err = bfsTraverser.Traverse(noPreProccessor, bfsDummyProcessor.process, nil)
 		c.Assert(err, chk.IsNil)
 
 		s3DummyProcessor := dummyProcessor{}
@@ -698,14 +698,14 @@ func (s *genericTraverserSuite) TestTraverserContainerAndLocalDirectory(c *chk.C
 			credentialInfo := common.CredentialInfo{CredentialType: common.ECredentialType.S3AccessKey()}
 			S3Traverser, err := newS3Traverser(credentialInfo.CredentialType, &rawS3URL, ctx, isRecursiveOn, false, func(common.EntityType) {})
 			c.Assert(err, chk.IsNil)
-			err = S3Traverser.traverse(noPreProccessor, s3DummyProcessor.process, nil)
+			err = S3Traverser.Traverse(noPreProccessor, s3DummyProcessor.process, nil)
 			c.Assert(err, chk.IsNil)
 		}
 		if gcpEnabled {
 			rawGCPURL := scenarioHelper{}.getRawGCPBucketURL(c, bucketNameGCP)
 			GCPTraverser, err := newGCPTraverser(&rawGCPURL, ctx, isRecursiveOn, false, func(entityType common.EntityType) {})
 			c.Assert(err, chk.IsNil)
-			err = GCPTraverser.traverse(noPreProccessor, gcpDummyProcessor.process, nil)
+			err = GCPTraverser.Traverse(noPreProccessor, gcpDummyProcessor.process, nil)
 			c.Assert(err, chk.IsNil)
 		}
 
@@ -816,7 +816,7 @@ func (s *genericTraverserSuite) TestTraverserWithVirtualAndLocalDirectory(c *chk
 		// invoke the local traversal with an indexer
 		// so that the results are indexed for easy validation
 		localIndexer := newObjectIndexer()
-		err := localTraverser.traverse(noPreProccessor, localIndexer.store, nil)
+		err := localTraverser.Traverse(noPreProccessor, localIndexer.store, nil)
 		c.Assert(err, chk.IsNil)
 
 		// construct a blob traverser
@@ -828,7 +828,7 @@ func (s *genericTraverserSuite) TestTraverserWithVirtualAndLocalDirectory(c *chk
 
 		// invoke the local traversal with a dummy processor
 		blobDummyProcessor := dummyProcessor{}
-		err = blobTraverser.traverse(noPreProccessor, blobDummyProcessor.process, nil)
+		err = blobTraverser.Traverse(noPreProccessor, blobDummyProcessor.process, nil)
 		c.Assert(err, chk.IsNil)
 
 		// construct an Azure File traverser
@@ -838,7 +838,7 @@ func (s *genericTraverserSuite) TestTraverserWithVirtualAndLocalDirectory(c *chk
 
 		// invoke the file traversal with a dummy processor
 		fileDummyProcessor := dummyProcessor{}
-		err = azureFileTraverser.traverse(noPreProccessor, fileDummyProcessor.process, nil)
+		err = azureFileTraverser.Traverse(noPreProccessor, fileDummyProcessor.process, nil)
 		c.Assert(err, chk.IsNil)
 
 		// construct a filesystem URL & pipeline
@@ -849,7 +849,7 @@ func (s *genericTraverserSuite) TestTraverserWithVirtualAndLocalDirectory(c *chk
 		// construct and run a FS traverser
 		bfsTraverser := newBlobFSTraverser(&rawFilesystemURL, bfsPipeline, ctx, isRecursiveOn, func(common.EntityType) {})
 		bfsDummyProcessor := dummyProcessor{}
-		err = bfsTraverser.traverse(noPreProccessor, bfsDummyProcessor.process, nil)
+		err = bfsTraverser.Traverse(noPreProccessor, bfsDummyProcessor.process, nil)
 
 		localTotalCount := len(localIndexer.indexMap)
 		localFileOnlyCount := 0
@@ -868,7 +868,7 @@ func (s *genericTraverserSuite) TestTraverserWithVirtualAndLocalDirectory(c *chk
 			credentialInfo := common.CredentialInfo{CredentialType: common.ECredentialType.S3AccessKey()}
 			S3Traverser, err := newS3Traverser(credentialInfo.CredentialType, &rawS3URL, ctx, isRecursiveOn, false, func(common.EntityType) {})
 			c.Assert(err, chk.IsNil)
-			err = S3Traverser.traverse(noPreProccessor, s3DummyProcessor.process, nil)
+			err = S3Traverser.Traverse(noPreProccessor, s3DummyProcessor.process, nil)
 			c.Assert(err, chk.IsNil)
 
 			// check that the results are the same length
@@ -878,7 +878,7 @@ func (s *genericTraverserSuite) TestTraverserWithVirtualAndLocalDirectory(c *chk
 			rawGCPURL := scenarioHelper{}.getRawGCPObjectURL(c, bucketNameGCP, virDirName+"/")
 			GCPTraverser, err := newGCPTraverser(&rawGCPURL, ctx, isRecursiveOn, false, func(common.EntityType) {})
 			c.Assert(err, chk.IsNil)
-			err = GCPTraverser.traverse(noPreProccessor, gcpDummyProcessor.process, nil)
+			err = GCPTraverser.Traverse(noPreProccessor, gcpDummyProcessor.process, nil)
 			c.Assert(err, chk.IsNil)
 
 			c.Assert(len(gcpDummyProcessor.record), chk.Equals, localFileOnlyCount)
@@ -942,19 +942,19 @@ func (s *genericTraverserSuite) TestSerialAndParallelBlobTraverser(c *chk.C) {
 
 		// invoke the parallel traversal with a dummy processor
 		parallelDummyProcessor := dummyProcessor{}
-		err := parallelBlobTraverser.traverse(noPreProccessor, parallelDummyProcessor.process, nil)
+		err := parallelBlobTraverser.Traverse(noPreProccessor, parallelDummyProcessor.process, nil)
 		c.Assert(err, chk.IsNil)
 
 		// invoke the serial traversal with a dummy processor
 		serialDummyProcessor := dummyProcessor{}
-		err = parallelBlobTraverser.traverse(noPreProccessor, serialDummyProcessor.process, nil)
+		err = parallelBlobTraverser.Traverse(noPreProccessor, serialDummyProcessor.process, nil)
 		c.Assert(err, chk.IsNil)
 
 		// make sure the results are as expected
 		c.Assert(len(parallelDummyProcessor.record), chk.Equals, len(serialDummyProcessor.record))
 
 		// compare the entries one by one
-		lookupMap := make(map[string]storedObject)
+		lookupMap := make(map[string]StoredObject)
 		for _, entry := range parallelDummyProcessor.record {
 			lookupMap[entry.relativePath] = entry
 		}

--- a/cmd/zt_interceptors_for_test.go
+++ b/cmd/zt_interceptors_for_test.go
@@ -168,10 +168,10 @@ func (*mockedLifecycleManager) GatherAllLogs(channel chan string) (result []stri
 }
 
 type dummyProcessor struct {
-	record []storedObject
+	record []StoredObject
 }
 
-func (d *dummyProcessor) process(storedObject storedObject) (err error) {
+func (d *dummyProcessor) process(storedObject StoredObject) (err error) {
 	d.record = append(d.record, storedObject)
 	return
 }

--- a/cmd/zt_sync_comparator_test.go
+++ b/cmd/zt_sync_comparator_test.go
@@ -39,11 +39,11 @@ func (s *syncComparatorSuite) TestSyncSourceComparator(c *chk.C) {
 	sourceComparator := newSyncSourceComparator(indexer, dummyCopyScheduler.process, false)
 
 	// create a sample destination object
-	sampleDestinationObject := storedObject{name: "test", relativePath: "/usr/test", lastModifiedTime: time.Now(), md5: destMD5}
+	sampleDestinationObject := StoredObject{name: "test", relativePath: "/usr/test", lastModifiedTime: time.Now(), md5: destMD5}
 
 	// test the comparator in case a given source object is not present at the destination
 	// meaning no entry in the index, so the comparator should pass the given object to schedule a transfer
-	compareErr := sourceComparator.processIfNecessary(storedObject{name: "only_at_source", relativePath: "only_at_source", lastModifiedTime: time.Now(), md5: srcMD5})
+	compareErr := sourceComparator.processIfNecessary(StoredObject{name: "only_at_source", relativePath: "only_at_source", lastModifiedTime: time.Now(), md5: srcMD5})
 	c.Assert(compareErr, chk.Equals, nil)
 
 	// check the source object was indeed scheduled
@@ -57,7 +57,7 @@ func (s *syncComparatorSuite) TestSyncSourceComparator(c *chk.C) {
 	// and it has a later modified time, so the comparator should pass the give object to schedule a transfer
 	err := indexer.store(sampleDestinationObject)
 	c.Assert(err, chk.IsNil)
-	compareErr = sourceComparator.processIfNecessary(storedObject{name: "test", relativePath: "/usr/test", lastModifiedTime: time.Now().Add(time.Hour), md5: srcMD5})
+	compareErr = sourceComparator.processIfNecessary(StoredObject{name: "test", relativePath: "/usr/test", lastModifiedTime: time.Now().Add(time.Hour), md5: srcMD5})
 	c.Assert(compareErr, chk.Equals, nil)
 
 	// check the source object was indeed scheduled
@@ -73,7 +73,7 @@ func (s *syncComparatorSuite) TestSyncSourceComparator(c *chk.C) {
 	// meaning that the source object is considered stale, so no transfer should be scheduled
 	err = indexer.store(sampleDestinationObject)
 	c.Assert(err, chk.IsNil)
-	compareErr = sourceComparator.processIfNecessary(storedObject{name: "test", relativePath: "/usr/test", lastModifiedTime: time.Now().Add(-time.Hour), md5: srcMD5})
+	compareErr = sourceComparator.processIfNecessary(StoredObject{name: "test", relativePath: "/usr/test", lastModifiedTime: time.Now().Add(-time.Hour), md5: srcMD5})
 	c.Assert(compareErr, chk.Equals, nil)
 
 	// check no source object was scheduled
@@ -92,7 +92,7 @@ func (s *syncComparatorSuite) TestSyncSrcCompDisableComparator(c *chk.C) {
 
 	// test the comparator in case a given source object is not present at the destination
 	// meaning no entry in the index, so the comparator should pass the given object to schedule a transfer
-	compareErr := sourceComparator.processIfNecessary(storedObject{name: "only_at_source", relativePath: "only_at_source", lastModifiedTime: time.Now(), md5: srcMD5})
+	compareErr := sourceComparator.processIfNecessary(StoredObject{name: "only_at_source", relativePath: "only_at_source", lastModifiedTime: time.Now(), md5: srcMD5})
 	c.Assert(compareErr, chk.Equals, nil)
 
 	// check the source object was indeed scheduled
@@ -104,14 +104,14 @@ func (s *syncComparatorSuite) TestSyncSrcCompDisableComparator(c *chk.C) {
 
 	// create a sample source object
 	currTime := time.Now()
-	destinationStoredObjects := []storedObject{
+	destinationStoredObjects := []StoredObject{
 		// file whose last modified time is greater than that of source
 		{name: "test1", relativePath: "/usr/test1", lastModifiedTime: currTime, md5: destMD5},
 		// file whose last modified time is less than that of source
 		{name: "test2", relativePath: "/usr/test2", lastModifiedTime: currTime, md5: destMD5},
 	}
 
-	sourceStoredObjects := []storedObject{
+	sourceStoredObjects := []StoredObject{
 		{name: "test1", relativePath: "/usr/test1", lastModifiedTime: currTime.Add(time.Hour), md5: srcMD5},
 		{name: "test2", relativePath: "/usr/test2", lastModifiedTime: currTime.Add(-time.Hour), md5: srcMD5},
 	}
@@ -140,11 +140,11 @@ func (s *syncComparatorSuite) TestSyncDestinationComparator(c *chk.C) {
 	destinationComparator := newSyncDestinationComparator(indexer, dummyCopyScheduler.process, dummyCleaner.process, false)
 
 	// create a sample source object
-	sampleSourceObject := storedObject{name: "test", relativePath: "/usr/test", lastModifiedTime: time.Now(), md5: srcMD5}
+	sampleSourceObject := StoredObject{name: "test", relativePath: "/usr/test", lastModifiedTime: time.Now(), md5: srcMD5}
 
 	// test the comparator in case a given destination object is not present at the source
 	// meaning it is an extra file that needs to be deleted, so the comparator should pass the given object to the destinationCleaner
-	compareErr := destinationComparator.processIfNecessary(storedObject{name: "only_at_dst", relativePath: "only_at_dst", lastModifiedTime: time.Now(), md5: destMD5})
+	compareErr := destinationComparator.processIfNecessary(StoredObject{name: "only_at_dst", relativePath: "only_at_dst", lastModifiedTime: time.Now(), md5: destMD5})
 	c.Assert(compareErr, chk.Equals, nil)
 
 	// verify that destination object is being deleted
@@ -161,7 +161,7 @@ func (s *syncComparatorSuite) TestSyncDestinationComparator(c *chk.C) {
 	// no transfer happens
 	err := indexer.store(sampleSourceObject)
 	c.Assert(err, chk.IsNil)
-	compareErr = destinationComparator.processIfNecessary(storedObject{name: "test", relativePath: "/usr/test", lastModifiedTime: time.Now().Add(time.Hour), md5: destMD5})
+	compareErr = destinationComparator.processIfNecessary(StoredObject{name: "test", relativePath: "/usr/test", lastModifiedTime: time.Now().Add(time.Hour), md5: destMD5})
 	c.Assert(compareErr, chk.Equals, nil)
 
 	// verify that the source object is scheduled for transfer
@@ -177,7 +177,7 @@ func (s *syncComparatorSuite) TestSyncDestinationComparator(c *chk.C) {
 	// meaning that the source object should be transferred since the destination object is stale
 	err = indexer.store(sampleSourceObject)
 	c.Assert(err, chk.IsNil)
-	compareErr = destinationComparator.processIfNecessary(storedObject{name: "test", relativePath: "/usr/test", lastModifiedTime: time.Now().Add(-time.Hour), md5: destMD5})
+	compareErr = destinationComparator.processIfNecessary(StoredObject{name: "test", relativePath: "/usr/test", lastModifiedTime: time.Now().Add(-time.Hour), md5: destMD5})
 	c.Assert(compareErr, chk.Equals, nil)
 
 	// verify that there's no transfer & no deletes
@@ -198,14 +198,14 @@ func (s *syncComparatorSuite) TestSyncDestCompDisableComparison(c *chk.C) {
 
 	// create a sample source object
 	currTime := time.Now()
-	sourceStoredObjects := []storedObject{
+	sourceStoredObjects := []StoredObject{
 		{name: "test1", relativePath: "/usr/test1", lastModifiedTime: currTime, md5: srcMD5},
 		{name: "test2", relativePath: "/usr/test2", lastModifiedTime: currTime, md5: srcMD5},
 	}
 
-	//onlyAtSrc := storedObject{name: "only_at_src", relativePath: "/usr/only_at_src", lastModifiedTime: currTime, md5: destMD5}
+	//onlyAtSrc := StoredObject{name: "only_at_src", relativePath: "/usr/only_at_src", lastModifiedTime: currTime, md5: destMD5}
 
-	destinationStoredObjects := []storedObject{
+	destinationStoredObjects := []StoredObject{
 		// file whose last modified time is greater than that of source
 		{name: "test1", relativePath: "/usr/test1", lastModifiedTime: time.Now().Add(time.Hour), md5: destMD5},
 		// file whose last modified time is less than that of source
@@ -214,7 +214,7 @@ func (s *syncComparatorSuite) TestSyncDestCompDisableComparison(c *chk.C) {
 
 	// test the comparator in case a given destination object is not present at the source
 	// meaning it is an extra file that needs to be deleted, so the comparator should pass the given object to the destinationCleaner
-	compareErr := destinationComparator.processIfNecessary(storedObject{name: "only_at_dst", relativePath: "only_at_dst", lastModifiedTime: currTime, md5: destMD5})
+	compareErr := destinationComparator.processIfNecessary(StoredObject{name: "only_at_dst", relativePath: "only_at_dst", lastModifiedTime: currTime, md5: destMD5})
 	c.Assert(compareErr, chk.Equals, nil)
 
 	// verify that destination object is being deleted

--- a/cmd/zt_sync_processor_test.go
+++ b/cmd/zt_sync_processor_test.go
@@ -55,7 +55,7 @@ func (s *syncProcessorSuite) TestLocalDeleter(c *chk.C) {
 	c.Assert(err, chk.IsNil)
 
 	// exercise the deleter
-	err = deleter.removeImmediately(storedObject{relativePath: dstFileName})
+	err = deleter.removeImmediately(StoredObject{relativePath: dstFileName})
 	c.Assert(err, chk.IsNil)
 
 	// validate that the file no longer exists
@@ -91,7 +91,7 @@ func (s *syncProcessorSuite) TestBlobDeleter(c *chk.C) {
 	c.Assert(err, chk.IsNil)
 
 	// exercise the deleter
-	err = deleter.removeImmediately(storedObject{relativePath: blobName})
+	err = deleter.removeImmediately(StoredObject{relativePath: blobName})
 	c.Assert(err, chk.IsNil)
 
 	// validate that the blob was deleted
@@ -127,7 +127,7 @@ func (s *syncProcessorSuite) TestFileDeleter(c *chk.C) {
 	c.Assert(err, chk.IsNil)
 
 	// exercise the deleter
-	err = deleter.removeImmediately(storedObject{relativePath: fileName})
+	err = deleter.removeImmediately(StoredObject{relativePath: fileName})
 	c.Assert(err, chk.IsNil)
 
 	// validate that the file was deleted

--- a/ste/concurrency.go
+++ b/ste/concurrency.go
@@ -146,8 +146,8 @@ func NewConcurrencySettings(maxFileAndSocketHandles int, requestAutoTuneGRs bool
 		InitialMainPoolSize:        initialMainPoolSize,
 		MaxMainPoolSize:            maxMainPoolSize,
 		TransferInitiationPoolSize: getTransferInitiationPoolSize(),
-		EnumerationPoolSize:        getEnumerationPoolSize(),
-		ParallelStatFiles:          getParallelStatFiles(),
+		EnumerationPoolSize:        GetEnumerationPoolSize(),
+		ParallelStatFiles:          GetParallelStatFiles(),
 		CheckCpuWhenTuning:         getCheckCpuUsageWhenTuning(),
 	}
 
@@ -230,7 +230,7 @@ func getTransferInitiationPoolSize() *ConfiguredInt {
 	return &ConfiguredInt{defaultTransferInitiationPoolSize, false, envVar.Name, "hard-coded default"}
 }
 
-func getEnumerationPoolSize() *ConfiguredInt {
+func GetEnumerationPoolSize() *ConfiguredInt {
 	envVar := common.EEnvironmentVariable.EnumerationPoolSize()
 
 	if c := tryNewConfiguredInt(envVar); c != nil {
@@ -241,7 +241,7 @@ func getEnumerationPoolSize() *ConfiguredInt {
 
 }
 
-func getParallelStatFiles() *ConfiguredBool {
+func GetParallelStatFiles() *ConfiguredBool {
 	envVar := common.EEnvironmentVariable.ParallelStatFiles()
 	if c := tryNewConfiguredBool(envVar); c != nil {
 		return c


### PR DESCRIPTION
- Exported function/struct from cmd package. So that user
  can write custome enumerator.
  Some of exported Structure/functions :-
  - cookedCopyCmdArgs
  - InitResourceTraverser
  - StoredObject
  - ObjectFilter
  - CopyEnumerator
- Apart from that changes also done in test files.
At this moment minimal changes done required to create custom
enumerator. In future we need to export more APIs depending on requirement.