### PR TITLE
Generic resource management in the name of cleaner syntax

### DIFF
--- a/e2etest/newe2e_resource_definitions.go
+++ b/e2etest/newe2e_resource_definitions.go
@@ -17,6 +17,12 @@ type ResourceDefinition interface {
 	ApplyDefinition(a Asserter, target ResourceManager, applicationFunctions map[cmd.LocationLevel]func(Asserter, ResourceManager, ResourceDefinition))
 }
 
+type MatchedResourceDefinition[T ResourceManager] interface {
+	ResourceDefinition
+
+	resourceDefinition() T
+}
+
 type ResourceDefinitionService struct {
 	//Location   common.Location // todo do we want/need this? does it make sense? CreateResource currently takes a ResourceManager, which can't target an AccountResourceManager because definitions differ
 	Containers map[string]ResourceDefinitionContainer
@@ -59,6 +65,10 @@ func (r ResourceDefinitionService) ApplyDefinition(a Asserter, target ResourceMa
 
 func (r ResourceDefinitionService) DefinitionTarget() cmd.LocationLevel {
 	return cmd.ELocationLevel.Service()
+}
+
+func (r ResourceDefinitionService) resourceDefinition() ServiceResourceManager {
+	panic("marker method")
 }
 
 type ResourceDefinitionContainer struct {
@@ -112,6 +122,10 @@ func (r ResourceDefinitionContainer) ApplyDefinition(a Asserter, target Resource
 	}
 }
 
+func (r ResourceDefinitionContainer) resourceDefinition() ContainerResourceManager {
+	panic("marker method")
+}
+
 func (r ResourceDefinitionContainer) DefinitionTarget() cmd.LocationLevel {
 	return cmd.ELocationLevel.Container()
 }
@@ -150,4 +164,8 @@ func (r ResourceDefinitionObject) ApplyDefinition(a Asserter, target ResourceMan
 
 func (r ResourceDefinitionObject) DefinitionTarget() cmd.LocationLevel {
 	return cmd.ELocationLevel.Object()
+}
+
+func (r ResourceDefinitionObject) resourceDefinition() ObjectResourceManager {
+	panic("marker method")
 }

--- a/e2etest/newe2e_task_resourcemanagement.go
+++ b/e2etest/newe2e_task_resourcemanagement.go
@@ -14,7 +14,9 @@ type ResourceTracker interface {
 	TrackCreatedAccount(account AccountResourceManager)
 }
 
-func CreateResource(a Asserter, base ResourceManager, definition ResourceDefinition) ResourceManager {
+func CreateResource[T ResourceManager](a Asserter, base ResourceManager, def MatchedResourceDefinition[T]) T {
+	definition := ResourceDefinition(def)
+
 	a.AssertNow("Base resource and definition must not be null", Not{IsNil{}}, base, definition)
 	a.AssertNow("Base resource must be at a equal or lower level than the resource definition", Equal{}, base.Level() <= definition.DefinitionTarget(), true)
 
@@ -52,7 +54,7 @@ func CreateResource(a Asserter, base ResourceManager, definition ResourceDefinit
 		matchingRes, matchingDef = matchingDef.MatchAdoptiveChild(a, matchingRes)
 	}
 
-	return matchingRes
+	return matchingRes.(T)
 }
 
 func ValidatePropertyPtr[T any](a Asserter, name string, expected, real *T) {
@@ -79,7 +81,7 @@ func ValidateTags(a Asserter, expected, real map[string]string) {
 	a.Assert("Tags must match", Equal{Deep: true}, expected, real)
 }
 
-func ValidateResource(a Asserter, target ResourceManager, definition ResourceDefinition, validateObjectContent bool) {
+func ValidateResource[T ResourceManager](a Asserter, target T, definition MatchedResourceDefinition[T], validateObjectContent bool) {
 	a.AssertNow("Target resource and definition must not be null", Not{IsNil{}}, a, target, definition)
 	a.AssertNow("Target resource must be at a equal level to the resource definition", Equal{}, target.Level(), definition.DefinitionTarget())
 

--- a/e2etest/zt_newe2e_example_test.go
+++ b/e2etest/zt_newe2e_example_test.go
@@ -28,11 +28,11 @@ func (s *ExampleSuite) Scenario_SingleFileCopySyncS2S(svm *ScenarioVariationMana
 	svm.InsertVariationSeparator(":")
 	body := NewRandomObjectContentContainer(svm, SizeFromString("10K"))
 	// Scale up from service to object
-	srcObj := CreateResource(svm, srcService, ResourceDefinitionObject{
+	srcObj := CreateResource[ObjectResourceManager](svm, srcService, ResourceDefinitionObject{
 		Body: body,
-	}).(ObjectResourceManager) // todo: generic CreateResource is something to pursue in another branch, but it's an interesting thought.
+	}) // todo: generic CreateResource is something to pursue in another branch, but it's an interesting thought.
 	// Scale up from service to container
-	dstObj := CreateResource(svm, dstService, ResourceDefinitionContainer{}).(ContainerResourceManager).GetObject(svm, "foobar", common.EEntityType.File())
+	dstObj := CreateResource[ContainerResourceManager](svm, dstService, ResourceDefinitionContainer{}).GetObject(svm, "foobar", common.EEntityType.File())
 
 	_, _ = srcObj, dstObj
 	RunAzCopy(
@@ -42,7 +42,7 @@ func (s *ExampleSuite) Scenario_SingleFileCopySyncS2S(svm *ScenarioVariationMana
 			Targets: []string{srcObj.URI(svm, true), dstObj.URI(svm, true)},
 		})
 
-	ValidateResource(svm, dstObj, ResourceDefinitionObject{
+	ValidateResource[ObjectResourceManager](svm, dstObj, ResourceDefinitionObject{
 		Body: body,
 	}, true)
 }


### PR DESCRIPTION
As opposed to `CreateResource(...).(ObjectResourceManager)` one now writes `CreateResource[ObjectResourceManager](...)`, and in future versions of Go (>1.21), it will be further reduced to `CreateResource(..., ResourceDefinitionObject{...})`