### PR TITLE
Added error message to failed transfer details.

### DIFF
--- a/common/rpc-models.go
+++ b/common/rpc-models.go
@@ -319,7 +319,8 @@ type TransferDetail struct {
 	IsFolderProperties bool
 	TransferStatus     TransferStatus
 	TransferSize       uint64
-	ErrorCode          int32 `json:",string"`
+	ErrorCode          int32  `json:",string"`
+	ErrorMessage       string `json:",string"`
 }
 
 type CancelPauseResumeResponse struct {

--- a/jobsAdmin/init.go
+++ b/jobsAdmin/init.go
@@ -423,6 +423,7 @@ func ResumeJobOrder(req common.ResumeJobRequest) common.CancelPauseResumeRespons
 				if jppt.TransferStatus() <= common.ETransferStatus.Failed() {
 					jppt.SetTransferStatus(common.ETransferStatus.Started(), true)
 					jppt.SetErrorCode(0, true)
+					jppt.SetErrorMessage("", true)
 				}
 			}
 		})
@@ -592,7 +593,8 @@ func resurrectJobSummary(jm ste.IJobMgr) common.ListJobSummaryResponse {
 						Dst:                dst,
 						IsFolderProperties: isFolder,
 						TransferStatus:     common.ETransferStatus.Failed(),
-						ErrorCode:          jppt.ErrorCode()}) // TODO: Optimize
+						ErrorCode:          jppt.ErrorCode(),
+						ErrorMessage:       jppt.ErrorMessage()}) // TODO: Optimize
 			case common.ETransferStatus.SkippedEntityAlreadyExists(),
 				common.ETransferStatus.SkippedBlobHasSnapshots():
 				js.TransfersSkipped++
@@ -713,7 +715,8 @@ func ListJobTransfers(r common.ListJobTransfersRequest) common.ListJobTransfersR
 			// getting source and destination of a transfer at index index for given jobId and part number.
 			src, dst, isFolder := jpp.TransferSrcDstStrings(t)
 			ljt.Details = append(ljt.Details,
-				common.TransferDetail{Src: src, Dst: dst, IsFolderProperties: isFolder, TransferStatus: transferEntry.TransferStatus(), ErrorCode: transferEntry.ErrorCode()})
+				common.TransferDetail{Src: src, Dst: dst, IsFolderProperties: isFolder, TransferStatus: transferEntry.TransferStatus(), ErrorCode: transferEntry.ErrorCode(),
+					ErrorMessage: transferEntry.ErrorMessage()})
 		}
 	}
 	return ljt

--- a/ste/JobPartPlan.go
+++ b/ste/JobPartPlan.go
@@ -16,9 +16,10 @@ import (
 const DataSchemaVersion common.Version = 17
 
 const (
-	CustomHeaderMaxBytes = 256
-	MetadataMaxBytes     = 1000 // If > 65536, then jobPartPlanBlobData's MetadataLength field's type must change
-	BlobTagsMaxByte      = 4000
+	CustomHeaderMaxBytes  = 256
+	MetadataMaxBytes      = 1000 // If > 65536, then jobPartPlanBlobData's MetadataLength field's type must change
+	BlobTagsMaxByte       = 4000
+	MaxErrorMessageLength = 1000
 )
 
 // //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -389,6 +390,10 @@ type JobPartPlanTransfer struct {
 	// atomicErrorCode has a default value (0) which means either there was no error or transfer failed because some non storageError.
 	// atomicErrorCode should not be directly accessed anywhere except by transferStatus and setTransferStatus
 	atomicErrorCode int32
+
+	// errorMessageLength represents the length of the error message for failed transfers.
+	errorMessageLength int32
+	errorMessage       [MaxErrorMessageLength]byte
 }
 
 // TransferStatus returns the transfer's status
@@ -416,6 +421,31 @@ func (jppt *JobPartPlanTransfer) SetTransferStatus(status common.TransferStatus,
 // ErrorCode returns the transfer's errorCode.
 func (jppt *JobPartPlanTransfer) ErrorCode() int32 {
 	return atomic.LoadInt32(&jppt.atomicErrorCode)
+}
+
+// ErrorMessage returns the transfer's error message.
+func (jppt *JobPartPlanTransfer) ErrorMessage() string {
+	return string(jppt.errorMessage[:atomic.LoadInt32(&jppt.errorMessageLength)])
+}
+
+// SetErrorMessage sets the error message if transfer failed.
+// overWrite flags if set to true overWrites the errorMessage.
+// If overWrite flag is set to false, then errorMessage won't be overwritten.
+func (jppt *JobPartPlanTransfer) SetErrorMessage(errorMessage string, overwrite bool) {
+	savedErrorMessageLength := atomic.LoadInt32(&jppt.errorMessageLength)
+	currentErrorMessageLength := int32(len(errorMessage))
+
+	// Make sure error message does not exceed max length.
+	if currentErrorMessageLength > MaxErrorMessageLength {
+		currentErrorMessageLength = MaxErrorMessageLength
+	}
+
+	// Overwrite, if this is the first error or caller wants this new errorMessage to overwrite the existing one.
+	if (savedErrorMessageLength == 0) || overwrite {
+		if atomic.CompareAndSwapInt32(&jppt.errorMessageLength, savedErrorMessageLength, currentErrorMessageLength) {
+			copy(jppt.errorMessage[:], []byte(errorMessage[:currentErrorMessageLength]))
+		}
+	}
 }
 
 // SetErrorCode sets the error code of the error if transfer failed.

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -44,6 +44,7 @@ type IJobPartTransferMgr interface {
 	TransferStatusIgnoringCancellation() common.TransferStatus
 	SetStatus(status common.TransferStatus)
 	SetErrorCode(errorCode int32)
+	SetErrorMessage(errorMessage string)
 	SetNumberOfChunks(numChunks uint32)
 	SetActionAfterLastChunk(f func())
 	ReportTransferDone() uint32
@@ -622,6 +623,16 @@ func (jptm *jobPartTransferMgr) SetErrorCode(errorCode int32) {
 	jptm.jobPartPlanTransfer.SetErrorCode(errorCode, false)
 }
 
+// ErrorMessage gets the error message of transfer for given job.
+func (jptm *jobPartTransferMgr) ErrorMessage() string {
+	return jptm.jobPartPlanTransfer.ErrorMessage()
+}
+
+// ErrorMessage updates the error message of transfer for given job.
+func (jptm *jobPartTransferMgr) SetErrorMessage(errorMessage string) {
+	jptm.jobPartPlanTransfer.SetErrorMessage(errorMessage, false)
+}
+
 // TODO: Can we kill this method?
 /*func (jptm *jobPartTransferMgr) ChunksDone() uint32 {
 	return atomic.LoadUint32(&jptm.atomicChunksDone)
@@ -781,6 +792,7 @@ func (jptm *jobPartTransferMgr) failActiveTransfer(typ transferErrorCode, descri
 		fullMsg := fmt.Sprintf("%s. When %s. X-Ms-Request-Id: %s\n", msg, descriptionOfWhereErrorOccurred, requestID) // trailing \n to separate it better from any later, unrelated, log lines
 		jptm.logTransferError(typ, jptm.Info().Source, jptm.Info().Destination, fullMsg, status)
 		jptm.SetStatus(failureStatus)
+		jptm.SetErrorMessage(fullMsg)
 		jptm.SetErrorCode(int32(status)) // TODO: what are the rules about when this needs to be set, and doesn't need to be (e.g. for earlier failures)?
 		// If the status code was 403, it means there was an authentication error and we exit.
 		// User can resume the job if completely ordered with a new sas.
@@ -790,7 +802,7 @@ func (jptm *jobPartTransferMgr) failActiveTransfer(typ transferErrorCode, descri
 			// display a clear message
 			common.GetLifecycleMgr().Info(fmt.Sprintf("Authentication failed, it is either not correct, or expired, or does not have the correct permission %s", err.Error()))
 			// and use the normal cancelling mechanism so that we can exit in a clean and controlled way
-			jptm.jobPartMgr.(*jobPartMgr).jobMgr.CancelPauseJobOrder(common.EJobStatus.Cancelling())
+			jptm.jobPartMgr.(*jobPartMgr).jobMgr.CancelPauseJobOrder(common.EJobStatus.Failed())
 			// TODO: this results in the final job output line being: Final Job Status: Cancelled
 			//     That's not ideal, because it would be better if it said Final Job Status: Failed
 			//     However, we don't have any way to distinguish "user cancelled after some failed files" from
@@ -929,6 +941,7 @@ func (jptm *jobPartTransferMgr) ReportTransferDone() uint32 {
 		TransferStatus:     jptm.jobPartPlanTransfer.TransferStatus(),
 		TransferSize:       uint64(jptm.Info().SourceSize),
 		ErrorCode:          jptm.ErrorCode(),
+		ErrorMessage:       jptm.ErrorMessage(),
 	})
 
 	return jptm.jobPartMgr.ReportTransferDone(jptm.jobPartPlanTransfer.TransferStatus())


### PR DESCRIPTION
Refer to the following commit https://github.com/Azure/azure-storage-azcopy/commit/b7993f7edaf49f2dd33d3faa1aa97e910b2fc0df from the PR https://github.com/Azure/azure-storage-azcopy/pull/1745

- add error message to JobPartPlanTransfer and failed transfer details

- change jobstatus of 403 errors from Cancelled to Failed

- use atomic operations for errormessage length

- check error message does not exceed max length

A new PR has been created in order to make the changes more modular, and easily reviewable.