### PR TITLE
Introduce xdm-relevant changes to and fix frontend

### DIFF
--- a/cmd/credentialUtil.go
+++ b/cmd/credentialUtil.go
@@ -58,11 +58,11 @@ const oauthLoginSessionCacheAccountName = "AzCopyOAuthTokenCache"
 // Note: Currently, only support to have TokenManager for one user mapping to one tenantID.
 func GetUserOAuthTokenManagerInstance() *common.UserOAuthTokenManager {
 	once.Do(func() {
-		if azcopyAppPathFolder == "" {
+		if AzcopyAppPathFolder == "" {
 			panic("invalid state, azcopyAppPathFolder should be initialized by root")
 		}
 		currentUserOAuthTokenManager = common.NewUserOAuthTokenManagerInstance(common.CredCacheOptions{
-			DPAPIFilePath: azcopyAppPathFolder,
+			DPAPIFilePath: AzcopyAppPathFolder,
 			KeyName:       oauthLoginSessionCacheKeyName,
 			ServiceName:   oauthLoginSessionCacheServiceName,
 			AccountName:   oauthLoginSessionCacheAccountName,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,7 +40,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var azcopyAppPathFolder string
+var AzcopyAppPathFolder string
 var azcopyLogPathFolder string
 var azcopyMaxFileAndSocketHandles int
 var outputFormatRaw string
@@ -156,7 +156,7 @@ var glcmSwapOnce = &sync.Once{}
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute(azsAppPathFolder, logPathFolder string, jobPlanFolder string, maxFileAndSocketHandles int, jobID common.JobID) {
-	azcopyAppPathFolder = azsAppPathFolder
+	AzcopyAppPathFolder = azsAppPathFolder
 	azcopyLogPathFolder = logPathFolder
 	common.AzcopyJobPlanFolder = jobPlanFolder
 	azcopyMaxFileAndSocketHandles = maxFileAndSocketHandles

--- a/jobsAdmin/JobsAdmin.go
+++ b/jobsAdmin/JobsAdmin.go
@@ -323,12 +323,12 @@ func (ja *jobsAdmin) SuccessfulBytesInActiveFiles() uint64 {
 
 func (ja *jobsAdmin) ResurrectJob(jobId common.JobID, sourceSAS string, destinationSAS string) bool {
 	// Search the existing plan files for the PartPlans for the given jobId
-	// only the files which have JobId has prefix and DataSchemaVersion as Suffix
+	// only the files which are not empty and have JobId has prefix and DataSchemaVersion as Suffix
 	// are include in the result
 	files := func(prefix, ext string) []os.FileInfo {
 		var files []os.FileInfo
 		filepath.Walk(ja.planDir, func(path string, fileInfo os.FileInfo, _ error) error {
-			if !fileInfo.IsDir() && strings.HasPrefix(fileInfo.Name(), prefix) && strings.HasSuffix(fileInfo.Name(), ext) {
+			if !fileInfo.IsDir() && fileInfo.Size() != 0 && strings.HasPrefix(fileInfo.Name(), prefix) && strings.HasSuffix(fileInfo.Name(), ext) {
 				files = append(files, fileInfo)
 			}
 			return nil
@@ -365,7 +365,7 @@ func (ja *jobsAdmin) ResurrectJobParts() {
 	files := func(ext string) []os.FileInfo {
 		var files []os.FileInfo
 		filepath.Walk(ja.planDir, func(path string, fileInfo os.FileInfo, _ error) error {
-			if !fileInfo.IsDir() && strings.HasSuffix(fileInfo.Name(), ext) {
+			if !fileInfo.IsDir() && fileInfo.Size() != 0 && strings.HasSuffix(fileInfo.Name(), ext) {
 				files = append(files, fileInfo)
 			}
 			return nil

--- a/jobsAdmin/init.go
+++ b/jobsAdmin/init.go
@@ -776,7 +776,7 @@ func GetJobFromTo(r common.GetJobFromToRequest) common.GetJobFromToResponse {
 		// Search the plan files in Azcopy folder and resurrect the Job.
 		if !JobsAdmin.ResurrectJob(r.JobID, EMPTY_SAS_STRING, EMPTY_SAS_STRING) {
 			return common.GetJobFromToResponse{
-				ErrorMsg: fmt.Sprintf("no job with JobID %v exists", r.JobID),
+				ErrorMsg: fmt.Sprintf("Job with JobID %v does not exist or is invalid", r.JobID),
 			}
 		}
 		jm, _ = JobsAdmin.JobMgr(r.JobID)

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -345,7 +345,11 @@ func (jptm *jobPartTransferMgr) Info() TransferInfo {
 				 * we can have 4 blocks in core, waiting for a disk or n/w operation. Any higher block size would *sort of*
 				 * serialize n/w and disk operations, and is better avoided.
 				 */
-				blockSize = sourceSize / common.MaxNumberOfBlocksPerBlob
+				if (sourceSize % common.MaxNumberOfBlocksPerBlob == 0) {
+					blockSize = sourceSize/common.MaxNumberOfBlocksPerBlob
+				} else {
+					blockSize = sourceSize/common.MaxNumberOfBlocksPerBlob +1
+				}
 				break
 			}
 		}


### PR DESCRIPTION
Refer to:
Export azcopyAppPathFolder variable.
https://github.com/Azure/azure-storage-azcopy/commit/7e86c2b4fb20c075b25aba8c8967e680c58d64af

Fix calculation for large file block size.
- This fix is in respect to support 190TB files.
  As of now due to wrong calculation azcopy fails after 24T.
https://github.com/Azure/azure-storage-azcopy/commit/36311199db508cb92b424206ec7b1c7996ca66e8

Handle panic error when plan file is empty.
https://github.com/Azure/azure-storage-azcopy/commit/c7722dec58e912d38a5d140bcedcdfd0c3d5ceaf

A new PR has been created in order to make the changes more modular, and easily reviewable.