### PR TITLE
Add support to change log level and let a calling app cancel enumeration

### DIFF
--- a/cmd/zc_enumerator.go
+++ b/cmd/zc_enumerator.go
@@ -392,7 +392,7 @@ func InitResourceTraverser(resource common.ResourceString, location common.Locat
 			output = newListTraverser(baseResource, location, nil, nil, recursive, toFollow, getProperties,
 				globChan, includeDirectoryStubs, incrementEnumerationCounter, s2sPreserveBlobTags, logLevel, cpkOptions)
 		} else {
-			output = newLocalTraverser(resource.ValueLocal(), recursive, toFollow, incrementEnumerationCounter)
+			output = newLocalTraverser(ctx, resource.ValueLocal(), recursive, toFollow, incrementEnumerationCounter)
 		}
 	case common.ELocation.Benchmark():
 		ben, err := newBenchmarkTraverser(resource.Value, incrementEnumerationCounter)

--- a/cmd/zc_enumerator.go
+++ b/cmd/zc_enumerator.go
@@ -392,7 +392,7 @@ func InitResourceTraverser(resource common.ResourceString, location common.Locat
 			output = newListTraverser(baseResource, location, nil, nil, recursive, toFollow, getProperties,
 				globChan, includeDirectoryStubs, incrementEnumerationCounter, s2sPreserveBlobTags, logLevel, cpkOptions)
 		} else {
-			output = newLocalTraverser(ctx, resource.ValueLocal(), recursive, toFollow, incrementEnumerationCounter)
+			output = newLocalTraverser(*ctx, resource.ValueLocal(), recursive, toFollow, incrementEnumerationCounter)
 		}
 	case common.ELocation.Benchmark():
 		ben, err := newBenchmarkTraverser(resource.Value, incrementEnumerationCounter)

--- a/cmd/zc_traverser_local.go
+++ b/cmd/zc_traverser_local.go
@@ -21,6 +21,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -38,7 +39,7 @@ type localTraverser struct {
 	fullPath       string
 	recursive      bool
 	followSymlinks bool
-
+	appCtx         *context.Context
 	// a generic function to notify that a new stored object has been enumerated
 	incrementEnumerationCounter enumerationCounterFunc
 }
@@ -154,7 +155,7 @@ func (s symlinkTargetFileInfo) Name() string {
 // Separate this from the traverser for two purposes:
 // 1) Cleaner code
 // 2) Easier to test individually than to test the entire traverser.
-func WalkWithSymlinks(fullPath string, walkFunc filepath.WalkFunc, followSymlinks bool) (err error) {
+func WalkWithSymlinks(appCtx context.Context, fullPath string, walkFunc filepath.WalkFunc, followSymlinks bool) (err error) {
 
 	// We want to re-queue symlinks up in their evaluated form because filepath.Walk doesn't evaluate them for us.
 	// So, what is the plan of attack?
@@ -184,7 +185,7 @@ func WalkWithSymlinks(fullPath string, walkFunc filepath.WalkFunc, followSymlink
 		walkQueue = walkQueue[1:]
 		// walk contents of this queueItem in parallel
 		// (for simplicity of coding, we don't parallelize across multiple queueItems)
-		parallel.Walk(queueItem.fullPath, EnumerationParallelism, EnumerationParallelStatFiles, func(filePath string, fileInfo os.FileInfo, fileError error) error {
+		parallel.Walk(appCtx, queueItem.fullPath, EnumerationParallelism, EnumerationParallelStatFiles, func(filePath string, fileInfo os.FileInfo, fileError error) error {
 			if fileError != nil {
 				WarnStdoutAndScanningLog(fmt.Sprintf("Accessing '%s' failed with error: %s", filePath, fileError))
 				return nil
@@ -384,7 +385,11 @@ func (t *localTraverser) Traverse(preprocessor objectMorpher, processor objectPr
 			}
 
 			// note: Walk includes root, so no need here to separately create StoredObject for root (as we do for other folder-aware sources)
-			return WalkWithSymlinks(t.fullPath, processFile, t.followSymlinks)
+			if t.appCtx != nil {
+				return WalkWithSymlinks(*t.appCtx, t.fullPath, processFile, t.followSymlinks)
+			} else {
+				return WalkWithSymlinks(nil, t.fullPath, processFile, t.followSymlinks)
+			}
 		} else {
 			// if recursive is off, we only need to scan the files immediately under the fullPath
 			// We don't transfer any directory properties here, not even the root. (Because the root's
@@ -462,11 +467,12 @@ func (t *localTraverser) Traverse(preprocessor objectMorpher, processor objectPr
 	return
 }
 
-func newLocalTraverser(fullPath string, recursive bool, followSymlinks bool, incrementEnumerationCounter enumerationCounterFunc) *localTraverser {
+func newLocalTraverser(ctx *context.Context, fullPath string, recursive bool, followSymlinks bool, incrementEnumerationCounter enumerationCounterFunc) *localTraverser {
 	traverser := localTraverser{
 		fullPath:                    cleanLocalPath(fullPath),
 		recursive:                   recursive,
 		followSymlinks:              followSymlinks,
+		appCtx:                      ctx,
 		incrementEnumerationCounter: incrementEnumerationCounter}
 	return &traverser
 }

--- a/cmd/zc_traverser_local.go
+++ b/cmd/zc_traverser_local.go
@@ -190,6 +190,12 @@ func WalkWithSymlinks(appCtx context.Context, fullPath string, walkFunc filepath
 				WarnStdoutAndScanningLog(fmt.Sprintf("Accessing '%s' failed with error: %s", filePath, fileError))
 				return nil
 			}
+
+			if fileInfo != nil {
+				WarnStdoutAndScanningLog(fmt.Sprintf("Accessing '%s' failed: File information missing", filePath))
+				return nil
+			}
+
 			computedRelativePath := strings.TrimPrefix(cleanLocalPath(filePath), cleanLocalPath(queueItem.fullPath))
 			computedRelativePath = cleanLocalPath(common.GenerateFullPath(queueItem.relativeBase, computedRelativePath))
 			computedRelativePath = strings.TrimPrefix(computedRelativePath, common.AZCOPY_PATH_SEPARATOR_STRING)
@@ -388,7 +394,7 @@ func (t *localTraverser) Traverse(preprocessor objectMorpher, processor objectPr
 			if t.appCtx != nil {
 				return WalkWithSymlinks(*t.appCtx, t.fullPath, processFile, t.followSymlinks)
 			} else {
-				return WalkWithSymlinks(nil, t.fullPath, processFile, t.followSymlinks)
+				return WalkWithSymlinks(context.TODO(), t.fullPath, processFile, t.followSymlinks)
 			}
 		} else {
 			// if recursive is off, we only need to scan the files immediately under the fullPath

--- a/cmd/zc_traverser_local.go
+++ b/cmd/zc_traverser_local.go
@@ -39,7 +39,7 @@ type localTraverser struct {
 	fullPath       string
 	recursive      bool
 	followSymlinks bool
-	appCtx         *context.Context
+	appCtx         context.Context
 	// a generic function to notify that a new stored object has been enumerated
 	incrementEnumerationCounter enumerationCounterFunc
 }
@@ -391,11 +391,7 @@ func (t *localTraverser) Traverse(preprocessor objectMorpher, processor objectPr
 			}
 
 			// note: Walk includes root, so no need here to separately create StoredObject for root (as we do for other folder-aware sources)
-			if t.appCtx != nil {
-				return WalkWithSymlinks(*t.appCtx, t.fullPath, processFile, t.followSymlinks)
-			} else {
-				return WalkWithSymlinks(context.TODO(), t.fullPath, processFile, t.followSymlinks)
-			}
+			return WalkWithSymlinks(t.appCtx, t.fullPath, processFile, t.followSymlinks)
 		} else {
 			// if recursive is off, we only need to scan the files immediately under the fullPath
 			// We don't transfer any directory properties here, not even the root. (Because the root's
@@ -473,7 +469,7 @@ func (t *localTraverser) Traverse(preprocessor objectMorpher, processor objectPr
 	return
 }
 
-func newLocalTraverser(ctx *context.Context, fullPath string, recursive bool, followSymlinks bool, incrementEnumerationCounter enumerationCounterFunc) *localTraverser {
+func newLocalTraverser(ctx context.Context, fullPath string, recursive bool, followSymlinks bool, incrementEnumerationCounter enumerationCounterFunc) *localTraverser {
 	traverser := localTraverser{
 		fullPath:                    cleanLocalPath(fullPath),
 		recursive:                   recursive,

--- a/cmd/zt_generic_service_traverser_test.go
+++ b/cmd/zt_generic_service_traverser_test.go
@@ -56,7 +56,7 @@ func (s *genericTraverserSuite) TestBlobFSServiceTraverserWithManyObjects(c *chk
 	scenarioHelper{}.generateLocalFilesFromList(c, dstDirName, objectList)
 
 	// Create a local traversal
-	localTraverser := newLocalTraverser(dstDirName, true, true, func(common.EntityType) {})
+	localTraverser := newLocalTraverser(nil, dstDirName, true, true, func(common.EntityType) {})
 
 	// Invoke the traversal with an indexer so the results are indexed for easy validation
 	localIndexer := newObjectIndexer()
@@ -172,7 +172,7 @@ func (s *genericTraverserSuite) TestServiceTraverserWithManyObjects(c *chk.C) {
 	scenarioHelper{}.generateLocalFilesFromList(c, dstDirName, objectList)
 
 	// Create a local traversal
-	localTraverser := newLocalTraverser(dstDirName, true, true, func(common.EntityType) {})
+	localTraverser := newLocalTraverser(nil, dstDirName, true, true, func(common.EntityType) {})
 
 	// Invoke the traversal with an indexer so the results are indexed for easy validation
 	localIndexer := newObjectIndexer()
@@ -357,7 +357,7 @@ func (s *genericTraverserSuite) TestServiceTraverserWithWildcards(c *chk.C) {
 	scenarioHelper{}.generateLocalFilesFromList(c, dstDirName, objectList)
 
 	// Create a local traversal
-	localTraverser := newLocalTraverser(dstDirName, true, true, func(common.EntityType) {})
+	localTraverser := newLocalTraverser(nil, dstDirName, true, true, func(common.EntityType) {})
 
 	// Invoke the traversal with an indexer so the results are indexed for easy validation
 	localIndexer := newObjectIndexer()

--- a/cmd/zt_generic_service_traverser_test.go
+++ b/cmd/zt_generic_service_traverser_test.go
@@ -56,7 +56,7 @@ func (s *genericTraverserSuite) TestBlobFSServiceTraverserWithManyObjects(c *chk
 	scenarioHelper{}.generateLocalFilesFromList(c, dstDirName, objectList)
 
 	// Create a local traversal
-	localTraverser := newLocalTraverser(nil, dstDirName, true, true, func(common.EntityType) {})
+	localTraverser := newLocalTraverser(context.TODO(), dstDirName, true, true, func(common.EntityType) {})
 
 	// Invoke the traversal with an indexer so the results are indexed for easy validation
 	localIndexer := newObjectIndexer()
@@ -172,7 +172,7 @@ func (s *genericTraverserSuite) TestServiceTraverserWithManyObjects(c *chk.C) {
 	scenarioHelper{}.generateLocalFilesFromList(c, dstDirName, objectList)
 
 	// Create a local traversal
-	localTraverser := newLocalTraverser(nil, dstDirName, true, true, func(common.EntityType) {})
+	localTraverser := newLocalTraverser(context.TODO(), dstDirName, true, true, func(common.EntityType) {})
 
 	// Invoke the traversal with an indexer so the results are indexed for easy validation
 	localIndexer := newObjectIndexer()
@@ -357,7 +357,7 @@ func (s *genericTraverserSuite) TestServiceTraverserWithWildcards(c *chk.C) {
 	scenarioHelper{}.generateLocalFilesFromList(c, dstDirName, objectList)
 
 	// Create a local traversal
-	localTraverser := newLocalTraverser(nil, dstDirName, true, true, func(common.EntityType) {})
+	localTraverser := newLocalTraverser(context.TODO(), dstDirName, true, true, func(common.EntityType) {})
 
 	// Invoke the traversal with an indexer so the results are indexed for easy validation
 	localIndexer := newObjectIndexer()

--- a/cmd/zt_generic_traverser_test.go
+++ b/cmd/zt_generic_traverser_test.go
@@ -261,7 +261,7 @@ func (s *genericTraverserSuite) TestWalkWithSymlinks_ToFolder(c *chk.C) {
 
 	fileCount := 0
 	sawLinkTargetDir := false
-	c.Assert(WalkWithSymlinks(nil, tmpDir, func(path string, fi os.FileInfo, err error) error {
+	c.Assert(WalkWithSymlinks(context.TODO(), tmpDir, func(path string, fi os.FileInfo, err error) error {
 		c.Assert(err, chk.IsNil)
 
 		if fi.IsDir() {
@@ -331,7 +331,7 @@ func (s *genericTraverserSuite) TestWalkWithSymlinksBreakLoop(c *chk.C) {
 	// Only 3 files should ever be found.
 	// This is because the symlink links back to the root dir
 	fileCount := 0
-	c.Assert(WalkWithSymlinks(nil, tmpDir, func(path string, fi os.FileInfo, err error) error {
+	c.Assert(WalkWithSymlinks(context.TODO(), tmpDir, func(path string, fi os.FileInfo, err error) error {
 		c.Assert(err, chk.IsNil)
 
 		if fi.IsDir() {
@@ -361,7 +361,7 @@ func (s *genericTraverserSuite) TestWalkWithSymlinksDedupe(c *chk.C) {
 	// Only 6 files should ever be found.
 	// 3 in the root dir, 3 in subdir, then symlinkdir should be ignored because it's been seen.
 	fileCount := 0
-	c.Assert(WalkWithSymlinks(nil, tmpDir, func(path string, fi os.FileInfo, err error) error {
+	c.Assert(WalkWithSymlinks(context.TODO(), tmpDir, func(path string, fi os.FileInfo, err error) error {
 		c.Assert(err, chk.IsNil)
 
 		if fi.IsDir() {
@@ -392,7 +392,7 @@ func (s *genericTraverserSuite) TestWalkWithSymlinksMultitarget(c *chk.C) {
 	trySymlink(filepath.Join(tmpDir, "extradir"), filepath.Join(tmpDir, "linktolink"), c)
 
 	fileCount := 0
-	c.Assert(WalkWithSymlinks(nil, tmpDir, func(path string, fi os.FileInfo, err error) error {
+	c.Assert(WalkWithSymlinks(context.TODO(), tmpDir, func(path string, fi os.FileInfo, err error) error {
 		c.Assert(err, chk.IsNil)
 
 		if fi.IsDir() {
@@ -425,7 +425,7 @@ func (s *genericTraverserSuite) TestWalkWithSymlinksToParentAndChild(c *chk.C) {
 	trySymlink(child, filepath.Join(root1, "tochild"), c)
 
 	fileCount := 0
-	c.Assert(WalkWithSymlinks(nil, root1, func(path string, fi os.FileInfo, err error) error {
+	c.Assert(WalkWithSymlinks(context.TODO(), root1, func(path string, fi os.FileInfo, err error) error {
 		c.Assert(err, chk.IsNil)
 
 		if fi.IsDir() {

--- a/cmd/zt_generic_traverser_test.go
+++ b/cmd/zt_generic_traverser_test.go
@@ -261,7 +261,7 @@ func (s *genericTraverserSuite) TestWalkWithSymlinks_ToFolder(c *chk.C) {
 
 	fileCount := 0
 	sawLinkTargetDir := false
-	c.Assert(WalkWithSymlinks(tmpDir, func(path string, fi os.FileInfo, err error) error {
+	c.Assert(WalkWithSymlinks(nil, tmpDir, func(path string, fi os.FileInfo, err error) error {
 		c.Assert(err, chk.IsNil)
 
 		if fi.IsDir() {
@@ -331,7 +331,7 @@ func (s *genericTraverserSuite) TestWalkWithSymlinksBreakLoop(c *chk.C) {
 	// Only 3 files should ever be found.
 	// This is because the symlink links back to the root dir
 	fileCount := 0
-	c.Assert(WalkWithSymlinks(tmpDir, func(path string, fi os.FileInfo, err error) error {
+	c.Assert(WalkWithSymlinks(nil, tmpDir, func(path string, fi os.FileInfo, err error) error {
 		c.Assert(err, chk.IsNil)
 
 		if fi.IsDir() {
@@ -361,7 +361,7 @@ func (s *genericTraverserSuite) TestWalkWithSymlinksDedupe(c *chk.C) {
 	// Only 6 files should ever be found.
 	// 3 in the root dir, 3 in subdir, then symlinkdir should be ignored because it's been seen.
 	fileCount := 0
-	c.Assert(WalkWithSymlinks(tmpDir, func(path string, fi os.FileInfo, err error) error {
+	c.Assert(WalkWithSymlinks(nil, tmpDir, func(path string, fi os.FileInfo, err error) error {
 		c.Assert(err, chk.IsNil)
 
 		if fi.IsDir() {
@@ -392,7 +392,7 @@ func (s *genericTraverserSuite) TestWalkWithSymlinksMultitarget(c *chk.C) {
 	trySymlink(filepath.Join(tmpDir, "extradir"), filepath.Join(tmpDir, "linktolink"), c)
 
 	fileCount := 0
-	c.Assert(WalkWithSymlinks(tmpDir, func(path string, fi os.FileInfo, err error) error {
+	c.Assert(WalkWithSymlinks(nil, tmpDir, func(path string, fi os.FileInfo, err error) error {
 		c.Assert(err, chk.IsNil)
 
 		if fi.IsDir() {
@@ -425,7 +425,7 @@ func (s *genericTraverserSuite) TestWalkWithSymlinksToParentAndChild(c *chk.C) {
 	trySymlink(child, filepath.Join(root1, "tochild"), c)
 
 	fileCount := 0
-	c.Assert(WalkWithSymlinks(root1, func(path string, fi os.FileInfo, err error) error {
+	c.Assert(WalkWithSymlinks(nil, root1, func(path string, fi os.FileInfo, err error) error {
 		c.Assert(err, chk.IsNil)
 
 		if fi.IsDir() {
@@ -484,7 +484,7 @@ func (s *genericTraverserSuite) TestTraverserWithSingleObject(c *chk.C) {
 		scenarioHelper{}.generateLocalFilesFromList(c, dstDirName, blobList)
 
 		// construct a local traverser
-		localTraverser := newLocalTraverser(filepath.Join(dstDirName, dstFileName), false, false, func(common.EntityType) {})
+		localTraverser := newLocalTraverser(nil, filepath.Join(dstDirName, dstFileName), false, false, func(common.EntityType) {})
 
 		// invoke the local traversal with a dummy processor
 		localDummyProcessor := dummyProcessor{}
@@ -645,7 +645,7 @@ func (s *genericTraverserSuite) TestTraverserContainerAndLocalDirectory(c *chk.C
 	// test two scenarios, either recursive or not
 	for _, isRecursiveOn := range []bool{true, false} {
 		// construct a local traverser
-		localTraverser := newLocalTraverser(dstDirName, isRecursiveOn, false, func(common.EntityType) {})
+		localTraverser := newLocalTraverser(nil, dstDirName, isRecursiveOn, false, func(common.EntityType) {})
 
 		// invoke the local traversal with an indexer
 		// so that the results are indexed for easy validation
@@ -807,7 +807,7 @@ func (s *genericTraverserSuite) TestTraverserWithVirtualAndLocalDirectory(c *chk
 	// test two scenarios, either recursive or not
 	for _, isRecursiveOn := range []bool{true, false} {
 		// construct a local traverser
-		localTraverser := newLocalTraverser(filepath.Join(dstDirName, virDirName), isRecursiveOn, false, func(common.EntityType) {})
+		localTraverser := newLocalTraverser(nil, filepath.Join(dstDirName, virDirName), isRecursiveOn, false, func(common.EntityType) {})
 
 		// invoke the local traversal with an indexer
 		// so that the results are indexed for easy validation

--- a/cmd/zt_generic_traverser_test.go
+++ b/cmd/zt_generic_traverser_test.go
@@ -484,7 +484,7 @@ func (s *genericTraverserSuite) TestTraverserWithSingleObject(c *chk.C) {
 		scenarioHelper{}.generateLocalFilesFromList(c, dstDirName, blobList)
 
 		// construct a local traverser
-		localTraverser := newLocalTraverser(nil, filepath.Join(dstDirName, dstFileName), false, false, func(common.EntityType) {})
+		localTraverser := newLocalTraverser(context.TODO(), filepath.Join(dstDirName, dstFileName), false, false, func(common.EntityType) {})
 
 		// invoke the local traversal with a dummy processor
 		localDummyProcessor := dummyProcessor{}
@@ -645,7 +645,7 @@ func (s *genericTraverserSuite) TestTraverserContainerAndLocalDirectory(c *chk.C
 	// test two scenarios, either recursive or not
 	for _, isRecursiveOn := range []bool{true, false} {
 		// construct a local traverser
-		localTraverser := newLocalTraverser(nil, dstDirName, isRecursiveOn, false, func(common.EntityType) {})
+		localTraverser := newLocalTraverser(context.TODO(), dstDirName, isRecursiveOn, false, func(common.EntityType) {})
 
 		// invoke the local traversal with an indexer
 		// so that the results are indexed for easy validation
@@ -807,7 +807,7 @@ func (s *genericTraverserSuite) TestTraverserWithVirtualAndLocalDirectory(c *chk
 	// test two scenarios, either recursive or not
 	for _, isRecursiveOn := range []bool{true, false} {
 		// construct a local traverser
-		localTraverser := newLocalTraverser(nil, filepath.Join(dstDirName, virDirName), isRecursiveOn, false, func(common.EntityType) {})
+		localTraverser := newLocalTraverser(context.TODO(), filepath.Join(dstDirName, virDirName), isRecursiveOn, false, func(common.EntityType) {})
 
 		// invoke the local traversal with an indexer
 		// so that the results are indexed for easy validation

--- a/common/logger.go
+++ b/common/logger.go
@@ -47,6 +47,7 @@ type ILoggerCloser interface {
 type ILoggerResetable interface {
 	OpenLog()
 	MinimumLogLevel() pipeline.LogLevel
+	ChangeLogLevel(pipeline.LogLevel)
 	ILoggerCloser
 }
 
@@ -156,6 +157,16 @@ func (jl *jobLogger) ShouldLog(level pipeline.LogLevel) bool {
 		return false
 	}
 	return level <= jl.minimumLevelToLog
+}
+
+// This update is not necessarily safe from multiple goroutines simultaneously calling it.
+// Typically we will call ChangeLogLevel() once at the beginning so it should be ok.
+func (jl *jobLogger) ChangeLogLevel(level pipeline.LogLevel) {
+	if level == pipeline.LogNone {
+		return
+	}
+	jl.minimumLevelToLog = level
+	return
 }
 
 func (jl *jobLogger) CloseLog() {

--- a/common/logger.go
+++ b/common/logger.go
@@ -36,6 +36,7 @@ import (
 type ILogger interface {
 	ShouldLog(level pipeline.LogLevel) bool
 	Log(level pipeline.LogLevel, msg string)
+	ChangeLogLevel(pipeline.LogLevel)
 	Panic(err error)
 }
 
@@ -47,7 +48,6 @@ type ILoggerCloser interface {
 type ILoggerResetable interface {
 	OpenLog()
 	MinimumLogLevel() pipeline.LogLevel
-	ChangeLogLevel(pipeline.LogLevel)
 	ILoggerCloser
 }
 
@@ -94,6 +94,15 @@ func (al *appLogger) Log(loglevel pipeline.LogLevel, msg string) {
 	// if al.ShouldLog(loglevel) {
 	//	al.logger.Println(msg)
 	// }
+}
+
+func (al *appLogger) ChangeLogLevel(level pipeline.LogLevel) {
+	// TODO consider delete completely to get rid of app logger
+	// if level == pipeline.LogNone {
+	// 	return
+	// }
+	// al.minimumLevelToLog = level
+	// return
 }
 
 func (al *appLogger) Panic(err error) {

--- a/common/parallel/FileSystemCrawler.go
+++ b/common/parallel/FileSystemCrawler.go
@@ -98,11 +98,8 @@ func Walk(appCtx context.Context, root string, parallelism int, parallelStat boo
 	// walk the stuff inside the root
 	reader, remainingParallelism := NewDirReader(parallelism, parallelStat)
 	defer reader.Close()
-	if appCtx != nil {
-		ctx, cancel = context.WithCancel(appCtx)
-	} else {
-		ctx, cancel = context.WithCancel(context.Background())
-	}
+
+	ctx, cancel = context.WithCancel(appCtx)
 	ch := CrawlLocalDirectory(ctx, root, remainingParallelism, reader)
 	for crawlResult := range ch {
 		entry, err := crawlResult.Item()

--- a/common/parallel/zt_FileSystemCrawlerTest_test.go
+++ b/common/parallel/zt_FileSystemCrawlerTest_test.go
@@ -22,12 +22,13 @@ package parallel
 
 import (
 	"context"
-	chk "gopkg.in/check.v1"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+
+	chk "gopkg.in/check.v1"
 )
 
 // Hookup to the testing framework
@@ -61,7 +62,7 @@ func (s *fileSystemCrawlerSuite) TestParallelEnumerationFindsTheRightFiles(c *ch
 
 	// our parallel walk
 	parallelResults := make(map[string]struct{})
-	Walk(dir, 16, false, func(path string, _ os.FileInfo, fileErr error) error {
+	Walk(nil, dir, 16, false, func(path string, _ os.FileInfo, fileErr error) error {
 		if fileErr == nil {
 			parallelResults[path] = struct{}{}
 		}
@@ -122,7 +123,7 @@ func (s *fileSystemCrawlerSuite) doTestParallelEnumerationGetsTheRightFileInfo(p
 
 	// our parallel walk
 	parallelResults := make(map[string]os.FileInfo)
-	Walk(dir, 64, parallelStat, func(path string, fi os.FileInfo, fileErr error) error {
+	Walk(nil, dir, 64, parallelStat, func(path string, fi os.FileInfo, fileErr error) error {
 		if fileErr == nil {
 			parallelResults[path] = fi
 		}
@@ -174,7 +175,7 @@ func (s *fileSystemCrawlerSuite) doTestParallelEnumerationGetsTheRightFileInfo(p
 func (s *fileSystemCrawlerSuite) TestRootErrorsAreSignalled(c *chk.C) {
 	receivedError := false
 	nonExistentDir := filepath.Join(os.TempDir(), "Big random-named directory that almost certainly doesn't exist 85784362628398473732827384")
-	Walk(nonExistentDir, 16, false, func(path string, _ os.FileInfo, fileErr error) error {
+	Walk(nil, nonExistentDir, 16, false, func(path string, _ os.FileInfo, fileErr error) error {
 		if fileErr != nil && path == nonExistentDir {
 			receivedError = true
 		}

--- a/common/parallel/zt_FileSystemCrawlerTest_test.go
+++ b/common/parallel/zt_FileSystemCrawlerTest_test.go
@@ -62,7 +62,7 @@ func (s *fileSystemCrawlerSuite) TestParallelEnumerationFindsTheRightFiles(c *ch
 
 	// our parallel walk
 	parallelResults := make(map[string]struct{})
-	Walk(nil, dir, 16, false, func(path string, _ os.FileInfo, fileErr error) error {
+	Walk(context.TODO(), dir, 16, false, func(path string, _ os.FileInfo, fileErr error) error {
 		if fileErr == nil {
 			parallelResults[path] = struct{}{}
 		}
@@ -123,7 +123,7 @@ func (s *fileSystemCrawlerSuite) doTestParallelEnumerationGetsTheRightFileInfo(p
 
 	// our parallel walk
 	parallelResults := make(map[string]os.FileInfo)
-	Walk(nil, dir, 64, parallelStat, func(path string, fi os.FileInfo, fileErr error) error {
+	Walk(context.TODO(), dir, 64, parallelStat, func(path string, fi os.FileInfo, fileErr error) error {
 		if fileErr == nil {
 			parallelResults[path] = fi
 		}
@@ -175,7 +175,7 @@ func (s *fileSystemCrawlerSuite) doTestParallelEnumerationGetsTheRightFileInfo(p
 func (s *fileSystemCrawlerSuite) TestRootErrorsAreSignalled(c *chk.C) {
 	receivedError := false
 	nonExistentDir := filepath.Join(os.TempDir(), "Big random-named directory that almost certainly doesn't exist 85784362628398473732827384")
-	Walk(nil, nonExistentDir, 16, false, func(path string, _ os.FileInfo, fileErr error) error {
+	Walk(context.TODO(), nonExistentDir, 16, false, func(path string, _ os.FileInfo, fileErr error) error {
 		if fileErr != nil && path == nonExistentDir {
 			receivedError = true
 		}

--- a/jobsAdmin/JobsAdmin.go
+++ b/jobsAdmin/JobsAdmin.go
@@ -328,7 +328,7 @@ func (ja *jobsAdmin) ResurrectJob(jobId common.JobID, sourceSAS string, destinat
 	files := func(prefix, ext string) []os.FileInfo {
 		var files []os.FileInfo
 		filepath.Walk(ja.planDir, func(path string, fileInfo os.FileInfo, _ error) error {
-			if !fileInfo.IsDir() && fileInfo.Size() != 0 && strings.HasPrefix(fileInfo.Name(), prefix) && strings.HasSuffix(fileInfo.Name(), ext) {
+			if fileInfo != nil && !fileInfo.IsDir() && fileInfo.Size() != 0 && strings.HasPrefix(fileInfo.Name(), prefix) && strings.HasSuffix(fileInfo.Name(), ext) {
 				files = append(files, fileInfo)
 			}
 			return nil

--- a/jobsAdmin/JobsAdmin.go
+++ b/jobsAdmin/JobsAdmin.go
@@ -473,6 +473,17 @@ func (ja *jobsAdmin) LogToJobLog(msg string, level pipeline.LogLevel) {
 	ja.jobLogger.Log(pipeline.LogWarning, prefix+msg) // use LogError here, so that it forces these to get logged, even if user is running at warning level instead of Info.  They won't have "warning" prefix, if Info level was passed in to MessagesForJobLog
 }
 
+func (ja *jobsAdmin) ChangeLogLevel(level pipeline.LogLevel, jobId common.JobID) error {
+	jm, found := ja.jobIDToJobMgr.Get(jobId)
+	if !found {
+		err := fmt.Errorf("No JobMgr found with this JobId(%s)", jobId.String())
+		return err
+	} else {
+		jm.ChangeLogLevel(level)
+		return nil
+	}
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 func (ja *jobsAdmin) TryGetPerformanceAdvice(bytesInJob uint64, filesInJob uint32, fromTo common.FromTo, dir common.TransferDirection, p *ste.PipelineNetworkStats) []common.PerformanceAdvice {

--- a/jobsAdmin/JobsAdmin.go
+++ b/jobsAdmin/JobsAdmin.go
@@ -438,6 +438,7 @@ func (ja *jobsAdmin) DeleteJob(jobID common.JobID) {
 */
 func (ja *jobsAdmin) ShouldLog(level pipeline.LogLevel) bool  { return ja.logger.ShouldLog(level) }
 func (ja *jobsAdmin) Log(level pipeline.LogLevel, msg string) { ja.logger.Log(level, msg) }
+func (ja *jobsAdmin) ChangeLogLevel(level pipeline.LogLevel)  { ja.logger.ChangeLogLevel(level) }
 func (ja *jobsAdmin) Panic(err error)                         { ja.logger.Panic(err) }
 func (ja *jobsAdmin) CloseLog()                               { ja.logger.CloseLog() }
 
@@ -471,17 +472,6 @@ func (ja *jobsAdmin) LogToJobLog(msg string, level pipeline.LogLevel) {
 		prefix = fmt.Sprintf("%s: ", common.LogLevel(level)) // so readers can find serious ones, but information ones still look uncluttered without INFO:
 	}
 	ja.jobLogger.Log(pipeline.LogWarning, prefix+msg) // use LogError here, so that it forces these to get logged, even if user is running at warning level instead of Info.  They won't have "warning" prefix, if Info level was passed in to MessagesForJobLog
-}
-
-func (ja *jobsAdmin) ChangeLogLevel(level pipeline.LogLevel, jobId common.JobID) error {
-	jm, found := ja.jobIDToJobMgr.Get(jobId)
-	if !found {
-		err := fmt.Errorf("No JobMgr found with this JobId(%s)", jobId.String())
-		return err
-	} else {
-		jm.ChangeLogLevel(level)
-		return nil
-	}
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -102,11 +102,6 @@ type IJobMgr interface {
 	CancelPauseJobOrder(desiredJobStatus common.JobStatus) common.CancelPauseResumeResponse
 	IsDaemon() bool
 	ChangeLogLevel(pipeline.LogLevel)
-
-	// Cleanup Functions
-	DeferredCleanupJobMgr()
-	CleanupJobStatusMgr()
-
 }
 
 // //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -101,6 +101,12 @@ type IJobMgr interface {
 	SuccessfulBytesInActiveFiles() uint64
 	CancelPauseJobOrder(desiredJobStatus common.JobStatus) common.CancelPauseResumeResponse
 	IsDaemon() bool
+	ChangeLogLevel(pipeline.LogLevel)
+
+	// Cleanup Functions
+	DeferredCleanupJobMgr()
+	CleanupJobStatusMgr()
+
 }
 
 // //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -190,6 +196,12 @@ func NewJobMgr(concurrency ConcurrencySettings, jobID common.JobID, appCtx conte
 	go jm.handleStatusUpdateMessage()
 
 	return &jm
+}
+
+func (jm *jobMgr) ChangeLogLevel(level pipeline.LogLevel) {
+	if jm.logger != nil {
+		jm.logger.ChangeLogLevel(level)
+	}
 }
 
 func (jm *jobMgr) getOverwritePrompter() *overwritePrompter {

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -897,6 +897,7 @@ func (jpm *jobPartMgr) ReleaseAConnection() {
 
 func (jpm *jobPartMgr) ShouldLog(level pipeline.LogLevel) bool  { return jpm.jobMgr.ShouldLog(level) }
 func (jpm *jobPartMgr) Log(level pipeline.LogLevel, msg string) { jpm.jobMgr.Log(level, msg) }
+func (jpm *jobPartMgr) ChangeLogLevel(level pipeline.LogLevel) { jpm.jobMgr.ChangeLogLevel(level) }
 func (jpm *jobPartMgr) Panic(err error)                         { jpm.jobMgr.Panic(err) }
 func (jpm *jobPartMgr) ChunkStatusLogger() common.ChunkStatusLogger {
 	return jpm.jobMgr.ChunkStatusLogger()

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -816,6 +816,10 @@ func (jptm *jobPartTransferMgr) Log(level pipeline.LogLevel, msg string) {
 	jptm.jobPartMgr.Log(level, fmt.Sprintf("%s: [P#%d-T#%d] ", common.LogLevel(level), plan.PartNum, jptm.transferIndex)+msg)
 }
 
+func (jptm *jobPartTransferMgr) ChangeLogLevel(level pipeline.LogLevel) {
+	jptm.jobPartMgr.ChangeLogLevel(level)
+}
+
 func (jptm *jobPartTransferMgr) ErrorCodeAndString(err error) (int, string) {
 	switch e := err.(type) {
 	case azblob.StorageError:


### PR DESCRIPTION
Refer to:
[Added the support to change the log level.](https://github.com/Azure/azure-storage-azcopy/pull/1745/commits/75129a5e3e8cfbe515d313ca2e27570573710a13) [75129a5](https://github.com/Azure/azure-storage-azcopy/pull/1745/commits/75129a5e3e8cfbe515d313ca2e27570573710a13)

[This patch for enabling calling app to cancel enumeration.](https://github.com/Azure/azure-storage-azcopy/pull/1745/commits/369828c7850c6684e752e7567aff0339295a2508) [369828c](https://github.com/Azure/azure-storage-azcopy/pull/1745/commits/369828c7850c6684e752e7567aff0339295a2508)

- Used appCtx in parallel-walk so that the app can cancel the
 enumeration as it requires.
- It doesn't effect azcopy working.

A new PR has been created in order to make the changes more modular, and easily reviewable.