### PR TITLE
Do not abruptly error out if listing fails

### DIFF
--- a/common/connReset_others.go
+++ b/common/connReset_others.go
@@ -1,0 +1,35 @@
+// +build !windows
+// Copyright Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package common
+
+import (
+	"errors"
+	"syscall"
+)
+
+func IsConnError(err error) bool {
+	if se, ok := err.(syscall.Errno); ok {
+		return se == syscall.ECONNRESET || se == syscall.ECONNABORTED
+	}
+	return errors.Is(err, syscall.ECONNABORTED) || errors.Is(err, syscall.ECONNRESET)
+	return false
+}

--- a/common/connReset_windows.go
+++ b/common/connReset_windows.go
@@ -1,0 +1,36 @@
+//go:build windows
+// +build windows
+
+// Copyright Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package common
+
+import (
+	"errors"
+	"syscall"
+)
+
+func IsConnError(err error) bool {
+	if se, ok := err.(syscall.Errno); ok {
+		return se == syscall.WSAECONNRESET || se == syscall.WSAECONNABORTED
+	} 
+	return errors.Is(err, syscall.WSAECONNRESET) || errors.Is(err, syscall.WSAECONNABORTED)
+}

--- a/common/environment.go
+++ b/common/environment.go
@@ -319,7 +319,7 @@ func (EnvironmentVariable) CredentialType() EnvironmentVariable {
 func (EnvironmentVariable) DefaultServiceApiVersion() EnvironmentVariable {
 	return EnvironmentVariable{
 		Name:         "AZCOPY_DEFAULT_SERVICE_API_VERSION",
-		DefaultValue: "2020-10-02",
+		DefaultValue: "2021-02-12",
 		Description:  "Overrides the service API version so that AzCopy could accommodate custom environments such as Azure Stack.",
 	}
 }

--- a/common/lifecyleMgr.go
+++ b/common/lifecyleMgr.go
@@ -138,7 +138,7 @@ func (lcm *lifecycleMgr) watchInputs() {
 
 		var req LCMMsgReq
 		if lcm.allowCancelFromStdIn && strings.EqualFold(msg, "cancel") {
-			lcm.cancelChannel <- os.Interrupt
+			lcm.cancelhannel <- os.Interrupt
 		} else if lcm.e2eAllowAwaitContinue && strings.EqualFold(msg, "continue") {
 			close(lcm.e2eContinueChannel)
 		} else if lcm.e2eAllowAwaitOpen && strings.EqualFold(msg, "open") {

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -454,9 +454,7 @@ func (jpm *jobPartMgr) ScheduleTransfers(jobCtx context.Context, sourceBlobToken
 			// TODO: insert the factory func interface in jptm.
 			// numChunks will be set by the transfer's prologue method
 		}
-		if jpm.ShouldLog(pipeline.LogInfo) {
-			jpm.Log(pipeline.LogInfo, fmt.Sprintf("scheduling JobID=%v, Part#=%d, Transfer#=%d, priority=%v", plan.JobID, plan.PartNum, t, plan.Priority))
-		}
+		jpm.Log(pipeline.LogDebug, fmt.Sprintf("scheduling JobID=%v, Part#=%d, Transfer#=%d, priority=%v", plan.JobID, plan.PartNum, t, plan.Priority))
 
 		// ===== TEST KNOB
 		relSrc, relDst := plan.TransferSrcDstRelatives(t)

--- a/ste/xferRetrypolicy.go
+++ b/ste/xferRetrypolicy.go
@@ -423,6 +423,8 @@ func NewBlobXferRetryPolicyFactory(o XferRetryOptions) pipeline.Factory {
 						}
 					} else if _, ok := err.(net.Error); ok {
 						action = "Retry: net.Error"
+					} else if common.IsConnError(err) {
+						action = "Retry: connection aborted Error"
 					} else if err == io.ErrUnexpectedEOF {
 						action = "Retry: io.UnexpectedEOF"
 					} else {


### PR DESCRIPTION
DO NOT MERGE

If we reset ECONNRESET while we are listing, we return from travserser with error. This would make command exit immediately while there are still files to be processed.
This change will stop command from exiting. Instead we will wait for finalizer (in the traverser) to complete the transfer and exit via lcm. 