### PR TITLE
Improved debug logging + improve over-pruning

### DIFF
--- a/ste/JobsAdmin.go
+++ b/ste/JobsAdmin.go
@@ -746,7 +746,7 @@ func (ja *jobsAdmin) CurrentMainPoolSize() int {
 
 func (ja *jobsAdmin) slicePoolPruneLoop() {
 	// if something in the pool has been unused for this long, we probably don't need it
-	const pruneInterval = 5 * time.Second
+	const pruneInterval = 10 * time.Second
 
 	ticker := time.NewTicker(pruneInterval)
 	defer ticker.Stop()


### PR DESCRIPTION
- Try to reduce new slice creation by letting go of buffer slice first before telling the cache limiter
- Increase pruning interval time to 10 sec from 5 sec