### PR TITLE
Allow azcopy remove to work with CPK encrypted blobs.

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -605,6 +605,9 @@ func (raw rawCopyCmdArgs) cook() (CookedCopyCmdArgs, error) {
 				"Assuming source is encrypted.")
 			cpkOptions.IsSourceEncrypted = true
 		}
+		if cooked.FromTo.IsDelete() {
+			cpkOptions.IsSourceEncrypted = true
+		}
 
 		// TODO: Remove these warnings once service starts supporting it
 		if cooked.blockBlobTier != common.EBlockBlobTier.None() || cooked.pageBlobTier != common.EPageBlobTier.None() {

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -119,4 +119,11 @@ func init() {
 	deleteCmd.PersistentFlags().StringVar(&raw.includeAfter, common.IncludeAfterFlagName, "", "Include only those files modified on or after the given date/time. The value should be in ISO8601 format. If no timezone is specified, the value is assumed to be in the local timezone of the machine running AzCopy. E.g. '2020-08-19T15:04:00Z' for a UTC time, or '2020-08-19' for midnight (00:00) in the local timezone. As of AzCopy 10.5, this flag applies only to files, not folders, so folder properties won't be copied when using this flag with --preserve-smb-info or --preserve-smb-permissions.")
 	deleteCmd.PersistentFlags().StringVar(&raw.trailingDot, "trailing-dot", "", "Enabled by default. Options for trailing dot support in file share. Available options: Enable, Disable. Choose disable to go back to legacy (potentially unsafe) treatment of trailing dot files.")
 
+
+	// Public Documentation: https://docs.microsoft.com/en-us/azure/storage/blobs/encryption-customer-provided-keys
+	// Clients making requests against Azure Blob storage have the option to provide an encryption key on a per-request basis.
+	// Including the encryption key on the request provides granular control over encryption settings for Blob storage operations.
+	// Customer-provided keys can be stored in Azure Key Vault or in another key store linked to storage account.
+	deleteCmd.PersistentFlags().StringVar(&raw.cpkScopeInfo, "cpk-by-name", "", "Client provided key by name let clients making requests against Azure Blob storage an option to provide an encryption key on a per-request basis. Provided key name will be fetched from Azure Key Vault and will be used to encrypt the data")
+	deleteCmd.PersistentFlags().BoolVar(&raw.cpkInfo, "cpk-by-value", false, "Client provided key by name let clients making requests against Azure Blob storage an option to provide an encryption key on a per-request basis. Provided key and its hash will be fetched from environment variables")
 }


### PR DESCRIPTION
Deletion requires metadata fetching, which, for CPK blobs, requires a CPK key to be set.

This fix allows remove operations to work when in a CPK scenario.