### PR TITLE
Job Manager changes

### DIFF
--- a/common/logger.go
+++ b/common/logger.go
@@ -47,6 +47,7 @@ type ILoggerCloser interface {
 type ILoggerResetable interface {
 	OpenLog()
 	MinimumLogLevel() pipeline.LogLevel
+	ChangeLogLevel(pipeline.LogLevel)
 	ILoggerCloser
 }
 
@@ -156,6 +157,16 @@ func (jl *jobLogger) ShouldLog(level pipeline.LogLevel) bool {
 		return false
 	}
 	return level <= jl.minimumLevelToLog
+}
+
+// This update is not necessarily safe from multiple goroutines simultaneously calling it.
+// Typically we will call ChangeLogLevel() once at the beginning so it should be ok.
+func (jl *jobLogger) ChangeLogLevel(level pipeline.LogLevel) {
+	if level == pipeline.LogNone {
+		return
+	}
+	jl.minimumLevelToLog = level
+	return
 }
 
 func (jl *jobLogger) CloseLog() {

--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -101,6 +101,11 @@ type IJobMgr interface {
 	SuccessfulBytesInActiveFiles() uint64
 	CancelPauseJobOrder(desiredJobStatus common.JobStatus) common.CancelPauseResumeResponse
 	IsDaemon() bool
+
+	ChangeLogLevel(pipeline.LogLevel)
+	// Cleanup Functions
+	DeferredCleanupJobMgr()
+	CleanupJobStatusMgr()
 }
 
 // //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -137,6 +142,12 @@ func NewJobMgr(concurrency ConcurrencySettings, jobID common.JobID, appCtx conte
 	jstm.listReq = make(chan bool)
 	jstm.partCreated = make(chan JobPartCreatedMsg, 100)
 	jstm.xferDone = make(chan xferDoneMsg, 1000)
+	jstm.done = make(chan struct{}, 1)
+	// Different logger for each job.
+	if jobLogger == nil {
+		jobLogger = common.NewJobLogger(jobID, common.ELogLevel.Debug(), logFileFolder, "" /* logFileNameSuffix */)
+		jobLogger.OpenLog()
+	}
 
 	jm := jobMgr{jobID: jobID, jobPartMgrs: newJobPartToJobPartMgr(), include: map[string]int{}, exclude: map[string]int{},
 		httpClient:           NewAzcopyHTTPClient(concurrency.MaxIdleConnections),
@@ -147,6 +158,7 @@ func NewJobMgr(concurrency ConcurrencySettings, jobID common.JobID, appCtx conte
 		pipelineNetworkStats: newPipelineNetworkStats(tuner), // let the stats coordinate with the concurrency tuner
 		initMu:               &sync.Mutex{},
 		jobPartProgress:      jobPartProgressCh,
+		reportCancelCh:       make(chan struct{}, 1),
 		coordinatorChannels: CoordinatorChannels{
 			partsChannel:     partsCh,
 			normalTransferCh: normalTransferCh,
@@ -158,12 +170,15 @@ func NewJobMgr(concurrency ConcurrencySettings, jobID common.JobID, appCtx conte
 			lowTransferCh:    lowTransferCh,
 			normalChunckCh:   normalChunkCh,
 			lowChunkCh:       lowChunkCh,
+			closeTransferCh:  make(chan struct{}, 100),
+			scheduleCloseCh:  make(chan struct{}, 1),
 		},
 		poolSizingChannels: poolSizingChannels{ // all deliberately unbuffered, because pool sizer routine works in lock-step with these - processing them as they happen, never catching up on populated buffer later
 			entryNotificationCh: make(chan struct{}),
 			exitNotificationCh:  make(chan struct{}),
 			scalebackRequestCh:  make(chan struct{}),
 			requestSlowTuneCh:   make(chan struct{}),
+			done:                make(chan struct{}, 1),
 		},
 		concurrencyTuner: tuner,
 		pacer:            pacer,
@@ -190,6 +205,12 @@ func NewJobMgr(concurrency ConcurrencySettings, jobID common.JobID, appCtx conte
 	go jm.handleStatusUpdateMessage()
 
 	return &jm
+}
+
+func (jm *jobMgr) ChangeLogLevel(level pipeline.LogLevel) {
+	if jm.logger != nil {
+		jm.logger.ChangeLogLevel(level)
+	}
 }
 
 func (jm *jobMgr) getOverwritePrompter() *overwritePrompter {
@@ -288,6 +309,10 @@ type jobMgr struct {
 	httpClient *http.Client
 
 	jobPartMgrs jobPartToJobPartMgr // The map of part #s to JobPartMgrs
+
+	// reportCancelCh to close the report thread.
+	reportCancelCh chan struct{}
+
 	// partsDone keep the count of completed part of the Job.
 	partsDone uint32
 	// throughput  common.CountPerSecond // TODO: Set LastCheckedTime to now
@@ -586,52 +611,68 @@ func (jm *jobMgr) reportJobPartDoneHandler() {
 	shouldLog := jm.ShouldLog(pipeline.LogInfo)
 
 	for {
-		partProgressInfo := <-jm.jobPartProgress
-		jobPart0Mgr, ok := jm.jobPartMgrs.Get(0)
-		if !ok {
-			jm.Panic(fmt.Errorf("Failed to find Job %v, Part #0", jm.jobID))
-		}
-		part0Plan := jobPart0Mgr.Plan()
-		jobStatus := part0Plan.JobStatus() // status of part 0 is status of job as a whole
-		partsDone := atomic.AddUint32(&jm.partsDone, 1)
-		jobProgressInfo.transfersCompleted += partProgressInfo.transfersCompleted
-		jobProgressInfo.transfersSkipped += partProgressInfo.transfersSkipped
-		jobProgressInfo.transfersFailed += partProgressInfo.transfersFailed
-
-		if partProgressInfo.completionChan != nil {
-			close(partProgressInfo.completionChan)
-		}
-
-		// If the last part is still awaited or other parts all still not complete,
-		// JobPart 0 status is not changed (unless we are cancelling)
-		haveFinalPart = atomic.LoadInt32(&jm.atomicFinalPartOrderedIndicator) == 1
-		allKnownPartsDone := partsDone == jm.jobPartMgrs.Count()
-		isCancelling := jobStatus == common.EJobStatus.Cancelling()
-		shouldComplete := allKnownPartsDone && (haveFinalPart || isCancelling)
-		if shouldComplete {
-			partDescription := "all parts of entire Job"
-			if !haveFinalPart {
-				partDescription = "known parts of incomplete Job"
-			}
-			if shouldLog {
-				jm.Log(pipeline.LogInfo, fmt.Sprintf("%s %s successfully completed, cancelled or paused", partDescription, jm.jobID.String()))
-			}
-
-			switch part0Plan.JobStatus() {
-			case common.EJobStatus.Cancelling():
-				part0Plan.SetJobStatus(common.EJobStatus.Cancelled())
-				if shouldLog {
-					jm.Log(pipeline.LogInfo, fmt.Sprintf("%s %v successfully cancelled", partDescription, jm.jobID))
+		select {
+		case <-jm.reportCancelCh:
+			jobPart0Mgr, ok := jm.jobPartMgrs.Get(0)
+			if ok {
+				part0plan := jobPart0Mgr.Plan()
+				if part0plan.JobStatus() == common.EJobStatus.InProgress() ||
+					part0plan.JobStatus() == common.EJobStatus.Cancelling() {
+					jm.Panic(fmt.Errorf("reportCancelCh received cancel event while job still not completed, Job(%s) in state: %s",
+						jm.jobID.String(), part0plan.JobStatus()))
 				}
-			case common.EJobStatus.InProgress():
-				part0Plan.SetJobStatus((common.EJobStatus).EnhanceJobStatusInfo(jobProgressInfo.transfersSkipped > 0,
-					jobProgressInfo.transfersFailed > 0,
-					jobProgressInfo.transfersCompleted > 0))
+			} else {
+				jm.Log(pipeline.LogError, "part0Plan of job invalid")
+			}
+			jm.Log(pipeline.LogInfo, "reportJobPartDoneHandler done called")
+			return
+
+		case partProgressInfo := <-jm.jobPartProgress:
+			jobPart0Mgr, ok := jm.jobPartMgrs.Get(0)
+			if !ok {
+				jm.Panic(fmt.Errorf("Failed to find Job %v, Part #0", jm.jobID))
+			}
+			part0Plan := jobPart0Mgr.Plan()
+			jobStatus := part0Plan.JobStatus() // status of part 0 is status of job as a whole
+			partsDone := atomic.AddUint32(&jm.partsDone, 1)
+			jobProgressInfo.transfersCompleted += partProgressInfo.transfersCompleted
+			jobProgressInfo.transfersSkipped += partProgressInfo.transfersSkipped
+			jobProgressInfo.transfersFailed += partProgressInfo.transfersFailed
+
+			if partProgressInfo.completionChan != nil {
+				close(partProgressInfo.completionChan)
 			}
 
-			// reset counters
-			atomic.StoreUint32(&jm.partsDone, 0)
-			jobProgressInfo = jobPartProgressInfo{}
+			// If the last part is still awaited or other parts all still not complete,
+			// JobPart 0 status is not changed (unless we are cancelling)
+			haveFinalPart = atomic.LoadInt32(&jm.atomicFinalPartOrderedIndicator) == 1
+			allKnownPartsDone := partsDone == jm.jobPartMgrs.Count()
+			isCancelling := jobStatus == common.EJobStatus.Cancelling()
+			shouldComplete := allKnownPartsDone && (haveFinalPart || isCancelling)
+			if shouldComplete {
+				partDescription := "all parts of entire Job"
+				if !haveFinalPart {
+					partDescription = "known parts of incomplete Job"
+				}
+				if shouldLog {
+					jm.Log(pipeline.LogInfo, fmt.Sprintf("%s %s successfully completed, cancelled or paused", partDescription, jm.jobID.String()))
+				}
+
+				switch part0Plan.JobStatus() {
+				case common.EJobStatus.Cancelling():
+					part0Plan.SetJobStatus(common.EJobStatus.Cancelled())
+					if shouldLog {
+						jm.Log(pipeline.LogInfo, fmt.Sprintf("%s %v successfully cancelled", partDescription, jm.jobID))
+					}
+				case common.EJobStatus.InProgress():
+					part0Plan.SetJobStatus((common.EJobStatus).EnhanceJobStatusInfo(jobProgressInfo.transfersSkipped > 0,
+						jobProgressInfo.transfersFailed > 0,
+						jobProgressInfo.transfersCompleted > 0))
+				}
+
+				// reset counters
+				atomic.StoreUint32(&jm.partsDone, 0)
+				jobProgressInfo = jobPartProgressInfo{}
 
 			// flush logs
 			jm.chunkStatusLogger.FlushLog() // TODO: remove once we sort out what will be calling CloseLog (currently nothing)
@@ -640,8 +681,9 @@ func (jm *jobMgr) reportJobPartDoneHandler() {
 			}
 		} // Else log and wait for next part to complete
 
-		if shouldLog {
-			jm.Log(pipeline.LogInfo, fmt.Sprintf("is part of Job which %d total number of parts done ", partsDone))
+			if shouldLog {
+				jm.Log(pipeline.LogInfo, fmt.Sprintf("is part of Job which %d total number of parts done ", partsDone))
+			}
 		}
 	}
 }
@@ -672,8 +714,70 @@ func (jm *jobMgr) CloseLog() {
 	jm.chunkStatusLogger.FlushLog()
 }
 
+// DeferredCleanupJobMgr cleanup all the jobMgr resources.
+// Warning: DeferredCleanupJobMgr should be called from JobMgrCleanup().
+//          As this function neither threadsafe nor idempotient. So if DeferredCleanupJobMgr called
+//          mulitple times, it may stuck as receiving channel already closed. Where as JobMgrCleanup()
+//          safe in that sense it will do the cleanup only once.
+//
+// TODO: Add JobsAdmin reference to each JobMgr so that in any circumstances JobsAdmin should not freed,
+//       while jobMgr running. Whereas JobsAdmin store number JobMgr running  at any time.
+//       At that point DeferredCleanupJobMgr() will delete jobMgr from jobsAdmin map.
+func (jm *jobMgr) DeferredCleanupJobMgr() {
+	jm.Log(pipeline.LogInfo, "DeferredCleanupJobMgr called")
+
+	time.Sleep(60 * time.Second)
+
+	jm.Log(pipeline.LogInfo, "DeferredCleanupJobMgr out of sleep")
+
+	// Call jm.Cancel to signal routines workdone.
+	// This will take care of any jobPartMgr release.
+	jm.Cancel()
+
+	// Cleanup the JobStatusMgr go routine.
+	jm.CleanupJobStatusMgr()
+
+	// Transfer Thread Cleanup.
+	jm.cleanupTransferRoutine()
+
+	// Remove JobPartsMgr from jobPartMgr kv.
+	jm.deleteJobPartsMgrs()
+
+	// Close chunk status logger.
+	jm.cleanupChunkStatusLogger()
+	jm.Log(pipeline.LogInfo, "DeferredCleanupJobMgr Exit, Closing the log")
+
+	// Sleep for sometime so that all go routine done with cleanUp and log the progress in job log.
+	time.Sleep(60 * time.Second)
+
+	jm.logger.CloseLog()
+}
+
 func (jm *jobMgr) ChunkStatusLogger() common.ChunkStatusLogger {
 	return jm.chunkStatusLogger
+}
+
+func (jm *jobMgr) cleanupChunkStatusLogger() {
+	jm.chunkStatusLogger.FlushLog()
+	jm.chunkStatusLogger.CloseLogger()
+}
+
+// TODO: find a better way for JobsAdmin to log (it doesn't have direct access to the job log, because it was originally designed to support multiple jobs
+func (jm *jobMgr) logJobsAdminMessages() {
+	/*
+		for {
+			select {
+			case msg := <-jobsAdmin.JobsAdmin.MessagesForJobLog():
+				prefix := ""
+				if msg.LogLevel <= pipeline.LogWarning {
+					prefix = fmt.Sprintf("%s: ", common.LogLevel(msg.LogLevel)) // so readers can find serious ones, but information ones still look uncluttered without INFO:
+				}
+				jm.Log(pipeline.LogWarning, prefix+msg.string) // use LogError here, so that it forces these to get logged, even if user is running at warning level instead of Info.  They won't have "warning" prefix, if Info level was passed in to MessagesForJobLog
+			default:
+				return
+			}
+		}
+	*/
 }
 
 // PartsDone returns the number of the Job's parts that are either completed or failed
@@ -697,6 +801,8 @@ type XferChannels struct {
 	lowTransferCh    <-chan IJobPartTransferMgr // Read-only
 	normalChunckCh   chan chunkFunc             // Read-write
 	lowChunkCh       chan chunkFunc             // Read-write
+	closeTransferCh  chan struct{}
+	scheduleCloseCh  chan struct{}
 }
 
 type poolSizingChannels struct {
@@ -704,6 +810,7 @@ type poolSizingChannels struct {
 	exitNotificationCh  chan struct{}
 	scalebackRequestCh  chan struct{}
 	requestSlowTuneCh   chan struct{}
+	done                chan struct{}
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -742,6 +849,26 @@ func (jm *jobMgr) ScheduleChunk(priority common.JobPriority, chunkFunc chunkFunc
 // its transfers will be scheduled
 func (jm *jobMgr) QueueJobParts(jpm IJobPartMgr) {
 	jm.coordinatorChannels.partsChannel <- jpm
+}
+
+// deleteJobPartsMgrs remove jobPartMgrs from jobPartToJobPartMgr kv.
+func (jm *jobMgr) deleteJobPartsMgrs() {
+	jm.Log(pipeline.LogInfo, "JobPartsMgrsDelete enter")
+	jm.jobPartMgrs.Iterate(false, func(k common.PartNumber, v IJobPartMgr) {
+		v.Close()
+		delete(jm.jobPartMgrs.m, k)
+	})
+	jm.Log(pipeline.LogInfo, "JobPartsMgrsDelete exit")
+}
+
+// cleanupTransferRoutine closes all the Transfer thread.
+// Note: Created the buffer channel so that, if somehow any thread missing(down), it should not stuck.
+func (jm *jobMgr) cleanupTransferRoutine() {
+	jm.reportCancelCh <- struct{}{}
+	jm.xferChannels.scheduleCloseCh <- struct{}{}
+	for cc := 0; cc < jm.concurrency.TransferInitiationPoolSize.Value; cc++ {
+		jm.xferChannels.closeTransferCh <- struct{}{}
+	}
 }
 
 // worker that sizes the chunkProcessor pool, dynamically if necessary
@@ -784,10 +911,15 @@ func (jm *jobMgr) poolSizer() {
 		} else if actualConcurrency > targetConcurrency {
 			hasHadTimeToStablize = false
 			jm.poolSizingChannels.scalebackRequestCh <- struct{}{}
+		} else if actualConcurrency == 0 && targetConcurrency == 0 {
+			jm.Log(pipeline.LogInfo, "Exits Pool sizer")
+			return
 		}
 
 		// wait for something to happen (maybe ack from the worker of the change, else a timer interval)
 		select {
+		case <-jm.poolSizingChannels.done:
+			targetConcurrency = 0
 		case <-jm.poolSizingChannels.entryNotificationCh:
 			// new worker has started
 			actualConcurrency++
@@ -802,7 +934,7 @@ func (jm *jobMgr) poolSizer() {
 			throughputMonitoringInterval = expandedMonitoringInterval
 			slowTuneCh = nil // so we won't keep running this case at the expense of others)
 		case <-time.After(throughputMonitoringInterval):
-			if actualConcurrency == targetConcurrency { // scalebacks can take time. Don't want to do any tuning if actual is not yet aligned to target
+			if targetConcurrency != 0 && actualConcurrency == targetConcurrency { // scalebacks can take time. Don't want to do any tuning if actual is not yet aligned to target
 				bytesOnWire := jm.pacer.GetTotalTraffic()
 				if hasHadTimeToStablize {
 					// throughput has had time to stabilize since last change, so we can meaningfully measure and act on throughput
@@ -840,15 +972,22 @@ func (jm *jobMgr) RequestTuneSlowly() {
 func (jm *jobMgr) scheduleJobParts() {
 	startedPoolSizer := false
 	for {
-		jobPart := <-jm.xferChannels.partsChannel
+		select {
+		case <-jm.xferChannels.scheduleCloseCh:
+			jm.Log(pipeline.LogInfo, "ScheduleJobParts done called")
+			jm.poolSizingChannels.done <- struct{}{}
+			return
 
-		if !startedPoolSizer {
-			// spin up a GR to co-ordinate dynamic sizing of the main pool
-			// It will automatically spin up the right number of chunk processors
-			go jm.poolSizer()
-			startedPoolSizer = true
+		case jobPart := <-jm.xferChannels.partsChannel:
+
+			if !startedPoolSizer {
+				// spin up a GR to co-ordinate dynamic sizing of the main pool
+				// It will automatically spin up the right number of chunk processors
+				go jm.poolSizer()
+				startedPoolSizer = true
+			}
+			jobPart.ScheduleTransfers(jm.Context())
 		}
-		jobPart.ScheduleTransfers(jm.Context())
 	}
 }
 
@@ -905,8 +1044,13 @@ func (jm *jobMgr) transferProcessor(workerID int) {
 	for {
 		// No scaleback check here, because this routine runs only in a small number of goroutines, so no need to kill them off
 		select {
+		case <-jm.xferChannels.closeTransferCh:
+			jm.Log(pipeline.LogInfo, "transferProcessor done called")
+			return
+
 		case jptm := <-jm.xferChannels.normalTransferCh:
 			startTransfer(jptm)
+
 		default:
 			select {
 			case jptm := <-jm.xferChannels.lowTransferCh:

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -877,6 +877,18 @@ func (jpm *jobPartMgr) Close() {
 	jpm.httpHeaders = common.ResourceHTTPHeaders{}
 	jpm.metadata = common.Metadata{}
 	jpm.preserveLastModifiedTime = false
+
+	/*
+	 * Set pipeline to nil, so that jpm/JobMgr can be GC'ed.
+	 *
+	 * TODO: We should not need to explicitly set this to nil but today we have a yet-unknown ref on pipeline which
+	 *       is leaking JobMgr memory, so we cause that to be freed by force dropping this ref.
+	 *
+	 * Note: Force setting this to nil can technically result in crashes since the containing object is still around,
+	 *       but we should be protected against that since we do this Close in a deferred manner, at least few minutes after the job completes.
+	 */
+	jpm.pipeline = nil
+
 	// TODO: Delete file?
 	/*if err := os.Remove(jpm.planFile.Name()); err != nil {
 		jpm.Panic(fmt.Errorf("error removing Job Part Plan file %s. Error=%v", jpm.planFile.Name(), err))


### PR DESCRIPTION
JobMgr Cleanup.

- Close all the go routines once job is done.

Fix for Report Handler routine cleanup.

Added the support to change the log level.

Memory Leak Fix.

- Set the nil to address allocated memory.

- Fixing some of memory issues.

- JobMgr is freed without setting channel to nil.