### PR TITLE
Dramatically reduce sync's memory footprint on larger jobs

### DIFF
--- a/cmd/syncComparator.go
+++ b/cmd/syncComparator.go
@@ -20,59 +20,11 @@
 
 package cmd
 
-import "strings"
+import (
+	"strings"
+)
 
-// with the help of an objectIndexer containing the source objects
-// find out the destination objects that should be transferred
-// in other words, this should be used when destination is being enumerated secondly
-type syncDestinationComparator struct {
-	// the rejected objects would be passed to the destinationCleaner
-	destinationCleaner objectProcessor
-
-	// the processor responsible for scheduling copy transfers
-	copyTransferScheduler objectProcessor
-
-	// storing the source objects
-	sourceIndex *objectIndexer
-
-	disableComparison bool
-}
-
-func newSyncDestinationComparator(i *objectIndexer, copyScheduler, cleaner objectProcessor, disableComparison bool) *syncDestinationComparator {
-	return &syncDestinationComparator{sourceIndex: i, copyTransferScheduler: copyScheduler, destinationCleaner: cleaner, disableComparison: disableComparison}
-}
-
-// it will only schedule transfers for destination objects that are present in the indexer but stale compared to the entry in the map
-// if the destinationObject is not at the source, it will be passed to the destinationCleaner
-// ex: we already know what the source contains, now we are looking at objects at the destination
-// if file x from the destination exists at the source, then we'd only transfer it if it is considered stale compared to its counterpart at the source
-// if file x does not exist at the source, then it is considered extra, and will be deleted
-func (f *syncDestinationComparator) processIfNecessary(destinationObject StoredObject) error {
-	sourceObjectInMap, present := f.sourceIndex.indexMap[destinationObject.relativePath]
-	if !present && f.sourceIndex.isDestinationCaseInsensitive {
-		lcRelativePath := strings.ToLower(destinationObject.relativePath)
-		sourceObjectInMap, present = f.sourceIndex.indexMap[lcRelativePath]
-	}
-
-	// if the destinationObject is present at source and stale, we transfer the up-to-date version from source
-	if present {
-		defer delete(f.sourceIndex.indexMap, destinationObject.relativePath)
-		if f.disableComparison || sourceObjectInMap.isMoreRecentThan(destinationObject) {
-			err := f.copyTransferScheduler(sourceObjectInMap)
-			if err != nil {
-				return err
-			}
-		}
-	} else {
-		// purposefully ignore the error from destinationCleaner
-		// it's a tolerable error, since it just means some extra destination object might hang around a bit longer
-		_ = f.destinationCleaner(destinationObject)
-	}
-
-	return nil
-}
-
-// with the help of an objectIndexer containing the destination objects
+// with the help of an destIndexer containing the destination objects
 // filter out the source objects that should be transferred
 // in other words, this should be used when source is being enumerated secondly
 type syncSourceComparator struct {
@@ -80,12 +32,12 @@ type syncSourceComparator struct {
 	copyTransferScheduler objectProcessor
 
 	// storing the destination objects
-	destinationIndex *objectIndexer
+	destinationIndex *destIndexer
 
 	disableComparison bool
 }
 
-func newSyncSourceComparator(i *objectIndexer, copyScheduler objectProcessor, disableComparison bool) *syncSourceComparator {
+func newSyncSourceComparator(i *destIndexer, copyScheduler objectProcessor, disableComparison bool) *syncSourceComparator {
 	return &syncSourceComparator{destinationIndex: i, copyTransferScheduler: copyScheduler, disableComparison: disableComparison}
 }
 
@@ -101,13 +53,13 @@ func (f *syncSourceComparator) processIfNecessary(sourceObject StoredObject) err
 		relPath = strings.ToLower(relPath)
 	}
 
-	destinationObjectInMap, present := f.destinationIndex.indexMap[relPath]
+	destinationObjectInMap, present := f.destinationIndex.indexMap.GetObject(relPath)
 
 	if present {
-		defer delete(f.destinationIndex.indexMap, relPath)
+		defer f.destinationIndex.indexMap.DeleteRecursive(relPath)
 
 		// if destination is stale, schedule source for transfer
-		if f.disableComparison || sourceObject.isMoreRecentThan(destinationObjectInMap) {
+		if f.disableComparison || sourceObject.isMoreRecentThanTime(destinationObjectInMap.(limitedStoredObject).lmt) {
 			return f.copyTransferScheduler(sourceObject)
 		}
 		// skip if source is more recent

--- a/cmd/syncTrie.go
+++ b/cmd/syncTrie.go
@@ -1,0 +1,129 @@
+package cmd
+
+type objectTrie struct {
+	// nil on the root.
+	parent *objectTrie
+	char   rune
+	leaves map[rune]*objectTrie
+	items  map[*objectTrie]bool // TODO: Should we bother trying to remove this from memory?
+	// for sync, this will either be just a raw LMT (*time.Time, for the destination) or a full storedObject for the source.
+	data interface{}
+	// For intentionally present but nil entries, so we don't delete them in a recursivedelete call.
+	presentButNil bool
+}
+
+// parent can be nil on the root.
+func newObjectTrie(parent *objectTrie) *objectTrie {
+	out := &objectTrie{
+		parent: parent,
+		leaves: make(map[rune]*objectTrie),
+	}
+
+	if parent == nil {
+		out.items = make(map[*objectTrie]bool)
+	}
+
+	return out
+}
+
+func (o *objectTrie) PutObject(path string, data interface{}) {
+	tidx := o                // trie index
+	for _, v := range path { // iterate over each rune, adding it to the trie
+		if newTIDX, ok := tidx.leaves[v]; !ok { // do not erase existing paths.
+			tidx.leaves[v] = newObjectTrie(tidx)
+			tidx = tidx.leaves[v]
+			tidx.char = v
+		} else {
+			tidx = newTIDX
+		}
+	}
+
+	// set the data
+	tidx.data = data
+	tidx.presentButNil = data == nil
+	// add the index to the root
+	o.items[tidx] = true
+}
+
+func (o *objectTrie) GetObject(path string) (data interface{}, present bool) {
+	tidx := o                // trie index
+	for _, v := range path { // iterate over each rune, do not add it if it's not present.
+		var ok bool
+		if tidx, ok = tidx.leaves[v]; !ok { // Only continue traversing if the path is actually present.
+			return nil, false
+		}
+	}
+
+	// return the data; include present because even nil can be present
+	return tidx.data, tidx.data != nil || tidx.presentButNil
+}
+
+func (o *objectTrie) DeleteRecursive(path string) {
+	tidx := o // trie index
+	completedSearch := true
+	for _, v := range path { // Find the end of the path.
+		var ok bool
+		if tidx, ok = tidx.leaves[v]; !ok { // Only continue traversing if the path is actually present.
+			completedSearch = false
+			break // Start deletion even if we didn't find the exact index-- there _may_ be orphans for some reason.
+		}
+	}
+
+	if completedSearch {
+		// Delete the index from the root
+		delete(o.items, tidx)
+	}
+
+	// start working backwards until we hit the root or something we can't delete.
+	for tidx != o && tidx.parent.Deletable() {
+		tidx = tidx.parent
+	}
+
+	// snip the entire branch
+	tidx.data = nil
+	tidx.presentButNil = false
+	if tidx.Deletable() {
+		toRemove := tidx.char
+		tidx = tidx.parent
+		delete(tidx.leaves, toRemove)
+	}
+}
+
+// Deletable denotes when a leaf on the trie is effectively pointless to keep around.
+// It has no children, no data, and it is not intentionally nil.
+func (o *objectTrie) Deletable() bool {
+	return o.data == nil && !o.presentButNil && len(o.leaves) == 0
+}
+
+func (o *objectTrie) GetName() string {
+	stack := ""
+	tidx := o
+	for tidx.parent != nil {
+		stack = string(tidx.char) + stack // reconstructing backwards.
+		tidx = tidx.parent
+	}
+
+	return stack
+}
+
+type trieIndex struct {
+	path string
+	data interface{}
+}
+
+func (o *objectTrie) GetIndexes() chan trieIndex {
+	out := make(chan trieIndex, 30) // Buffered channel, because indexing will take some time in larger workloads, and we don't want to buffer literally every index, bypassing the need for a trie in the first place.
+
+	go func() {
+		for k, _ := range o.items {
+			out <- trieIndex{
+				path: k.GetName(),
+				data: k.data,
+			}
+		}
+
+		close(out)
+	}()
+
+	return out
+}

--- a/cmd/syncTrie.go
+++ b/cmd/syncTrie.go
@@ -62,10 +62,11 @@ func (o *objectTrie) DeleteRecursive(path string) {
 	tidx := o // trie index
 	completedSearch := true
 	for _, v := range path { // Find the end of the path.
-		var ok bool
-		if tidx, ok = tidx.leaves[v]; !ok { // Only continue traversing if the path is actually present.
+		if tmpidx, ok := tidx.leaves[v]; !ok { // Only continue traversing if the path is actually present.
 			completedSearch = false
 			break // Start deletion even if we didn't find the exact index-- there _may_ be orphans for some reason.
+		} else {
+			tidx = tmpidx // Only set tidx if we find the next leaf; otherwise it's nil.
 		}
 	}
 
@@ -79,13 +80,15 @@ func (o *objectTrie) DeleteRecursive(path string) {
 		tidx = tidx.parent
 	}
 
-	// snip the entire branch
-	tidx.data = nil
-	tidx.presentButNil = false
-	if tidx.Deletable() {
-		toRemove := tidx.char
-		tidx = tidx.parent
-		delete(tidx.leaves, toRemove)
+	// snip the entire branch if it's not the root
+	if tidx != o {
+		tidx.data = nil
+		tidx.presentButNil = false
+		if tidx.Deletable() {
+			toRemove := tidx.char
+			tidx = tidx.parent // delete from the parent
+			delete(tidx.leaves, toRemove)
+		}
 	}
 }
 

--- a/cmd/zc_enumerator.go
+++ b/cmd/zc_enumerator.go
@@ -92,6 +92,10 @@ func (s *StoredObject) isMoreRecentThan(storedObject2 StoredObject) bool {
 	return s.lastModifiedTime.After(storedObject2.lastModifiedTime)
 }
 
+func (s *StoredObject) isMoreRecentThanTime(lmt time.Time) bool {
+	return s.lastModifiedTime.After(lmt)
+}
+
 func (s *StoredObject) isSingleSourceFile() bool {
 	return s.relativePath == "" && s.entityType == common.EEntityType.File()
 }
@@ -303,7 +307,7 @@ type enumerationCounterFunc func(entityType common.EntityType)
 // errorOnDirWOutRecursive is used by copy.
 
 func InitResourceTraverser(resource common.ResourceString, location common.Location, ctx *context.Context,
-	credential *common.CredentialInfo, followSymlinks *bool,listOfFilesChannel chan string, recursive, getProperties,
+	credential *common.CredentialInfo, followSymlinks *bool, listOfFilesChannel chan string, recursive, getProperties,
 	includeDirectoryStubs bool, incrementEnumerationCounter enumerationCounterFunc, listOfVersionIds chan string,
 	s2sPreserveBlobTags bool, logLevel pipeline.LogLevel, cpkOptions common.CpkOptions) (ResourceTraverser, error) {
 	var output ResourceTraverser
@@ -343,7 +347,7 @@ func InitResourceTraverser(resource common.ResourceString, location common.Locat
 		}
 
 		output = newListTraverser(resource, location, credential, ctx, recursive, toFollow, getProperties,
-		listOfFilesChannel, includeDirectoryStubs, incrementEnumerationCounter, s2sPreserveBlobTags, logLevel, cpkOptions)
+			listOfFilesChannel, includeDirectoryStubs, incrementEnumerationCounter, s2sPreserveBlobTags, logLevel, cpkOptions)
 		return output, nil
 	}
 
@@ -591,7 +595,7 @@ type syncEnumerator struct {
 	secondaryTraverser ResourceTraverser
 
 	// the results from the primary traverser would be stored here
-	objectIndexer *objectIndexer
+	objectIndexer *destIndexer
 
 	// general filters apply to both the primary and secondary traverser
 	filters []ObjectFilter
@@ -605,7 +609,7 @@ type syncEnumerator struct {
 	finalize func() error
 }
 
-func newSyncEnumerator(primaryTraverser, secondaryTraverser ResourceTraverser, indexer *objectIndexer,
+func newSyncEnumerator(primaryTraverser, secondaryTraverser ResourceTraverser, indexer *destIndexer,
 	filters []ObjectFilter, comparator objectProcessor, finalize func() error) *syncEnumerator {
 	return &syncEnumerator{
 		primaryTraverser:   primaryTraverser,

--- a/cmd/zt_generic_service_traverser_test.go
+++ b/cmd/zt_generic_service_traverser_test.go
@@ -73,15 +73,15 @@ func (s *genericTraverserSuite) TestBlobFSServiceTraverserWithManyObjects(c *chk
 	err = blobAccountTraverser.Traverse(noPreProccessor, blobDummyProcessor.process, nil)
 	c.Assert(err, chk.IsNil)
 
-	c.Assert(len(blobDummyProcessor.record), chk.Equals, len(localIndexer.indexMap)*len(containerList))
+	c.Assert(len(blobDummyProcessor.record), chk.Equals, len(localIndexer.indexMap.items)*len(containerList))
 
 	for _, storedObject := range blobDummyProcessor.record {
-		correspondingLocalFile, present := localIndexer.indexMap[storedObject.relativePath]
+		_, present := localIndexer.indexMap.GetObject(storedObject.relativePath)
 		_, cnamePresent := cnames[storedObject.ContainerName]
 
 		c.Assert(present, chk.Equals, true)
 		c.Assert(cnamePresent, chk.Equals, true)
-		c.Assert(correspondingLocalFile.name, chk.Equals, storedObject.name)
+		// checking the name is no longer required.
 	}
 }
 
@@ -227,10 +227,10 @@ func (s *genericTraverserSuite) TestServiceTraverserWithManyObjects(c *chk.C) {
 
 	records := append(blobDummyProcessor.record, fileDummyProcessor.record...)
 
-	localTotalCount := len(localIndexer.indexMap)
+	localTotalCount := len(localIndexer.indexMap.items)
 	localFileOnlyCount := 0
-	for _, x := range localIndexer.indexMap {
-		if x.entityType == common.EEntityType.File() {
+	for x := range localIndexer.indexMap.GetIndexes() {
+		if x.data.(limitedStoredObject).entityType == common.EEntityType.File() {
 			localFileOnlyCount++
 		}
 	}
@@ -246,12 +246,11 @@ func (s *genericTraverserSuite) TestServiceTraverserWithManyObjects(c *chk.C) {
 	}
 
 	for _, storedObject := range records {
-		correspondingLocalFile, present := localIndexer.indexMap[storedObject.relativePath]
+		_, present := localIndexer.indexMap.GetObject(storedObject.relativePath)
 		_, cnamePresent := cnames[storedObject.ContainerName]
 
 		c.Assert(present, chk.Equals, true)
 		c.Assert(cnamePresent, chk.Equals, true)
-		c.Assert(correspondingLocalFile.name, chk.Equals, storedObject.name)
 	}
 }
 
@@ -429,10 +428,10 @@ func (s *genericTraverserSuite) TestServiceTraverserWithWildcards(c *chk.C) {
 
 	records := append(blobDummyProcessor.record, fileDummyProcessor.record...)
 
-	localTotalCount := len(localIndexer.indexMap)
+	localTotalCount := len(localIndexer.indexMap.items)
 	localFileOnlyCount := 0
-	for _, x := range localIndexer.indexMap {
-		if x.entityType == common.EEntityType.File() {
+	for x := range localIndexer.indexMap.GetIndexes() {
+		if x.data.(limitedStoredObject).entityType == common.EEntityType.File() {
 			localFileOnlyCount++
 		}
 	}
@@ -450,22 +449,20 @@ func (s *genericTraverserSuite) TestServiceTraverserWithWildcards(c *chk.C) {
 	}
 
 	for _, storedObject := range records {
-		correspondingLocalFile, present := localIndexer.indexMap[storedObject.relativePath]
+		_, present := localIndexer.indexMap.GetObject(storedObject.relativePath)
 		_, cnamePresent := cnames[storedObject.ContainerName]
 
 		c.Assert(present, chk.Equals, true)
 		c.Assert(cnamePresent, chk.Equals, true)
-		c.Assert(correspondingLocalFile.name, chk.Equals, storedObject.name)
 	}
 
 	// Test ADLSG2 separately due to different container naming
-	c.Assert(len(bfsDummyProcessor.record), chk.Equals, len(localIndexer.indexMap)*2)
+	c.Assert(len(bfsDummyProcessor.record), chk.Equals, len(localIndexer.indexMap.items)*2)
 	for _, storedObject := range bfsDummyProcessor.record {
-		correspondingLocalFile, present := localIndexer.indexMap[storedObject.relativePath]
+		_, present := localIndexer.indexMap.GetObject(storedObject.relativePath)
 		_, cnamePresent := bfscnames[storedObject.ContainerName]
 
 		c.Assert(present, chk.Equals, true)
 		c.Assert(cnamePresent, chk.Equals, true)
-		c.Assert(correspondingLocalFile.name, chk.Equals, storedObject.name)
 	}
 }

--- a/cmd/zt_generic_traverser_test.go
+++ b/cmd/zt_generic_traverser_test.go
@@ -711,10 +711,10 @@ func (s *genericTraverserSuite) TestTraverserContainerAndLocalDirectory(c *chk.C
 		}
 
 		// make sure the results are as expected
-		localTotalCount := len(localIndexer.indexMap)
+		localTotalCount := len(localIndexer.indexMap.items)
 		localFileOnlyCount := 0
-		for _, x := range localIndexer.indexMap {
-			if x.entityType == common.EEntityType.File() {
+		for x := range localIndexer.indexMap.GetIndexes() {
+			if x.data.(limitedStoredObject).entityType == common.EEntityType.File() {
 				localFileOnlyCount++
 			}
 		}
@@ -741,10 +741,9 @@ func (s *genericTraverserSuite) TestTraverserContainerAndLocalDirectory(c *chk.C
 		// if s3dummyprocessor is empty, it's A-OK because no records will be tested
 		for _, storedObject := range append(append(append(append(blobDummyProcessor.record, fileDummyProcessor.record...), bfsDummyProcessor.record...), s3DummyProcessor.record...), gcpDummyProcessor.record...) {
 			if isRecursiveOn || storedObject.entityType == common.EEntityType.File() { // folder enumeration knowingly NOT consistent when non-recursive (since the folders get stripped out by ToNewCopyTransfer when non-recursive anyway)
-				correspondingLocalFile, present := localIndexer.indexMap[storedObject.relativePath]
+				_, present := localIndexer.indexMap.GetObject(storedObject.relativePath)
 
 				c.Assert(present, chk.Equals, true)
-				c.Assert(correspondingLocalFile.name, chk.Equals, storedObject.name)
 
 				if !isRecursiveOn {
 					c.Assert(strings.Contains(storedObject.relativePath, common.AZCOPY_PATH_SEPARATOR_STRING), chk.Equals, false)
@@ -852,10 +851,10 @@ func (s *genericTraverserSuite) TestTraverserWithVirtualAndLocalDirectory(c *chk
 		bfsDummyProcessor := dummyProcessor{}
 		err = bfsTraverser.Traverse(noPreProccessor, bfsDummyProcessor.process, nil)
 
-		localTotalCount := len(localIndexer.indexMap)
+		localTotalCount := len(localIndexer.indexMap.items)
 		localFileOnlyCount := 0
-		for _, x := range localIndexer.indexMap {
-			if x.entityType == common.EEntityType.File() {
+		for x := range localIndexer.indexMap.GetIndexes() {
+			if x.data.(limitedStoredObject).entityType == common.EEntityType.File() {
 				localFileOnlyCount++
 			}
 		}
@@ -899,13 +898,13 @@ func (s *genericTraverserSuite) TestTraverserWithVirtualAndLocalDirectory(c *chk
 		for _, storedObject := range append(append(append(append(blobDummyProcessor.record, fileDummyProcessor.record...), bfsDummyProcessor.record...), s3DummyProcessor.record...), gcpDummyProcessor.record...) {
 			if isRecursiveOn || storedObject.entityType == common.EEntityType.File() { // folder enumeration knowingly NOT consistent when non-recursive (since the folders get stripped out by ToNewCopyTransfer when non-recursive anyway)
 
-				correspondingLocalFile, present := localIndexer.indexMap[storedObject.relativePath]
+				correspondingLocalFile, present := localIndexer.indexMap.GetObject(storedObject.relativePath)
 
 				c.Assert(present, chk.Equals, true)
-				c.Assert(correspondingLocalFile.name, chk.Equals, storedObject.name)
 				// Say, here's a good question, why do we have this last check?
 				// None of the other tests have it.
-				c.Assert(correspondingLocalFile.isMoreRecentThan(storedObject), chk.Equals, true)
+				object := correspondingLocalFile.(limitedStoredObject).ToStoredObject(storedObject.relativePath)
+				c.Assert(object.isMoreRecentThan(storedObject), chk.Equals, true)
 
 				if !isRecursiveOn {
 					c.Assert(strings.Contains(storedObject.relativePath, common.AZCOPY_PATH_SEPARATOR_STRING), chk.Equals, false)

--- a/cmd/zt_sync_blob_blob_test.go
+++ b/cmd/zt_sync_blob_blob_test.go
@@ -907,7 +907,5 @@ func (s *cmdIntegrationSuite) TestDryrunSyncBlobtoBlobJson(c *chk.C) {
 		c.Assert(errMarshal, chk.IsNil)
 		c.Check(strings.Contains(syncMessage.Source, blobsToDelete[0]), chk.Equals, true)
 		c.Check(strings.Compare(syncMessage.EntityType.String(), common.EEntityType.File().String()), chk.Equals, 0)
-		c.Check(strings.Compare(string(syncMessage.BlobType), "BlockBlob"), chk.Equals, 0)
-
 	})
 }

--- a/cmd/zt_sync_comparator_test.go
+++ b/cmd/zt_sync_comparator_test.go
@@ -21,8 +21,9 @@
 package cmd
 
 import (
-	chk "gopkg.in/check.v1"
 	"time"
+
+	chk "gopkg.in/check.v1"
 )
 
 type syncComparatorSuite struct{}
@@ -63,7 +64,7 @@ func (s *syncComparatorSuite) TestSyncSourceComparator(c *chk.C) {
 	// check the source object was indeed scheduled
 	c.Assert(len(dummyCopyScheduler.record), chk.Equals, 1)
 	c.Assert(dummyCopyScheduler.record[0].md5, chk.DeepEquals, srcMD5)
-	c.Assert(len(indexer.indexMap), chk.Equals, 0)
+	c.Assert(len(indexer.indexMap.items), chk.Equals, 0)
 
 	// reset the processor so that it's empty
 	dummyCopyScheduler = dummyProcessor{}
@@ -78,7 +79,7 @@ func (s *syncComparatorSuite) TestSyncSourceComparator(c *chk.C) {
 
 	// check no source object was scheduled
 	c.Assert(len(dummyCopyScheduler.record), chk.Equals, 0)
-	c.Assert(len(indexer.indexMap), chk.Equals, 0)
+	c.Assert(len(indexer.indexMap.items), chk.Equals, 0)
 }
 
 func (s *syncComparatorSuite) TestSyncSrcCompDisableComparator(c *chk.C) {
@@ -125,115 +126,6 @@ func (s *syncComparatorSuite) TestSyncSrcCompDisableComparator(c *chk.C) {
 		compareErr = sourceComparator.processIfNecessary(sourceStoredObjects[key])
 		c.Assert(compareErr, chk.Equals, nil)
 		c.Assert(len(dummyCopyScheduler.record), chk.Equals, key+1)
-		c.Assert(len(indexer.indexMap), chk.Equals, 0)
-	}
-}
-
-func (s *syncComparatorSuite) TestSyncDestinationComparator(c *chk.C) {
-	dummyCopyScheduler := dummyProcessor{}
-	dummyCleaner := dummyProcessor{}
-	srcMD5 := []byte{'s'}
-	destMD5 := []byte{'d'}
-
-	// set up the indexer as well as the destination comparator
-	indexer := newObjectIndexer()
-	destinationComparator := newSyncDestinationComparator(indexer, dummyCopyScheduler.process, dummyCleaner.process, false)
-
-	// create a sample source object
-	sampleSourceObject := StoredObject{name: "test", relativePath: "/usr/test", lastModifiedTime: time.Now(), md5: srcMD5}
-
-	// test the comparator in case a given destination object is not present at the source
-	// meaning it is an extra file that needs to be deleted, so the comparator should pass the given object to the destinationCleaner
-	compareErr := destinationComparator.processIfNecessary(StoredObject{name: "only_at_dst", relativePath: "only_at_dst", lastModifiedTime: time.Now(), md5: destMD5})
-	c.Assert(compareErr, chk.Equals, nil)
-
-	// verify that destination object is being deleted
-	c.Assert(len(dummyCopyScheduler.record), chk.Equals, 0)
-	c.Assert(len(dummyCleaner.record), chk.Equals, 1)
-	c.Assert(dummyCleaner.record[0].md5, chk.DeepEquals, destMD5)
-
-	// reset dummy processors
-	dummyCopyScheduler = dummyProcessor{}
-	dummyCleaner = dummyProcessor{}
-
-	// test the comparator in case a given destination object is present at the source
-	// and it has a later modified time, since the source data is stale,
-	// no transfer happens
-	err := indexer.store(sampleSourceObject)
-	c.Assert(err, chk.IsNil)
-	compareErr = destinationComparator.processIfNecessary(StoredObject{name: "test", relativePath: "/usr/test", lastModifiedTime: time.Now().Add(time.Hour), md5: destMD5})
-	c.Assert(compareErr, chk.Equals, nil)
-
-	// verify that the source object is scheduled for transfer
-	c.Assert(len(dummyCopyScheduler.record), chk.Equals, 0)
-	c.Assert(len(dummyCleaner.record), chk.Equals, 0)
-
-	// reset dummy processors
-	dummyCopyScheduler = dummyProcessor{}
-	dummyCleaner = dummyProcessor{}
-
-	// test the comparator in case a given destination object is present at the source
-	// but is has an earlier modified time compared to the one at the source
-	// meaning that the source object should be transferred since the destination object is stale
-	err = indexer.store(sampleSourceObject)
-	c.Assert(err, chk.IsNil)
-	compareErr = destinationComparator.processIfNecessary(StoredObject{name: "test", relativePath: "/usr/test", lastModifiedTime: time.Now().Add(-time.Hour), md5: destMD5})
-	c.Assert(compareErr, chk.Equals, nil)
-
-	// verify that there's no transfer & no deletes
-	c.Assert(len(dummyCopyScheduler.record), chk.Equals, 1)
-	c.Assert(dummyCopyScheduler.record[0].md5, chk.DeepEquals, srcMD5)
-	c.Assert(len(dummyCleaner.record), chk.Equals, 0)
-}
-
-func (s *syncComparatorSuite) TestSyncDestCompDisableComparison(c *chk.C) {
-	dummyCopyScheduler := dummyProcessor{}
-	dummyCleaner := dummyProcessor{}
-	srcMD5 := []byte{'s'}
-	destMD5 := []byte{'d'}
-
-	// set up the indexer as well as the destination comparator
-	indexer := newObjectIndexer()
-	destinationComparator := newSyncDestinationComparator(indexer, dummyCopyScheduler.process, dummyCleaner.process, true)
-
-	// create a sample source object
-	currTime := time.Now()
-	sourceStoredObjects := []StoredObject{
-		{name: "test1", relativePath: "/usr/test1", lastModifiedTime: currTime, md5: srcMD5},
-		{name: "test2", relativePath: "/usr/test2", lastModifiedTime: currTime, md5: srcMD5},
-	}
-
-	//onlyAtSrc := StoredObject{name: "only_at_src", relativePath: "/usr/only_at_src", lastModifiedTime: currTime, md5: destMD5}
-
-	destinationStoredObjects := []StoredObject{
-		// file whose last modified time is greater than that of source
-		{name: "test1", relativePath: "/usr/test1", lastModifiedTime: time.Now().Add(time.Hour), md5: destMD5},
-		// file whose last modified time is less than that of source
-		{name: "test2", relativePath: "/usr/test2", lastModifiedTime: time.Now().Add(-time.Hour), md5: destMD5},
-	}
-
-	// test the comparator in case a given destination object is not present at the source
-	// meaning it is an extra file that needs to be deleted, so the comparator should pass the given object to the destinationCleaner
-	compareErr := destinationComparator.processIfNecessary(StoredObject{name: "only_at_dst", relativePath: "only_at_dst", lastModifiedTime: currTime, md5: destMD5})
-	c.Assert(compareErr, chk.Equals, nil)
-
-	// verify that destination object is being deleted
-	c.Assert(len(dummyCopyScheduler.record), chk.Equals, 0)
-	c.Assert(len(dummyCleaner.record), chk.Equals, 1)
-	c.Assert(dummyCleaner.record[0].md5, chk.DeepEquals, destMD5)
-
-	// reset dummy processors
-	dummyCopyScheduler = dummyProcessor{}
-	dummyCleaner = dummyProcessor{}
-
-	// test the comparator in case a given destination object is present at the source
-	// and it has a later modified time, since the source data is stale,
-	// no transfer happens
-	for key, srcStoredObject := range sourceStoredObjects {
-		err := indexer.store(srcStoredObject)
-		c.Assert(err, chk.IsNil)
-		compareErr = destinationComparator.processIfNecessary(destinationStoredObjects[key])
-		c.Assert(compareErr, chk.Equals, nil)
-		c.Assert(len(dummyCopyScheduler.record), chk.Equals, key+1)
+		c.Assert(len(indexer.indexMap.items), chk.Equals, 0)
 	}
 }

--- a/cmd/zt_sync_trie_test.go
+++ b/cmd/zt_sync_trie_test.go
@@ -75,6 +75,9 @@ func (*trieSuite) TestPutDeleteGet(c *chk.C) {
 	data, returned = o.GetObject("ab")
 	c.Assert(returned, chk.Equals, false)
 	c.Assert(data, chk.Equals, nil)
+
+	// try to delete something that doesn't exist.
+	o.DeleteRecursive("idontexist")
 }
 
 func (*trieSuite) TestGetName(c *chk.C) {

--- a/cmd/zt_sync_trie_test.go
+++ b/cmd/zt_sync_trie_test.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	chk "gopkg.in/check.v1"
+)
+
+type trieSuite struct{}
+
+var _ = chk.Suite(&trieSuite{})
+
+func (*trieSuite) TestPutGet(c *chk.C) {
+	o := newObjectTrie(nil)
+	o.PutObject("abc", "aoeu")
+	o.PutObject("abd", "asdf")
+
+	// test items were added properly
+	c.Assert(len(o.items), chk.Equals, 2)
+
+	// test paths didn't overwrite eachother
+	data, returned := o.GetObject("abc")
+	c.Assert(returned, chk.Equals, true)
+	c.Assert(data, chk.Equals, "aoeu")
+
+	data, returned = o.GetObject("abd")
+	c.Assert(returned, chk.Equals, true)
+	c.Assert(data, chk.Equals, "asdf")
+
+	// test we're properly handling non-entries
+	data, returned = o.GetObject("adb")
+	c.Assert(returned, chk.Equals, false)
+	c.Assert(data, chk.Equals, nil)
+}
+
+func (*trieSuite) TestPutDeleteGet(c *chk.C) {
+	o := newObjectTrie(nil)
+	o.PutObject("abcd", "aoeu")
+	o.PutObject("abdc", "asdf")
+	o.PutObject("abed", "test")
+	o.PutObject("ab", nil) // let's try nil data!
+
+	// Delete the abcd path, leaving abdc and abed
+	o.DeleteRecursive("abcd")
+
+	// Check abdc, ab and abed are still in-tact
+	data, returned := o.GetObject("abdc")
+	c.Assert(returned, chk.Equals, true)
+	c.Assert(data, chk.Equals, "asdf")
+
+	data, returned = o.GetObject("abed")
+	c.Assert(returned, chk.Equals, true)
+	c.Assert(data, chk.Equals, "test")
+
+	data, returned = o.GetObject("ab")
+	c.Assert(returned, chk.Equals, true)
+	c.Assert(data, chk.Equals, nil)
+
+	// Check abcd is gone
+	data, returned = o.GetObject("abcd")
+	c.Assert(returned, chk.Equals, false)
+	c.Assert(data, chk.Equals, nil)
+
+	// Delete ab, check the other two are in tact
+	o.DeleteRecursive("ab")
+
+	// Check abdc, ab and abed are still in-tact
+	data, returned = o.GetObject("abdc")
+	c.Assert(returned, chk.Equals, true)
+	c.Assert(data, chk.Equals, "asdf")
+
+	data, returned = o.GetObject("abed")
+	c.Assert(returned, chk.Equals, true)
+	c.Assert(data, chk.Equals, "test")
+
+	// ab has nothing?
+	data, returned = o.GetObject("ab")
+	c.Assert(returned, chk.Equals, false)
+	c.Assert(data, chk.Equals, nil)
+}
+
+func (*trieSuite) TestGetName(c *chk.C) {
+	o := newObjectTrie(nil)
+	o.PutObject("abcd", nil)
+
+	c.Assert(o.leaves['a'].leaves['b'].leaves['c'].leaves['d'].GetName(), chk.Equals, "abcd")
+}
+
+func (*trieSuite) TestGetIndexes(c *chk.C) {
+	o := newObjectTrie(nil)
+	indexes := map[string]bool{
+		"asdf":     true,
+		"aoeu":     true,
+		"asong":    true,
+		"aoedipus": true,
+	}
+
+	for k, v := range indexes {
+		o.PutObject(k, v)
+	}
+
+	c.Assert(len(o.items), chk.Equals, len(indexes))
+	for v := range o.GetIndexes() {
+		c.Assert(indexes[v.path], chk.Equals, true)
+	}
+	for k := range indexes {
+		_, present := o.GetObject(k)
+		c.Assert(present, chk.Equals, true)
+	}
+}


### PR DESCRIPTION
This PR attempts to reduce the memory usage of sync through a couple of changes:

1. The original map of relative paths to stored objects is replaced with a trie.
2. The amount of data stored in the ObjectIndexer is reduced to only mandatory properties (LMT & Entity type), path & name are determined from the trie location when needed
3. The perf change made for uploads is removed in favor of reduced memory footprint