### PR TITLE
OOM issue solution 2: lock down slice pool memory usage

### DIFF
--- a/ste/JobsAdmin.go
+++ b/ste/JobsAdmin.go
@@ -746,7 +746,7 @@ func (ja *jobsAdmin) CurrentMainPoolSize() int {
 
 func (ja *jobsAdmin) slicePoolPruneLoop() {
 	// if something in the pool has been unused for this long, we probably don't need it
-	const pruneInterval = 5 * time.Second
+	const pruneInterval = 10 * time.Second
 
 	ticker := time.NewTicker(pruneInterval)
 	defer ticker.Stop()

--- a/ste/JobsAdmin.go
+++ b/ste/JobsAdmin.go
@@ -157,6 +157,7 @@ func initJobsAdmin(appCtx context.Context, concurrency ConcurrencySettings, targ
 		// could be shut down. But, it's global anyway, so we just leave it running until application exit.
 	}
 
+	bufferCacheLimiter := common.NewCacheLimiter(maxRamBytesToUse)
 	ja := &jobsAdmin{
 		concurrency:             concurrency,
 		logger:                  common.NewAppLogger(pipeline.LogInfo, azcopyLogPathFolder),
@@ -164,8 +165,8 @@ func initJobsAdmin(appCtx context.Context, concurrency ConcurrencySettings, targ
 		logDir:                  azcopyLogPathFolder,
 		planDir:                 azcopyJobPlanFolder,
 		pacer:                   pacer,
-		slicePool:               common.NewMultiSizeSlicePool(common.MaxBlockBlobBlockSize),
-		cacheLimiter:            common.NewCacheLimiter(maxRamBytesToUse),
+		slicePool:               common.NewMultiSizeSlicePool(common.MaxBlockBlobBlockSize, bufferCacheLimiter),
+		cacheLimiter:            bufferCacheLimiter,
 		fileCountLimiter:        common.NewCacheLimiter(int64(concurrency.MaxOpenDownloadFiles)),
 		cpuMonitor:              cpuMon,
 		appCtx:                  appCtx,

--- a/ste/xfer-remoteToLocal-file.go
+++ b/ste/xfer-remoteToLocal-file.go
@@ -246,12 +246,6 @@ func remoteToLocal_file(jptm IJobPartTransferMgr, p pipeline.Pipeline, pacer pac
 
 		id := common.NewChunkID(info.Destination, startIndex, adjustedChunkSize) // TODO: stop using adjustedChunkSize, below, and use the size that's in the ID
 
-		// Wait until its OK to schedule it
-		// To prevent excessive RAM consumption, we have a limit on the amount of scheduled-but-not-yet-saved data
-		// TODO: as per comment above, currently, if there's an error here we must continue because we must schedule all chunks
-		// TODO: ... Can we refactor/improve that?
-		_ = dstWriter.WaitToScheduleChunk(jptm.Context(), id, adjustedChunkSize)
-
 		// create download func that is a appropriate to the remote data source
 		downloadFunc := dl.GenerateDownloadFunc(jptm, p, dstWriter, id, adjustedChunkSize, pacer)
 


### PR DESCRIPTION
Two problems causes potentially more memory usage:

1. We use desired length with the cache limiter which is not correct, as we may end up rounding up the desired length (in base 2) and assign more memory. 
2. The slice pool doesn't know how much actual memory it's using, it could have a bunch of pools just hanging around and not being used, while the cache limiter **thinks** that we are below the limit. 

Therefore, to solve the disconnection between the cache limiter and the slice pool, we could let the slice pool watch for memory pressure directly, so that it never oversteps the limit.
