### PR TITLE
Fix files sync by determining which LMT to use via smb properties flag

### DIFF
--- a/cmd/syncEnumerator.go
+++ b/cmd/syncEnumerator.go
@@ -155,7 +155,7 @@ func (cca *cookedSyncCmdArgs) initEnumerator(ctx context.Context) (enumerator *s
 		// when uploading, we can delete remote objects immediately, because as we traverse the remote location
 		// we ALREADY have available a complete map of everything that exists locally
 		// so as soon as we see a remote destination object we can know whether it exists in the local source
-		comparator = newSyncDestinationComparator(indexer, transferScheduler.scheduleCopyTransfer, destCleanerFunc, cca.mirrorMode).processIfNecessary
+		comparator = newSyncDestinationComparator(indexer, transferScheduler.scheduleCopyTransfer, destCleanerFunc, cca.preserveSMBInfo, cca.mirrorMode).processIfNecessary
 		finalize = func() error {
 			// schedule every local file that doesn't exist at the destination
 			err = indexer.traverse(transferScheduler.scheduleCopyTransfer, filters)
@@ -179,7 +179,7 @@ func (cca *cookedSyncCmdArgs) initEnumerator(ctx context.Context) (enumerator *s
 		indexer.isDestinationCaseInsensitive = IsDestinationCaseInsensitive(cca.fromTo)
 		// in all other cases (download and S2S), the destination is scanned/indexed first
 		// then the source is scanned and filtered based on what the destination contains
-		comparator = newSyncSourceComparator(indexer, transferScheduler.scheduleCopyTransfer, cca.mirrorMode).processIfNecessary
+		comparator = newSyncSourceComparator(indexer, transferScheduler.scheduleCopyTransfer, cca.preserveSMBInfo, cca.mirrorMode).processIfNecessary
 
 		finalize = func() error {
 			// remove the extra files at the destination that were not present at the source

--- a/cmd/zc_enumerator.go
+++ b/cmd/zc_enumerator.go
@@ -92,13 +92,13 @@ type StoredObject struct {
 	leaseDuration azblob.LeaseDurationType
 }
 
-func (s *StoredObject) isMoreRecentThan(storedObject2 StoredObject) bool {
+func (s *StoredObject) isMoreRecentThan(storedObject2 StoredObject, preferSMBTime bool) bool {
 	lmtA := s.lastModifiedTime
-	if !s.smbLastModifiedTime.IsZero() {
+	if preferSMBTime && !s.smbLastModifiedTime.IsZero() {
 		lmtA = s.smbLastModifiedTime
 	}
 	lmtB := storedObject2.lastModifiedTime
-	if !storedObject2.smbLastModifiedTime.IsZero() {
+	if preferSMBTime && !storedObject2.smbLastModifiedTime.IsZero() {
 		lmtB = storedObject2.smbLastModifiedTime
 	}
 

--- a/cmd/zt_generic_traverser_test.go
+++ b/cmd/zt_generic_traverser_test.go
@@ -897,7 +897,7 @@ func (s *genericTraverserSuite) TestTraverserWithVirtualAndLocalDirectory(c *chk
 				c.Assert(correspondingLocalFile.name, chk.Equals, storedObject.name)
 				// Say, here's a good question, why do we have this last check?
 				// None of the other tests have it.
-				c.Assert(correspondingLocalFile.isMoreRecentThan(storedObject), chk.Equals, true)
+				c.Assert(correspondingLocalFile.isMoreRecentThan(storedObject, false), chk.Equals, true)
 
 				if !isRecursiveOn {
 					c.Assert(strings.Contains(storedObject.relativePath, common.AZCOPY_PATH_SEPARATOR_STRING), chk.Equals, false)

--- a/cmd/zt_sync_comparator_test.go
+++ b/cmd/zt_sync_comparator_test.go
@@ -137,7 +137,7 @@ func (s *syncComparatorSuite) TestSyncDestinationComparator(c *chk.C) {
 
 	// set up the indexer as well as the destination comparator
 	indexer := newObjectIndexer()
-	destinationComparator := newSyncDestinationComparator(indexer, dummyCopyScheduler.process, dummyCleaner.process, false)
+	destinationComparator := newSyncDestinationComparator(indexer, dummyCopyScheduler.process, dummyCleaner.process, false, false)
 
 	// create a sample source object
 	sampleSourceObject := StoredObject{name: "test", relativePath: "/usr/test", lastModifiedTime: time.Now(), md5: srcMD5}
@@ -194,7 +194,7 @@ func (s *syncComparatorSuite) TestSyncDestCompDisableComparison(c *chk.C) {
 
 	// set up the indexer as well as the destination comparator
 	indexer := newObjectIndexer()
-	destinationComparator := newSyncDestinationComparator(indexer, dummyCopyScheduler.process, dummyCleaner.process, true)
+	destinationComparator := newSyncDestinationComparator(indexer, dummyCopyScheduler.process, dummyCleaner.process, false, true)
 
 	// create a sample source object
 	currTime := time.Now()
@@ -203,7 +203,7 @@ func (s *syncComparatorSuite) TestSyncDestCompDisableComparison(c *chk.C) {
 		{name: "test2", relativePath: "/usr/test2", lastModifiedTime: currTime, md5: srcMD5},
 	}
 
-	//onlyAtSrc := StoredObject{name: "only_at_src", relativePath: "/usr/only_at_src", lastModifiedTime: currTime, md5: destMD5}
+	// onlyAtSrc := StoredObject{name: "only_at_src", relativePath: "/usr/only_at_src", lastModifiedTime: currTime, md5: destMD5}
 
 	destinationStoredObjects := []StoredObject{
 		// file whose last modified time is greater than that of source

--- a/cmd/zt_sync_comparator_test.go
+++ b/cmd/zt_sync_comparator_test.go
@@ -36,7 +36,7 @@ func (s *syncComparatorSuite) TestSyncSourceComparator(c *chk.C) {
 
 	// set up the indexer as well as the source comparator
 	indexer := newObjectIndexer()
-	sourceComparator := newSyncSourceComparator(indexer, dummyCopyScheduler.process, false)
+	sourceComparator := newSyncSourceComparator(indexer, dummyCopyScheduler.process, false, false)
 
 	// create a sample destination object
 	sampleDestinationObject := StoredObject{name: "test", relativePath: "/usr/test", lastModifiedTime: time.Now(), md5: destMD5}
@@ -88,7 +88,7 @@ func (s *syncComparatorSuite) TestSyncSrcCompDisableComparator(c *chk.C) {
 
 	// set up the indexer as well as the source comparator
 	indexer := newObjectIndexer()
-	sourceComparator := newSyncSourceComparator(indexer, dummyCopyScheduler.process, true)
+	sourceComparator := newSyncSourceComparator(indexer, dummyCopyScheduler.process, false, true)
 
 	// test the comparator in case a given source object is not present at the destination
 	// meaning no entry in the index, so the comparator should pass the given object to schedule a transfer

--- a/e2etest/declarativeHelpers.go
+++ b/e2etest/declarativeHelpers.go
@@ -157,7 +157,7 @@ type params struct {
 	cancelFromStdin           bool
 	backupMode                bool
 	preserveSMBPermissions    bool
-	preserveSMBInfo           bool
+	preserveSMBInfo           *bool
 	preservePOSIXProperties   bool
 	relativeSourcePath        string
 	blobTags                  string

--- a/e2etest/pointers.go
+++ b/e2etest/pointers.go
@@ -1,0 +1,6 @@
+package e2etest
+
+// todo: upgrade to go 1.18 and use generics
+func BoolPointer(b bool) *bool {
+	return &b
+}

--- a/e2etest/runner.go
+++ b/e2etest/runner.go
@@ -82,7 +82,7 @@ func (t *TestRunner) SetAllFlags(p params, o Operation) {
 	set("s2s-detect-source-changed", p.s2sSourceChangeValidation, false)
 	set("metadata", p.metadata, "")
 	set("cancel-from-stdin", p.cancelFromStdin, false)
-	set("preserve-smb-info", p.preserveSMBInfo, false)
+	set("preserve-smb-info", p.preserveSMBInfo, true)
 	set("preserve-smb-permissions", p.preserveSMBPermissions, false)
 	set("backup", p.backupMode, false)
 	set("blob-tags", p.blobTags, "")

--- a/e2etest/runner.go
+++ b/e2etest/runner.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -59,6 +60,17 @@ func (t *TestRunner) SetAllFlags(p params, o Operation) {
 			return // nothing to do. The flag is not supposed to be set
 		}
 
+		reflectVal := reflect.ValueOf(value) // check for pointer
+		if reflectVal.Kind() == reflect.Pointer {
+			result := reflectVal.Elem() // attempt to deref
+
+			if result != (reflect.Value{}) && result.CanInterface() { // can we grab the underlying value?
+				value = result.Interface()
+			} else {
+				return // nothing to use
+			}
+		}
+
 		format := "%v"
 		if len(formats) > 0 {
 			format = formats[0]
@@ -83,7 +95,7 @@ func (t *TestRunner) SetAllFlags(p params, o Operation) {
 	set("s2s-detect-source-changed", p.s2sSourceChangeValidation, false)
 	set("metadata", p.metadata, "")
 	set("cancel-from-stdin", p.cancelFromStdin, false)
-	set("preserve-smb-info", p.preserveSMBInfo, true)
+	set("preserve-smb-info", p.preserveSMBInfo, nil)
 	set("preserve-smb-permissions", p.preserveSMBPermissions, false)
 	set("backup", p.backupMode, false)
 	set("blob-tags", p.blobTags, "")

--- a/e2etest/zt_basic_copy_sync_remove_test.go
+++ b/e2etest/zt_basic_copy_sync_remove_test.go
@@ -394,8 +394,8 @@ func TestBasic_SyncLMTSwitch_PreferSMBLMT(t *testing.T) {
 		anonymousAuthOnly,
 		anonymousAuthOnly,
 		params{
-			// default, but present for clarity
-			//preserveSMBInfo: BoolPointer(true),
+			// enforce for Linux/MacOS tests
+			preserveSMBInfo: BoolPointer(true),
 		},
 		&hooks{
 			beforeRunJob: func(h hookHelper) {

--- a/e2etest/zt_basic_copy_sync_remove_test.go
+++ b/e2etest/zt_basic_copy_sync_remove_test.go
@@ -342,7 +342,7 @@ func TestBasic_SyncLMTSwitch_PreferServiceLMT(t *testing.T) {
 	RunScenarios(
 		t,
 		eOperation.Sync(),
-		eTestFromTo.Other(common.EFromTo.LocalFile(), common.EFromTo.FileLocal()),
+		eTestFromTo.Other(common.EFromTo.FileFile()),
 		eValidate.Auto(),
 		anonymousAuthOnly,
 		anonymousAuthOnly,
@@ -389,7 +389,7 @@ func TestBasic_SyncLMTSwitch_PreferSMBLMT(t *testing.T) {
 	RunScenarios(
 		t,
 		eOperation.Sync(),
-		eTestFromTo.Other(common.EFromTo.LocalFile(), common.EFromTo.FileLocal()),
+		eTestFromTo.Other(common.EFromTo.FileFile()),
 		eValidate.Auto(),
 		anonymousAuthOnly,
 		anonymousAuthOnly,

--- a/e2etest/zt_basic_copy_sync_remove_test.go
+++ b/e2etest/zt_basic_copy_sync_remove_test.go
@@ -22,6 +22,7 @@ package e2etest
 
 import (
 	"testing"
+	"time"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
@@ -329,6 +330,105 @@ func TestBasic_CopyWithShareRoot(t *testing.T) {
 				f("asdf.txt"),
 				folder("a"),
 				f("a/asdf.txt"),
+			},
+		},
+		EAccountType.Standard(),
+		EAccountType.Standard(),
+		"",
+	)
+}
+
+func TestBasic_SyncLMTSwitch_PreferServiceLMT(t *testing.T) {
+	RunScenarios(
+		t,
+		eOperation.Sync(),
+		eTestFromTo.Other(common.EFromTo.LocalFile(), common.EFromTo.FileLocal()),
+		eValidate.Auto(),
+		anonymousAuthOnly,
+		anonymousAuthOnly,
+		params{
+			preserveSMBInfo: false,
+		},
+		&hooks{
+			beforeRunJob: func(h hookHelper) {
+				// re-create dotransfer on the destination before the source to allow an overwrite.
+				// create the files endpoint with an LMT in the future.
+				fromTo := h.FromTo()
+				if fromTo.To() == common.ELocation.File() {
+					// if we're ignoring the SMB LMT, then the service LMT will still indicate the file is old, rather than new.
+					h.CreateFile(f("dotransfer", with{lastWriteTime: time.Now().Add(time.Second * 60)}), false)
+				} else {
+					h.CreateFile(f("dotransfer"), false)
+				}
+				time.Sleep(time.Second * 5)
+				if fromTo.From() == common.ELocation.File() {
+					// if we're ignoring the SMB LMT, then the service LMT will indicate the destination is older, not newer.
+					h.CreateFile(f("dotransfer", with{lastWriteTime: time.Now().Add(-time.Second * 60)}), true)
+				} else {
+					h.CreateFile(f("dotransfer"), true)
+				}
+			},
+		},
+		testFiles{
+			defaultSize: "1K",
+			shouldTransfer: []interface{}{
+				folder(""),
+				f("dotransfer"),
+			},
+			shouldSkip: []interface{}{
+				f("donottransfer"), // "real"/service LMT should be out of date
+			},
+		},
+		EAccountType.Standard(),
+		EAccountType.Standard(),
+		"",
+		)
+}
+
+func TestBasic_SyncLMTSwitch_PreferSMBLMT(t *testing.T) {
+	RunScenarios(
+		t,
+		eOperation.Sync(),
+		eTestFromTo.Other(common.EFromTo.LocalFile(), common.EFromTo.FileLocal()),
+		eValidate.Auto(),
+		anonymousAuthOnly,
+		anonymousAuthOnly,
+		params{
+			preserveSMBInfo: true,
+		},
+		&hooks{
+			beforeRunJob: func(h hookHelper) {
+				/*
+				In a typical scenario, the source is written before the destination.
+				This way, the destination is always skipped in the case of overwrite on Sync.
+
+				In this case, because we distinctly DO NOT want to test the service LMT, we'll create the destination before the source.
+				But, we'll create those files with an SMB LMT that would lead to a skipped file.
+				 */
+
+				newTestFiles := testFiles{
+					defaultSize: "1K",
+					shouldTransfer: []interface{}{
+						folder(""),
+						f("do overwrite"),
+					},
+					shouldSkip: []interface{}{
+						f("do not overwrite"),
+					},
+				}
+
+				// create do not overwrite in the future, so that it does not get overwritten
+				h.CreateFile(f("do not overwrite", with{lastWriteTime: time.Now().Add(time.Second * 60)}), false)
+				// create do overwrite in the past, so that it does get overwritten
+				h.CreateFile(f("do overwrite", with{lastWriteTime: time.Now().Add(-time.Second * 60)}), false)
+				time.Sleep(time.Second * 5)
+				h.CreateFiles(newTestFiles, true, true, false)
+			},
+		},
+		testFiles{
+			defaultSize: "1K",
+			shouldTransfer: []interface{}{
+				folder(""),
 			},
 		},
 		EAccountType.Standard(),

--- a/e2etest/zt_basic_copy_sync_remove_test.go
+++ b/e2etest/zt_basic_copy_sync_remove_test.go
@@ -347,7 +347,7 @@ func TestBasic_SyncLMTSwitch_PreferServiceLMT(t *testing.T) {
 		anonymousAuthOnly,
 		anonymousAuthOnly,
 		params{
-			preserveSMBInfo: false,
+			preserveSMBInfo: BoolPointer(false),
 		},
 		&hooks{
 			beforeRunJob: func(h hookHelper) {
@@ -394,7 +394,8 @@ func TestBasic_SyncLMTSwitch_PreferSMBLMT(t *testing.T) {
 		anonymousAuthOnly,
 		anonymousAuthOnly,
 		params{
-			preserveSMBInfo: true,
+			// default, but present for clarity
+			//preserveSMBInfo: BoolPointer(true),
 		},
 		&hooks{
 			beforeRunJob: func(h hookHelper) {

--- a/e2etest/zt_copy_file_smb_test.go
+++ b/e2etest/zt_copy_file_smb_test.go
@@ -10,8 +10,10 @@ import (
 func TestSMB_FromShareSnapshot(t *testing.T) {
 	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.FileFile()), eValidate.AutoPlusContent(), anonymousAuthOnly, anonymousAuthOnly, params{
 		recursive:              true,
-		preserveSMBInfo:        true,
 		preserveSMBPermissions: true,
+
+		// default, but present for clarity
+		//preserveSMBInfo:        BoolPointer(true),
 	}, &hooks{
 		// create a snapshot for the source share
 		beforeRunJob: func(h hookHelper) {
@@ -39,7 +41,7 @@ func TestSMB_ToDevNull(t *testing.T) {
 		params{
 			recursive:              true,
 			preserveSMBPermissions: isWindows,
-			preserveSMBInfo:        isWindows,
+			preserveSMBInfo:        BoolPointer(isWindows),
 			checkMd5:               common.EHashValidationOption.FailIfDifferent(),
 			destNull:               true,
 		},

--- a/e2etest/zt_preserve_smb_properties_test.go
+++ b/e2etest/zt_preserve_smb_properties_test.go
@@ -68,8 +68,10 @@ func TestProperties_SMBPermissionsSDDLPreserved(t *testing.T) {
 		common.EFromTo.FileFile(),
 	), eValidate.Auto(), anonymousAuthOnly, anonymousAuthOnly, params{
 		recursive:              true,
-		preserveSMBInfo:        true,
 		preserveSMBPermissions: true,
+
+		// default, but present for clarity
+		//preserveSMBInfo:        BoolPointer(true),
 	}, nil, testFiles{
 		defaultSize: "1K",
 		shouldTransfer: []interface{}{
@@ -88,7 +90,9 @@ func TestProperties_SMBPermissionsSDDLPreserved(t *testing.T) {
 func TestProperties_SMBDates(t *testing.T) {
 	RunScenarios(t, eOperation.CopyAndSync(), eTestFromTo.Other(common.EFromTo.LocalFile(), common.EFromTo.FileLocal()), eValidate.Auto(), anonymousAuthOnly, anonymousAuthOnly, params{
 		recursive:       true,
-		preserveSMBInfo: true,
+
+		// default, but present for clarity
+		//preserveSMBInfo:        BoolPointer(true),
 	}, &hooks{
 		beforeRunJob: func(h hookHelper) {
 			// Pause then re-write all the files, so that their LastWriteTime is different from their creation time
@@ -118,7 +122,9 @@ func TestProperties_SMBDates(t *testing.T) {
 func TestProperties_SMBFlags(t *testing.T) {
 	RunScenarios(t, eOperation.CopyAndSync(), eTestFromTo.Other(common.EFromTo.LocalFile(), common.EFromTo.FileFile(), common.EFromTo.FileLocal()), eValidate.Auto(), anonymousAuthOnly, anonymousAuthOnly, params{
 		recursive:       true,
-		preserveSMBInfo: true,
+
+		// default, but present for clarity
+		//preserveSMBInfo:        BoolPointer(true),
 	}, nil, testFiles{
 		defaultSize: "1K",
 		shouldTransfer: []interface{}{
@@ -143,7 +149,9 @@ func TestProperties_SMBPermsAndFlagsWithIncludeAfter(t *testing.T) {
 
 	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.FileLocal()), eValidate.Auto(), anonymousAuthOnly, anonymousAuthOnly, params{
 		recursive:       true,
-		preserveSMBInfo: true, // this wasn't compatible with time-sensitive filtering prior.
+
+		// default, but present for clarity
+		//preserveSMBInfo:        BoolPointer(true),
 		// includeAfter: SET LATER
 	}, &hooks{
 		beforeRunJob: func(h hookHelper) {
@@ -190,7 +198,9 @@ func TestProperties_SMBPermsAndFlagsWithSync(t *testing.T) {
 
 	RunScenarios(t, eOperation.Sync(), eTestFromTo.Other(common.EFromTo.LocalFile(), common.EFromTo.FileLocal()), eValidate.Auto(), anonymousAuthOnly, anonymousAuthOnly, params{
 		recursive:       true,
-		preserveSMBInfo: true, // this wasn't compatible with time-sensitive filtering prior.
+
+		// default, but present for clarity
+		//preserveSMBInfo:        BoolPointer(true),
 	}, &hooks{
 		beforeRunJob: func(h hookHelper) {
 			// Pause then re-write all the files, so that their LastWriteTime is different from their creation time
@@ -244,7 +254,9 @@ func TestProperties_SMBWithCopyWithShareRoot(t *testing.T) {
 			recursive:              true,
 			invertedAsSubdir:       true,
 			preserveSMBPermissions: true,
-			preserveSMBInfo:        true,
+
+			// default, but present for clarity
+			//preserveSMBInfo:        BoolPointer(true),
 		},
 		nil,
 		testFiles{
@@ -276,7 +288,9 @@ func TestProperties_SMBTimes(t *testing.T) {
 		anonymousAuthOnly,
 		params{
 			recursive:       true,
-			preserveSMBInfo: true,
+
+			// default, but present for clarity
+			//preserveSMBInfo:        BoolPointer(true),
 		},
 		nil,
 		testFiles{

--- a/e2etest/zt_resume_windows_test.go
+++ b/e2etest/zt_resume_windows_test.go
@@ -10,10 +10,12 @@ func TestResume_FolderState(t *testing.T) {
 	// Create a child file before the folder itself, then persist the properties of the folder upon resume, knowing that we created the folder.
 	RunScenarios(t, eOperation.CopyAndSync()|eOperation.Resume(), eTestFromTo.Other(common.EFromTo.LocalFile(), common.EFromTo.FileFile(), common.EFromTo.FileLocal()), eValidate.Auto(), anonymousAuthOnly, anonymousAuthOnly, params{
 		recursive:       true,
-		preserveSMBInfo: true,
 		debugSkipFiles: []string{
 			"a",
 		},
+
+		// default, but present for clarity
+		//preserveSMBInfo:        BoolPointer(true),
 	}, nil, testFiles{
 		defaultSize: "1K",
 
@@ -29,11 +31,13 @@ func TestResume_NoCreateFolder(t *testing.T) {
 	// Don't create the folder "ourselves", and let AzCopy find that out on a resume.
 	RunScenarios(t, eOperation.Copy()|eOperation.Resume(), eTestFromTo.Other(common.EFromTo.LocalFile(), common.EFromTo.FileFile(), common.EFromTo.FileLocal()), eValidate.Auto(), anonymousAuthOnly, anonymousAuthOnly, params{
 		recursive:       true,
-		preserveSMBInfo: true,
 		debugSkipFiles: []string{
 			"a",
 			"a/b",
 		},
+
+		// default, but present for clarity
+		//preserveSMBInfo:        BoolPointer(true),
 	}, &hooks{
 		beforeResumeHook: func(h hookHelper) {
 			// Create the folder in the middle of the transfer


### PR DESCRIPTION
https://github.com/Azure/azure-storage-azcopy/issues/1956

It turns out having two completely unreliable LMTs doesn't work well.