### PR TITLE
Prevent re-creating an already open plan file

### DIFF
--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -241,6 +241,7 @@ func (raw rawBenchmarkCmdArgs) createCleanupJobArgs(benchmarkDest common.Resourc
 	rc.setMandatoryDefaults()
 
 	cooked, err := rc.cook()
+	cooked.jobID = common.NewJobID() // Override the job ID that cook gave us-- That would cause us to fail deletion.
 	cooked.isCleanupJob = true
 	cooked.cleanupJobMessage = "Running cleanup job to delete files created during benchmarking"
 	return &cooked, err

--- a/ste/JobPartPlanFileName.go
+++ b/ste/JobPartPlanFileName.go
@@ -17,6 +17,11 @@ import (
 
 type JobPartPlanFileName string
 
+func (jppfn *JobPartPlanFileName) Exists() bool {
+	_, err := os.Stat(jppfn.GetJobPartPlanPath())
+	return err == nil
+}
+
 func (jppfn *JobPartPlanFileName) GetJobPartPlanPath() string {
 	return fmt.Sprintf("%s%s%s", JobsAdmin.AppPathFolder(), common.AZCOPY_PATH_SEPARATOR_STRING, string(*jppfn))
 }
@@ -70,6 +75,10 @@ func (jpfn JobPartPlanFileName) Map() *JobPartPlanMMF {
 
 // createJobPartPlanFile creates the memory map JobPartPlanHeader using the given JobPartOrder and JobPartPlanBlobData
 func (jpfn JobPartPlanFileName) Create(order common.CopyJobPartOrderRequest) {
+	if jpfn.Exists() {
+		return // This is *probably* for a cleanup job.
+	}
+
 	// Validate that the passed-in strings can fit in their respective fields
 	if len(order.SourceRoot.Value) > len(JobPartPlanHeader{}.SourceRoot) {
 		panic(fmt.Errorf("source root string is too large: %q", order.SourceRoot))

--- a/ste/JobPartPlanFileName.go
+++ b/ste/JobPartPlanFileName.go
@@ -76,7 +76,7 @@ func (jpfn JobPartPlanFileName) Map() *JobPartPlanMMF {
 // createJobPartPlanFile creates the memory map JobPartPlanHeader using the given JobPartOrder and JobPartPlanBlobData
 func (jpfn JobPartPlanFileName) Create(order common.CopyJobPartOrderRequest) {
 	if jpfn.Exists() {
-		panic(fmt.Sprintf("Duplicate job created. You probably shouldn't ever see this, but if you do, try cleaning out", JobsAdmin.(*jobsAdmin).planDir))
+		panic(fmt.Sprint("Duplicate job created. You probably shouldn't ever see this, but if you do, try cleaning out", JobsAdmin.(*jobsAdmin).planDir))
 	}
 
 	// Validate that the passed-in strings can fit in their respective fields

--- a/ste/JobPartPlanFileName.go
+++ b/ste/JobPartPlanFileName.go
@@ -76,7 +76,7 @@ func (jpfn JobPartPlanFileName) Map() *JobPartPlanMMF {
 // createJobPartPlanFile creates the memory map JobPartPlanHeader using the given JobPartOrder and JobPartPlanBlobData
 func (jpfn JobPartPlanFileName) Create(order common.CopyJobPartOrderRequest) {
 	if jpfn.Exists() {
-		return // This is *probably* for a cleanup job.
+		panic(fmt.Sprintf("Duplicate job created. You probably shouldn't ever see this, but if you do, try cleaning out", JobsAdmin.(*jobsAdmin).planDir))
 	}
 
 	// Validate that the passed-in strings can fit in their respective fields


### PR DESCRIPTION
The `benchmark` command had a flag enabled by default, `delete-test-data` which would issue a second job under the same ID sometimes and cause AzCopy to panic, since it'd try to re-create the job plan file. This resolves #1474 and #1623