### PR TITLE
OOM trial solution 3: flush chunks as we download

### DIFF
--- a/common/decompressingWriter.go
+++ b/common/decompressingWriter.go
@@ -42,7 +42,7 @@ var decompressingWriterBufferPool = NewMultiSizeSlicePool(decompressingWriterCop
 // Gzip headers. Both of those formats compress a single file (often a .tar archive in the case of Gzip).
 // So there is no need to to expand the decompressed info out into multiple files (as we would have to do,
 // if we were to support "zip" compression). See https://stackoverflow.com/a/20765054
-func NewDecompressingWriter(destination io.WriteCloser, ct CompressionType) io.WriteCloser {
+func NewDecompressingWriter(destination io.WriteCloser, ct CompressionType) WriteSyncCloser {
 	preader, pwriter := io.Pipe()
 
 	d := &decompressingWriter{
@@ -114,6 +114,11 @@ func (d decompressingWriter) Write(p []byte) (n int, err error) {
 	}
 
 	return n, writeErr
+}
+
+func (d decompressingWriter) Sync() error {
+	// TODO no-op for now
+	return nil
 }
 
 func (d decompressingWriter) Close() error {

--- a/common/environment.go
+++ b/common/environment.go
@@ -361,3 +361,11 @@ func (EnvironmentVariable) MimeMapping() EnvironmentVariable {
 		Description:  "Location of the file to override default OS mime mapping",
 	}
 }
+
+func (EnvironmentVariable) FlushInterval() EnvironmentVariable {
+	return EnvironmentVariable{
+		Name:         "AZCOPY_FLUSH_INTERVAL",
+		DefaultValue: "",
+		Description:  "When downloading, flush every x chunks where x=AZCOPY_FLUSH_INTERVAL.",
+	}
+}

--- a/ste/xfer-remoteToLocal-file.go
+++ b/ste/xfer-remoteToLocal-file.go
@@ -158,7 +158,7 @@ func remoteToLocal_file(jptm IJobPartTransferMgr, p pipeline.Pipeline, pacer pac
 		return
 	}
 
-	var dstFile io.WriteCloser
+	var dstFile common.WriteSyncCloser
 	if strings.EqualFold(info.Destination, common.Dev_Null) {
 		// the user wants to discard the downloaded data
 		dstFile = devNullWriter{}
@@ -269,7 +269,7 @@ func remoteToLocal_file(jptm IJobPartTransferMgr, p pipeline.Pipeline, pacer pac
 
 }
 
-func createDestinationFile(jptm IJobPartTransferMgr, destination string, size int64, writeThrough bool) (file io.WriteCloser, err error) {
+func createDestinationFile(jptm IJobPartTransferMgr, destination string, size int64, writeThrough bool) (file common.WriteSyncCloser, err error) {
 	ct := common.ECompressionType.None()
 	if jptm.ShouldDecompress() {
 		size = 0                                  // we don't know what the final size will be, so we can't pre-size it
@@ -282,7 +282,7 @@ func createDestinationFile(jptm IJobPartTransferMgr, destination string, size in
 		// and we still need to set size to zero here, so relying on enumeration more wouldn't simply this code much, if at all.
 	}
 
-	var dstFile io.WriteCloser
+	var dstFile common.WriteSyncCloser
 	dstFile, err = common.CreateFileOfSizeWithWriteThroughOption(destination, size, writeThrough, jptm.GetFolderCreationTracker(), jptm.GetForceIfReadOnly())
 	if err != nil {
 		return nil, err
@@ -485,5 +485,9 @@ func (devNullWriter) Write(p []byte) (n int, err error) {
 }
 
 func (devNullWriter) Close() error {
+	return nil
+}
+
+func (devNullWriter) Sync() error {
 	return nil
 }


### PR DESCRIPTION
- Added knob to control flushing of chunks when downloading
- Ex: specify AZCOPY_FLUSH_INTERVAL=5 so that we flush after at most 5 chunks. We could flush earlier if we ran into a gap while writing chunks, aka a slow chunk. 
- Note that by default the behavior is the same as before, no flushing at all.
- Flushing is done by calling fsync on the file.