### PR TITLE
fix: failed files should not be accounted as failed when the job is resumed

### DIFF
--- a/jobsAdmin/init.go
+++ b/jobsAdmin/init.go
@@ -597,17 +597,7 @@ func resurrectJobSummary(jm ste.IJobMgr) common.ListJobSummaryResponse {
 			case common.ETransferStatus.Failed(),
 				common.ETransferStatus.TierAvailabilityCheckFailure(),
 				common.ETransferStatus.BlobTierFailure():
-				js.TransfersFailed++
-				// getting the source and destination for failed transfer at position - index
-				src, dst, isFolder := jpp.TransferSrcDstStrings(t)
-				// appending to list of failed transfer
-				js.FailedTransfers = append(js.FailedTransfers,
-					common.TransferDetail{
-						Src:                src,
-						Dst:                dst,
-						IsFolderProperties: isFolder,
-						TransferStatus:     common.ETransferStatus.Failed(),
-						ErrorCode:          jppt.ErrorCode()}) // TODO: Optimize
+				js.TotalBytesExpected += uint64(jppt.SourceSize)
 			case common.ETransferStatus.SkippedEntityAlreadyExists(),
 				common.ETransferStatus.SkippedBlobHasSnapshots():
 				js.TransfersSkipped++


### PR DESCRIPTION
Once the job is resumed I believe we should not treat any previous failures in statistics as the default behavior is to retry those failed elements. We do not want to end up in situation when if the retry succeeds - we would report the retried item both as failure and as a success.  

This directly addresses an issue: https://github.com/Azure/azure-storage-azcopy/issues/2461

