### PR TITLE
Allow source urls larger than 1,000 characters

### DIFF
--- a/ste/JobPartPlan.go
+++ b/ste/JobPartPlan.go
@@ -42,7 +42,7 @@ type JobPartPlanHeader struct {
 	JobID                  common.JobID      // Job Part's JobID
 	PartNum                common.PartNumber // Job Part's part number (0+)
 	SourceRootLength       uint16            // The length of the source root path
-	SourceRoot             [1000]byte        // The root directory of the source
+	SourceRoot             [2000]byte        // The root directory of the source
 	SourceExtraQueryLength uint16
 	SourceExtraQuery       [1000]byte // Extra query params applicable to the source
 	DestinationRootLength  uint16     // The length of the destination root path


### PR DESCRIPTION
AzCopy currently has a limit of 1,000 characters for the source url. Increasing this to 2,000 shouldn't be a problem.
That's about 1Kb more of memory used for every transfer as it is a static allocation.

This would allow for larger source urls such as ones from a service like mine below.

My service allows server-to-server transfers from Google Takeout URLs as Azure currently converts `%2F`s to `/`s. As an
aside, I've reported the escaping issue, but I have no longer have traction:

https://docs.microsoft.com/en-us/answers/questions/641723/i-can39t-get-azure-storage-to-support-putting-data.html

I've come up with a workaround that uses Cloudflare Workers as a workaround, and it is very cost-efficient and
performant:

https://github.com/nelsonjchen/gtr-proxy

Workaround or not, the Google Takeout URLs are ~1500 characters long. With the base64 encoding overhead's workaround,
they are about ~1800 characters long. I am able to copy files from my service with a test C# program that uses the
workaround and a modified AzCopy that has this change as well.

I understand that AzCopy does not officially support copying from URLs that aren't exactly part of the server-to-server
Google Cloud and/or AWS S3 transfer features and being able to copy from URLs not part of those other cloud services is
a by-product. I want to make the case that this limitation can affect official usages too. On Azure Blob, S3, and GCP,
the limit is 1024 characters for the key/blob name of an object. With Azure Blob and its URL signature scheme, the URLs
could easily exceed 1,000 characters if the blob name in Azure Blob are hovering around that limit. Would going to 2,000
just be OK? It's just 1Kb more of memory allocated per transfer. The original 1,000 character limit doesn't seem very
scientific or researched anyway.

Example stock AzCopy call I wish to make:

```shell
azcopy copy "https://gtr-proxy.mindflakes.com/p/aHR0cHM6Ly8wMGY3NGJhNDRiMDE0MmNlYWNjYTdiNTZiMTFkOGFmODg4MThjYWM4YTktYXBpZGF0YS5nb29nbGV1c2VyY29udGVudC5jb20vZG93bmxvYWQvc3RvcmFnZS92MS9iL2RhdGFsaWJlcmF0aW9uL28vMjAyMjAzMDZUMDk0NDMwWiUyRi00MzExNjkzNzE3NzE2MDEyNTQ1JTJGNTYyYzU5ZjUtNzlmNC00YWNjLWEzZjItZWM2ZGU2N2NjZWM2JTJGMSUyRjdlMTk2ZWJiLWNhNjQtNDI5YS04YWYyLWE3OTYyNmYyMWVhMj9qaz1BRnNoRTNVcE90X1NKd0dMb3dNU0g2M01NR3RRWmZUQ1VSUEpOd3lTQmRTV0t2WGQzTmhRZlhBdC00Tm1MY21oSWJfaVpSRF9LRExNZ2ppZmVRQlhCRVl6SzBRZXhDU0pSbE1PblBxM2NIYVY3TGZJRGkxdm9EVXR3c1k5d0gxT0djMW43dkJCRkY5ZjEwdzV1TjlZXy1LQVl1UkxjV0RIY1FPMU5lbl85bjZDWGktbnpkZVIxSmVrTlB6aTBOa2g1QXEydERWLW84N2hScDZfLXVqbFVleWEzQkRoQjREcWVRakltTWktV3FfaUR4VTU5aElvb3FqWDBHRjRiSUUtcEl3a1dRWkQyRXdUV1lWZmktWnF4aXhTNl9ORW5HQ19jdkNYTV82cnNIamRFMWxOZWotdHhXbU5NdnpyTnBIdm9sbUF5VzV5ZmczeWNzU2tXakh1bzZWSHN3N3liRGM4dE54WXdrSlB6THVvMGE4bTVHazV1V3pqRnVvTGdHRHczQmZicjZMMXFwVEhPZmliUnVieHkwWlIxaTVVbllzRTh3ZGNOdmpHbEZ6dS1ua1JVQjJ6THVKNy1PVXMxcnFTWjVOdzNjT25KVWdBNmtBd0ZnT1BEbjVQcW1IT01salpPOHQ3LVVRZXM5U2tlVkZBSVEtZkFLeFU4dWFTYU4xSW5ENmI4amxQMGYyS3B5Rm5OckN0ZjN5S04ySWZ0Z2ZaazBWSkhuYXd3UkNRbGpURGdoMXlRSlBLTkg1a3FTMVFqdlNtSUVIb2htQ0Q4UzVmN0xpYnFwT05hNXllOW1USGROWUNsOGZNNjU1T1Z6eHNmVDRPTzhrUVJtSm94YWhCd0ZCOV9NbnJoMTlOcG9JSzlRb2pMZ0JHYWxiSGF5ZkRoZlBNWHl1RVVjOURRbFBfSnJBVlVIQTlxY2k2Z3Q3S1J2eFE2Qml1a190TWFIOG83QkNaejNKVGtfQlBEaEFzUWVnVlJBWUZNSFpPbXhXZnJCZkF5UWZKYWI4cWtnR0dJMUZOc2VsN2JxUXZkc1hOUkEyY3ZqdWY4alNiMkZ1ZmRrQVgyLTBTeElfMHV0cWNqMEF6djY4Yl9tRFR4elhHQlk5STN2bUVSWk11dzFqb3I5b09vU0xQdU1yX3NMVW5oS2xfR0I0a19qMkswWEt6TVRBckpWUDhHd0t0a3FyRVM1cUwxT3ZmZkYwSlFBR19USjFGd1ZDcXVfbTRLcjBkbWFsQV9Xc1BrZVlMXzFJbldQZnhsRk5BN0NYYmpRbWs3c1pJSm4xckQyLXIwRW5GWmtnYTZnY0xTRGF4OHRSc0xIbXh4UHRQNVUwbzB4ZWtRSF9oYXEydWFIZGVkWFFBUjlUZ0dCTDZKZU9Db2FBWEtRa2lEZzFTd0F3RXBHUFlYa3Jmemt6cVQ4THlXX2NuOVlzUlFIc21ndnZHTElXa2huSEdHcGFudkthQXFKdE1JQ0tjMTJBUyZpc2NhPTE=/test.dat" "https://urlcopytest.blob.core.windows.net/some-container?sp=racw&st=2022-03-06T10:01:47Z&se=2022-03-10T18:01:47Z&spr=https&sv=2020-08-04&sr=c&sig=xxxxxxxxxxxxxxxxxxxxxxxxx%3D" --from-to BlobBlob
```

Note that the takeout URL that is encoded has long expired and only last for 15 minutes anyway. When it was valid, my
modified AzCopy was able to facilitate the transfer successfully. If you try to run this command while the URL has
not expired, the code that panics as the URL cannot fit in the buffer won't run.