### PR TITLE
Fix container->container behaviour w/ preserve-permissions

### DIFF
--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -119,8 +119,14 @@ func (cca *CookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 	}
 
 	// When copying a container directly to a container, strip the top directory, unless we're attempting to persist permissions.
-	if srcLevel == ELocationLevel.Container() && dstLevel == ELocationLevel.Container() && cca.FromTo.From().IsRemote() && cca.FromTo.To().IsRemote() && !cca.preservePermissions.IsTruthy() {
-		cca.StripTopDir = true
+	if srcLevel == ELocationLevel.Container() && dstLevel == ELocationLevel.Container() && cca.FromTo.From().IsRemote() && cca.FromTo.To().IsRemote() {
+		if cca.preservePermissions.IsTruthy() {
+			// if we're preserving permissions, we need to keep the top directory, but with container->container, we don't need to add the container name to the path.
+			// asSubdir is a better option than stripTopDir as stripTopDir disincludes the root.
+			cca.asSubdir = false
+		} else {
+			cca.StripTopDir = true
+		}
 	}
 
 	// Create a Remote resource resolver

--- a/e2etest/declarativeResourceManagers.go
+++ b/e2etest/declarativeResourceManagers.go
@@ -21,6 +21,7 @@
 package e2etest
 
 import (
+	"github.com/Azure/azure-storage-azcopy/v10/azbfs"
 	"net/url"
 	"os"
 	"path"
@@ -235,6 +236,28 @@ func (r *resourceBlobContainer) createFiles(a asserter, s *scenario, isSource bo
 		options.accessTier = s.p.accessTier
 	}
 	scenarioHelper{}.generateBlobsFromList(a, options)
+
+	// set root ACL
+	if r.accountType == EAccountType.HierarchicalNamespaceEnabled() {
+		containerURLParts := azblob.NewBlobURLParts(r.containerURL.URL())
+
+		for _,v := range options.generateFromListOptions.fs {
+			if v.name == "" {
+				if v.creationProperties.adlsPermissionsACL == nil {
+					break
+				}
+
+				rootURL := TestResourceFactory{}.GetDatalakeServiceURL(r.accountType).NewFileSystemURL(containerURLParts.ContainerName).NewDirectoryURL("/")
+
+				_, err := rootURL.SetAccessControl(ctx, azbfs.BlobFSAccessControl{
+					ACL: *v.creationProperties.adlsPermissionsACL,
+				})
+				a.AssertNoErr(err)
+
+				break
+			}
+		}
+	}
 }
 
 func (r *resourceBlobContainer) createFile(a asserter, o *testObject, s *scenario, isSource bool) {
@@ -294,7 +317,22 @@ func (r *resourceBlobContainer) appendSourcePath(filePath string, useSas bool) {
 }
 
 func (r *resourceBlobContainer) getAllProperties(a asserter) map[string]*objectProperties {
-	return scenarioHelper{}.enumerateContainerBlobProperties(a, *r.containerURL)
+	objects := scenarioHelper{}.enumerateContainerBlobProperties(a, *r.containerURL)
+
+	if r.accountType == EAccountType.HierarchicalNamespaceEnabled() {
+		urlParts := azblob.NewBlobURLParts(r.containerURL.URL())
+		fsURL := TestResourceFactory{}.GetDatalakeServiceURL(r.accountType).NewFileSystemURL(urlParts.ContainerName).NewDirectoryURL("/")
+
+		ACL, err := fsURL.GetAccessControl(ctx)
+		a.AssertNoErr(err)
+
+		objects[""] = &objectProperties{
+			entityType: common.EEntityType.Folder(),
+			adlsPermissionsACL: &ACL.ACL,
+		}
+	}
+
+	return objects
 }
 
 func (r *resourceBlobContainer) downloadContent(a asserter, options downloadContentOptions) []byte {

--- a/e2etest/declarativeScenario.go
+++ b/e2etest/declarativeScenario.go
@@ -412,6 +412,9 @@ func (s *scenario) getTransferInfo() (srcRoot string, dstRoot string, expectFold
 			addedDirAtDest = tf.destTarget
 		}
 		dstRoot = fmt.Sprintf("%s%c%s", dstRoot, os.PathSeparator, addedDirAtDest)
+	} else if s.state.source.isContainerLike() && s.state.dest.isContainerLike() && s.p.preserveSMBPermissions {
+		// Preserving permissions includes the root folder, but for container-container, we don't expect any added folder name.
+		expectRootFolder = true
 	} else {
 		if tf.objectTarget == "" && tf.destTarget == "" {
 			addedDirAtDest = srcBase

--- a/e2etest/validator.go
+++ b/e2etest/validator.go
@@ -123,7 +123,7 @@ func (Validator) ValidateCopyTransfersAreScheduled(c asserter, isSrcEncoded bool
 
 		if transfer.Dst != os.DevNull { // Don't check if the destination is NUL-- It won't be correct.
 			// the relative paths should be equal
-			c.Assert(srcRelativeFilePath, equals(), dstRelativeFilePath)
+			c.Assert(dstRelativeFilePath, equals(), srcRelativeFilePath)
 		}
 
 		// look up the path from the expected transfers, make sure it exists

--- a/e2etest/zt_preserve_smb_properties_test.go
+++ b/e2etest/zt_preserve_smb_properties_test.go
@@ -306,3 +306,34 @@ func TestProperties_SMBTimes(t *testing.T) {
 		"",
 	)
 }
+
+func TestProperties_EnsureContainerBehavior(t *testing.T) {
+	RunScenarios(
+		t,
+		eOperation.Copy(),
+		eTestFromTo.Other(common.EFromTo.FileFile()),
+		eValidate.Auto(),
+		anonymousAuthOnly,
+		anonymousAuthOnly,
+		params{
+			recursive: true,
+			preserveSMBInfo: BoolPointer(true),
+			preserveSMBPermissions: true,
+		},
+		nil,
+		testFiles{
+			defaultSize: "1K",
+			shouldTransfer: []interface{}{
+				folder(""),
+				f("aeiou.txt"),
+				folder("a"),
+				f("a/asdf.txt"),
+				folder("b"),
+				f("b/1234.txt"),
+			},
+		},
+		EAccountType.Standard(),
+		EAccountType.Standard(),
+		"",
+	)
+}


### PR DESCRIPTION
In 10.18, we incorrectly adjusted the behavior of container->container w/ preserve-permissions to no longer strip the top directory. The behavior has been adjusted to use as-subdir to resolve the regression.

Linked to #2141 