### PR TITLE
Widen managed disk accounts to all md- accounts instead of just md-impexp- accounts

### DIFF
--- a/ste/downloader-blob.go
+++ b/ste/downloader-blob.go
@@ -97,12 +97,10 @@ func (bd *blobDownloader) GenerateDownloadFunc(jptm IJobPartTransferMgr, srcPipe
 		info := jptm.Info()
 		u, _ := url.Parse(info.Source)
 		srcBlobURL := azblob.NewBlobURL(*u, srcPipeline)
-		isNewStyleImpExp := isInManagedDiskImportExportAccount(*u)
-		isOldStyleDiskExport := isInLegacyDiskExportAccount(*u)
 
 		// set access conditions, to protect against inconsistencies from changes-while-being-read
 		accessConditions := azblob.BlobAccessConditions{ModifiedAccessConditions: azblob.ModifiedAccessConditions{IfUnmodifiedSince: jptm.LastModifiedTime()}}
-		if isNewStyleImpExp || isOldStyleDiskExport {
+		if isInManagedDiskImportExportAccount(*u) {
 			// no access conditions (and therefore no if-modified checks) are supported on managed disk import/export (md-impexp)
 			// They are also unsupported on old "md-" style export URLs on the new (2019) large size disks.
 			// And if fact you can't have an md- URL in existence if the blob is mounted as a disk, so it won't be getting changed anyway, so we just treat all md-disks the same

--- a/ste/sender-pageBlob.go
+++ b/ste/sender-pageBlob.go
@@ -69,8 +69,7 @@ type pageBlobSenderBase struct {
 }
 
 const (
-	managedDiskImportExportAccountPrefix = "md-impexp-"
-	legacyDiskExportPrefix               = "md-" // these don't have the impepx bit that follows
+	managedDiskImportExportAccountPrefix = "md-"
 
 	// Start high(ish), because it auto-tunes downwards faster than it auto-tunes upwards
 	pageBlobInitialBytesPerSecond = (4 * 1000 * 1000 * 1000) / 8
@@ -152,15 +151,6 @@ func newPageBlobSenderBase(jptm IJobPartTransferMgr, destination string, p pipel
 // these accounts have special restrictions of which APIs operations they support
 func isInManagedDiskImportExportAccount(u url.URL) bool {
 	return strings.HasPrefix(u.Host, managedDiskImportExportAccountPrefix)
-}
-
-// "legacy" is perhaps not the best name, since these remain in use for (all?) EXports of managed disks.
-// These "legacy" ones an older mechanism than the new md-impexp path that is used for IMports as of mid 2019.
-func isInLegacyDiskExportAccount(u url.URL) bool {
-	if isInManagedDiskImportExportAccount(u) {
-		return false // it's the new-style md-impexp
-	}
-	return strings.HasPrefix(u.Host, legacyDiskExportPrefix) // md-....
 }
 
 func (s *pageBlobSenderBase) isInManagedDiskImportExportAccount() bool {


### PR DESCRIPTION
Confidential VM Provisioning Service (CPS) works directly with DiskRP for creation of managed disk. DiskRP sends a read-write SAS of an empty managed disk blob (it could have prefix md- or md-ssd- and not md-impexp-) to CPS. CPS is then supposed to upload encrypted VHD file to this managed disk blob. DiskRP then uses this blob for creation of managed disk. 
As the managed disk SAS that CPS get is of type md- or md-ssd- and not md-impexp-, azcopy doesn’t treat these SAS as managed disk blob but as typical unmanaged blob. Therefore, during upload to these blobs PutBlob is called which result in deletion of the original blob and re-creation of a new one wiping properties and metadata of the original blob. It also messes up the caching that BlobService has put in place for managed disk usecases.
This PR aims to consider all md- account as managed disk account and just md-impexp-.