### PR TITLE
Refactor STE: Part 3

### DIFF
--- a/jobsAdmin/JobsAdmin.go
+++ b/jobsAdmin/JobsAdmin.go
@@ -343,7 +343,7 @@ func (ja *jobsAdmin) ResurrectJob(jobId common.JobID, sourceSAS string, destinat
 		}
 		mmf := planFile.Map()
 		jm := ja.JobMgrEnsureExists(jobID, mmf.Plan().LogLevel, "")
-		jm.AddJobPart(partNum, planFile, mmf, sourceSAS, destinationSAS, false)
+		jm.AddJobPart(partNum, planFile, mmf, sourceSAS, destinationSAS, false, nil)
 	}
 
 	jm, _ := ja.JobMgr(jobId)
@@ -377,7 +377,7 @@ func (ja *jobsAdmin) ResurrectJobParts() {
 		mmf := planFile.Map()
 		//todo : call the compute transfer function here for each job.
 		jm := ja.JobMgrEnsureExists(jobID, mmf.Plan().LogLevel, "")
-		jm.AddJobPart(partNum, planFile, mmf, EMPTY_SAS_STRING, EMPTY_SAS_STRING, false)
+		jm.AddJobPart(partNum, planFile, mmf, EMPTY_SAS_STRING, EMPTY_SAS_STRING, false, nil)
 	}
 }
 

--- a/jobsAdmin/JobsAdmin.go
+++ b/jobsAdmin/JobsAdmin.go
@@ -294,7 +294,7 @@ func (ja *jobsAdmin) JobMgrEnsureExists(jobID common.JobID,
 	return ja.jobIDToJobMgr.EnsureExists(jobID,
 		func() ste.IJobMgr {
 			// Return existing or new IJobMgr to caller
-			return ste.NewJobMgr(ja.concurrency, jobID, ja.appCtx, ja.cpuMonitor, level, commandString, ja.logDir, ja.concurrencyTuner, ja.pacer, ja.slicePool, ja.cacheLimiter, ja.fileCountLimiter, ja.jobLogger)
+			return ste.NewJobMgr(ja.concurrency, jobID, ja.appCtx, ja.cpuMonitor, level, commandString, ja.logDir, ja.concurrencyTuner, ja.pacer, ja.slicePool, ja.cacheLimiter, ja.fileCountLimiter, ja.jobLogger, false)
 		})
 }
 

--- a/jobsAdmin/init.go
+++ b/jobsAdmin/init.go
@@ -180,7 +180,7 @@ func ExecuteNewCopyJobPartOrder(order common.CopyJobPartOrderRequest) common.Cop
 			CredentialInfo: order.CredentialInfo,
 		})
 	// Supply no plan MMF because we don't have one, and AddJobPart will create one on its own.
-	jm.AddJobPart(order.PartNum, jppfn, nil, order.SourceRoot.SAS, order.DestinationRoot.SAS, true) // Add this part to the Job and schedule its transfers
+	jm.AddJobPart(order.PartNum, jppfn, nil, order.SourceRoot.SAS, order.DestinationRoot.SAS, true, nil) // Add this part to the Job and schedule its transfers
 
 	// Update jobPart Status with the status Manager
 	jm.SendJobPartCreatedMsg(ste.JobPartCreatedMsg{TotalTransfers: uint32(len(order.Transfers.List)),

--- a/ste/jobStatusManager.go
+++ b/ste/jobStatusManager.go
@@ -43,27 +43,26 @@ type jobStatusManager struct {
 	xferDone    chan xferDoneMsg
 }
 
-var jstm jobStatusManager
-
 /* These functions should not fail */
 func (jm *jobMgr) SendJobPartCreatedMsg(msg JobPartCreatedMsg) {
-	jstm.partCreated <- msg
+	jm.jstm.partCreated <- msg
 }
 
 func (jm *jobMgr) SendXferDoneMsg(msg xferDoneMsg) {
-	jstm.xferDone <- msg
+	jm.jstm.xferDone <- msg
 }
 
 func (jm *jobMgr) ListJobSummary() common.ListJobSummaryResponse {
-	jstm.listReq <- true
-	return <-jstm.respChan
+	jm.jstm.listReq <- true
+	return <-jm.jstm.respChan
 }
 
 func (jm *jobMgr) ResurrectSummary(js common.ListJobSummaryResponse) {
-	jstm.js = js
+	jm.jstm.js = js
 }
 
 func (jm *jobMgr) handleStatusUpdateMessage() {
+	jstm := jm.jstm
 	js := &jstm.js
 	js.JobID = jm.jobID
 	js.CompleteJobOrdered = false

--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -128,6 +128,7 @@ func NewJobMgr(concurrency ConcurrencySettings, jobID common.JobID, appCtx conte
 	
 	/* Create book-keeping channels */
 	jobPartProgressCh := make(chan jobPartProgressInfo)
+	var jstm jobStatusManager
 	jstm.respChan = make(chan common.ListJobSummaryResponse)
 	jstm.listReq = make(chan bool)
 	jstm.partCreated = make(chan JobPartCreatedMsg, 100)
@@ -167,6 +168,7 @@ func NewJobMgr(concurrency ConcurrencySettings, jobID common.JobID, appCtx conte
 		cacheLimiter:                 cacheLimiter,
 		fileCountLimiter:             fileCountLimiter,
 		cpuMon:                       cpuMon,
+		jstm:                         &jstm,
 		/*Other fields remain zero-value until this job is scheduled */}
 	jm.reset(appCtx, commandString)
 	jm.logJobsAdminMessages()
@@ -311,6 +313,7 @@ type jobMgr struct {
 	slicePool           common.ByteSlicePooler
 	cacheLimiter        common.CacheLimiter
 	fileCountLimiter    common.CacheLimiter
+	jstm                *jobStatusManager
 
 	/* Pool sizer related stuff */
 	atomicCurrentMainPoolSize          int32 // align 64 bit integers for 32 bit arch

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -237,6 +237,7 @@ type jobPartProgressInfo struct {
 	transfersCompleted int
 	transfersSkipped   int
 	transfersFailed    int
+	completionChan     chan struct{}
 }
 
 // jobPartMgr represents the runtime information for a Job's Part
@@ -310,6 +311,8 @@ type jobPartMgr struct {
 	atomicTransfersSkipped   uint32
 
 	cpkOptions common.CpkOptions
+
+	closeOnCompletion chan struct{}
 }
 
 func (jpm *jobPartMgr) getOverwritePrompter() *overwritePrompter {
@@ -843,6 +846,7 @@ func (jpm *jobPartMgr) ReportTransferDone(status common.TransferStatus) (transfe
 			transfersCompleted: int(atomic.LoadUint32(&jpm.atomicTransfersCompleted)),
 			transfersSkipped:   int(atomic.LoadUint32(&jpm.atomicTransfersSkipped)),
 			transfersFailed:    int(atomic.LoadUint32(&jpm.atomicTransfersFailed)),
+			completionChan:     jpm.closeOnCompletion,
 		}
 		jpm.jobMgr.ReportJobPartDone(jppi)
 	}

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -762,7 +762,8 @@ func (jptm *jobPartTransferMgr) failActiveTransfer(typ transferErrorCode, descri
 		jptm.SetErrorCode(int32(status)) // TODO: what are the rules about when this needs to be set, and doesn't need to be (e.g. for earlier failures)?
 		// If the status code was 403, it means there was an authentication error and we exit.
 		// User can resume the job if completely ordered with a new sas.
-		if status == http.StatusForbidden {
+		if status == http.StatusForbidden &&
+		!jptm.jobPartMgr.(*jobPartMgr).jobMgr.IsDaemon() {
 			// quit right away, since without proper authentication no work can be done
 			// display a clear message
 			common.GetLifecycleMgr().Info(fmt.Sprintf("Authentication failed, it is either not correct, or expired, or does not have the correct permission %s", err.Error()))


### PR DESCRIPTION
This PR includes 4 individual changes and can be viewed separately.

- Move jobStatus manager to JobManager. This will allow to have multiple JMs running in parallel
- Add daemon mode to JobManager
- Mechanism to notify on completion of a jobPart
- Move exclusive destination map to JobManager initState. Currently first jobPart would initialize it. 