### PR TITLE
Updated version check string to indicate current AzCopy version

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -292,7 +292,7 @@ func beginDetectNewVersion() chan struct{} {
 			executableName := executablePathSegments[len(executablePathSegments)-1]
 
 			// output in info mode instead of stderr, as it was crashing CI jobs of some people
-			glcm.Info(executableName + ": A newer version " + remoteVersion + " is available to download\n")
+			glcm.Info(executableName + " " + common.AzcopyVersion + ": A newer version " + remoteVersion + " is available to download\n")
 		}
 
 		// let caller know we have finished, if they want to know


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-storage-azcopy/issues/1502

Version check string now looks as follows (I just manually downgraded the version string when locally testing)

INFO: azcopy.exe 10.16.0: A newer version 10.16.2 is available to download
