### PR TITLE
[AzCopyV10][Bug] Uploading from top directory on linux fails when sub folder has the same name

### DIFF
--- a/cmd/copyEnumeratorHelper.go
+++ b/cmd/copyEnumeratorHelper.go
@@ -13,11 +13,7 @@ var EnumerationParallelStatFiles = false
 
 // addTransfer accepts a new transfer, if the threshold is reached, dispatch a job part order.
 func addTransfer(e *common.CopyJobPartOrderRequest, transfer common.CopyTransfer, cca *CookedCopyCmdArgs) error {
-	// Remove the source and destination roots from the path to save space in the plan files
-
-	// TODO: Remove this line because transfer.Source and transfer.Destination are already a relative paths
-	// transfer.Source = strings.TrimPrefix(transfer.Source, e.SourceRoot.Value)
-	// transfer.Destination = strings.TrimPrefix(transfer.Destination, e.DestinationRoot.Value)
+	// Source and destination paths are and should be relative paths. 
 
 	// dispatch the transfers once the number reaches NumOfFilesPerDispatchJobPart
 	// we do this so that in the case of large transfer, the transfer engine can get started

--- a/cmd/copyEnumeratorHelper.go
+++ b/cmd/copyEnumeratorHelper.go
@@ -3,11 +3,9 @@ package cmd
 import (
 	"fmt"
 	"github.com/Azure/azure-pipeline-go/pipeline"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-azcopy/v10/jobsAdmin"
 	"math/rand"
-	"strings"
-
-	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 var EnumerationParallelism = 1
@@ -16,8 +14,10 @@ var EnumerationParallelStatFiles = false
 // addTransfer accepts a new transfer, if the threshold is reached, dispatch a job part order.
 func addTransfer(e *common.CopyJobPartOrderRequest, transfer common.CopyTransfer, cca *CookedCopyCmdArgs) error {
 	// Remove the source and destination roots from the path to save space in the plan files
-	transfer.Source = strings.TrimPrefix(transfer.Source, e.SourceRoot.Value)
-	transfer.Destination = strings.TrimPrefix(transfer.Destination, e.DestinationRoot.Value)
+
+	// TODO: Remove this line because transfer.Source and transfer.Destination are already a relative paths
+	// transfer.Source = strings.TrimPrefix(transfer.Source, e.SourceRoot.Value)
+	// transfer.Destination = strings.TrimPrefix(transfer.Destination, e.DestinationRoot.Value)
 
 	// dispatch the transfers once the number reaches NumOfFilesPerDispatchJobPart
 	// we do this so that in the case of large transfer, the transfer engine can get started

--- a/cmd/copyEnumeratorHelper_test.go
+++ b/cmd/copyEnumeratorHelper_test.go
@@ -42,6 +42,7 @@ func newRemoteRes(url string) common.ResourceString {
 }
 
 func (s *copyEnumeratorHelperTestSuite) TestAddTransferPathRootsTrimmed(c *chk.C) {
+	// TODO: this test will fail
 	// setup
 	request := common.CopyJobPartOrderRequest{
 		SourceRoot:      newLocalRes("a/b/"),

--- a/cmd/copyEnumeratorHelper_test.go
+++ b/cmd/copyEnumeratorHelper_test.go
@@ -41,8 +41,8 @@ func newRemoteRes(url string) common.ResourceString {
 	return r
 }
 
-func (s *copyEnumeratorHelperTestSuite) TestAddTransferPathRootsTrimmed(c *chk.C) {
-	// TODO: this test will fail
+/*func (s *copyEnumeratorHelperTestSuite) TestAddTransferPathRootsTrimmed(c *chk.C) {
+	// TODO: this test will fail because root trimming behavior in addTransfer() is removed
 	// setup
 	request := common.CopyJobPartOrderRequest{
 		SourceRoot:      newLocalRes("a/b/"),
@@ -61,4 +61,26 @@ func (s *copyEnumeratorHelperTestSuite) TestAddTransferPathRootsTrimmed(c *chk.C
 	c.Assert(err, chk.IsNil)
 	c.Assert(request.Transfers.List[0].Source, chk.Equals, "c.txt")
 	c.Assert(request.Transfers.List[0].Destination, chk.Equals, "c.txt")
+}*/
+
+func (s *copyEnumeratorHelperTestSuite) TestRelativePath(c *chk.C) {
+	// setup
+	cca := CookedCopyCmdArgs{
+		Source:      newLocalRes("a/b/"),
+		Destination: newLocalRes("y/z/"),
+	}
+
+	object := StoredObject{
+		name:         "c.txt",
+		entityType:   1,
+		relativePath: "c.txt",
+	}
+
+	// execute
+	srcRelPath := cca.MakeEscapedRelativePath(true, false, false, object)
+	destRelPath := cca.MakeEscapedRelativePath(false, true, false, object)
+
+	// assert
+	c.Assert(srcRelPath, chk.Equals, "/c.txt")
+	c.Assert(destRelPath, chk.Equals, "/c.txt")
 }

--- a/cmd/copyEnumeratorHelper_test.go
+++ b/cmd/copyEnumeratorHelper_test.go
@@ -41,28 +41,6 @@ func newRemoteRes(url string) common.ResourceString {
 	return r
 }
 
-/*func (s *copyEnumeratorHelperTestSuite) TestAddTransferPathRootsTrimmed(c *chk.C) {
-	// TODO: this test will fail because root trimming behavior in addTransfer() is removed
-	// setup
-	request := common.CopyJobPartOrderRequest{
-		SourceRoot:      newLocalRes("a/b/"),
-		DestinationRoot: newLocalRes("y/z/"),
-	}
-
-	transfer := common.CopyTransfer{
-		Source:      "a/b/c.txt",
-		Destination: "y/z/c.txt",
-	}
-
-	// execute
-	err := addTransfer(&request, transfer, &CookedCopyCmdArgs{})
-
-	// assert
-	c.Assert(err, chk.IsNil)
-	c.Assert(request.Transfers.List[0].Source, chk.Equals, "c.txt")
-	c.Assert(request.Transfers.List[0].Destination, chk.Equals, "c.txt")
-}*/
-
 func (s *copyEnumeratorHelperTestSuite) TestRelativePath(c *chk.C) {
 	// setup
 	cca := CookedCopyCmdArgs{


### PR DESCRIPTION
Fresh PR for: https://github.com/Azure/azure-storage-azcopy/pull/1762

Context:
- In linux, cx is creating folders under root folder with same name (ex: /event -> root dir, /event/event_stuff/foo.txt)
- Line 19 in cmd/copyEnumeratorHelper.go causes a bug in linux in which the root folder name is removed from path.
i.e. e.SourceRoot.Value = "/event" and transfer.Source = "/event_stuff/foo.txt" --> incorrectly changes transfer.Source to "_stuff/foo.txt"

PR Info:
- The transfer.Source and transfer.Destination is already a relative path and this line of code can be removed because we already pass the relative path for both transfer.Source and transfer.Destination prior to calling addTransfer, see line 265: https://github.com/Azure/azure-storage-azcopy/blob/main/cmd/copyEnumeratorInit.go#L265. 