### PR TITLE
Update block ID generation logic

### DIFF
--- a/common/extensions.go
+++ b/common/extensions.go
@@ -183,6 +183,8 @@ func GenerateFullPathWithQuery(rootPath, childPath, extraQuery string) string {
 	}
 }
 
+// Block Names of blobs are of format noted below. We generate prefix here. 
+// md5-Sum{ <128 Bit GUID of AzCopy JobID><5B PartNum><5B Index in the jobPart><5B blockNum> }
 func GenerateBlockBlobBlockID(blockNamePrefix string, index int32) string {
 	blockNameMd5 := md5.Sum([]byte(fmt.Sprintf("%s%05d", blockNamePrefix, index)))
 	blockID, _ := uuid.FromBytes(blockNameMd5[:]) //This func returns error if size of blockNameMd5 is not 16

--- a/common/extensions.go
+++ b/common/extensions.go
@@ -2,12 +2,16 @@ package common
 
 import (
 	"bytes"
+	"crypto/md5"
+	"encoding/base64"
+	"fmt"
 	"net/http"
 	"net/url"
 	"runtime"
 	"strings"
 
 	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
+	"github.com/google/uuid"
 
 	"github.com/Azure/azure-storage-file-go/azfile"
 )
@@ -177,4 +181,10 @@ func GenerateFullPathWithQuery(rootPath, childPath, extraQuery string) string {
 	} else {
 		return p + "?" + extraQuery
 	}
+}
+
+func GenerateBlockBlobBlockID(blockNamePrefix string, index int32) string {
+	blockNameMd5 := md5.Sum([]byte(fmt.Sprintf("%s%05d", blockNamePrefix, index)))
+	blockID, _ := uuid.FromBytes(blockNameMd5[:]) //This func returns error if size of blockNameMd5 is not 16
+	return base64.StdEncoding.EncodeToString([]byte(blockID.String()))
 }

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -96,6 +96,7 @@ type IJobPartTransferMgr interface {
 	PropertiesToTransfer() common.SetPropertiesFlags
 	ResetSourceSize() // sets source size to 0 (made to be used by setProperties command to make number of bytes transferred = 0)
 	SuccessfulBytesTransferred() int64
+	TransferIndex() (partNum, transferIndex uint32)
 }
 
 type TransferInfo struct {
@@ -120,9 +121,6 @@ type TransferInfo struct {
 	SrcBlobType    azblob.BlobType       // used for both S2S and for downloads to local from blob
 	S2SSrcBlobTier azblob.AccessTierType // AccessTierType (string) is used to accommodate service-side support matrix change.
 
-	// NumChunks is the number of chunks in which transfer will be split into while uploading the transfer.
-	// NumChunks is not used in case of AppendBlob transfer.
-	NumChunks         uint16
 	RehydratePriority azblob.RehydratePriorityType
 }
 
@@ -549,6 +547,11 @@ func (jptm *jobPartTransferMgr) PropertiesToTransfer() common.SetPropertiesFlags
 
 func (jptm *jobPartTransferMgr) ResetSourceSize() {
 	jptm.transferInfo.SourceSize = 0
+}
+
+// This will identity a file in a job
+func (jptm *jobPartTransferMgr) TransferIndex() (partNum, transferIndex uint32) {
+	return uint32(jptm.jobPartMgr.Plan().PartNum), jptm.transferIndex
 }
 
 // JobHasLowFileCount returns an estimate of whether we only have a very small number of files in the overall job

--- a/ste/sender-blockBlob.go
+++ b/ste/sender-blockBlob.go
@@ -22,8 +22,6 @@ package ste
 
 import (
 	"context"
-	"crypto/md5"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/url"
@@ -37,7 +35,6 @@ import (
 	"github.com/Azure/azure-storage-blob-go/azblob"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
-	"github.com/google/uuid"
 )
 
 var lowMemoryLimitAdvice sync.Once
@@ -293,7 +290,5 @@ func (s *blockBlobSenderBase) setBlockID(index int32, value string) {
 }
 
 func (s *blockBlobSenderBase) generateEncodedBlockID(index int32) string {
-	blockNameMd5 := md5.Sum([]byte(fmt.Sprintf("%s%05d", s.blockNamePrefix, index)))
-	blockID, _ := uuid.FromBytes(blockNameMd5[:]) //This func returns error if size of blockNameMd5 is not 16
-	return base64.StdEncoding.EncodeToString([]byte(blockID.String()))
+	return common.GenerateBlockBlobBlockID(s.blockNamePrefix, index)
 }

--- a/ste/sender-blockBlobFromLocal.go
+++ b/ste/sender-blockBlobFromLocal.go
@@ -86,7 +86,7 @@ func (u *blockBlobUploader) GenerateUploadFunc(id common.ChunkID, blockIndex int
 func (u *blockBlobUploader) generatePutBlock(id common.ChunkID, blockIndex int32, reader common.SingleChunkReader) chunkFunc {
 	return createSendToRemoteChunkFunc(u.jptm, id, func() {
 		// step 1: generate block ID
-		encodedBlockID := u.generateEncodedBlockID()
+		encodedBlockID := u.generateEncodedBlockID(blockIndex)
 
 		// step 2: save the block ID into the list of block IDs
 		u.setBlockID(blockIndex, encodedBlockID)

--- a/ste/sender-blockBlobFromURL.go
+++ b/ste/sender-blockBlobFromURL.go
@@ -126,7 +126,7 @@ func (c *urlToBlockBlobCopier) generateCreateEmptyBlob(id common.ChunkID) chunkF
 func (c *urlToBlockBlobCopier) generatePutBlockFromURL(id common.ChunkID, blockIndex int32, adjustedChunkSize int64) chunkFunc {
 	return createSendToRemoteChunkFunc(c.jptm, id, func() {
 		// step 1: generate block ID
-		encodedBlockID := c.generateEncodedBlockID()
+		encodedBlockID := c.generateEncodedBlockID(blockIndex)
 
 		// step 2: save the block ID into the list of block IDs
 		c.setBlockID(blockIndex, encodedBlockID)


### PR DESCRIPTION
The block ID names will have a context of the jobID, transfer cookie in the job and block/offset in the source file.
Encoded ID: <5B empty placeholder> <16B GUID of AzCopy re-interpreted as string><5B PartNum><5B Index in the jobPart><5B blockNum>