### PR TITLE
UX improvement: avoid crash when copying S2S with user delegation SAS

### DIFF
--- a/ste/xfer-anyToRemote-file.go
+++ b/ste/xfer-anyToRemote-file.go
@@ -66,7 +66,7 @@ func prepareDestAccountInfo(bURL azblob.BlobURL, jptm IJobPartTransferMgr, ctx c
 			} else {
 				tierSetPossibleFail = true
 				glcm := common.GetLifecycleMgr()
-				glcm.Info("Transfers are likely to fail because destination does not support tiers.")
+				glcm.Info("Transfers could fail because AzCopy could not verify if the destination supports tiers.")
 				destAccountSKU = "failget"
 				destAccountKind = "failget"
 			}
@@ -127,8 +127,9 @@ func ValidateTier(jptm IJobPartTransferMgr, blobTier azblob.AccessTierType, blob
 		// Let's check if we can confirm we'll be able to check the destination blob's account info.
 		// A SAS token, even with write-only permissions is enough. OR, OAuth with the account owner.
 		// We can't guess that last information, so we'll take a gamble and try to get account info anyway.
+		// User delegation SAS is the same as OAuth
 		destParts := azblob.NewBlobURLParts(blobURL.URL())
-		mustGet := destParts.SAS.Encode() != ""
+		mustGet := destParts.SAS.Encode() != "" && destParts.SAS.SignedTid() == ""
 
 		prepareDestAccountInfo(blobURL, jptm, ctx, mustGet)
 		tierAvailable := BlobTierAllowed(blobTier)


### PR DESCRIPTION
Previously, if a user was copying S2S with a user delegation SAS and had s2s-preserve-tier set to the default value, the tool would crash. We should avoid this problem as the error message is not clear nor actionable.

Instead, we should simply go ahead with the transfer and see if tier is tolerated. 