### PR TITLE
[AzCopyV10][Bug] Uploading from top directory on linux fails when sub folder has the same name

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -34,6 +34,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
@@ -1150,6 +1151,15 @@ type CookedCopyCmdArgs struct {
 
 	// Optional flag that permanently deletes soft deleted blobs
 	permanentDeleteOption common.PermanentDeleteOption
+
+	// defines whether first part has been ordered or not.
+	// 0 means first part is not ordered and 1 means first part is ordered.
+	atomicFirstPartOrdered uint32
+}
+
+// setFirstPartOrdered sets the value of atomicFirstPartOrdered to 1
+func (cca *CookedCopyCmdArgs) setFirstPartOrdered() {
+	atomic.StoreUint32(&cca.atomicFirstPartOrdered, 1)
 }
 
 func (cca *CookedCopyCmdArgs) isRedirection() bool {

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -1214,17 +1214,17 @@ type CookedCopyCmdArgs struct {
 	// defines whether first part has been ordered or not.
 	// 0 means first part is not ordered and 1 means first part is ordered.
 	atomicFirstPartOrdered uint32
-}
-
-// setFirstPartOrdered sets the value of atomicFirstPartOrdered to 1
-func (cca *CookedCopyCmdArgs) setFirstPartOrdered() {
-	atomic.StoreUint32(&cca.atomicFirstPartOrdered, 1)
 
 	// Optional flag that sets rehydrate priority for rehydration
 	rehydratePriority common.RehydratePriorityType
 
 	// Bitmasked uint checking which properties to transfer
 	propertiesToTransfer common.SetPropertiesFlags
+}
+
+// setFirstPartOrdered sets the value of atomicFirstPartOrdered to 1
+func (cca *CookedCopyCmdArgs) setFirstPartOrdered() {
+	atomic.StoreUint32(&cca.atomicFirstPartOrdered, 1)
 }
 
 func (cca *CookedCopyCmdArgs) isRedirection() bool {

--- a/cmd/copyEnumeratorHelper.go
+++ b/cmd/copyEnumeratorHelper.go
@@ -15,8 +15,10 @@ var EnumerationParallelStatFiles = false
 
 // addTransfer accepts a new transfer, if the threshold is reached, dispatch a job part order.
 func addTransfer(e *common.CopyJobPartOrderRequest, transfer common.CopyTransfer, cca *CookedCopyCmdArgs) error {
-	// Remove the source and destination roots from the path to save space in the plan files
-	transfer.Source = strings.TrimPrefix(transfer.Source, e.SourceRoot.Value)
+	// Remove the destination roots from the path to save space in the plan files
+
+	// TODO: Remove this code because transfer.Source will already have relative path
+	// transfer.Source = strings.TrimPrefix(transfer.Source, e.SourceRoot.Value)
 	transfer.Destination = strings.TrimPrefix(transfer.Destination, e.DestinationRoot.Value)
 
 	// dispatch the transfers once the number reaches NumOfFilesPerDispatchJobPart

--- a/cmd/copyEnumeratorHelper.go
+++ b/cmd/copyEnumeratorHelper.go
@@ -13,6 +13,7 @@ import (
 var EnumerationParallelism = 1
 var EnumerationParallelStatFiles = false
 
+// TODO: potentially remove addTransfer and replace this with scheduleCopyTransfer
 // addTransfer accepts a new transfer, if the threshold is reached, dispatch a job part order.
 func addTransfer(e *common.CopyJobPartOrderRequest, transfer common.CopyTransfer, cca *CookedCopyCmdArgs) error {
 	// Remove the destination roots from the path to save space in the plan files

--- a/cmd/copyEnumeratorHelper_test.go
+++ b/cmd/copyEnumeratorHelper_test.go
@@ -41,23 +41,4 @@ func newRemoteRes(url string) common.ResourceString {
 	return r
 }
 
-func (s *copyEnumeratorHelperTestSuite) TestAddTransferPathRootsTrimmed(c *chk.C) {
-	// setup
-	request := common.CopyJobPartOrderRequest{
-		SourceRoot:      newLocalRes("a/b/"),
-		DestinationRoot: newLocalRes("y/z/"),
-	}
-
-	transfer := common.CopyTransfer{
-		Source:      "a/b/c.txt",
-		Destination: "y/z/c.txt",
-	}
-
-	// execute
-	err := addTransfer(&request, transfer, &CookedCopyCmdArgs{})
-
-	// assert
-	c.Assert(err, chk.IsNil)
-	c.Assert(request.Transfers.List[0].Source, chk.Equals, "c.txt")
-	c.Assert(request.Transfers.List[0].Destination, chk.Equals, "c.txt")
-}
+// TODO: delete this file?

--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -282,7 +282,6 @@ func (cca *CookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 
 		srcRelPath := cca.MakeEscapedRelativePath(true, isDestDir, cca.asSubdir, object)
 		dstRelPath := cca.MakeEscapedRelativePath(false, isDestDir, cca.asSubdir, object)
-		object.relativePath = srcRelPath // set rel path in stored object
 
 		transfer, shouldSendToSte := object.ToNewCopyTransfer(
 			cca.autoDecompress && cca.FromTo.IsDownload(),

--- a/cmd/zt_copy_s2smigration_test.go
+++ b/cmd/zt_copy_s2smigration_test.go
@@ -114,7 +114,7 @@ func validateS2STransfersAreScheduled(c *chk.C, srcDirName string, dstDirName st
 		srcRelativeFilePath, _ := url.PathUnescape(transfer.Source)
 		dstRelativeFilePath, _ := url.PathUnescape(transfer.Destination)
 
-		unescapedSrcDir, _ := url.PathUnescape(srcDirName)
+		/*unescapedSrcDir, _ := url.PathUnescape(srcDirName)
 		unescapedDstDir, _ := url.PathUnescape(dstDirName)
 
 		srcRelativeFilePath = strings.Replace(srcRelativeFilePath, unescapedSrcDir, "", 1)
@@ -123,7 +123,7 @@ func validateS2STransfersAreScheduled(c *chk.C, srcDirName string, dstDirName st
 			// Thing we were searching for is bigger than what we are searching in, due to ending end a /
 			// Happens for root dir
 			dstRelativeFilePath = ""
-		}
+		}*/
 
 		if debugMode {
 			fmt.Println("srcRelativeFilePath: ", srcRelativeFilePath)


### PR DESCRIPTION
Line 19 in cmd/copyEnumeratorHelper.go causes a bug in linux in which the root folder name is removed from path.

i.e. e.SourceRoot.Value = "/event"  and transfer.Source = "/event_stuff/foo.txt" --> incorrectly changes transfer.Source to "_stuff/foo.txt"

The transfer.Source is already a relative path and this line of code can be removed.

--- 
Refactoring AzCopy copy to use scheduleCopyTransfer instead of addTransfer.

Steps of scheduleCopyTransfer:

1. Gets source and destination relative path from stored object (transfer)
2. Sets up copy transfer and figures out if stored object should be sent to STE
3. If destination is none, then blobtier, metadata, and blob tags are set accordingly
4. If the stored object should not be sent to STE, it skips this object
5. If transfer has dry run mode on, it logs info and skips the object
6. If the length of transfers is same as number of transfers per part, then reset transfers buffer
7. Append transfer to list after checking and dispatching a part
8. If transfer type is file, increment file count or else increment folder count

Steps of addTransfer:

1. Trims prefix for source and destination url (to get relative paths for both)
2. Dispatch transfers once number of files reaches the number of files per dispatch job part (10000) and reset transfers buffer.
3. Append transfer to transfer list after a part has been checked and dispatched
4. If transfer type is file, increment file count or else increment folder count