### PR TITLE
Support follow-symlinks SMB properties

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -676,10 +676,6 @@ func (raw rawCopyCmdArgs) cook() (CookedCopyCmdArgs, error) {
 
 	cooked.IncludeDirectoryStubs = raw.includeDirectoryStubs
 
-	if err = crossValidateSymlinksAndPermissions(cooked.SymlinkHandling, cooked.preservePermissions.IsTruthy()); err != nil {
-		return cooked, err
-	}
-
 	cooked.backupMode = raw.backupMode
 	if err = validateBackupMode(cooked.backupMode, cooked.FromTo); err != nil {
 		return cooked, err
@@ -1001,13 +997,6 @@ func validateSymlinkHandlingMode(symlinkHandling common.SymlinkHandlingType, fro
 	}
 
 	return nil // other older symlink handling modes can work on all OSes
-}
-
-func crossValidateSymlinksAndPermissions(symlinkHandling common.SymlinkHandlingType, preservePermissions bool) error {
-	if symlinkHandling != common.ESymlinkHandlingType.Skip() && preservePermissions {
-		return errors.New("cannot handle symlinks when preserving permissions (since the correct permission inheritance behaviour for symlink targets is undefined)")
-	}
-	return nil
 }
 
 func validateBackupMode(backupMode bool, fromTo common.FromTo) error {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -214,9 +214,6 @@ func (raw *rawSyncCmdArgs) cook() (cookedSyncCmdArgs, error) {
 	if err = cooked.symlinkHandling.Determine(raw.followSymlinks, raw.preserveSymlinks); err != nil {
 		return cooked, err
 	}
-	if err = crossValidateSymlinksAndPermissions(cooked.symlinkHandling, true /* replace with real value when available */); err != nil {
-		return cooked, err
-	}
 	cooked.recursive = raw.recursive
 	cooked.forceIfReadOnly = raw.forceIfReadOnly
 	if err = validateForceIfReadOnly(cooked.forceIfReadOnly, cooked.fromTo); err != nil {


### PR DESCRIPTION
Due to the way symlink following worked (followed in the traverser, then submitted to the plan file as the destination), the flag check may simply be disabled with the consequence being that the actual destination file is checked (in alignment with the suggested behaviour from the files team).

~~I still need to look into if we can run the test suite as an administrator, as it would be required for testing this functionality, since creating Symlinks on Windows requires admin permissions~~

No, we can't test this automatically unless we self-host a Windows agent.