### PR TITLE
Refactor STE: Part 4

### DIFF
--- a/ste/JobPartPlan.go
+++ b/ste/JobPartPlan.go
@@ -13,7 +13,7 @@ import (
 // dataSchemaVersion defines the data schema version of JobPart order files supported by
 // current version of azcopy
 // To be Incremented every time when we release azcopy with changed dataSchema
-const DataSchemaVersion common.Version = 16
+const DataSchemaVersion common.Version = 17
 
 const (
 	CustomHeaderMaxBytes = 256
@@ -81,6 +81,7 @@ type JobPartPlanHeader struct {
 	// jobStatus_doNotUse is a private member whose value can be accessed by Status and SetJobStatus
 	// jobStatus_doNotUse should not be directly accessed anywhere except by the Status and SetJobStatus
 	atomicJobStatus common.JobStatus
+	atomicPartStatus common.JobStatus
 
 	// For delete operation specify what to do with snapshots
 	DeleteSnapshotsOption common.DeleteSnapshotsOption
@@ -98,6 +99,14 @@ func (jpph *JobPartPlanHeader) JobStatus() common.JobStatus {
 func (jpph *JobPartPlanHeader) SetJobStatus(newJobStatus common.JobStatus) {
 	jpph.atomicJobStatus.AtomicStore(newJobStatus)
 }
+
+func (jpph *JobPartPlanHeader) JobPartStatus() common.JobStatus {
+	return jpph.atomicPartStatus.AtomicLoad()
+}
+
+func (jpph *JobPartPlanHeader) SetJobPartStatus(newJobStatus common.JobStatus) {
+	jpph.atomicPartStatus.AtomicStore(newJobStatus)
+} 
 
 // Transfer api gives memory map JobPartPlanTransfer header for given index
 func (jpph *JobPartPlanHeader) Transfer(transferIndex uint32) *JobPartPlanTransfer {

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -848,6 +848,8 @@ func (jpm *jobPartMgr) ReportTransferDone(status common.TransferStatus) (transfe
 			transfersFailed:    int(atomic.LoadUint32(&jpm.atomicTransfersFailed)),
 			completionChan:     jpm.closeOnCompletion,
 		}
+		jpm.Plan().SetJobPartStatus(common.EJobStatus.EnhanceJobStatusInfo(jppi.transfersSkipped > 0,
+			jppi.transfersFailed > 0, jppi.transfersCompleted > 0))
 		jpm.jobMgr.ReportJobPartDone(jppi)
 	}
 	return transfersDone


### PR DESCRIPTION
1. Introduce JobPartStatus in jobPartManager
2. Remove MessagesToJobLog() (This was a workaround because of late creation of logger. Fixed by moving creation to root.go)
3. Export Reset() method in JobMgr