### PR TITLE
Add mitigation for weird NtQuerySecurityObject behavior on NAS sources

### DIFF
--- a/cmd/zt_generic_traverser_test.go
+++ b/cmd/zt_generic_traverser_test.go
@@ -459,7 +459,7 @@ func (s *genericTraverserSuite) TestTraverserWithSingleObject(c *chk.C) {
 	s3Client, err := createS3ClientWithMinio(createS3ResOptions{})
 	s3Enabled := err == nil && !isS3Disabled()
 	gcpClient, err := createGCPClientWithGCSSDK()
-	gcpEnabled := err == nil && gcpTestsDisabled()
+	gcpEnabled := err == nil && !gcpTestsDisabled()
 	var bucketName string
 	var bucketNameGCP string
 	if s3Enabled {

--- a/cmd/zt_test.go
+++ b/cmd/zt_test.go
@@ -595,13 +595,18 @@ func deleteGCPBucket(c *chk.C, client *gcpUtils.Client, bucketName string, waitQ
 	it := bucket.Objects(ctx, &gcpUtils.Query{Prefix: ""})
 	for {
 		attrs, err := it.Next()
-		if err == iterator.Done {
-			break
+		if err != nil { // if Next returns an error other than iterator.Done, all subsequent calls will return the same error.
+			if err == iterator.Done {
+				break
+			}
+
+			c.Log("Failed to clear GCS bucket:", err) // todo: maybe this code should be more resilient
+			return
 		}
 		if err == nil {
 			err = bucket.Object(attrs.Name).Delete(nil)
 			if err != nil {
-				c.Log("Could not clear GCS Buckets.")
+				c.Log("Could not clear GCS Buckets:", err) // todo: maybe this code should be more resilient
 				return
 			}
 		}

--- a/cmd/zt_test.go
+++ b/cmd/zt_test.go
@@ -647,8 +647,13 @@ func cleanGCPAccount(c *chk.C, client *gcpUtils.Client) {
 	it := client.Buckets(ctx, projectID)
 	for {
 		battrs, err := it.Next()
-		if err == iterator.Done {
-			break
+		if err != nil {
+			if err == iterator.Done {
+				break
+			}
+
+			c.Assert(err, chk.Equals, nil)
+			return
 		}
 		deleteGCPBucket(c, client, battrs.Name, false)
 	}

--- a/ste/sourceInfoProvider-Local_windows.go
+++ b/ste/sourceInfoProvider-Local_windows.go
@@ -70,9 +70,11 @@ func (f localFileSourceInfoProvider) GetSDDL() (string, error) {
 			uint32(len(buf)),
 			&bufLen)
 
-		// mitigate weirdness with 0 buflen on success with a NAS source
-		if status == ntdll.STATUS_SUCCESS && bufLen == 0 {
-			bufLen = uint32(len(buf))
+		// get real buffer length, since what's returned by ntquerysecurityobject is questionable for STATUS_SUCCESS
+		if status == ntdll.STATUS_SUCCESS {
+			sd := (*windows.SECURITY_DESCRIPTOR)(unsafe.Pointer(&buf[0])) // ntdll.SecurityDescriptor is equivalent
+
+			bufLen = sd.Length()
 			needValidate = true
 		}
 

--- a/ste/sourceInfoProvider-Local_windows.go
+++ b/ste/sourceInfoProvider-Local_windows.go
@@ -70,6 +70,15 @@ func (f localFileSourceInfoProvider) GetSDDL() (string, error) {
 			uint32(len(buf)),
 			&bufLen)
 
+		/*
+			On certain older versions of Windows/Server and certain SAN/SMB emulator software,
+			on any status but STATUS_BUFFER_TOO_SMALL, bufLen will be returned as 0.
+
+			CallWithExpandingBuffer does not handle this correctly.
+			Thus, we have to attain the real length of the security descriptor and correct the output,
+			otherwise we panic due to an OOB error on the array.
+		*/
+
 		// get real buffer length, since what's returned by ntquerysecurityobject is questionable for STATUS_SUCCESS
 		if status == ntdll.STATUS_SUCCESS {
 			sd := (*windows.SECURITY_DESCRIPTOR)(unsafe.Pointer(&buf[0])) // ntdll.SecurityDescriptor is equivalent


### PR DESCRIPTION
For whatever odd reason, NtQuerySecurityObject likes to return 0 on the buffer length when it succeeds targeting an object on a NAS source, but still returns a valid security descriptor struct.

This PR adds a check for that, and validates the struct if the edge case conditions were met.