### PR TITLE
Add feature-parity with copy to enable force-if-readonly

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -784,7 +784,7 @@ func init() {
 	syncCmd.PersistentFlags().BoolVar(&raw.preservePOSIXProperties, "preserve-posix-properties", false, "'Preserves' property info gleaned from stat or statx into object metadata.")
 
 	// TODO: enable when we support local <-> File
-	// syncCmd.PersistentFlags().BoolVar(&raw.forceIfReadOnly, "force-if-read-only", false, "When overwriting an existing file on Windows or Azure Files, force the overwrite to work even if the existing file has its read-only attribute set")
+	syncCmd.PersistentFlags().BoolVar(&raw.forceIfReadOnly, "force-if-read-only", false, "When overwriting an existing file on Windows or Azure Files, force the overwrite to work even if the existing file has its read-only attribute set")
 	// syncCmd.PersistentFlags().BoolVar(&raw.preserveOwner, common.PreserveOwnerFlagName, common.PreserveOwnerDefault, "Only has an effect in downloads, and only when --preserve-smb-permissions is used. If true (the default), the file Owner and Group are preserved in downloads. If set to false, --preserve-smb-permissions will still preserve ACLs but Owner and Group will be based on the user running AzCopy")
 	// syncCmd.PersistentFlags().BoolVar(&raw.backupMode, common.BackupModeFlagName, false, "Activates Windows' SeBackupPrivilege for uploads, or SeRestorePrivilege for downloads, to allow AzCopy to see read all files, regardless of their file system permissions, and to restore all permissions. Requires that the account running AzCopy already has these permissions (e.g. has Administrator rights or is a member of the 'Backup Operators' group). All this flag does is activate privileges that the account already has")
 

--- a/e2etest/declarativeHelpers.go
+++ b/e2etest/declarativeHelpers.go
@@ -147,10 +147,11 @@ type params struct {
 	includeAttributes         string
 	excludePath               string
 	excludePattern            string
-	excludeAttributes         string
-	capMbps                   float32
+	excludeAttributes 		  string
+	forceIfReadOnly   		  bool
+	capMbps           		  float32
 	blockSizeMB               float32
-	deleteDestination         common.DeleteDestination
+	deleteDestination         common.DeleteDestination // Manual validation is needed.
 	s2sSourceChangeValidation bool
 	metadata                  string
 	cancelFromStdin           bool

--- a/e2etest/runner.go
+++ b/e2etest/runner.go
@@ -108,6 +108,7 @@ func (t *TestRunner) SetAllFlags(p params, o Operation) {
 	set("debug-skip-files", strings.Join(p.debugSkipFiles, ";"), "")
 	set("check-md5", p.checkMd5.String(), "FailIfDifferent")
 	set("trailing-dot", p.trailingDot.String(), "Enable")
+	set("force-if-read-only", p.forceIfReadOnly, false)
 
 	if o == eOperation.Copy() {
 		set("s2s-preserve-access-tier", p.s2sPreserveAccessTier, true)


### PR DESCRIPTION
Resolves #1578

Enables the force-if-readonly flag in sync, and adds support for clearing the readonly bit in the destination files deleter