### PR TITLE
Enable copying folder properties to the share root.

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -123,7 +123,7 @@ type rawCopyCmdArgs struct {
 	preserveSMBPermissions bool
 	preservePermissions    bool // Separate flag so that we don't get funkiness with two "flags" targeting the same boolean
 	preserveOwner          bool // works in conjunction with preserveSmbPermissions
-	// Opt-in "rename" flag.
+	// Default true; false indicates that the destination is the target directory, rather than something we'd put a directory under (e.g. a container)
 	asSubdir bool
 	// Opt-in flag to persist additional SMB properties to Azure Files. Named ...info instead of ...properties
 	// because the latter was similar enough to preserveSMBPermissions to induce user error

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -123,6 +123,8 @@ type rawCopyCmdArgs struct {
 	preserveSMBPermissions bool
 	preservePermissions    bool // Separate flag so that we don't get funkiness with two "flags" targeting the same boolean
 	preserveOwner          bool // works in conjunction with preserveSmbPermissions
+	// Opt-in "rename" flag.
+	shareRoot bool
 	// Opt-in flag to persist additional SMB properties to Azure Files. Named ...info instead of ...properties
 	// because the latter was similar enough to preserveSMBPermissions to induce user error
 	preserveSMBInfo bool
@@ -647,6 +649,9 @@ func (raw rawCopyCmdArgs) cook() (CookedCopyCmdArgs, error) {
 		cooked.isHNStoHNS = true // override HNS settings, since if a user is tx'ing blob->blob and copying permissions, it's DEFINITELY going to be HNS (since perms don't exist w/o HNS).
 	}
 
+	// --share-root is OK on all sources and destinations, but additional verification has to be done down the line. (e.g. https://account.blob.core.windows.net is not a valid root)
+	cooked.shareRoot = raw.shareRoot
+
 	cooked.IncludeDirectoryStubs = raw.includeDirectoryStubs || (cooked.isHNStoHNS && cooked.preservePermissions.IsTruthy())
 
 	if err = crossValidateSymlinksAndPermissions(cooked.FollowSymlinks, cooked.preservePermissions.IsTruthy()); err != nil {
@@ -1087,6 +1092,9 @@ type CookedCopyCmdArgs struct {
 
 	// Whether to enable Windows special privileges
 	backupMode bool
+
+	// Whether to rename/share the root
+	shareRoot bool
 
 	// whether user wants to preserve full properties during service to service copy, the default value is true.
 	// For S3 and Azure File non-single file source, as list operation doesn't return full properties of objects/files,
@@ -1841,6 +1849,7 @@ func init() {
 	cpCmd.PersistentFlags().BoolVar(&raw.noGuessMimeType, "no-guess-mime-type", false, "Prevents AzCopy from detecting the content-type based on the extension or content of the file.")
 	cpCmd.PersistentFlags().BoolVar(&raw.preserveLastModifiedTime, "preserve-last-modified-time", false, "Only available when destination is file system.")
 	cpCmd.PersistentFlags().BoolVar(&raw.preserveSMBPermissions, "preserve-smb-permissions", false, "False by default. Preserves SMB ACLs between aware resources (Windows and Azure Files). For downloads, you will also need the --backup flag to restore permissions where the new Owner will not be the user running AzCopy. This flag applies to both files and folders, unless a file-only filter is specified (e.g. include-pattern).")
+	cpCmd.PersistentFlags().BoolVar(&raw.shareRoot, "share-root", false, "False by default. Indicates that the destination and source are the same, and that the source is not a sub-folder. Effectively a rename of the source. Can be used to persist permissions to a file share's root folder.") // TODO: Debate the name and description of this flag. If we get it wrong, we confuse a lot of people.
 	cpCmd.PersistentFlags().BoolVar(&raw.preserveOwner, common.PreserveOwnerFlagName, common.PreserveOwnerDefault, "Only has an effect in downloads, and only when --preserve-smb-permissions is used. If true (the default), the file Owner and Group are preserved in downloads. If set to false, --preserve-smb-permissions will still preserve ACLs but Owner and Group will be based on the user running AzCopy")
 	cpCmd.PersistentFlags().BoolVar(&raw.preserveSMBInfo, "preserve-smb-info", true, "For SMB-aware locations, flag will be set to true by default. Preserves SMB property info (last write time, creation time, attribute bits) between SMB-aware resources (Windows and Azure Files). Only the attribute bits supported by Azure Files will be transferred; any others will be ignored. This flag applies to both files and folders, unless a file-only filter is specified (e.g. include-pattern). The info transferred for folders is the same as that for files, except for Last Write Time which is never preserved for folders.")
 	cpCmd.PersistentFlags().BoolVar(&raw.forceIfReadOnly, "force-if-read-only", false, "When overwriting an existing file on Windows or Azure Files, force the overwrite to work even if the existing file has its read-only attribute set")

--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -82,7 +82,7 @@ func (cca *CookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 		!cca.Recursive && // Copies the folder & everything under it
 		!cca.StripTopDir { // Copies only everything under it
 		// todo: dir only transfer, also todo: support syncing the root folder's acls on sync.
-		return nil, errors.New("cannot use directory as source without --recursive, --share-root or a trailing wildcard (/*)")
+		return nil, errors.New("cannot use directory as source without --recursive or a trailing wildcard (/*)")
 	}
 
 	// Check if the destination is a directory so we can correctly decide where our files land
@@ -116,8 +116,8 @@ func (cca *CookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 		return nil, errors.New("cannot transfer individual files/folders to the root of a service. Add a container or directory to the destination URL")
 	}
 
-	if srcLevel == ELocationLevel.Container() && dstLevel == ELocationLevel.Service() && cca.shareRoot {
-		return nil, errors.New("cannot use share-root with a service level destination")
+	if srcLevel == ELocationLevel.Container() && dstLevel == ELocationLevel.Service() && !cca.asSubdir {
+		return nil, errors.New("cannot use --as-subdir=false with a service level destination")
 	}
 
 	// When copying a container directly to a container, strip the top directory
@@ -262,8 +262,8 @@ func (cca *CookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 			}
 		}
 
-		srcRelPath := cca.MakeEscapedRelativePath(true, isDestDir, cca.shareRoot, object)
-		dstRelPath := cca.MakeEscapedRelativePath(false, isDestDir, cca.shareRoot, object)
+		srcRelPath := cca.MakeEscapedRelativePath(true, isDestDir, cca.asSubdir, object)
+		dstRelPath := cca.MakeEscapedRelativePath(false, isDestDir, cca.asSubdir, object)
 
 		transfer, shouldSendToSte := object.ToNewCopyTransfer(
 			cca.autoDecompress && cca.FromTo.IsDownload(),
@@ -579,7 +579,7 @@ func pathEncodeRules(path string, fromTo common.FromTo, disableAutoDecoding bool
 	return path
 }
 
-func (cca *CookedCopyCmdArgs) MakeEscapedRelativePath(source bool, dstIsDir bool, shareRoot bool, object StoredObject) (relativePath string) {
+func (cca *CookedCopyCmdArgs) MakeEscapedRelativePath(source bool, dstIsDir bool, asSubdir bool, object StoredObject) (relativePath string) {
 	// write straight to /dev/null, do not determine a indirect path
 	if !source && cca.Destination.Value == common.Dev_Null {
 		return "" // ignore path encode rules
@@ -609,8 +609,8 @@ func (cca *CookedCopyCmdArgs) MakeEscapedRelativePath(source bool, dstIsDir bool
 		return pathEncodeRules(relativePath, cca.FromTo, cca.disableAutoDecoding, source)
 	}
 
-	// user is renaming a folder/sharing the root
-	if object.isSourceRootFolder() && shareRoot {
+	// user is not placing the source as a subdir
+	if object.isSourceRootFolder() && !asSubdir {
 		relativePath = ""
 	}
 
@@ -623,7 +623,7 @@ func (cca *CookedCopyCmdArgs) MakeEscapedRelativePath(source bool, dstIsDir bool
 
 	if common.IffString(source, object.ContainerName, object.DstContainerName) != "" {
 		relativePath = `/` + common.IffString(source, object.ContainerName, object.DstContainerName) + relativePath
-	} else if !source && !cca.StripTopDir && !cca.shareRoot { // Avoid doing this where the root is shared or renamed.
+	} else if !source && !cca.StripTopDir && cca.asSubdir { // Avoid doing this where the root is shared or renamed.
 		// We ONLY need to do this adjustment to the destination.
 		// The source SAS has already been removed. No need to convert it to a URL or whatever.
 		// Save to a directory

--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -80,8 +80,8 @@ func (cca *CookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 	isSourceDir := traverser.IsDirectory(true)
 	if isSourceDir &&
 		!cca.Recursive && // Copies the folder & everything under it
-		!cca.StripTopDir && // Copies only everything under it
-		!cca.shareRoot { // Copies only the folder properties, if recursive isn't specified.
+		!cca.StripTopDir { // Copies only everything under it
+		// todo: dir only transfer, also todo: support syncing the root folder's acls on sync.
 		return nil, errors.New("cannot use directory as source without --recursive, --share-root or a trailing wildcard (/*)")
 	}
 

--- a/cmd/zt_copy_s2smigration_test.go
+++ b/cmd/zt_copy_s2smigration_test.go
@@ -89,6 +89,7 @@ func getDefaultRawCopyInput(src, dst string) rawCopyCmdArgs {
 		s2sInvalidMetadataHandleOption: defaultS2SInvalideMetadataHandleOption.String(),
 		forceWrite:                     common.EOverwriteOption.True().String(),
 		preserveOwner:                  common.PreserveOwnerDefault,
+		asSubdir:                       true,
 	}
 }
 

--- a/cmd/zt_scenario_helpers_for_test.go
+++ b/cmd/zt_scenario_helpers_for_test.go
@@ -21,7 +21,6 @@
 package cmd
 
 import (
-	gcpUtils "cloud.google.com/go/storage"
 	"context"
 	"fmt"
 	"io"
@@ -34,8 +33,10 @@ import (
 	"strings"
 	"time"
 
+	gcpUtils "cloud.google.com/go/storage"
+
 	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
-	minio "github.com/minio/minio-go"
+	"github.com/minio/minio-go"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-blob-go/azblob"
@@ -847,6 +848,7 @@ func getDefaultCopyRawInput(src string, dst string) rawCopyCmdArgs {
 		s2sInvalidMetadataHandleOption: defaultS2SInvalideMetadataHandleOption.String(),
 		forceWrite:                     common.EOverwriteOption.True().String(),
 		preserveOwner:                  common.PreserveOwnerDefault,
+		asSubdir: true,
 	}
 }
 

--- a/e2etest/declarativeHelpers.go
+++ b/e2etest/declarativeHelpers.go
@@ -139,6 +139,7 @@ func (a *testingAsserter) CompactScenarioName() string {
 
 type params struct {
 	recursive                 bool
+	shareRoot                 bool
 	includePath               string
 	includePattern            string
 	includeAfter              string

--- a/e2etest/declarativeHelpers.go
+++ b/e2etest/declarativeHelpers.go
@@ -139,7 +139,7 @@ func (a *testingAsserter) CompactScenarioName() string {
 
 type params struct {
 	recursive                 bool
-	shareRoot                 bool
+	invertedAsSubdir          bool // this flag is INVERTED, because it is TRUE by default. todo: use pointers instead?
 	includePath               string
 	includePattern            string
 	includeAfter              string

--- a/e2etest/declarativeTestFiles.go
+++ b/e2etest/declarativeTestFiles.go
@@ -307,6 +307,7 @@ func folder(n string, properties ...withPropertyProvider) *testObject {
 type testFiles struct {
 	defaultSize  string                  // how big should the files be? Applies to those files that don't specify individual sizes. Uses the same K, M, G suffixes as benchmark mode's size-per-file
 	objectTarget string                  // should we target only a single file/folder?
+	destTarget   string                  // do we want to copy under a folder or rename?
 	sourcePublic azblob.PublicAccessType // should the source blob container be public? (ONLY APPLIES TO BLOB.)
 
 	// The files/folders that we expect to be transferred. Elements of the list must be strings or testObject's.
@@ -329,6 +330,7 @@ func (tf testFiles) cloneShouldTransfers() testFiles {
 	return testFiles{
 		defaultSize:    tf.defaultSize,
 		objectTarget:   tf.objectTarget,
+		destTarget:     tf.destTarget,
 		sourcePublic:   tf.sourcePublic,
 		shouldTransfer: tf.shouldTransfer,
 	}
@@ -339,6 +341,7 @@ func (tf testFiles) DeepCopy() testFiles {
 	ret.defaultSize = tf.defaultSize
 
 	ret.objectTarget = tf.objectTarget
+	ret.destTarget = tf.destTarget
 	ret.sourcePublic = tf.sourcePublic
 	ret.shouldTransfer = tf.copyList(tf.shouldTransfer)
 	ret.shouldIgnore = tf.copyList(tf.shouldIgnore)

--- a/e2etest/runner.go
+++ b/e2etest/runner.go
@@ -68,7 +68,7 @@ func (t *TestRunner) SetAllFlags(p params) {
 
 	// TODO: TODO: nakulkar-msft there will be many more to add here
 	set("recursive", p.recursive, false)
-	set("share-root", p.shareRoot, false)
+	set("as-subdir", !p.invertedAsSubdir, true)
 	set("include-path", p.includePath, "")
 	set("exclude-path", p.excludePath, "")
 	set("include-pattern", p.includePattern, "")

--- a/e2etest/runner.go
+++ b/e2etest/runner.go
@@ -68,6 +68,7 @@ func (t *TestRunner) SetAllFlags(p params) {
 
 	// TODO: TODO: nakulkar-msft there will be many more to add here
 	set("recursive", p.recursive, false)
+	set("share-root", p.shareRoot, false)
 	set("include-path", p.includePath, "")
 	set("exclude-path", p.excludePath, "")
 	set("include-pattern", p.includePattern, "")

--- a/e2etest/zt_basic_copy_sync_remove_test.go
+++ b/e2etest/zt_basic_copy_sync_remove_test.go
@@ -314,13 +314,13 @@ func TestBasic_CopyWithShareRoot(t *testing.T) {
 		eTestFromTo.AllUploads(),
 		eValidate.Auto(),
 		params{
-			recursive: true,
-			shareRoot: true,
+			recursive:        true,
+			invertedAsSubdir: true,
 		},
 		nil,
 		testFiles{
 			defaultSize: "1K",
-			destTarget: "newName",
+			destTarget:  "newName",
 
 			shouldTransfer: []interface{}{
 				folder(""),

--- a/e2etest/zt_basic_copy_sync_remove_test.go
+++ b/e2etest/zt_basic_copy_sync_remove_test.go
@@ -306,3 +306,30 @@ func TestBasic_CopyToWrongBlobType(t *testing.T) {
 		}
 	}
 }
+
+func TestBasic_CopyWithShareRoot(t *testing.T) {
+	RunScenarios(
+		t,
+		eOperation.Copy(), // Sync already shares the root by default.
+		eTestFromTo.AllUploads(),
+		eValidate.Auto(),
+		params{
+			recursive: true,
+			shareRoot: true,
+		},
+		nil,
+		testFiles{
+			defaultSize: "1K",
+			destTarget: "newName",
+
+			shouldTransfer: []interface{}{
+				folder(""),
+				f("asdf.txt"),
+				folder("a"),
+				f("a/asdf.txt"),
+			},
+		},
+		EAccountType.Standard(),
+		"",
+	)
+}

--- a/e2etest/zt_preserve_smb_properties_test.go
+++ b/e2etest/zt_preserve_smb_properties_test.go
@@ -214,3 +214,49 @@ func TestProperties_SMBPermsAndFlagsWithSync(t *testing.T) {
 		shouldIgnore:   recreateFiles,
 	}, EAccountType.Standard(), "")
 }
+
+func TestProperties_SMBWithCopyWithShareRoot(t *testing.T) {
+	fileSDDL, err := AdjustSDDLToLocal(SampleSDDL, SampleSDDLPlaceHolder)
+	if err != nil {
+		t.Error(err)
+	}
+
+	rootSDDL, err := AdjustSDDLToLocal(RootSampleSDDL, SampleSDDLPlaceHolder)
+	if err != nil {
+		t.Error(err)
+	}
+
+	folderSDDL, err := AdjustSDDLToLocal(FolderSampleSDDL, SampleSDDLPlaceHolder)
+	if err != nil {
+		t.Error(err)
+	}
+
+	RunScenarios(
+		t,
+		eOperation.Copy(), // Sync already shares the root by default.
+		eTestFromTo.Other(common.EFromTo.LocalFile()),
+		eValidate.Auto(),
+		params{
+			recursive:              true,
+			shareRoot:              true,
+			preserveSMBPermissions: true,
+			preserveSMBInfo:        true,
+		},
+		nil,
+		testFiles{
+			defaultSize: "1K",
+			destTarget:  "newName",
+
+			shouldTransfer: []interface{}{
+				folder("", with{smbAttributes: 2, smbPermissionsSddl: rootSDDL}),
+				f("asdf.txt", with{smbAttributes: 2, smbPermissionsSddl: fileSDDL}),
+				folder("a", with{smbAttributes: 2, smbPermissionsSddl: folderSDDL}),
+				f("a/asdf.txt", with{smbAttributes: 2, smbPermissionsSddl: fileSDDL}),
+				folder("a/b", with{smbAttributes: 2, smbPermissionsSddl: folderSDDL}),
+				f("a/b/asdf.txt", with{smbAttributes: 2, smbPermissionsSddl: fileSDDL}),
+			},
+		},
+		EAccountType.Standard(),
+		"",
+	)
+}

--- a/e2etest/zt_preserve_smb_properties_test.go
+++ b/e2etest/zt_preserve_smb_properties_test.go
@@ -238,7 +238,7 @@ func TestProperties_SMBWithCopyWithShareRoot(t *testing.T) {
 		eValidate.Auto(),
 		params{
 			recursive:              true,
-			shareRoot:              true,
+			invertedAsSubdir:       true,
 			preserveSMBPermissions: true,
 			preserveSMBInfo:        true,
 		},

--- a/ste/downloader-azureFiles_windows.go
+++ b/ste/downloader-azureFiles_windows.go
@@ -4,13 +4,14 @@ package ste
 
 import (
 	"fmt"
-	"github.com/Azure/azure-storage-file-go/azfile"
 	"net/url"
 	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
 	"unsafe"
+
+	"github.com/Azure/azure-storage-file-go/azfile"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 
@@ -92,6 +93,12 @@ var globalSetAclMu = &sync.Mutex{}
 func (a *azureFilesDownloader) PutSDDL(sip ISMBPropertyBearingSourceInfoProvider, txInfo TransferInfo) error {
 	// Let's start by getting our SDDL and parsing it.
 	sddlString, err := sip.GetSDDL()
+
+	// There's nothing to set.
+	if sddlString == "" {
+		return nil
+	}
+
 	// TODO: be better at handling these errors.
 	// GetSDDL will fail on a file-level SAS token.
 	if err != nil {

--- a/ste/sender-azureFile.go
+++ b/ste/sender-azureFile.go
@@ -272,7 +272,13 @@ func (u *azureFileSenderBase) addPermissionsToHeaders(info TransferInfo, destUrl
 		// If we didn't do the workaround, then let's get the SDDL and put it later.
 		if u.headersToApply.PermissionKey == nil || *u.headersToApply.PermissionKey == "" {
 			pString, err := sddlSIP.GetSDDL()
-			u.headersToApply.PermissionString = &pString
+
+			// Sending "" to the service is invalid, but the service will return it sometimes (e.g. on file shares)
+			// Thus, we'll let the files SDK fill in "inherit" for us, so the service is happy.
+			if pString != "" {
+				u.headersToApply.PermissionString = &pString
+			}
+
 			if err != nil {
 				return "Getting permissions", err
 			}


### PR DESCRIPTION
This is a PR that I expect to cause a little debate.

The functionality, I believe we're all in agreement on. However, the naming of the flag & description are questionable.

I went through a couple different ideas for the flag's name:

- `--rename`: Quite literal, but might mislead a user into thinking that it's a cut&paste type operation
- `--dest-is-target`: Wordy, doesn't deliver it's point
- `--copy-into-destination`: Similarly wordy, similarly doesn't get the point across.
- `--share-root`: At first glance, this seemed offputting-- This operation isn't ONLY for copying to the share root. However, thinking past the technical term, I realized that it's quite fitting-- The root is literally being shared, as in, this is just a merge into the destination folder, not a new folder.
- `--as-subdir=false`: The default (true) demonstrates present activity (placing directories as subdirectories) and the opposite functionality (treating the destination as the target) in the name