### PR TITLE
azcopy fail to copy 12TB file to Storage containers

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,14 @@
 
 # Change Log
 
+## Version 10.16.2
+
+### Bug Fixes
+
+1. Fixed an issue where sync would always re-download files as we were comparing against the service LMT, not the SMB LMT
+2. Fixed a crash when copying objects service to service using a user delegation SAS token
+3. Fixed a crash when deleting folders that may have a raw path string
+
 ## Version 10.16.1
 
 ### Documentation changes

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,15 +48,37 @@ jobs:
 
       - script: |
           GOARCH=amd64 GOOS=linux go build -o "$(Build.ArtifactStagingDirectory)/azcopy_linux_amd64"
+        displayName: 'Generate Linux AMD64'
+        condition: eq(variables.type, 'linux')
+
+      - script: |
           GOARCH=amd64 GOOS=linux go build -tags "se_integration" -o "$(Build.ArtifactStagingDirectory)/azcopy_linux_se_amd64"
+        displayName: 'Generate Linux AMD64 SE Integration'
+        condition: eq(variables.type, 'linux')
+
+      - script: |
           GOARCH=arm64 GOOS=linux go build -o "$(Build.ArtifactStagingDirectory)/azcopy_linux_arm64"
+        displayName: 'Generate Linux ARM64'
+        condition: eq(variables.type, 'linux')
 
+      - script: |
           GOARCH=amd64 GOOS=windows go build -o "$(Build.ArtifactStagingDirectory)/azcopy_windows_amd64.exe"
-          GOARCH=386 GOOS=windows go build -o "$(Build.ArtifactStagingDirectory)/azcopy_windows_386.exe"
-          GOARCH=arm GOARM=7 GOOS=windows go build -o "$(Build.ArtifactStagingDirectory)/azcopy_windows_v7_arm.exe"
+        displayName: 'Generate Windows AMD64'
+        condition: eq(variables.type, 'linux')
 
+      - script: |
+          GOARCH=386 GOOS=windows go build -o "$(Build.ArtifactStagingDirectory)/azcopy_windows_386.exe"
+        displayName: 'Generate Windows i386'
+        condition: eq(variables.type, 'linux')
+
+      - script: |
+          GOARCH=arm GOARM=7 GOOS=windows go build -o "$(Build.ArtifactStagingDirectory)/azcopy_windows_v7_arm.exe"
+        displayName: 'Generate Windows ARM'
+        condition: eq(variables.type, 'linux')
+
+      - script: |
           cp NOTICE.txt $(Build.ArtifactStagingDirectory)
-        displayName: 'Generate Linux And Windows Build'
+        displayName: 'Copy NOTICE.txt'
         condition: eq(variables.type, 'linux')
 
       - script: |

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -943,8 +943,8 @@ func areBothLocationsSMBAware(fromTo common.FromTo) bool {
 func areBothLocationsPOSIXAware(fromTo common.FromTo) bool {
 	// POSIX properties are stored in blob metadata-- They don't need a special persistence strategy for BlobBlob.
 	return runtime.GOOS == "linux" && (
-	// fromTo == common.EFromTo.BlobLocal() || TODO
-	fromTo == common.EFromTo.LocalBlob()) ||
+		// fromTo == common.EFromTo.BlobLocal() || TODO
+		fromTo == common.EFromTo.LocalBlob()) ||
 		fromTo == common.EFromTo.BlobBlob()
 }
 

--- a/cmd/zc_traverser_file.go
+++ b/cmd/zc_traverser_file.go
@@ -87,6 +87,9 @@ func (t *fileTraverser) Traverse(preprocessor objectMorpher, processor objectPro
 				targetURLParts.ShareName,
 			)
 
+			smbLastWriteTime, _ := time.Parse(azfile.ISO8601, fileProperties.FileLastWriteTime()) // no need to worry about error since we'll only check against it if it's non-zero for sync
+			storedObject.smbLastModifiedTime = smbLastWriteTime
+
 			if t.incrementEnumerationCounter != nil {
 				t.incrementEnumerationCounter(common.EEntityType.File())
 			}
@@ -111,6 +114,7 @@ func (t *fileTraverser) Traverse(preprocessor objectMorpher, processor objectPro
 
 		// We need to omit some properties if we don't get properties
 		lmt := time.Time{}
+		smbLMT := time.Time{}
 		var contentProps contentPropsProvider = noContentProps
 		var meta common.Metadata = nil
 
@@ -124,6 +128,7 @@ func (t *fileTraverser) Traverse(preprocessor objectMorpher, processor objectPro
 				}, err
 			}
 			lmt = fullProperties.LastModified()
+			smbLMT, _ = time.Parse(azfile.ISO8601, fullProperties.FileLastWriteTime())
 			if f.entityType == common.EEntityType.File() {
 				contentProps = fullProperties.(*azfile.FileGetPropertiesResponse) // only files have content props. Folders don't.
 				// Get an up-to-date size, because it's documented that the size returned by the listing might not be up-to-date,
@@ -135,7 +140,7 @@ func (t *fileTraverser) Traverse(preprocessor objectMorpher, processor objectPro
 			}
 			meta = common.FromAzFileMetadataToCommonMetadata(fullProperties.NewMetadata())
 		}
-		return newStoredObject(
+		obj := newStoredObject(
 			preprocessor,
 			getObjectNameOnly(f.name),
 			relativePath,
@@ -146,7 +151,11 @@ func (t *fileTraverser) Traverse(preprocessor objectMorpher, processor objectPro
 			noBlobProps,
 			meta,
 			targetURLParts.ShareName,
-		), nil
+		)
+
+		obj.smbLastModifiedTime = smbLMT
+
+		return obj, nil
 	}
 
 	processStoredObject := func(s StoredObject) error {
@@ -262,7 +271,7 @@ func newFileTraverser(rawURL *url.URL, p pipeline.Pipeline, ctx context.Context,
 	return
 }
 
-//  allows polymorphic treatment of folders and files
+// allows polymorphic treatment of folders and files
 type azfileEntity struct {
 	name           string
 	contentLength  int64
@@ -301,4 +310,5 @@ func newAzFileRootFolderEntity(rootDir azfile.DirectoryURL, name string) azfileE
 type azfilePropertiesAdapter interface {
 	NewMetadata() azfile.Metadata
 	LastModified() time.Time
+	FileLastWriteTime() string
 }

--- a/common/environment.go
+++ b/common/environment.go
@@ -70,6 +70,7 @@ var VisibleEnvironmentVariables = []EnvironmentVariable{
 	EEnvironmentVariable.CPKEncryptionKeySHA256(),
 	EEnvironmentVariable.DisableSyslog(),
 	EEnvironmentVariable.MimeMapping(),
+	EEnvironmentVariable.DownloadToTempPath(),
 }
 
 var EEnvironmentVariable = EnvironmentVariable{}

--- a/common/folderDeletionManager.go
+++ b/common/folderDeletionManager.go
@@ -130,7 +130,7 @@ func (s *standardFolderDeletionManager) getParent(u *url.URL) (*url.URL, bool) {
 	out := s.clean(u)
 	out.Path = out.Path[:strings.LastIndex(out.Path, "/")]
 	if out.RawPath != "" {
-		out.RawPath = out.Path[:strings.LastIndex(out.RawPath, "/")]
+		out.RawPath = out.RawPath[:strings.LastIndex(out.RawPath, "/")]
 	}
 	return out, true
 }

--- a/common/oauthTokenManager.go
+++ b/common/oauthTokenManager.go
@@ -774,6 +774,11 @@ func fixupTokenJson(bytes []byte) []byte {
 	separatorString := `"not_before":"`
 	stringSlice := strings.Split(byteSliceToString, separatorString)
 
+	// OIDC token issuer returns an integer for "not_before" and not a string
+	if len(stringSlice) == 1 {
+		return bytes
+	}
+
 	if stringSlice[1][0] != '"' {
 		return bytes
 	}

--- a/common/version.go
+++ b/common/version.go
@@ -1,6 +1,6 @@
 package common
 
-const AzcopyVersion = "10.16.1"
+const AzcopyVersion = "10.16.2"
 const UserAgent = "AzCopy/" + AzcopyVersion
 const S3ImportUserAgent = "S3Import " + UserAgent
 const GCPImportUserAgent = "GCPImport " + UserAgent

--- a/e2etest/declarativeResourceAdapters.go
+++ b/e2etest/declarativeResourceAdapters.go
@@ -111,6 +111,11 @@ func (a filesResourceAdapter) toHeaders(c asserter, share azfile.ShareURL) azfil
 		headers.SMBProperties.FileAttributes = &attribs
 	}
 
+	if a.obj.creationProperties.lastWriteTime != nil {
+		lwt := *a.obj.creationProperties.lastWriteTime
+		headers.SMBProperties.FileLastWriteTime = &lwt
+	}
+
 	props := a.obj.creationProperties.contentHeaders
 	if props == nil {
 		return headers

--- a/e2etest/zt_preserve_smb_properties_test.go
+++ b/e2etest/zt_preserve_smb_properties_test.go
@@ -83,8 +83,8 @@ func TestProperties_SMBPermissionsSDDLPreserved(t *testing.T) {
 }
 
 // TODO: add some tests (or modify the above) to make assertions about case preservation (or not) in metadata
-//    See https://github.com/Azure/azure-storage-azcopy/issues/113 (which incidentally, I'm not observing in the tests above, for reasons unknown)
 //
+//	See https://github.com/Azure/azure-storage-azcopy/issues/113 (which incidentally, I'm not observing in the tests above, for reasons unknown)
 func TestProperties_SMBDates(t *testing.T) {
 	RunScenarios(t, eOperation.CopyAndSync(), eTestFromTo.Other(common.EFromTo.LocalFile(), common.EFromTo.FileLocal()), eValidate.Auto(), anonymousAuthOnly, anonymousAuthOnly, params{
 		recursive:       true,
@@ -258,6 +258,33 @@ func TestProperties_SMBWithCopyWithShareRoot(t *testing.T) {
 				f("a/asdf.txt", with{smbAttributes: 2, smbPermissionsSddl: fileSDDL}),
 				folder("a/b", with{smbAttributes: 2, smbPermissionsSddl: folderSDDL}),
 				f("a/b/asdf.txt", with{smbAttributes: 2, smbPermissionsSddl: fileSDDL}),
+			},
+		},
+		EAccountType.Standard(),
+		EAccountType.Standard(),
+		"",
+	)
+}
+
+func TestProperties_SMBTimes(t *testing.T) {
+	RunScenarios(
+		t,
+		eOperation.Sync(),
+		eTestFromTo.Other(common.EFromTo.FileLocal()),
+		eValidate.Auto(),
+		anonymousAuthOnly,
+		anonymousAuthOnly,
+		params{
+			recursive:       true,
+			preserveSMBInfo: true,
+		},
+		nil,
+		testFiles{
+			defaultSize: "1K",
+
+			shouldSkip: []interface{}{
+				folder("", with{lastWriteTime: time.Now().Add(-time.Hour)}),    // If the fix worked, these should not be overwritten.
+				f("asdf.txt", with{lastWriteTime: time.Now().Add(-time.Hour)}), // If the fix did not work, we'll be relying upon the service's "real" LMT, which is not what we persisted, and an hour ahead of our files.
 			},
 		},
 		EAccountType.Standard(),

--- a/jobsAdmin/JobsAdmin.go
+++ b/jobsAdmin/JobsAdmin.go
@@ -545,7 +545,7 @@ func (ja *jobsAdmin) LogToJobLog(msg string, level pipeline.LogLevel) {
 	if level <= pipeline.LogWarning {
 		prefix = fmt.Sprintf("%s: ", common.LogLevel(level)) // so readers can find serious ones, but information ones still look uncluttered without INFO:
 	}
-	ja.jobLogger.Log(pipeline.LogWarning, prefix+msg) // use LogError here, so that it forces these to get logged, even if user is running at warning level instead of Info.  They won't have "warning" prefix, if Info level was passed in to MessagesForJobLog
+	ja.jobLogger.Log(level, prefix+msg)
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func main() {
 		azcopyLogPathFolder = azcopyAppPathFolder
 	}
 	if err := os.Mkdir(azcopyLogPathFolder, os.ModeDir|os.ModePerm); err != nil && !os.IsExist(err) {
-		common.PanicIfErr(err)
+		log.Fatalf("Problem making .azcopy directory. Try setting AZCOPY_LOG_LOCATION env variable. %v", err)
 	}
 
 	// the user can optionally put the plan files somewhere else
@@ -66,7 +66,7 @@ func main() {
 		azcopyJobPlanFolder = path.Join(azcopyAppPathFolder, "plans")
 	}
 	if err := os.Mkdir(azcopyJobPlanFolder, os.ModeDir|os.ModePerm); err != nil && !os.IsExist(err) {
-		common.PanicIfErr(err)
+		log.Fatalf("Problem making .azcopy directory. Try setting AZCOPY_PLAN_FILE_LOCATION env variable. %v", err)
 	}
 
 	jobID := common.NewJobID()

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -95,6 +95,7 @@ type IJobPartTransferMgr interface {
 	GetS2SSourceBlobTokenCredential() azblob.TokenCredential
 	PropertiesToTransfer() common.SetPropertiesFlags
 	ResetSourceSize() // sets source size to 0 (made to be used by setProperties command to make number of bytes transferred = 0)
+	SuccessfulBytesTransferred() int64
 }
 
 type TransferInfo struct {
@@ -972,4 +973,8 @@ func (jptm *jobPartTransferMgr) ShouldInferContentType() bool {
 	// For local files, even if the file size is 0B, we try to infer the content based on file extension
 	fromTo := jptm.FromTo()
 	return fromTo.From() == common.ELocation.Local()
+}
+
+func (jptm *jobPartTransferMgr) SuccessfulBytesTransferred() int64 {
+	return atomic.LoadInt64(&jptm.atomicSuccessfulBytes)
 }

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -341,7 +341,7 @@ func (jptm *jobPartTransferMgr) Info() TransferInfo {
 	// does not exceeds 50000 (max number of block per blob)
 	if blockSize == 0 {
 		blockSize = common.DefaultBlockBlobBlockSize
-		for ; uint32(sourceSize/blockSize) > common.MaxNumberOfBlocksPerBlob; blockSize = 2 * blockSize {
+		for ; sourceSize > common.MaxNumberOfBlocksPerBlob * blockSize; blockSize = 2 * blockSize {
 			if blockSize > common.BlockSizeThreshold {
 				/*
 				 * For a RAM usage of 0.5G/core, we would have 4G memory on typical 8 core device, meaning at a blockSize of 256M,

--- a/ste/sourceInfoProvider-Local_linux.go
+++ b/ste/sourceInfoProvider-Local_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package ste
@@ -123,7 +124,7 @@ func (s statTAdapter) BTime() time.Time {
 }
 
 func (s statTAdapter) NLink() uint64 {
-	return s.Nlink
+	return uint64(s.Nlink) // On amd64, this is a uint64. On arm64, this is a uint32. Do not remove this typecast.
 }
 
 func (s statTAdapter) Owner() uint32 {

--- a/ste/xfer-anyToRemote-file.go
+++ b/ste/xfer-anyToRemote-file.go
@@ -66,7 +66,7 @@ func prepareDestAccountInfo(bURL azblob.BlobURL, jptm IJobPartTransferMgr, ctx c
 			} else {
 				tierSetPossibleFail = true
 				glcm := common.GetLifecycleMgr()
-				glcm.Info("Transfers are likely to fail because destination does not support tiers.")
+				glcm.Info("Transfers could fail because AzCopy could not verify if the destination supports tiers.")
 				destAccountSKU = "failget"
 				destAccountKind = "failget"
 			}
@@ -127,8 +127,9 @@ func ValidateTier(jptm IJobPartTransferMgr, blobTier azblob.AccessTierType, blob
 		// Let's check if we can confirm we'll be able to check the destination blob's account info.
 		// A SAS token, even with write-only permissions is enough. OR, OAuth with the account owner.
 		// We can't guess that last information, so we'll take a gamble and try to get account info anyway.
+		// User delegation SAS is the same as OAuth
 		destParts := azblob.NewBlobURLParts(blobURL.URL())
-		mustGet := destParts.SAS.Encode() != ""
+		mustGet := destParts.SAS.Encode() != "" && destParts.SAS.SignedTid() == ""
 
 		prepareDestAccountInfo(blobURL, jptm, ctx, mustGet)
 		tierAvailable := BlobTierAllowed(blobTier)


### PR DESCRIPTION
The logic is used to calculate proper blockSize if it’s not provided, and due to the uint32 cast, it can’t give proper blockSize if filesize is between 50000 * (8 * 1024 * 1024) * X + 1, to 50000 * (8 * 1024 * 1024) * X + 49999. It should return 16MB instead of 8MB blockSize.