### PR TITLE
Set GC to default

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,6 @@ import (
 	"os"
 	"path"
 	"runtime"
-	"runtime/debug"
 	"time"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
@@ -78,7 +77,6 @@ func main() {
 	}
 
 	configureGoMaxProcs()
-	configureGC()
 
 	// Perform os specific initialization
 	maxFileAndSocketHandles, err := ProcessOSSpecificInitialization()
@@ -88,16 +86,6 @@ func main() {
 
 	cmd.Execute(azcopyLogPathFolder, azcopyJobPlanFolder, maxFileAndSocketHandles, jobID)
 	glcm.Exit(nil, common.EExitCode.Success())
-}
-
-// Golang's default behaviour is to GC when new objects = (100% of) total of objects surviving previous GC.
-// But our "survivors" add up to many GB, so its hard for users to be confident that we don't have
-// a memory leak (since with that default setting new GCs are very rare in our case). So configure them to be more frequent.
-func configureGC() {
-	go func() {
-		time.Sleep(20 * time.Second) // wait a little, so that our initial pool of buffers can get allocated without heaps of (unnecessary) GC activity
-		debug.SetGCPercent(20)       // activate more aggressive/frequent GC than the default
-	}()
 }
 
 // Ensure we always have more than 1 OS thread running goroutines, since there are issues with having just 1.


### PR DESCRIPTION
This change was recommended by XDM, with the data that it would improve performance.

I've tested it with the under-development perf suite and debug variable gctrace=1. Observations are inline with observations by XDM. The allocations always remain under 400MB, and with GC at 20% - frequent GC cycles are triggered, and overall percentages remains at 2% of total azcopy runtime. 

With default value,% GC  remains under 1% of total runtime.