### PR TITLE
[Bug] Correct odd behaviour surrounding folder overwrites

### DIFF
--- a/common/folderCreationTracker_interface.go
+++ b/common/folderCreationTracker_interface.go
@@ -5,7 +5,7 @@ package common
 // with the fact that when overwrite == false, we only set file properties on files created
 // by the current job)
 type FolderCreationTracker interface {
-	RecordCreation(folder string)
+	CreateFolder(folder string, doCreation func() error) error
 	ShouldSetProperties(folder string, overwrite OverwriteOption, prompter Prompter) bool
 	StopTracking(folder string)
 }

--- a/common/writeThoughFile.go
+++ b/common/writeThoughFile.go
@@ -62,20 +62,9 @@ func CreateDirectoryIfNotExist(directory string, tracker FolderCreationTracker) 
 		CreateParentDirectoryIfNotExist(directory, tracker)
 
 		// then create the directory
-		mkDirErr := os.Mkdir(directory, os.ModePerm)
-
-		// if Mkdir succeeds, no error is dropped-- it is nil.
-		// therefore, returning here is perfectly acceptable as it either succeeds (or it doesn't)
-		if mkDirErr == nil {
-			// To run our folder overwrite logic, we have to know if this current job created the folder.
-			// As per the comments above, we are technically wrong here in a write-only scenario (maybe it already
-			// existed and our Stat failed).  But using overwrite=false on a write-only destination doesn't make
-			// a lot of sense anyway. Yes, we'll make the wrong decision here in a write-only scenario, but we'll
-			// make the _same_ wrong overwrite decision for all the files too (not just folders). So this is, at least,
-			// consistent.
-			tracker.RecordCreation(directory)
-			return nil
-		}
+		mkDirErr := tracker.CreateFolder(directory, func() error {
+			return os.Mkdir(directory, os.ModePerm)
+		})
 
 		// another routine might have created the directory at the same time
 		// check whether the directory now exists

--- a/ste/sender-azureFile.go
+++ b/ste/sender-azureFile.go
@@ -336,7 +336,7 @@ func (u *azureFileSenderBase) Epilogue() {
 	//   2. The service started updating the last-write-time in March 2021 when the file is modified.
 	//      So when we uploaded the ranges, we've unintentionally changed the last-write-time.
 	if u.jptm.IsLive() && u.jptm.Info().PreserveSMBInfo {
-		//This is an extra round trip, but we can live with that for these relatively rare cases
+		// This is an extra round trip, but we can live with that for these relatively rare cases
 		_, err := u.fileURL().SetHTTPHeaders(u.ctx, u.headersToApply)
 		if err != nil {
 			u.jptm.FailActiveSend("Applying final attribute settings", err)
@@ -464,16 +464,12 @@ func (d AzureFileParentDirCreator) CreateDirToRoot(ctx context.Context, dirURL a
 			// Try to create the directories
 			for i := 0; i < len(segments); i++ {
 				curDirURL = curDirURL.NewDirectoryURL(segments[i])
-				// TODO: Persist permissions on folders.
-				_, err := curDirURL.Create(ctx, azfile.Metadata{}, azfile.SMBProperties{})
-				if err == nil {
-					// We did create it, so record that fact. I.e. THIS job created the folder.
-					// Must do it here, in the routine that is shared by both the folder and the file code,
-					// because due to the parallelism of AzCopy, we don't know which will get here first, file code, or folder code.
-					dirUrl := curDirURL.URL()
-					dirUrl.RawQuery = ""
-					t.RecordCreation(dirUrl.String())
-				}
+				recorderURL := curDirURL.URL()
+				recorderURL.RawQuery = ""
+				err = t.CreateFolder(recorderURL.String(), func() error {
+					_, err := curDirURL.Create(ctx, azfile.Metadata{}, azfile.SMBProperties{})
+					return err
+				})
 				if verifiedErr := d.verifyAndHandleCreateErrors(err); verifiedErr != nil {
 					return verifiedErr
 				}

--- a/ste/sender-blobFolders.go
+++ b/ste/sender-blobFolders.go
@@ -90,20 +90,23 @@ func (b *blobFolderSender) EnsureFolderExists() error {
 		return fmt.Errorf("when getting additional folder properties: %w", err)
 	}
 
-	_, err = b.destination.Upload(b.jptm.Context(),
-		strings.NewReader(""),
-		b.headersToAppply,
-		b.metadataToApply,
-		azblob.BlobAccessConditions{},
-		azblob.DefaultAccessTier, // It doesn't make sense to use a special access tier, the blob will be 0 bytes.
-		b.blobTagsToApply,
-		b.cpkToApply,
-		azblob.ImmutabilityPolicyOptions{})
+	err = t.CreateFolder(b.DirUrlToString(), func() error {
+		_, err := b.destination.Upload(b.jptm.Context(),
+			strings.NewReader(""),
+			b.headersToAppply,
+			b.metadataToApply,
+			azblob.BlobAccessConditions{},
+			azblob.DefaultAccessTier, // It doesn't make sense to use a special access tier, the blob will be 0 bytes.
+			b.blobTagsToApply,
+			b.cpkToApply,
+			azblob.ImmutabilityPolicyOptions{})
+
+		return err
+	})
+
 	if err != nil {
 		return fmt.Errorf("when creating folder: %w", err)
 	}
-
-	t.RecordCreation(b.DirUrlToString())
 
 	return folderPropertiesSetInCreation{}
 }


### PR DESCRIPTION
# Bug description

Assume a directory structure `C:\like\this`.

On one thread, AzCopy goes to create `this` and set it's properties.
On the other thread, AzCopy goes to create `like` and set it's properties.

`this` creates it's parent directory `like`, but before the folder creation manager can be informed this has occurred, `like` skipped over folder creation, having existed, and locks the mutex on the folder creation manager.

Though we created `like`, we're not sure we did, because it hasn't been inserted into the creation manager yet.

# Solution

Change the folder creation manager such that the act of creating the directory is done under the mutex to prevent getting locked out when trying to inform the manager.