### PR TITLE
Fix ADLS Gen 2 ACL tests & copying

### DIFF
--- a/common/fe-ste-models.go
+++ b/common/fe-ste-models.go
@@ -154,7 +154,7 @@ var ETrailingDotOption = TrailingDotOption(0)
 
 type TrailingDotOption uint8
 
-func (TrailingDotOption) Enable() TrailingDotOption    { return TrailingDotOption(0) }
+func (TrailingDotOption) Enable() TrailingDotOption  { return TrailingDotOption(0) }
 func (TrailingDotOption) Disable() TrailingDotOption { return TrailingDotOption(1) }
 
 func (d TrailingDotOption) String() string {
@@ -276,11 +276,11 @@ var EOverwriteOption = OverwriteOption(0)
 
 type OverwriteOption uint8
 
-func (OverwriteOption) True() OverwriteOption          { return OverwriteOption(0) }
-func (OverwriteOption) False() OverwriteOption         { return OverwriteOption(1) }
-func (OverwriteOption) Prompt() OverwriteOption        { return OverwriteOption(2) }
-func (OverwriteOption) IfSourceNewer() OverwriteOption { return OverwriteOption(3) }
-func (OverwriteOption) PosixProperties() OverwriteOption {return OverwriteOption(4)}
+func (OverwriteOption) True() OverwriteOption            { return OverwriteOption(0) }
+func (OverwriteOption) False() OverwriteOption           { return OverwriteOption(1) }
+func (OverwriteOption) Prompt() OverwriteOption          { return OverwriteOption(2) }
+func (OverwriteOption) IfSourceNewer() OverwriteOption   { return OverwriteOption(3) }
+func (OverwriteOption) PosixProperties() OverwriteOption { return OverwriteOption(4) }
 
 func (o *OverwriteOption) Parse(s string) error {
 	val, err := enum.Parse(reflect.TypeOf(o), s, true)
@@ -540,6 +540,10 @@ func (l Location) IsFolderAware() bool {
 }
 
 func (l Location) CanForwardOAuthTokens() bool {
+	return l == ELocation.Blob() || l == ELocation.BlobFS()
+}
+
+func (l Location) SupportsHnsACLs() bool {
 	return l == ELocation.Blob() || l == ELocation.BlobFS()
 }
 
@@ -1487,9 +1491,9 @@ var EEntityType = EntityType(0)
 
 type EntityType uint8
 
-func (EntityType) File()           EntityType { return EntityType(0) }
-func (EntityType) Folder()         EntityType { return EntityType(1) }
-func (EntityType) Symlink()        EntityType { return EntityType(2) }
+func (EntityType) File() EntityType           { return EntityType(0) }
+func (EntityType) Folder() EntityType         { return EntityType(1) }
+func (EntityType) Symlink() EntityType        { return EntityType(2) }
 func (EntityType) FileProperties() EntityType { return EntityType(3) }
 
 func (e EntityType) String() string {
@@ -1642,7 +1646,7 @@ func (rpt RehydratePriorityType) ToRehydratePriorityType() blob.RehydratePriorit
 	}
 }
 
-////////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////////
 type SyncHashType uint8
 
 var ESyncHashType SyncHashType = 0
@@ -1667,7 +1671,7 @@ func (ht SyncHashType) String() string {
 	return enum.StringInt(ht, reflect.TypeOf(ht))
 }
 
-////////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////////
 type SymlinkHandlingType uint8 // SymlinkHandlingType is only utilized internally to avoid having to carry around two contradictory flags. Thus, it doesn't have a parse method.
 
 // for reviewers: This is different than we usually implement enums, but it's something I've found to be more pleasant in personal projects, especially for bitflags. Should we change the pattern to match this in the future?

--- a/e2etest/declarativeResourceManagers.go
+++ b/e2etest/declarativeResourceManagers.go
@@ -50,7 +50,7 @@ type downloadContentOptions struct {
 type downloadBlobContentOptions struct {
 	containerClient *container.Client
 	cpkInfo         *blob.CPKInfo
-	cpkScopeInfo *blob.CPKScopeInfo
+	cpkScopeInfo    *blob.CPKScopeInfo
 }
 
 type downloadFileContentOptions struct {
@@ -246,7 +246,7 @@ func (r *resourceBlobContainer) createFiles(a asserter, s *scenario, isSource bo
 		containerURLParts, err := blob.ParseURL(r.containerClient.URL())
 		a.AssertNoErr(err)
 
-		for _,v := range options.generateFromListOptions.fs {
+		for _, v := range options.generateFromListOptions.fs {
 			if v.name == "" {
 				if v.creationProperties.adlsPermissionsACL == nil {
 					break
@@ -274,7 +274,7 @@ func (r *resourceBlobContainer) createFile(a asserter, o *testObject, s *scenari
 		},
 	}
 
-	if s.fromTo.IsDownload()|| s.fromTo.IsDelete() {
+	if s.fromTo.IsDownload() || s.fromTo.IsDelete() {
 		options.cpkInfo = common.GetCpkInfo(s.p.cpkByValue)
 		options.cpkScopeInfo = common.GetCpkScopeInfo(s.p.cpkByName)
 	}
@@ -326,12 +326,18 @@ func (r *resourceBlobContainer) appendSourcePath(filePath string, useSas bool) {
 }
 
 func (r *resourceBlobContainer) getAllProperties(a asserter) map[string]*objectProperties {
-	objects := scenarioHelper{}.enumerateContainerBlobProperties(a, r.containerClient)
-
+	var fileSystem *azbfs.FileSystemURL
 	if r.accountType == EAccountType.HierarchicalNamespaceEnabled() {
 		urlParts, err := blob.ParseURL(r.containerClient.URL())
 		a.AssertNoErr(err)
-		fsURL := TestResourceFactory{}.GetDatalakeServiceURL(r.accountType).NewFileSystemURL(urlParts.ContainerName).NewDirectoryURL("/")
+		fsURL := TestResourceFactory{}.GetDatalakeServiceURL(r.accountType).NewFileSystemURL(urlParts.ContainerName)
+		fileSystem = &fsURL
+	}
+
+	objects := scenarioHelper{}.enumerateContainerBlobProperties(a, r.containerClient, fileSystem)
+
+	if fileSystem != nil {
+		fsURL := fileSystem.NewDirectoryURL("/")
 
 		ACL, err := fsURL.GetAccessControl(ctx)
 		if stgErr, ok := err.(azbfs.StorageError); ok {
@@ -342,7 +348,7 @@ func (r *resourceBlobContainer) getAllProperties(a asserter) map[string]*objectP
 		a.AssertNoErr(err)
 
 		objects[""] = &objectProperties{
-			entityType: common.EEntityType.Folder(),
+			entityType:         common.EEntityType.Folder(),
 			adlsPermissionsACL: &ACL.ACL,
 		}
 	}

--- a/e2etest/declarativeScenario.go
+++ b/e2etest/declarativeScenario.go
@@ -523,7 +523,7 @@ func (s *scenario) validateProperties() {
 		s.validateLastWriteTime(expected.lastWriteTime, actual.lastWriteTime)
 		s.validateCPKByScope(expected.cpkScopeInfo, actual.cpkScopeInfo)
 		s.validateCPKByValue(expected.cpkInfo, actual.cpkInfo)
-		s.validateADLSACLs(expected.adlsPermissionsACL, actual.adlsPermissionsACL)
+		s.validateADLSACLs(f.name, expected.adlsPermissionsACL, actual.adlsPermissionsACL)
 		if expected.smbPermissionsSddl != nil {
 			if actual.smbPermissionsSddl == nil {
 				s.a.Error("Expected a SDDL on file " + destName + ", but none was found")
@@ -676,16 +676,24 @@ func (s *scenario) validateMetadata(expected, actual map[string]*string) {
 	}
 }
 
-func (s *scenario) validateADLSACLs(expected, actual *string) {
+func (s *scenario) validateADLSACLs(name string, expected, actual *string) {
 	if expected == nil && actual == nil {
 		return
 	}
-	if expected == nil || actual == nil {
-		s.a.Failed()
+	if eitherNil := expected == nil || actual == nil; eitherNil {
+		e, a := "nil", "nil"
+		if expected != nil {
+			e = *expected
+		}
+		if actual != nil {
+			a = *actual
+		}
+
+		s.a.Assert(eitherNil, equals(), false, fmt.Sprintf("for object %s: If either expected or actual ACLs are nonzero, both must be nonzero (expected: %s actual: %s)", name, e, a))
 		return
 	}
 
-	s.a.Assert(expected, equals(), actual, fmt.Sprintf("Expected Gen 2 ACL: %s but found: %s", *expected, *actual))
+	s.a.Assert(expected, equals(), actual, fmt.Sprintf("for object %s: Expected Gen 2 ACL: %s but found: %s", name, *expected, *actual))
 }
 
 func (s *scenario) validateCPKByScope(expected, actual *blob.CPKScopeInfo) {

--- a/e2etest/scenario_helpers.go
+++ b/e2etest/scenario_helpers.go
@@ -148,7 +148,7 @@ func (s scenarioHelper) generateLocalFilesFromList(c asserter, options *generate
 				mode = *file.creationProperties.posixProperties.mode
 			}
 			switch {
-			case mode & common.S_IFIFO == common.S_IFIFO || mode & common.S_IFSOCK == common.S_IFSOCK:
+			case mode&common.S_IFIFO == common.S_IFIFO || mode&common.S_IFSOCK == common.S_IFSOCK:
 				osScenarioHelper{}.Mknod(c, destFile, mode, 0)
 			default:
 				sourceData, err := s.generateLocalFile(
@@ -367,7 +367,7 @@ func (s scenarioHelper) generateFileSharesAndFilesFromLists(c asserter, serviceC
 		c.AssertNoErr(err)
 
 		s.generateAzureFilesFromList(c, &generateAzureFilesFromListOptions{
-			shareClient:    sURL,
+			shareClient: sURL,
 			fileList:    fileList,
 			defaultSize: defaultStringFileSize,
 		})
@@ -394,18 +394,18 @@ func (s scenarioHelper) generateS3BucketsAndObjectsFromLists(c asserter, s3Clien
 }
 
 type generateFromListOptions struct {
-	fs          []*testObject
-	defaultSize string
+	fs                      []*testObject
+	defaultSize             string
 	preservePosixProperties bool
-	accountType AccountType
+	accountType             AccountType
 }
 
 type generateBlobFromListOptions struct {
 	rawSASURL       url.URL
 	containerClient *container.Client
 	cpkInfo         *blob.CPKInfo
-	cpkScopeInfo *blob.CPKScopeInfo
-	accessTier   *blob.AccessTier
+	cpkScopeInfo    *blob.CPKScopeInfo
+	accessTier      *blob.AccessTier
 	generateFromListOptions
 }
 
@@ -448,7 +448,7 @@ func (scenarioHelper) generateBlobsFromList(c asserter, options *generateBlobFro
 				mode := *b.creationProperties.posixProperties.mode
 
 				// todo: support for device rep files may be difficult in a testing environment.
-				if mode & common.S_IFSOCK == common.S_IFSOCK || mode & common.S_IFIFO == common.S_IFIFO {
+				if mode&common.S_IFSOCK == common.S_IFSOCK || mode&common.S_IFIFO == common.S_IFIFO {
 					b.body = make([]byte, 0)
 				}
 			}
@@ -496,7 +496,7 @@ func (scenarioHelper) generateBlobsFromList(c asserter, options *generateBlobFro
 				blockID := base64.StdEncoding.EncodeToString([]byte(uuid.NewString()))
 				_, err = bb.StageBlock(ctx, blockID, reader,
 					&blockblob.StageBlockOptions{
-						CPKInfo: options.cpkInfo,
+						CPKInfo:      options.cpkInfo,
 						CPKScopeInfo: options.cpkScopeInfo,
 					})
 
@@ -505,11 +505,11 @@ func (scenarioHelper) generateBlobsFromList(c asserter, options *generateBlobFro
 				_, err = bb.CommitBlockList(ctx,
 					[]string{blockID},
 					&blockblob.CommitBlockListOptions{
-						HTTPHeaders: headers,
-						Metadata: metadata,
-						Tier: options.accessTier,
-						Tags: tags,
-						CPKInfo: options.cpkInfo,
+						HTTPHeaders:  headers,
+						Metadata:     metadata,
+						Tier:         options.accessTier,
+						Tags:         tags,
+						CPKInfo:      options.cpkInfo,
 						CPKScopeInfo: options.cpkScopeInfo,
 					})
 
@@ -518,11 +518,11 @@ func (scenarioHelper) generateBlobsFromList(c asserter, options *generateBlobFro
 				// handle empty blobs
 				_, err := bb.Upload(ctx, reader,
 					&blockblob.UploadOptions{
-						HTTPHeaders: headers,
-						Metadata: metadata,
-						Tier: options.accessTier,
-						Tags: tags,
-						CPKInfo: options.cpkInfo,
+						HTTPHeaders:  headers,
+						Metadata:     metadata,
+						Tier:         options.accessTier,
+						Tags:         tags,
+						CPKInfo:      options.cpkInfo,
 						CPKScopeInfo: options.cpkScopeInfo,
 					})
 
@@ -533,17 +533,17 @@ func (scenarioHelper) generateBlobsFromList(c asserter, options *generateBlobFro
 			_, err := pb.Create(ctx, int64(size),
 				&pageblob.CreateOptions{
 					SequenceNumber: to.Ptr(int64(0)),
-					HTTPHeaders: headers,
-					Metadata: metadata,
-					Tags: tags,
-					CPKInfo: options.cpkInfo,
-					CPKScopeInfo: options.cpkScopeInfo,
+					HTTPHeaders:    headers,
+					Metadata:       metadata,
+					Tags:           tags,
+					CPKInfo:        options.cpkInfo,
+					CPKScopeInfo:   options.cpkScopeInfo,
 				})
 			c.AssertNoErr(err)
 
 			_, err = pb.UploadPages(ctx, reader, blob.HTTPRange{Offset: 0, Count: int64(size)},
 				&pageblob.UploadPagesOptions{
-					CPKInfo: options.cpkInfo,
+					CPKInfo:      options.cpkInfo,
 					CPKScopeInfo: options.cpkScopeInfo,
 				})
 			c.AssertNoErr(err)
@@ -551,17 +551,17 @@ func (scenarioHelper) generateBlobsFromList(c asserter, options *generateBlobFro
 			ab := options.containerClient.NewAppendBlobClient(b.name)
 			_, err := ab.Create(ctx,
 				&appendblob.CreateOptions{
-					HTTPHeaders: headers,
-					Metadata: metadata,
-					Tags: tags,
-					CPKInfo: options.cpkInfo,
+					HTTPHeaders:  headers,
+					Metadata:     metadata,
+					Tags:         tags,
+					CPKInfo:      options.cpkInfo,
 					CPKScopeInfo: options.cpkScopeInfo,
 				})
 			c.AssertNoErr(err)
 
 			_, err = ab.AppendBlock(ctx, reader,
 				&appendblob.AppendBlockOptions{
-					CPKInfo: options.cpkInfo,
+					CPKInfo:      options.cpkInfo,
 					CPKScopeInfo: options.cpkScopeInfo,
 				})
 			c.AssertNoErr(err)
@@ -600,7 +600,7 @@ func (scenarioHelper) generateBlobsFromList(c asserter, options *generateBlobFro
 	time.Sleep(time.Millisecond * 1050)
 }
 
-func (s scenarioHelper) enumerateContainerBlobProperties(a asserter, containerClient *container.Client) map[string]*objectProperties {
+func (s scenarioHelper) enumerateContainerBlobProperties(a asserter, containerClient *container.Client, fileSystemURL *azbfs.FileSystemURL) map[string]*objectProperties {
 	result := make(map[string]*objectProperties)
 
 	pager := containerClient.NewListBlobsFlatPager(&container.ListBlobsFlatOptions{Include: container.ListBlobsInclude{Metadata: true, Tags: true}})
@@ -623,17 +623,25 @@ func (s scenarioHelper) enumerateContainerBlobProperties(a asserter, containerCl
 			}
 			md := blobInfo.Metadata
 
+			var acl *string
+			if fileSystemURL != nil {
+				fURL := fileSystemURL.NewDirectoryURL(*relativePath).NewFileUrl()
+				accessControl, err := fURL.GetAccessControl(ctx)
+				a.AssertNoErr(err, "getting ACLs")
+				acl = &accessControl.ACL
+			}
+
 			props := objectProperties{
-				entityType:         common.EEntityType.File(), // todo: posix properties includes folders
-				size:               bp.ContentLength,
-				contentHeaders:     &h,
-				nameValueMetadata:  md,
-				creationTime:       bp.CreationTime,
-				lastWriteTime:      bp.LastModified,
-				cpkInfo:            &blob.CPKInfo{EncryptionKeySHA256: bp.CustomerProvidedKeySHA256},
-				cpkScopeInfo:       &blob.CPKScopeInfo{EncryptionScope: bp.EncryptionScope},
+				entityType:        common.EEntityType.File(), // todo: posix properties includes folders
+				size:              bp.ContentLength,
+				contentHeaders:    &h,
+				nameValueMetadata: md,
+				creationTime:      bp.CreationTime,
+				lastWriteTime:     bp.LastModified,
+				cpkInfo:           &blob.CPKInfo{EncryptionKeySHA256: bp.CustomerProvidedKeySHA256},
+				cpkScopeInfo:      &blob.CPKScopeInfo{EncryptionScope: bp.EncryptionScope},
 				// TODO : Return ACL in list
-				//adlsPermissionsACL: bp.ACL,
+				adlsPermissionsACL: acl,
 				// smbAttributes and smbPermissions don't exist in blob
 			}
 
@@ -682,7 +690,7 @@ func (scenarioHelper) generatePageBlobsFromList(c asserter, containerClient *con
 			int64(len(data)),
 			&pageblob.CreateOptions{
 				SequenceNumber: to.Ptr(int64(0)),
-				HTTPHeaders: &blob.HTTPHeaders{BlobContentType: to.Ptr("text/random")},
+				HTTPHeaders:    &blob.HTTPHeaders{BlobContentType: to.Ptr("text/random")},
 			})
 		c.AssertNoErr(err)
 
@@ -811,7 +819,7 @@ func (scenarioHelper) generateAzureFilesFromList(c asserter, options *generateAz
 			if f.creationProperties.smbPermissionsSddl != nil || f.creationProperties.smbAttributes != nil || f.creationProperties.lastWriteTime != nil {
 				_, err := dir.SetProperties(ctx, &directory.SetPropertiesOptions{
 					FileSMBProperties: ad.toSMBProperties(c),
-					FilePermissions: ad.toPermissions(c, options.shareClient),
+					FilePermissions:   ad.toPermissions(c, options.shareClient),
 				})
 				c.AssertNoErr(err)
 
@@ -867,9 +875,9 @@ func (scenarioHelper) generateAzureFilesFromList(c asserter, options *generateAz
 
 			_, err := fileClient.Create(ctx, fileSize, &sharefile.CreateOptions{
 				SMBProperties: ad.toSMBProperties(c),
-				Permissions: ad.toPermissions(c, options.shareClient),
-				HTTPHeaders: ad.toHeaders(),
-				Metadata: ad.obj.creationProperties.nameValueMetadata,
+				Permissions:   ad.toPermissions(c, options.shareClient),
+				HTTPHeaders:   ad.toHeaders(),
+				Metadata:      ad.obj.creationProperties.nameValueMetadata,
 			})
 			c.AssertNoErr(err)
 
@@ -892,9 +900,9 @@ func (scenarioHelper) generateAzureFilesFromList(c asserter, options *generateAz
 				*/
 
 				_, err := fileClient.SetHTTPHeaders(ctx, &sharefile.SetHTTPHeadersOptions{
-					HTTPHeaders: ad.toHeaders(),
+					HTTPHeaders:   ad.toHeaders(),
 					SMBProperties: ad.toSMBProperties(c),
-					Permissions: ad.toPermissions(c, options.shareClient),
+					Permissions:   ad.toPermissions(c, options.shareClient),
 				})
 				c.AssertNoErr(err)
 
@@ -941,7 +949,7 @@ func (s scenarioHelper) enumerateShareFileProperties(a asserter, sc *share.Clien
 	result[""] = &objectProperties{
 		entityType:         common.EEntityType.Folder(),
 		smbPermissionsSddl: rootPerm,
-		smbAttributes: to.Ptr(ste.FileAttributesToUint32(*rootAttr)),
+		smbAttributes:      to.Ptr(ste.FileAttributesToUint32(*rootAttr)),
 	}
 
 	dirQ = append(dirQ, root)

--- a/go.sum
+++ b/go.sum
@@ -10,7 +10,6 @@ cloud.google.com/go/iam v0.8.0/go.mod h1:lga0/y3iH6CX7sYqypWJ33hf7kkfXJag67naqGE
 cloud.google.com/go/longrunning v0.3.0 h1:NjljC+FYPV3uh5/OwWT6pVU+doBqMg2x/rZlE+CamDs=
 cloud.google.com/go/storage v1.29.0 h1:6weCgzRvMg7lzuUurI4697AqIRPU1SvzHhynwpW31jI=
 cloud.google.com/go/storage v1.29.0/go.mod h1:4puEjyTKnku6gfKoTfNOU/W+a9JyuVNxjpS5GBrB8h4=
-github.com/Azure/azure-pipeline-go v0.2.1/go.mod h1:UGSo8XybXnIGZ3epmeBw7Jdz+HiUVpqIlpz/HKHylF4=
 github.com/Azure/azure-pipeline-go v0.2.4-0.20220425205405-09e6f201e1e4 h1:hDJImUzpTAeIw/UasFUUDB/+UsZm5Q/6x2/jKKvEUiw=
 github.com/Azure/azure-pipeline-go v0.2.4-0.20220425205405-09e6f201e1e4/go.mod h1:x841ezTBIMG6O3lAcl8ATHnsOPVl2bqk7S3ta6S6u4k=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.0 h1:8kDqDngH+DmVBiCtIjCFTGa7MBnsIOkF9IccInFEbjk=
@@ -24,8 +23,6 @@ github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.1.0 h1:nVocQV40OQne5613E
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.1.0/go.mod h1:7QJP7dr2wznCMeqIrhMgWGf7XpAQnVrJqDm9nvV3Cu4=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azfile v1.0.0 h1:iqXx16jKhIkx1FLPA4tsaXLc6zIrj/kMesoutWDv6MI=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azfile v1.0.0/go.mod h1:AjDdvSU6d92BGS2JfdsKi+H/c2vQY3OFp4qhxzsUH8g=
-github.com/Azure/azure-storage-file-go v0.8.0 h1:OX8DGsleWLUE6Mw4R/OeWEZMvsTIpwN94J59zqKQnTI=
-github.com/Azure/azure-storage-file-go v0.8.0/go.mod h1:3w3mufGcMjcOJ3w+4Gs+5wsSgkT7xDwWWqMMIrXtW4c=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest/adal v0.9.18 h1:kLnPsRjzZZUF3K5REu/Kc+qMQrvuza2bwSnNdhmzLfQ=
@@ -110,13 +107,11 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
-github.com/mattn/go-ieproxy v0.0.0-20190610004146-91bb50d98149/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
 github.com/mattn/go-ieproxy v0.0.1/go.mod h1:pYabZ6IHcRpFh7vIaLfK7rdcWgFEb3SFJ6/gNWuh88E=
 github.com/mattn/go-ieproxy v0.0.11 h1:MQ/5BuGSgDAHZOJe6YY80IF2UVCfGkwfo6AeD7HtHYo=
 github.com/mattn/go-ieproxy v0.0.11/go.mod h1:/NsJd+kxZBmjMc5hrJCKMbP57B84rvq9BiDRbtO9AS0=
@@ -175,7 +170,6 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20191112182307-2180aed22343/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -192,7 +186,6 @@ golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191112214154-59a1497f0cea/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201101102859-da207088b7d1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/ste/sender-blobFolders.go
+++ b/ste/sender-blobFolders.go
@@ -20,14 +20,13 @@ type blobFolderSender struct {
 	destinationClient *blockblob.Client // We'll treat all folders as block blobs
 	jptm              IJobPartTransferMgr
 	sip               ISourceInfoProvider
-	metadataToApply common.Metadata
-	headersToApply  blob.HTTPHeaders
-	blobTagsToApply common.BlobTags
+	metadataToApply   common.Metadata
+	headersToApply    blob.HTTPHeaders
+	blobTagsToApply   common.BlobTags
 }
 
 func newBlobFolderSender(jptm IJobPartTransferMgr, destination string, sip ISourceInfoProvider) (sender, error) {
 	destinationClient := common.CreateBlockBlobClient(destination, jptm.CredentialInfo(), jptm.CredentialOpOptions(), jptm.ClientOptions())
-
 
 	props, err := sip.Properties()
 	if err != nil {
@@ -112,7 +111,8 @@ func (b *blobFolderSender) overwriteDFSProperties() (string, error) {
 	}
 
 	// Upload ADLS Gen 2 ACLs
-	if b.jptm.FromTo() == common.EFromTo.BlobBlob() && b.jptm.Info().PreserveSMBPermissions.IsTruthy() {
+	fromTo := b.jptm.FromTo()
+	if fromTo.From().SupportsHnsACLs() && fromTo.To().SupportsHnsACLs() && b.jptm.Info().PreserveSMBPermissions.IsTruthy() {
 		b.setDatalakeACLs()
 	}
 
@@ -177,11 +177,11 @@ func (b *blobFolderSender) EnsureFolderExists() error {
 			_, err := b.destinationClient.Delete(b.jptm.Context(), nil)
 			if err != nil {
 				if bloberror.HasCode(err, "DirectoryIsNotEmpty") { // this is DFS, and we cannot do a standard replacement on it. Opt to simply overwrite the properties.
-						where, err := b.overwriteDFSProperties()
-						if err != nil {
-							return fmt.Errorf("%w. When %s", err, where)
-						}
-						return nil
+					where, err := b.overwriteDFSProperties()
+					if err != nil {
+						return fmt.Errorf("%w. When %s", err, where)
+					}
+					return nil
 				}
 				return fmt.Errorf("when deleting existing blob: %w", err)
 			}
@@ -210,10 +210,10 @@ func (b *blobFolderSender) EnsureFolderExists() error {
 		// It doesn't make sense to use a special access tier for a blob folder, the blob will be 0 bytes.
 		_, err := b.destinationClient.Upload(b.jptm.Context(), streaming.NopCloser(bytes.NewReader(nil)),
 			&blockblob.UploadOptions{
-				HTTPHeaders: &b.headersToApply,
-				Metadata: b.metadataToApply,
-				Tags: b.blobTagsToApply,
-				CPKInfo: b.jptm.CpkInfo(),
+				HTTPHeaders:  &b.headersToApply,
+				Metadata:     b.metadataToApply,
+				Tags:         b.blobTagsToApply,
+				CPKInfo:      b.jptm.CpkInfo(),
 				CPKScopeInfo: b.jptm.CpkScopeInfo(),
 			})
 
@@ -225,7 +225,8 @@ func (b *blobFolderSender) EnsureFolderExists() error {
 	}
 
 	// Upload ADLS Gen 2 ACLs
-	if b.jptm.FromTo() == common.EFromTo.BlobBlob() && b.jptm.Info().PreserveSMBPermissions.IsTruthy() {
+	fromTo := b.jptm.FromTo()
+	if fromTo.From().SupportsHnsACLs() && fromTo.To().SupportsHnsACLs() && b.jptm.Info().PreserveSMBPermissions.IsTruthy() {
 		b.setDatalakeACLs()
 	}
 

--- a/ste/sender-blockBlob.go
+++ b/ste/sender-blockBlob.go
@@ -254,7 +254,8 @@ func (s *blockBlobSenderBase) Epilogue() {
 	}
 
 	// Upload ADLS Gen 2 ACLs
-	if jptm.FromTo() == common.EFromTo.BlobBlob() && jptm.Info().PreserveSMBPermissions.IsTruthy() {
+	fromTo := jptm.FromTo()
+	if fromTo.From().SupportsHnsACLs() && fromTo.To().SupportsHnsACLs() && jptm.Info().PreserveSMBPermissions.IsTruthy() {
 		blobURLParts, err := blob.ParseURL(s.destBlockBlobClient.URL())
 		if err != nil {
 			jptm.FailActiveSend("Parsing blob URL", err)


### PR DESCRIPTION
When updating the DFS handling code to actually record all dfs endpoints as BlobFS and handle the swapping at the time it's needed, some faulty testing caused us to believe that this code was actually working. It was not.

This PR repairs both the ACL copying functionality and the testing for that functionality.