### PR TITLE
OAuth token refreshes bug fix + optimization

### DIFF
--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -964,10 +964,7 @@ func (jm *jobMgr) scheduleJobParts() {
 				go jm.poolSizer()
 				startedPoolSizer = true
 			}
-			getCredential := true
-			if jm.credential != nil {
-				getCredential = false
-			}
+			getCredential := jm.credential == nil
 			jobPart.ScheduleTransfers(jm.Context(), getCredential, jm.credential)
 			if getCredential {
 				jm.credential = jobPart.SourceCredential()

--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -964,9 +964,9 @@ func (jm *jobMgr) scheduleJobParts() {
 				go jm.poolSizer()
 				startedPoolSizer = true
 			}
-			getCredential := jm.credential == nil
-			jobPart.ScheduleTransfers(jm.Context(), getCredential, jm.credential)
-			if getCredential {
+			getSourceCredential := jm.credential == nil
+			jobPart.ScheduleTransfers(jm.Context(), getSourceCredential, jm.credential)
+			if getSourceCredential {
 				jm.credential = jobPart.SourceCredential()
 			}
 		}

--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -964,9 +964,8 @@ func (jm *jobMgr) scheduleJobParts() {
 				go jm.poolSizer()
 				startedPoolSizer = true
 			}
-			getSourceCredential := jm.credential == nil
-			jobPart.ScheduleTransfers(jm.Context(), getSourceCredential, jm.credential)
-			if getSourceCredential {
+			jobPart.ScheduleTransfers(jm.Context(), jm.credential)
+			if jm.credential == nil {
 				jm.credential = jobPart.SourceCredential()
 			}
 		}

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -28,7 +28,7 @@ var DebugSkipFiles = make(map[string]bool)
 
 type IJobPartMgr interface {
 	Plan() *JobPartPlanHeader
-	ScheduleTransfers(jobCtx context.Context, getCredential bool, credential pipeline.Factory)
+	ScheduleTransfers(jobCtx context.Context, getSourceCredential bool, credential pipeline.Factory)
 	StartJobXfer(jptm IJobPartTransferMgr)
 	ReportTransferDone(status common.TransferStatus) uint32
 	GetOverwriteOption() common.OverwriteOption
@@ -340,7 +340,7 @@ func (jpm *jobPartMgr) Plan() *JobPartPlanHeader {
 }
 
 // ScheduleTransfers schedules this job part's transfers. It is called when a new job part is ordered & is also called to resume a paused Job
-func (jpm *jobPartMgr) ScheduleTransfers(jobCtx context.Context, getCredential bool, credential pipeline.Factory) {
+func (jpm *jobPartMgr) ScheduleTransfers(jobCtx context.Context, getSourceCredential bool, credential pipeline.Factory) {
 	jobCtx = context.WithValue(jobCtx, ServiceAPIVersionOverride, DefaultServiceApiVersion)
 	jpm.atomicTransfersDone = 0 // Reset the # of transfers done back to 0
 	// partplan file is opened and mapped when job part is added
@@ -409,7 +409,7 @@ func (jpm *jobPartMgr) ScheduleTransfers(jobCtx context.Context, getCredential b
 
 	jpm.priority = plan.Priority
 
-	jpm.createPipelines(jobCtx, getCredential, credential) // pipeline is created per job part manager
+	jpm.createPipelines(jobCtx, getSourceCredential, credential) // pipeline is created per job part manager
 
 	// *** Schedule this job part's transfers ***
 	for t := uint32(0); t < plan.NumTransfers; t++ {

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -632,7 +632,7 @@ func (jpm *jobPartMgr) createPipelines(ctx context.Context, sourceCredential pip
 		} else {
 			cred = sourceCredential.(azblob.Credential)
 		}
-		jpm.Log(pipeline.LogInfo, fmt.Sprintf("JobID=%v, sourceCredential type: %v", jpm.Plan().JobID, credInfo.CredentialType))
+		jpm.Log(pipeline.LogInfo, fmt.Sprintf("JobID=%v, credential type: %v", jpm.Plan().JobID, credInfo.CredentialType))
 		jpm.pipeline = NewBlobPipeline(
 			cred,
 			azblob.PipelineOptions{

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -512,7 +512,7 @@ func (jpm *jobPartMgr) RescheduleTransfer(jptm IJobPartTransferMgr) {
 	jpm.jobMgr.ScheduleTransfer(jpm.priority, jptm)
 }
 
-func (jpm *jobPartMgr) createPipelines(ctx context.Context, getCredential bool, credential pipeline.Factory) {
+func (jpm *jobPartMgr) createPipelines(ctx context.Context, getSourceCredential bool, credential pipeline.Factory) {
 	if atomic.SwapUint32(&jpm.atomicPipelinesInitedIndicator, 1) != 0 {
 		panic("init client and pipelines for same jobPartMgr twice")
 	}
@@ -561,7 +561,7 @@ func (jpm *jobPartMgr) createPipelines(ctx context.Context, getCredential bool, 
 				CallerID: fmt.Sprintf("JobID=%v, Part#=%d", jpm.Plan().JobID, jpm.Plan().PartNum),
 				Cancel:   jpm.jobMgr.Cancel,
 			}
-			if getCredential {
+			if getSourceCredential {
 				sourceCred = common.CreateBlobCredential(ctx, jobState.CredentialInfo.WithType(jobState.S2SSourceCredentialType), credOption)
 				jpm.sourceCredential = sourceCred
 			} else {
@@ -627,7 +627,7 @@ func (jpm *jobPartMgr) createPipelines(ctx context.Context, getCredential bool, 
 	case common.EFromTo.BlobTrash(), common.EFromTo.BlobLocal(), common.EFromTo.LocalBlob(), common.EFromTo.BenchmarkBlob(),
 		common.EFromTo.BlobBlob(), common.EFromTo.FileBlob(), common.EFromTo.S3Blob(), common.EFromTo.GCPBlob(), common.EFromTo.BlobNone(), common.EFromTo.BlobFSNone():
 		var cred azblob.Credential
-		if getCredential {
+		if getSourceCredential {
 			cred = common.CreateBlobCredential(ctx, credInfo, credOption)
 		} else {
 			cred = credential.(azblob.Credential)


### PR DESCRIPTION
Currently any large job using OAuth will eventually hit a service error we're refreshes are happening too frequently, due to the nature of jobs concurrently running in parts, the token is refreshed too many times rather than reusing the already created fresh token. This PR fixes that - it also led to better perf due to the lower number of service calls.

Resolves https://github.com/Azure/azure-storage-azcopy/issues/1984
Resolves https://github.com/Azure/azure-storage-azcopy/issues/1957