### PR TITLE
Fixed memory usage issue with list of skipped/failed transfers

### DIFF
--- a/ste/jobStatusManager.go
+++ b/ste/jobStatusManager.go
@@ -102,6 +102,11 @@ func (jm *jobMgr) handleStatusUpdateMessage() {
 			/* Display stats */
 			js.Timestamp = time.Now().UTC()
 			jstm.respChan <- *js
+
+			// Reset the lists so that they don't keep accumulating and take up excessive memory
+			// There is no need to keep sending the same items over and over again
+			js.FailedTransfers = []common.TransferDetail{}
+			js.SkippedTransfers = []common.TransferDetail{}
 		}
 	}
 }


### PR DESCRIPTION
To confirm the new behavior with Storage Explorer folks.

In short, we build a complete list of all failed/skipped transfers, to be sent with each job summary update. However, this becomes a serious memory usage problem when the number of files goes into millions. One cx ran out of memory (10GB+ of usage) because of this problem.

In essence, there is no good reason to send the same files over and over again.