### PR TITLE
Fix azcopy on architectures that are strict about alignment (ARM)

### DIFF
--- a/ste/JobPartPlan.go
+++ b/ste/JobPartPlan.go
@@ -103,9 +103,11 @@ func (jpph *JobPartPlanHeader) Transfer(transferIndex uint32) *JobPartPlanTransf
 		panic(errors.New("requesting a transfer index greater than what is available"))
 	}
 
-	// (Job Part Plan's file address) + (header size) --> beginning of transfers in file
+	// (Job Part Plan's file address) + (header size) + (padding to 8 bytes) --> beginning of transfers in file
 	// Add (transfer size) * (transfer index)
-	return (*JobPartPlanTransfer)(unsafe.Pointer((uintptr(unsafe.Pointer(jpph)) + unsafe.Sizeof(*jpph) + uintptr(jpph.CommandStringLength)) + (unsafe.Sizeof(JobPartPlanTransfer{}) * uintptr(transferIndex))))
+	transfersOffset := unsafe.Sizeof(*jpph) + uintptr(jpph.CommandStringLength)
+	transfersOffset = (transfersOffset + 7) & ^uintptr(7)
+	return (*JobPartPlanTransfer)(unsafe.Pointer((uintptr(unsafe.Pointer(jpph)) + transfersOffset) + (unsafe.Sizeof(JobPartPlanTransfer{}) * uintptr(transferIndex))))
 }
 
 // CommandString returns the command string given by user when job was created

--- a/ste/JobPartPlanFileName.go
+++ b/ste/JobPartPlanFileName.go
@@ -232,6 +232,16 @@ func (jpfn JobPartPlanFileName) Create(order common.CopyJobPartOrderRequest) {
 	}
 	eof += int64(bytesWritten)
 
+	// ensure 8 byte alignment so that Atomic fields of JobPartPlanTransfer can actually be accessed atomically
+	paddingLen := ((eof + 7) & ^7) - eof
+	if paddingLen != 0 {
+		bytesWritten, err := file.Write(make([]byte, paddingLen))
+		if err != nil {
+			panic(err)
+		}
+		eof += int64(bytesWritten)
+	}
+
 	// srcDstStringsOffset points to after the header & all the transfers; this is where the src/dst strings go for each transfer
 	srcDstStringsOffset := make([]int64, jpph.NumTransfers)
 


### PR DESCRIPTION
This PR fixes azcopy on ARM architectures (tested on ARM64) by ensuring that JobPartPlanTransfer is properly 8 byte aligned inside the plan file. JobPartPlanTransfer is located after a variable size string and so its alignment was dependent on what was being copied.

Tested using go 1.16.2 and `GOARCH=arm64 go build`.

Fixes #972
Fixes #882
Fixes #427