### PR TITLE
[AzCopyV10][UX] Also print friendly message about tier when destination account info cannot be obtained

### DIFF
--- a/ste/xfer-anyToRemote-file.go
+++ b/ste/xfer-anyToRemote-file.go
@@ -65,6 +65,8 @@ func prepareDestAccountInfo(bURL azblob.BlobURL, jptm IJobPartTransferMgr, ctx c
 				getDestAccountInfoError = err
 			} else {
 				tierSetPossibleFail = true
+				glcm := common.GetLifecycleMgr()
+				glcm.Info("Transfers are likely to fail because destination does not support tiers.")
 				destAccountSKU = "failget"
 				destAccountKind = "failget"
 			}


### PR DESCRIPTION
When using OAuth, the get account info API does not work: https://docs.microsoft.com/en-us/rest/api/storageservices/get-account-information#authorization

thus, if we do a std -> premium job, the transfers will fail because tiering is not supported on the destination. 