### PR TITLE
Introduce changes for job progress status and fix symlink

### DIFF
--- a/cmd/zc_traverser_local.go
+++ b/cmd/zc_traverser_local.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
@@ -72,7 +73,13 @@ func (t *localTraverser) getInfoIfSingleFile() (os.FileInfo, bool, error) {
 }
 
 func UnfurlSymlinks(symlinkPath string) (result string, err error) {
+	var count uint32
 	unfurlingPlan := []string{symlinkPath}
+
+	// We need to do some special UNC path handling for windows.
+	if runtime.GOOS != "windows" {
+		return filepath.EvalSymlinks(symlinkPath)
+	}
 
 	for len(unfurlingPlan) > 0 {
 		item := unfurlingPlan[0]
@@ -93,7 +100,7 @@ func UnfurlSymlinks(symlinkPath string) (result string, err error) {
 			// Previously, we'd try to detect if the read link was a relative path by appending and starting the item
 			// However, it seems to be a fairly unlikely and hard to reproduce scenario upon investigation (Couldn't manage to reproduce the scenario)
 			// So it was dropped. However, on the off chance, we'll still do it if syntactically it makes sense.
-			if len(result) == 0 || result[0] == '.' { // A relative path being "" or "." likely (and in the latter case, on our officially supported OSes, always) means that it's just the same folder.
+			if result == "" || result == "." { // A relative path being "" or "." likely (and in the latter case, on our officially supported OSes, always) means that it's just the same folder.
 				result = filepath.Dir(item)
 			} else if !os.IsPathSeparator(result[0]) { // We can assume that a relative path won't start with a separator
 				possiblyResult := filepath.Join(filepath.Dir(item), result)
@@ -104,12 +111,21 @@ func UnfurlSymlinks(symlinkPath string) (result string, err error) {
 
 			result = common.ToExtendedPath(result)
 
+			/*
+			 * Either we can store all the symlink seen till now for this path or we count how many iterations to find out cyclic loop.
+			 * Choose the count method and restrict the number of links to 40. Which linux kernel adhere.
+			 */
+			if count >= 40 {
+				return "", errors.New("failed to unfurl symlink: too many links")
+			}
+
 			unfurlingPlan = append(unfurlingPlan, result)
 		} else {
 			return item, nil
 		}
 
 		unfurlingPlan = unfurlingPlan[1:]
+		count++
 	}
 
 	return "", errors.New("failed to unfurl symlink: exited loop early")
@@ -197,10 +213,27 @@ func WalkWithSymlinks(fullPath string, walkFunc filepath.WalkFunc, followSymlink
 				computedRelativePath = ""
 			}
 
+			// TODO: Later we might want to transfer these special files as such.
+			unsupportedFileTypes := (os.ModeSocket | os.ModeNamedPipe | os.ModeIrregular | os.ModeDevice)
+
+			if (fileInfo.Mode() & unsupportedFileTypes) != 0 {
+				err := fmt.Errorf("Unsupported file type %s: %v", filePath, fileInfo.Mode())
+				WarnStdoutAndScanningLog(err.Error())
+				return nil
+			}
+
 			if fileInfo.Mode()&os.ModeSymlink != 0 {
 				if !followSymlinks {
 					return nil // skip it
 				}
+
+				/*
+				 * There is one case where symlink can point to outside of sharepoint(symlink is absolute path). In that case
+				 * we need to throw error. Its very unlikely same file or folder present on the agent side.
+				 * In that case it anywaythrow the error.
+				 *
+				 * TODO: Need to handle this case.
+				 */
 				result, err := UnfurlSymlinks(filePath)
 
 				if err != nil {
@@ -246,24 +279,16 @@ func WalkWithSymlinks(fullPath string, walkFunc filepath.WalkFunc, followSymlink
 						WarnStdoutAndScanningLog(fmt.Sprintf("Ignored already linked directory pointed at %s (link at %s)", result, common.GenerateFullPath(fullPath, computedRelativePath)))
 					}
 				} else {
-					WarnStdoutAndScanningLog(fmt.Sprintf("Symlinks to individual files are not currently supported, so will ignore file at %s (link at %s)", result, common.GenerateFullPath(fullPath, computedRelativePath)))
-					// TODO: remove the above info call and enable the below, with suitable multi-OS testing
-					//    including enable the test: TestWalkWithSymlinks_ToFile
-					/*
-							// It's a symlink to a file. Just process the file because there's no danger of cycles with links to individual files.
-							// (this does create the inconsistency that if there are two symlinks to the same file we will process it twice,
-							// but if there are two symlinks to the same directory we will process it only once. Because only directories are
-							// deduped to break cycles.  For now, we are living with the inconsistency. The alternative would be to "burn" more
-							// RAM by putting filepaths into seenDirs too, but that could be a non-trivial amount of RAM in big directories trees).
+					// It's a symlink to a file and we handle cyclic symlinks.
+					// (this does create the inconsistency that if there are two symlinks to the same file we will process it twice,
+					// but if there are two symlinks to the same directory we will process it only once. Because only directories are
+					// deduped to break cycles.  For now, we are living with the inconsistency. The alternative would be to "burn" more
+					// RAM by putting filepaths into seenDirs too, but that could be a non-trivial amount of RAM in big directories trees).
+					targetFi := symlinkTargetFileInfo{rStat, fileInfo.Name()}
 
-							// TODO: this code here won't handle the case of (file-type symlink) -> (another file-type symlink) -> file
-						    //    But do we WANT to handle that?  (since it opens us to risk of file->file cycles, and we are deliberately NOT
-						    //    putting files in our map, to reduce RAM usage).  Maybe just detect if the target of a file symlink its itself a symlink
-						    //    and skip those cases with an error message?
-							// Make file info that has name of source, and stats of dest (to mirror what os.Stat calls on source will give us later)
-							targetFi := symlinkTargetFileInfo{rStat, fileInfo.Name()}
-							return walkFunc(common.GenerateFullPath(fullPath, computedRelativePath), targetFi, fileError)
-					*/
+					err := walkFunc(common.GenerateFullPath(fullPath, computedRelativePath), targetFi, fileError)
+					_, err = getProcessingError(err)
+					return err
 				}
 				return nil
 			} else {

--- a/jobsAdmin/init.go
+++ b/jobsAdmin/init.go
@@ -24,11 +24,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/Azure/azure-storage-azcopy/v10/ste"
 	"io/ioutil"
 	"math"
 	"net/http"
 	"time"
+
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
@@ -476,6 +477,30 @@ func GetJobSummary(jobID common.JobID) common.ListJobSummaryResponse {
 	}
 	part0PlanStatus := part0.Plan().JobStatus()
 
+	// This is added to let FE to continue fetching the Job Progress Summary
+	// in case of resume. In case of resume, the Job is already completely
+	// ordered so the progress summary should be fetched until all job parts
+	// are iterated and have been scheduled
+	js.CompleteJobOrdered = js.CompleteJobOrdered || jm.AllTransfersScheduled()
+
+	if part0PlanStatus != common.EJobStatus.Cancelled() && part0PlanStatus != common.EJobStatus.Failed() &&
+		(js.CompleteJobOrdered) && (part0PlanStatus.IsJobDone()) {
+		/*
+		 * Plan file (hence part0PlanStatus.IsJobDone) is updated inline by jm.reportJobPartDoneHandler()
+		 * while the various transfer stats are updated via xferDone messages processed by handleStatusUpdateMessage().
+		 * Now that the job has completed, make sure we drain all queued-but-not-processed-yet xferDone messages so as to
+		 * return correct updated job status to our caller who may not call us again since we declare job completion.
+		 */
+		if jm.DrainXferDoneMessages() {
+			// Let's get JobStatus once again to get the updated value.
+			js = jm.ListJobSummary()
+			js.Timestamp = time.Now().UTC()
+			js.JobID = jm.JobID()
+			js.ErrorMsg = ""
+			js.CompleteJobOrdered = true
+		}
+	}
+
 	// Add on byte count from files in flight, to get a more accurate running total
 	js.TotalBytesTransferred += jm.SuccessfulBytesInActiveFiles()
 	if js.TotalBytesExpected == 0 {
@@ -484,12 +509,6 @@ func GetJobSummary(jobID common.JobID) common.ListJobSummaryResponse {
 	} else {
 		js.PercentComplete = 100 * float32(js.TotalBytesTransferred) / float32(js.TotalBytesExpected)
 	}
-
-	// This is added to let FE to continue fetching the Job Progress Summary
-	// in case of resume. In case of resume, the Job is already completely
-	// ordered so the progress summary should be fetched until all job parts
-	// are iterated and have been scheduled
-	js.CompleteJobOrdered = js.CompleteJobOrdered || jm.AllTransfersScheduled()
 
 	js.BytesOverWire = uint64(JobsAdmin.BytesOverWire())
 

--- a/ste/jobStatusManager.go
+++ b/ste/jobStatusManager.go
@@ -21,8 +21,10 @@
 package ste
 
 import (
+	"fmt"
 	"time"
 
+	"github.com/Azure/azure-pipeline-go/pipeline"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
@@ -36,11 +38,17 @@ type JobPartCreatedMsg struct {
 
 type xferDoneMsg = common.TransferDetail
 type jobStatusManager struct {
-	js          common.ListJobSummaryResponse
-	respChan    chan common.ListJobSummaryResponse
-	listReq     chan bool
-	partCreated chan JobPartCreatedMsg
-	xferDone    chan xferDoneMsg
+	js                            common.ListJobSummaryResponse
+	respChan                      chan common.ListJobSummaryResponse
+	listReq                       chan bool
+	partCreated                   chan JobPartCreatedMsg
+	xferDone                      chan xferDoneMsg
+	done                          chan struct{}
+	doneHandleStatusUpdateManager bool
+	xferDoneDrainCalled           bool
+	xferDoneDrained               bool
+	drainXferDoneSignal           chan struct{} // This is signal to drain all messages in XferDone channel.
+	xferDoneDrainedSignal         chan struct{} // This is signal when all messages in XferDone channel drained.
 }
 
 /* These functions should not fail */
@@ -53,12 +61,81 @@ func (jm *jobMgr) SendXferDoneMsg(msg xferDoneMsg) {
 }
 
 func (jm *jobMgr) ListJobSummary() common.ListJobSummaryResponse {
-	jm.jstm.listReq <- true
-	return <-jm.jstm.respChan
+	/*
+	 * Query job summary from handleStatusUpdateManager, but only if it's running.
+	 * Ideally we should never find it exited, but we play safe, else we will be blocked for ever.
+	 */
+	if !jm.jstm.doneHandleStatusUpdateManager {
+		jm.jstm.listReq <- true
+		return <-jm.jstm.respChan
+	} else {
+		return jm.jstm.js
+	}
 }
 
 func (jm *jobMgr) ResurrectSummary(js common.ListJobSummaryResponse) {
 	jm.jstm.js = js
+}
+
+// DrainXferDoneMessages() function drain all message on XferDone channel. There is risk of HandleStatusUpdateManager() already exited and we are blocked.
+// We safeguard against it by checking boolean set on exit of HandleStatusUpdateManager(). We try to make risk factor as low as we can, by calling this function only once.
+//
+// Note: This is not thread safe function. Onus on caller to handle that.
+func (jm *jobMgr) DrainXferDoneMessages() bool {
+	// Poke handleStatusUpdateManager to drain the xferDone channel, but only if it's running.
+	if !jm.jstm.doneHandleStatusUpdateManager && !jm.jstm.xferDoneDrainCalled {
+		jm.jstm.xferDoneDrainCalled = true
+		jm.jstm.drainXferDoneSignal <- struct{}{}
+		close(jm.jstm.xferDone)
+
+		// Wait for handleStatusUpdateManager while it drains messages from the xferDone channel.
+		<-jm.jstm.xferDoneDrainedSignal
+
+		return true
+	} else {
+		jm.Log(pipeline.LogError, fmt.Sprintf("DrainXferDoneMessages already called and its status: %s", common.IffString(jm.jstm.xferDoneDrained, "Success", "Running")))
+		return false
+	}
+}
+
+func (jm *jobMgr) CleanupJobStatusMgr() {
+	jm.Log(pipeline.LogInfo, "CleanJobStatusMgr called.")
+	jm.jstm.done <- struct{}{}
+}
+
+// drainXferDoneCh drains all pending message in xferDone channel.
+func drainXferDoneCh(jm *jobMgr) {
+	jstm := jm.jstm
+	js := &jstm.js
+
+	jm.Log(pipeline.LogError, fmt.Sprintf("xferDoneCh: len: %v, cap: %v", len(jstm.xferDone), cap(jstm.xferDone)))
+
+	for msg := range jstm.xferDone {
+		processXferDoneMsg(msg, js)
+	}
+	jstm.xferDoneDrained = true
+	jstm.xferDoneDrainedSignal <- struct{}{}
+}
+
+// processXferDoneMsg process the XferDone message.
+func processXferDoneMsg(msg common.TransferDetail, js *common.ListJobSummaryResponse) {
+	msg.Src = common.URLStringExtension(msg.Src).RedactSecretQueryParamForLogging()
+	msg.Dst = common.URLStringExtension(msg.Dst).RedactSecretQueryParamForLogging()
+
+	switch msg.TransferStatus {
+	case common.ETransferStatus.Success():
+		js.TransfersCompleted++
+		js.TotalBytesTransferred += msg.TransferSize
+	case common.ETransferStatus.Failed(),
+		common.ETransferStatus.TierAvailabilityCheckFailure(),
+		common.ETransferStatus.BlobTierFailure():
+		js.TransfersFailed++
+		js.FailedTransfers = append(js.FailedTransfers, msg)
+	case common.ETransferStatus.SkippedEntityAlreadyExists(),
+		common.ETransferStatus.SkippedBlobHasSnapshots():
+		js.TransfersSkipped++
+		js.SkippedTransfers = append(js.SkippedTransfers, msg)
+	}
 }
 
 func (jm *jobMgr) handleStatusUpdateMessage() {
@@ -68,44 +145,46 @@ func (jm *jobMgr) handleStatusUpdateMessage() {
 	js.CompleteJobOrdered = false
 	js.ErrorMsg = ""
 
+	// Set jstm.doneHandleStatusUpdateManager when handleStatusUpdateMessage goroutine exits.
+	defer func() {
+		jstm.doneHandleStatusUpdateManager = true
+	}()
+
 	for {
 		select {
-		case msg := <-jstm.partCreated:
-			js.CompleteJobOrdered = js.CompleteJobOrdered || msg.IsFinalPart
-			js.TotalTransfers += msg.TotalTransfers
-			js.FileTransfers += msg.FileTransfers
-			js.FolderPropertyTransfers += msg.FolderTransfer
-			js.TotalBytesEnumerated += msg.TotalBytesEnumerated
-			js.TotalBytesExpected += msg.TotalBytesEnumerated
+		// drainXferDoneSignal is high priority channel,process any message pending on xferDone channel.
+		case <-jstm.drainXferDoneSignal:
+			drainXferDoneCh(jm)
+		default:
+			select {
+			case msg := <-jstm.partCreated:
+				js.CompleteJobOrdered = js.CompleteJobOrdered || msg.IsFinalPart
+				js.TotalTransfers += msg.TotalTransfers
+				js.FileTransfers += msg.FileTransfers
+				js.FolderPropertyTransfers += msg.FolderTransfer
+				js.TotalBytesEnumerated += msg.TotalBytesEnumerated
+				js.TotalBytesExpected += msg.TotalBytesEnumerated
 
-		case msg := <-jstm.xferDone:
-			msg.Src = common.URLStringExtension(msg.Src).RedactSecretQueryParamForLogging()
-			msg.Dst = common.URLStringExtension(msg.Dst).RedactSecretQueryParamForLogging()
+			case msg := <-jstm.xferDone:
+				processXferDoneMsg(msg, js)
 
-			switch msg.TransferStatus {
-			case common.ETransferStatus.Success():
-				js.TransfersCompleted++
-				js.TotalBytesTransferred += msg.TransferSize
-			case common.ETransferStatus.Failed(),
-				common.ETransferStatus.TierAvailabilityCheckFailure(),
-				common.ETransferStatus.BlobTierFailure():
-				js.TransfersFailed++
-				js.FailedTransfers = append(js.FailedTransfers, msg)
-			case common.ETransferStatus.SkippedEntityAlreadyExists(),
-				common.ETransferStatus.SkippedBlobHasSnapshots():
-				js.TransfersSkipped++
-				js.SkippedTransfers = append(js.SkippedTransfers, msg)
+			case <-jstm.listReq:
+				/* Display stats */
+				js.Timestamp = time.Now().UTC()
+				jstm.respChan <- *js
+
+				// Reset the lists so that they don't keep accumulating and take up excessive memory
+				// There is no need to keep sending the same items over and over again
+				js.FailedTransfers = []common.TransferDetail{}
+				js.SkippedTransfers = []common.TransferDetail{}
+
+			case <-jstm.drainXferDoneSignal:
+				drainXferDoneCh(jm)
+
+			case <-jstm.done:
+				fmt.Println("Cleanup JobStatusmgr")
+				return
 			}
-
-		case <-jstm.listReq:
-			/* Display stats */
-			js.Timestamp = time.Now().UTC()
-			jstm.respChan <- *js
-
-			// Reset the lists so that they don't keep accumulating and take up excessive memory
-			// There is no need to keep sending the same items over and over again
-			js.FailedTransfers = []common.TransferDetail{}
-			js.SkippedTransfers = []common.TransferDetail{}
 		}
 	}
 }


### PR DESCRIPTION
Changes for jobProgress status.

- If job marked complete, drain all the messages from jobStatus channel.

Fix the symlink.

- Calling filepath.evalsymlinks in case of linux.
- Explicit checking "." (current directory) for symlink.

Remove snippet of code not relevant to the cherry-picked commits.