### PR TITLE
Fix sync overwrite logging

### DIFF
--- a/cmd/syncComparator.go
+++ b/cmd/syncComparator.go
@@ -28,13 +28,13 @@ import (
 )
 
 const (
-	syncSkipReasonTime = "the source has an older LMT than the destination"
-	syncSkipReasonMissingHash = "the source lacks an associated hash; please upload with --put-md5"
-	syncSkipReasonSameHash = "the source has the same hash"
+	syncSkipReasonTime           = "the source has an older LMT than the destination"
+	syncSkipReasonMissingHash    = "the source lacks an associated hash; please upload with --put-md5"
+	syncSkipReasonSameHash       = "the source has the same hash"
 	syncOverwriteReasonNewerHash = "the source has a differing hash"
-	syncOverwriteResaonNewerLMT = "the source is more recent than the destination"
-	syncStatusSkipped = "skipped"
-	syncStatusOverwritten = "overwritten"
+	syncOverwriteResaonNewerLMT  = "the source is more recent than the destination"
+	syncStatusSkipped            = "skipped"
+	syncStatusOverwritten        = "overwritten"
 )
 
 func syncComparatorLog(fileName, status, skipReason string, stdout bool) {
@@ -64,7 +64,7 @@ type syncDestinationComparator struct {
 
 	comparisonHashType common.SyncHashType
 
-  	preferSMBTime     bool
+	preferSMBTime     bool
 	disableComparison bool
 }
 
@@ -113,10 +113,9 @@ func (f *syncDestinationComparator) processIfNecessary(destinationObject StoredO
 			syncComparatorLog(sourceObjectInMap.relativePath, syncStatusSkipped, syncSkipReasonSameHash, false)
 			return nil
 		} else if sourceObjectInMap.isMoreRecentThan(destinationObject, f.preferSMBTime) {
+			syncComparatorLog(sourceObjectInMap.relativePath, syncStatusOverwritten, syncOverwriteResaonNewerLMT, false)
 			return f.copyTransferScheduler(sourceObjectInMap)
 		}
-
-		syncComparatorLog(sourceObjectInMap.relativePath, syncStatusOverwritten, syncOverwriteResaonNewerLMT, false)
 	} else {
 		// purposefully ignore the error from destinationCleaner
 		// it's a tolerable error, since it just means some extra destination object might hang around a bit longer
@@ -138,7 +137,7 @@ type syncSourceComparator struct {
 
 	comparisonHashType common.SyncHashType
 
-  preferSMBTime     bool
+	preferSMBTime     bool
 	disableComparison bool
 }
 
@@ -164,7 +163,7 @@ func (f *syncSourceComparator) processIfNecessary(sourceObject StoredObject) err
 	if present {
 		defer delete(f.destinationIndex.indexMap, relPath)
 
-    // if destination is stale, schedule source for transfer
+		// if destination is stale, schedule source for transfer
 		if f.disableComparison {
 			return f.copyTransferScheduler(sourceObject)
 		}


### PR DESCRIPTION
When Hash Based Sync was introduced, the behavior surrounding logging overwrites was incorrect, and we would always log that we would overwrite due to LMT, whether we actually would or not. This did not affect actual overwrite behavior.