### PR TITLE
Allow specifying "Cold" tier

### DIFF
--- a/common/fe-ste-models.go
+++ b/common/fe-ste-models.go
@@ -759,6 +759,7 @@ func (BlockBlobTier) None() BlockBlobTier    { return BlockBlobTier(0) }
 func (BlockBlobTier) Hot() BlockBlobTier     { return BlockBlobTier(1) }
 func (BlockBlobTier) Cool() BlockBlobTier    { return BlockBlobTier(2) }
 func (BlockBlobTier) Archive() BlockBlobTier { return BlockBlobTier(3) }
+func (BlockBlobTier) Cold() BlockBlobTier    { return BlockBlobTier(4) }
 
 func (bbt BlockBlobTier) String() string {
 	return enum.StringInt(bbt, reflect.TypeOf(bbt))

--- a/e2etest/zt_preserve_access_tier_test.go
+++ b/e2etest/zt_preserve_access_tier_test.go
@@ -26,6 +26,19 @@ import (
 	"testing"
 )
 
+//func TestTier_UploadCold(t *testing.T) {
+//	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.LocalBlob()), eValidate.Auto(), anonymousAuthOnly, anonymousAuthOnly, params{
+//		recursive:             true,
+//		accessTier:            common.EBlockBlobTier.Cold().ToAccessTierType(), // this is not valid yet on the service, so this test is disabled.
+//	}, nil, testFiles{
+//		defaultSize: "4M",
+//		shouldTransfer: []interface{}{
+//			folder(""), // root folder
+//			f("filea"),
+//		},
+//	}, EAccountType.Classic(), EAccountType.Standard(), "")
+//}
+
 func TestTier_V2ToClassicAccount(t *testing.T) {
 
 	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.BlobBlob()), eValidate.AutoPlusContent(), anonymousAuthOnly, anonymousAuthOnly, params{

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -174,6 +174,17 @@ func NewBlobPipeline(c azblob.Credential, o azblob.PipelineOptions, r XferRetryO
 		pipeline.MethodFactoryMarker(), // indicates at what stage in the pipeline the method factory is invoked
 		// NewPacerPolicyFactory(p),
 		NewVersionPolicyFactory(),
+		// Bump the service version when using the Cold access tier.
+		pipeline.FactoryFunc(func(next pipeline.Policy, po *pipeline.PolicyOptions) pipeline.PolicyFunc {
+			// TODO: Remove me when bumping the service version is no longer relevant.
+			return func(ctx context.Context, request pipeline.Request) (pipeline.Response, error) {
+				if request.Header.Get("x-ms-access-tier") == common.EBlockBlobTier.Cold().String() {
+					request.Header.Set("x-ms-version", "2021-12-02")
+				}
+
+				return next.Do(ctx, request)
+			}
+		}),
 		NewRequestLogPolicyFactory(RequestLogOptions{
 			LogWarningIfTryOverThreshold: o.RequestLog.LogWarningIfTryOverThreshold,
 			SyslogDisabled:               common.IsForceLoggingDisabled(),

--- a/ste/xfer-anyToRemote-file.go
+++ b/ste/xfer-anyToRemote-file.go
@@ -116,7 +116,7 @@ func BlobTierAllowed(destTier azblob.AccessTierType) bool {
 		// Standard storage account. If it's Hot, Cool, or Archive, we're A-OK.
 		// Page blobs, however, don't have an access tier on Standard accounts.
 		// However, this is also OK, because the pageblob sender code prevents us from using a standard access tier type.
-		return destTier == azblob.AccessTierArchive || destTier == azblob.AccessTierCool || destTier == azblob.AccessTierHot
+		return destTier == azblob.AccessTierArchive || destTier == azblob.AccessTierCool || destTier == common.EBlockBlobTier.Cold().ToAccessTierType() || destTier == azblob.AccessTierHot
 	}
 }
 


### PR DESCRIPTION
Supports specifying cold tier for Block Blobs.

Testing is disabled since this isn't available service-side yet, but this PR is nice & simple since we can just pass a new value in and the SDK doesn't validate.