### PR TITLE
Return error on failure to split URL

### DIFF
--- a/cmd/pathUtils.go
+++ b/cmd/pathUtils.go
@@ -186,7 +186,7 @@ func GetResourceRoot(resource string, location common.Location) (resourceBase st
 func SplitResourceString(raw string, loc common.Location) (common.ResourceString, error) {
 	sasless, sas, err := splitAuthTokenFromResource(raw, loc)
 	if err != nil {
-		return common.ResourceString{}, nil
+		return common.ResourceString{}, err
 	}
 	main, query := splitQueryFromSaslessResource(sasless, loc)
 	return common.ResourceString{


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-storage-azcopy/issues/2183

This will result in the code panicing or erroring out if a file share url is passed without a sas