### PR TITLE
Fix some oopsies in the unix properties PR

### DIFF
--- a/ste/sender-appendBlobFromLocal.go
+++ b/ste/sender-appendBlobFromLocal.go
@@ -36,6 +36,9 @@ type appendBlobUploader struct {
 func (u *appendBlobUploader) Prologue(ps common.PrologueState) (destinationModified bool) {
 	if u.jptm.Info().PreservePOSIXProperties {
 		if unixSIP, ok := u.sip.(IUNIXPropertyBearingSourceInfoProvider); ok {
+			// Clone the metadata before we write to it, we shouldn't be writing to the same metadata as every other blob.
+			u.metadataToApply = common.Metadata(u.metadataToApply).Clone().ToAzBlobMetadata()
+
 			statAdapter, err := unixSIP.GetUNIXProperties()
 			if err != nil {
 				u.jptm.FailActiveSend("GetUNIXProperties", err)

--- a/ste/sender-blockBlobFromLocal.go
+++ b/ste/sender-blockBlobFromLocal.go
@@ -47,7 +47,11 @@ func newBlockBlobUploader(jptm IJobPartTransferMgr, destination string, p pipeli
 
 func (s *blockBlobUploader) Prologue(ps common.PrologueState) (destinationModified bool) {
 	if s.jptm.Info().PreservePOSIXProperties {
+
 		if unixSIP, ok := s.sip.(IUNIXPropertyBearingSourceInfoProvider); ok {
+			// Clone the metadata before we write to it, we shouldn't be writing to the same metadata as every other blob.
+			s.metadataToApply = common.Metadata(s.metadataToApply).Clone().ToAzBlobMetadata()
+
 			statAdapter, err := unixSIP.GetUNIXProperties()
 			if err != nil {
 				s.jptm.FailActiveSend("GetUNIXProperties", err)

--- a/ste/sender-pageBlobFromLocal.go
+++ b/ste/sender-pageBlobFromLocal.go
@@ -47,6 +47,9 @@ func newPageBlobUploader(jptm IJobPartTransferMgr, destination string, p pipelin
 func (u *pageBlobUploader) Prologue(ps common.PrologueState) (destinationModified bool) {
 	if u.jptm.Info().PreservePOSIXProperties {
 		if unixSIP, ok := u.sip.(IUNIXPropertyBearingSourceInfoProvider); ok {
+			// Clone the metadata before we write to it, we shouldn't be writing to the same metadata as every other blob.
+			u.metadataToApply = common.Metadata(u.metadataToApply).Clone().ToAzBlobMetadata()
+
 			statAdapter, err := unixSIP.GetUNIXProperties()
 			if err != nil {
 				u.jptm.FailActiveSend("GetUNIXProperties", err)

--- a/ste/sourceInfoProvider-Local_linux.go
+++ b/ste/sourceInfoProvider-Local_linux.go
@@ -97,7 +97,7 @@ func (s statxTAdapter) MTime() time.Time {
 }
 
 func (s statxTAdapter) CTime() time.Time {
-	return time.Unix(s.Btime.Sec, int64(s.Ctime.Nsec))
+	return time.Unix(s.Ctime.Sec, int64(s.Ctime.Nsec))
 }
 
 type statTAdapter unix.Stat_t


### PR DESCRIPTION
1. We didn't clone the metadata map when we were going to modify it for individual blobs, meaning we'd encounter data races, and incorrect properties would be written
2. The incorrect seconds value was used for CTime, leading to an invalid value for UnixNano.