### PR TITLE
Support copy operations from non-AWS S3 endpoints

### DIFF
--- a/cmd/credentialUtil.go
+++ b/cmd/credentialUtil.go
@@ -473,7 +473,7 @@ func checkAuthSafeForTarget(ct common.CredentialType, resource, extraSuffixesAAD
 			parts, err := common.NewS3URLParts(*u) // strip any leading bucket name from URL, to get an endpoint we can pass to s3utils
 			if err == nil {
 				u, err := url.Parse("https://" + parts.Endpoint)
-				ok = err == nil && s3utils.IsAmazonEndpoint(*u)
+				ok = err == nil && (s3utils.IsAmazonEndpoint(*u) || strings.HasSuffix(u.Host, common.GetS3EssentialHostPart()))
 			}
 		}
 

--- a/cmd/zc_traverser_s3.go
+++ b/cmd/zc_traverser_s3.go
@@ -221,7 +221,7 @@ func newS3Traverser(credentialType common.CredentialType, rawURL *url.URL, ctx c
 // For info see: https://github.com/aws/aws-sdk-go/issues/720#issuecomment-243891223
 // Once we change to bucketExists, assuming its reliable, we will be able to re allow this URL type.
 func showS3UrlTypeWarning(s3URLParts common.S3URLParts) {
-	if strings.EqualFold(s3URLParts.Host, "s3.amazonaws.com") {
+	if strings.EqualFold(s3URLParts.Host, "s3." + common.GetS3EssentialHostPart()) {
 		s3UrlWarningOncer.Do(func() {
 			glcm.Info("Instead of transferring from the 's3.amazonaws.com' URL, in this version of AzCopy we recommend you " +
 				"use a region-specific endpoint to transfer from one specific region. E.g. s3.us-east-1.amazonaws.com or a virtual-hosted reference to a single bucket.")

--- a/common/environment.go
+++ b/common/environment.go
@@ -47,6 +47,7 @@ var VisibleEnvironmentVariables = []EnvironmentVariable{
 	EEnvironmentVariable.AWSAccessKeyID(),
 	EEnvironmentVariable.AWSSecretAccessKey(),
 	EEnvironmentVariable.AWSEssentialHostPart(),
+	EEnvironmentVariable.AWSObjectMD5MetadataName(),
 	EEnvironmentVariable.GoogleAppCredentials(),
 	EEnvironmentVariable.ShowPerfStates(),
 	EEnvironmentVariable.PacePageBlobs(),
@@ -292,6 +293,13 @@ func (EnvironmentVariable) AWSEssentialHostPart() EnvironmentVariable {
 	return EnvironmentVariable{
 		Name:        "AWS_ESSENTIAL_HOST_PART",
 		Description: "The essential host part used to construct S3 URLs, defaults to 'amazonaws.com'.",
+	}
+}
+
+func (EnvironmentVariable) AWSObjectMD5MetadataName() EnvironmentVariable {
+	return EnvironmentVariable{
+		Name:        "AWS_OBJECT_MD5_METADATA_NAME",
+		Description: "The name of the metadata value that contains the object MD5 sum for objects composed from a list of blocks",
 	}
 }
 

--- a/common/environment.go
+++ b/common/environment.go
@@ -46,6 +46,7 @@ var VisibleEnvironmentVariables = []EnvironmentVariable{
 	EEnvironmentVariable.BufferGB(),
 	EEnvironmentVariable.AWSAccessKeyID(),
 	EEnvironmentVariable.AWSSecretAccessKey(),
+	EEnvironmentVariable.AWSEssentialHostPart(),
 	EEnvironmentVariable.GoogleAppCredentials(),
 	EEnvironmentVariable.ShowPerfStates(),
 	EEnvironmentVariable.PacePageBlobs(),
@@ -284,6 +285,13 @@ func (EnvironmentVariable) AWSSecretAccessKey() EnvironmentVariable {
 		Name:        "AWS_SECRET_ACCESS_KEY",
 		Description: "The AWS secret access key for S3 source used in service to service copy.",
 		Hidden:      true,
+	}
+}
+
+func (EnvironmentVariable) AWSEssentialHostPart() EnvironmentVariable {
+	return EnvironmentVariable{
+		Name:        "AWS_ESSENTIAL_HOST_PART",
+		Description: "The essential host part used to construct S3 URLs, defaults to 'amazonaws.com'.",
 	}
 }
 

--- a/common/s3URLParts.go
+++ b/common/s3URLParts.go
@@ -63,7 +63,7 @@ const s3KeywordDualStack = "dualstack"
 
 // returns the S3 essential host part, 'amazonaws.com' by default
 //
-//	can be overriden by the AWS_ESSENTIAL_HOST_PART env variable
+//	can be overridden by the AWS_ESSENTIAL_HOST_PART env variable
 func GetS3EssentialHostPart() string {
 	if os.Getenv("AWS_ESSENTIAL_HOST_PART") != "" {
 		return os.Getenv("AWS_ESSENTIAL_HOST_PART")


### PR DESCRIPTION
Updates based on v10.20.1 to allow copy operations from non-AWS S3 endpoints.  The default 'amazonaws.com' S3 host part can be overridden via an environment variable to point to a different provider that utilizes the same S3 URL scheme as AWS S3.

Non-AWS S3 endpoints are enabled by the specifying the `AWS_ESSENTIAL_HOST_PART` environment variable with a value of the essential host part of the S3 provider, e.g. `wasabisys.com`.

Also added the ability to specify an S3 metadata field that will contain the MD5 sum for multi-block objects and propagate that value into the Content MD5 field on an Azure Blob during a copy operation.  This feature is enabled by the `AWS_OBJECT_MD5_METADATA_NAME` environment variable.  It is set to the metadata name that contains the base64-encoded md5 sum, e.g. `md5chksum`.



#832 