### PR TITLE
Fix copying ADLS Gen 2 ACLs

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -85,7 +85,7 @@ type rawSyncCmdArgs struct {
 	// Provided key name will be fetched from Azure Key Vault and will be used to encrypt the data
 	cpkScopeInfo string
 	// dry run mode bool
-	dryrun              bool
+	dryrun bool
 }
 
 func (raw *rawSyncCmdArgs) parsePatterns(pattern string) (cookedPatterns []string) {
@@ -246,9 +246,6 @@ func (raw *rawSyncCmdArgs) cook() (cookedSyncCmdArgs, error) {
 	if err = validatePreserveSMBPropertyOption(cooked.preserveSMBInfo, cooked.fromTo, nil, "preserve-smb-info"); err != nil {
 		return cooked, err
 	}
-	if cooked.fromTo == common.EFromTo.BlobBlob() && cooked.preservePermissions.IsTruthy() {
-		cooked.isHNSToHNS = true // override HNS settings, since if a user is tx'ing blob->blob and copying permissions, it's DEFINITELY going to be HNS (since perms don't exist w/o HNS).
-	}
 
 	isUserPersistingPermissions := raw.preserveSMBPermissions || raw.preservePermissions
 	if cooked.preserveSMBInfo && !isUserPersistingPermissions {
@@ -263,6 +260,9 @@ func (raw *rawSyncCmdArgs) cook() (cookedSyncCmdArgs, error) {
 	//	return cooked, err
 	//}
 	cooked.preservePermissions = common.NewPreservePermissionsOption(isUserPersistingPermissions, raw.preserveOwner, cooked.fromTo)
+	if cooked.fromTo == common.EFromTo.BlobBlob() && cooked.preservePermissions.IsTruthy() {
+		cooked.isHNSToHNS = true // override HNS settings, since if a user is tx'ing blob->blob and copying permissions, it's DEFINITELY going to be HNS (since perms don't exist w/o HNS).
+	}
 
 	cooked.putMd5 = raw.putMd5
 	if err = validatePutMd5(cooked.putMd5, cooked.fromTo); err != nil {
@@ -346,7 +346,7 @@ type cookedSyncCmdArgs struct {
 
 	source         common.ResourceString
 	destination    common.ResourceString
-        fromTo         common.FromTo
+	fromTo         common.FromTo
 	credentialInfo common.CredentialInfo
 	isHNSToHNS     bool // Because DFS sources and destinations are obscured, this is necessary for folder property transfers on ADLS Gen 2.
 

--- a/cmd/zc_traverser_blob.go
+++ b/cmd/zc_traverser_blob.go
@@ -234,13 +234,13 @@ func (t *blobTraverser) parallelList(containerURL azblob.ContainerURL, container
 
 					if t.includeDirectoryStubs {
 						// try to get properties on the directory itself, since it's not listed in BlobItems
-						fblobURL := containerURL.NewBlobURL(strings.TrimSuffix(currentDirPath+virtualDir.Name, common.AZCOPY_PATH_SEPARATOR_STRING))
+						fblobURL := containerURL.NewBlobURL(strings.TrimSuffix(virtualDir.Name, common.AZCOPY_PATH_SEPARATOR_STRING))
 						resp, err := fblobURL.GetProperties(t.ctx, azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
 						if err == nil {
 							storedObject := newStoredObject(
 								preprocessor,
-								getObjectNameOnly(strings.TrimSuffix(currentDirPath+virtualDir.Name, common.AZCOPY_PATH_SEPARATOR_STRING)),
-								strings.TrimSuffix(currentDirPath+virtualDir.Name, common.AZCOPY_PATH_SEPARATOR_STRING),
+								getObjectNameOnly(strings.TrimSuffix(virtualDir.Name, common.AZCOPY_PATH_SEPARATOR_STRING)),
+								strings.TrimSuffix(virtualDir.Name, common.AZCOPY_PATH_SEPARATOR_STRING),
 								common.EEntityType.File(), // folder stubs are treated like files in in the serial lister as well
 								resp.LastModified(),
 								resp.ContentLength(),

--- a/e2etest/validator.go
+++ b/e2etest/validator.go
@@ -54,7 +54,7 @@ func (Validator) ValidateRemoveTransfer(c asserter, isSrcEncoded bool, isDstEnco
 	// TODO: Think of how to validate files in case of remove
 }
 func (Validator) ValidateCopyTransfersAreScheduled(c asserter, isSrcEncoded bool, isDstEncoded bool,
-	sourcePrefix string, destinationPrefix string, expectedTransfers []*testObject, actualTransfers []common.TransferDetail, statusToTest common.TransferStatus) {
+	sourcePrefix string, destinationPrefix string, expectedTransfers []*testObject, actualTransfers []common.TransferDetail, statusToTest common.TransferStatus, fromTo common.FromTo) {
 
 	sourcePrefix = makeSlashesComparable(sourcePrefix)
 	destinationPrefix = makeSlashesComparable(destinationPrefix)
@@ -82,7 +82,7 @@ func (Validator) ValidateCopyTransfersAreScheduled(c asserter, isSrcEncoded bool
 		return s + "/"
 	}
 	lookupMap := scenarioHelper{}.convertListToMap(expectedTransfers, func(to *testObject) string {
-		if to.isFolder() {
+		if to.isFolder() && fromTo != common.EFromTo.BlobBlob() { // Blob has no concept of folders, except in ADLSG2. However, internally, they're treated as blobs anyway.
 			return addFolderSuffix(to.name)
 		} else {
 			return to.name

--- a/e2etest/zt_preserve_properties_test.go
+++ b/e2etest/zt_preserve_properties_test.go
@@ -64,7 +64,13 @@ func TestProperties_HNSACLs(t *testing.T) {
 		defaultSize: "1K",
 		shouldTransfer: []interface{}{
 			folder(""),
-			f("filea", with{adlsPermissionsACL: "user::rwx,group::rwx,other::--x"}),
+			f("filea", with{adlsPermissionsACL: "user::rwx,group::rwx,other::r--"}),
+			folder("a", with{adlsPermissionsACL: "user::rwx,group::rwx,other::-w-"}),
+			f("a/fileb", with{adlsPermissionsACL: "user::rwx,group::rwx,other::--x"}),
+			folder("a/b", with{adlsPermissionsACL: "user::rwx,group::rwx,other::rw-"}),
+			f("a/b/filec", with{adlsPermissionsACL: "user::rwx,group::rwx,other::r-x"}),
+			folder("d", with{adlsPermissionsACL: "user::rwx,group::rwx,other::-wx"}),
+			f("d/filed", with{adlsPermissionsACL: "user::rwx,group::rwx,other::rwx"}),
 		},
 	}, EAccountType.HierarchicalNamespaceEnabled(), "")
 }


### PR DESCRIPTION
In 10.12, with the introduction of ADLS Gen 2 ACL copying, our method of obtaining the folder objects was incorrect, and would lead to an inability to grab and copy ACLs on directory stubs.

This PR extends the test present and fixes this issue.