### PR TITLE
Deprecate login command

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -23,6 +23,7 @@ package cmd
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
@@ -30,6 +31,10 @@ import (
 )
 
 var loginCmdArg = loginCmdArgs{tenantID: common.DefaultTenantID}
+
+var loginNotice = "'azcopy %s' command will be deprecated starting release 10.22. " +
+				  "Use auto-login instead. Visit %s to know more."
+var autoLoginURL = "https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-authorize-azure-active-directory#authorize-without-a-secret-store "
 
 var lgCmd = &cobra.Command{
 	Use:        "login",
@@ -45,6 +50,7 @@ var lgCmd = &cobra.Command{
 		loginCmdArg.clientSecret = glcm.GetEnvironmentVariable(common.EEnvironmentVariable.ClientSecret())
 		loginCmdArg.persistToken = true
 
+		glcm.Info(fmt.Sprintf(loginNotice, "login", autoLoginURL))
 		if loginCmdArg.certPass != "" || loginCmdArg.clientSecret != "" {
 			glcm.Info(environmentVariableNotice)
 		}

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -53,6 +53,7 @@ func init() {
 type logoutCmdArgs struct{}
 
 func (lca logoutCmdArgs) process() error {
+	glcm.Info(fmt.Sprintf(loginNotice, "logout", autoLoginURL))
 	uotm := GetUserOAuthTokenManagerInstance()
 	if err := uotm.RemoveCachedToken(); err != nil {
 		return err


### PR DESCRIPTION
```
PS C:\Users\<>\go\src\github.com\Azure\azure-storage-azcopy> .\azure-storage-azcopy.exe login
INFO: 'azcopy login' command will be deprecated starting release 10.22. Use auto-login instead. Visit https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-authorize-azure-active-directory#authorize-without-a-secret-store  to know more.
INFO: If you set an environment variable by using the command line, that variable will be readable in your command line history. Consider clearing variables that contain credentials from your command line history.  To keep variables from appearing in your history, you can use a script to prompt the user for their credentials, and to set the environment variable.
```

```
PS C:\Users\<>\go\src\github.com\Azure\azure-storage-azcopy> .\azure-storage-azcopy.exe logout
INFO: 'azcopy logout' command will be deprecated starting release 10.22. Use auto-login instead. Visit https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-authorize-azure-active-directory#authorize-without-a-secret-store  to know more.
```