### PR TITLE
Option to transfer properties-only in jobPart

### DIFF
--- a/common/fe-ste-models.go
+++ b/common/fe-ste-models.go
@@ -1470,9 +1470,10 @@ var EEntityType = EntityType(0)
 
 type EntityType uint8
 
-func (EntityType) File() EntityType    { return EntityType(0) }
-func (EntityType) Folder() EntityType  { return EntityType(1) }
-func (EntityType) Symlink() EntityType { return EntityType(2) }
+func (EntityType) File()           EntityType { return EntityType(0) }
+func (EntityType) Folder()         EntityType { return EntityType(1) }
+func (EntityType) Symlink()        EntityType { return EntityType(2) }
+func (EntityType) FileProperties() EntityType { return EntityType(3) }
 
 func (e EntityType) String() string {
 	return enum.StringInt(e, reflect.TypeOf(e))

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -124,6 +124,11 @@ type TransferInfo struct {
 	RehydratePriority azblob.RehydratePriorityType
 }
 
+
+func (i TransferInfo) IsFilePropertiesTransfer() bool {
+	return i.EntityType == common.EEntityType.FileProperties()
+}
+
 func (i TransferInfo) IsFolderPropertiesTransfer() bool {
 	return i.EntityType == common.EEntityType.Folder()
 }
@@ -148,6 +153,8 @@ func (i TransferInfo) ShouldTransferLastWriteTime() bool {
 func (i TransferInfo) entityTypeLogIndicator() string {
 	if i.IsFolderPropertiesTransfer() {
 		return "(folder properties) "
+	} else if i.IsFilePropertiesTransfer() {
+		return "(file properties) "
 	} else {
 		return ""
 	}

--- a/ste/xfer-anyToRemote-file.go
+++ b/ste/xfer-anyToRemote-file.go
@@ -182,6 +182,8 @@ func anyToRemote(jptm IJobPartTransferMgr, p pipeline.Pipeline, pacer pacer, sen
 	switch info.EntityType {
 	case common.EEntityType.Folder():
 		anyToRemote_folder(jptm, info, p, pacer, senderFactory, sipf)
+	case common.EEntityType.FileProperties():
+		anyToRemote_fileProperties(jptm, info, p, pacer, senderFactory, sipf)
 	case common.EEntityType.File():
 		if jptm.GetOverwriteOption() == common.EOverwriteOption.PosixProperties() {
 			anyToRemote_fileProperties(jptm, info, p, pacer, senderFactory, sipf)


### PR DESCRIPTION
This is in addition to #1964. In the earlier code, it was required for entire jobPart to have a common entity type. In a requirement where you want some files to transferred entirely, and only metadata for some other files in the same jobPart, this change is required.