### PR TITLE
[Storage Explorer] Add support for High Throughput Append Blob

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -360,9 +360,9 @@ func (raw rawCopyCmdArgs) cook() (CookedCopyCmdArgs, error) {
 	}
 
 	// If the given blobType is AppendBlob, block-size-mb should not be greater than
-	// 4MB.
+	// 100MB.
 	if cookedSize, _ := blockSizeInBytes(raw.blockSizeMB); cooked.blobType == common.EBlobType.AppendBlob() && cookedSize > common.MaxAppendBlobBlockSize {
-		return cooked, fmt.Errorf("block size cannot be greater than 4MB for AppendBlob blob type")
+		return cooked, fmt.Errorf("block size cannot be greater than 100MB for AppendBlob blob type")
 	}
 
 	err = cooked.blockBlobTier.Parse(raw.blockBlobTier)
@@ -1540,7 +1540,7 @@ func (cca *CookedCopyCmdArgs) processCopyJobPartOrders() (err error) {
 	options := createClientOptions(common.AzcopyCurrentJobLogger)
 	var azureFileSpecificOptions any
 	if cca.FromTo.From() == common.ELocation.File() {
-		azureFileSpecificOptions = &common.FileClientOptions {
+		azureFileSpecificOptions = &common.FileClientOptions{
 			AllowTrailingDot: cca.trailingDot == common.ETrailingDotOption.Enable(),
 		}
 	}
@@ -1562,8 +1562,8 @@ func (cca *CookedCopyCmdArgs) processCopyJobPartOrders() (err error) {
 	}
 
 	if cca.FromTo.To() == common.ELocation.File() {
-		azureFileSpecificOptions = &common.FileClientOptions {
-			AllowTrailingDot: cca.trailingDot == common.ETrailingDotOption.Enable(),
+		azureFileSpecificOptions = &common.FileClientOptions{
+			AllowTrailingDot:       cca.trailingDot == common.ETrailingDotOption.Enable(),
 			AllowSourceTrailingDot: (cca.trailingDot == common.ETrailingDotOption.Enable() && cca.FromTo.From() == common.ELocation.File()),
 		}
 	}

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -362,7 +362,7 @@ func (raw rawCopyCmdArgs) cook() (CookedCopyCmdArgs, error) {
 	// If the given blobType is AppendBlob, block-size-mb should not be greater than
 	// 100MB.
 	if cookedSize, _ := blockSizeInBytes(raw.blockSizeMB); cooked.blobType == common.EBlobType.AppendBlob() && cookedSize > common.MaxAppendBlobBlockSize {
-		return cooked, fmt.Errorf("block size cannot be greater than 100MB for AppendBlob blob type")
+		return cooked, fmt.Errorf("block size cannot be greater than %dMB for AppendBlob blob type", common.MaxAppendBlobBlockSize/1048576)
 	}
 
 	err = cooked.blockBlobTier.Parse(raw.blockBlobTier)

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -360,9 +360,9 @@ func (raw rawCopyCmdArgs) cook() (CookedCopyCmdArgs, error) {
 	}
 
 	// If the given blobType is AppendBlob, block-size-mb should not be greater than
-	// 100MB.
+	// common.MaxAppendBlobBlockSize.
 	if cookedSize, _ := blockSizeInBytes(raw.blockSizeMB); cooked.blobType == common.EBlobType.AppendBlob() && cookedSize > common.MaxAppendBlobBlockSize {
-		return cooked, fmt.Errorf("block size cannot be greater than %dMB for AppendBlob blob type", common.MaxAppendBlobBlockSize/1048576)
+		return cooked, fmt.Errorf("block size cannot be greater than %dMB for AppendBlob blob type", common.MaxAppendBlobBlockSize/common.MegaByte)
 	}
 
 	err = cooked.blockBlobTier.Parse(raw.blockBlobTier)

--- a/common/fe-ste-models.go
+++ b/common/fe-ste-models.go
@@ -1080,6 +1080,7 @@ const (
 	MaxNumberOfBlocksPerBlob       = 50000
 	BlockSizeThreshold             = 256 * 1024 * 1024
 	MinParallelChunkCountThreshold = 4 /* minimum number of chunks in parallel for AzCopy to be performant. */
+	MegaByte                       = 1024 * 1024
 )
 
 // This struct represent a single transfer entry with source and destination details

--- a/common/fe-ste-models.go
+++ b/common/fe-ste-models.go
@@ -180,7 +180,7 @@ var EPermanentDeleteOption = PermanentDeleteOption(3) // Default to "None"
 type PermanentDeleteOption uint8
 
 func (PermanentDeleteOption) Snapshots() PermanentDeleteOption { return PermanentDeleteOption(0) }
-func (PermanentDeleteOption) Versions()  PermanentDeleteOption  { return PermanentDeleteOption(1) }
+func (PermanentDeleteOption) Versions() PermanentDeleteOption  { return PermanentDeleteOption(1) }
 func (PermanentDeleteOption) SnapshotsAndVersions() PermanentDeleteOption {
 	return PermanentDeleteOption(2)
 }
@@ -332,8 +332,9 @@ func (ExitCode) Error() ExitCode   { return ExitCode(1) }
 // NoExit is used as a marker, to suppress the normal exit behaviour
 func (ExitCode) NoExit() ExitCode { return ExitCode(99) }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 type LogLevel uint8
+
 const (
 	// LogNone tells a logger not to log any entries passed to it.
 	LogNone LogLevel = iota
@@ -396,14 +397,15 @@ func (ll LogLevel) String() string {
 	}
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // LogSanitizer can be implemented to clean secrets from lines logged by ForceLog
 // By default no implementation is provided here, because pipeline may be used in many different
 // contexts, so the correct implementation is context-dependent
 type LogSanitizer interface {
 	SanitizeLogMessage(raw string) string
 }
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 var EJobPriority = JobPriority(0)
 
 // JobPriority defines the transfer priorities supported by the Storage Transfer Engine's channels
@@ -574,9 +576,10 @@ func (l Location) SupportsTrailingDot() bool {
 	if (l == ELocation.File()) || (l == ELocation.Local() && runtime.GOOS != "windows") {
 		return true
 	}
-	
+
 	return false
 }
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 var EFromTo = FromTo(0)
@@ -1066,7 +1069,7 @@ func (i *InvalidMetadataHandleOption) UnmarshalJSON(b []byte) error {
 const (
 	DefaultBlockBlobBlockSize      = 8 * 1024 * 1024
 	MaxBlockBlobBlockSize          = 4000 * 1024 * 1024
-	MaxAppendBlobBlockSize         = 4 * 1024 * 1024
+	MaxAppendBlobBlockSize         = 100 * 1024 * 1024
 	DefaultPageBlobChunkSize       = 4 * 1024 * 1024
 	DefaultAzureFileChunkSize      = 4 * 1024 * 1024
 	MaxRangeGetSize                = 4 * 1024 * 1024

--- a/e2etest/zt_basic_copy_sync_remove_test.go
+++ b/e2etest/zt_basic_copy_sync_remove_test.go
@@ -31,6 +31,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -79,59 +80,59 @@ func TestBasic_CopyUploadLargeBlob(t *testing.T) {
 
 func TestBasic_CopyUploadLargeAppendBlob(t *testing.T) {
 	dst := common.EBlobType.AppendBlob()
-	src := dst
 
 	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.BlobBlob(), common.EFromTo.LocalBlob()), eValidate.Auto(), anonymousAuthOnly, anonymousAuthOnly, params{
 		recursive: true,
-		blobType:  src.String(),
+		blobType:  dst.String(),
 	}, &hooks{
-		beforeRunJob: func(h hookHelper) {
-			h.CreateFile(f("test.txt", with{blobType: dst}), false)
-		},
 		afterValidation: func(h hookHelper) {
 			props := h.GetDestination().getAllProperties(h.GetAsserter())
-			bprops, ok := props["test.txt"]
-			h.GetAsserter().Assert(ok, equals(), true)
-			if ok {
-				h.GetAsserter().Assert(bprops.blobType, equals(), dst)
+			h.GetAsserter().Assert(len(props), equals(), 1)
+			bprops := &objectProperties{}
+			for key, _ := range props {
+				// we try to match the test.txt substring because local test files have randomizing prefix to file names
+				if strings.Contains(key, "test.txt") {
+					bprops = props[key]
+				}
 			}
+			h.GetAsserter().Assert(bprops.blobType, equals(), dst)
 		},
 	}, testFiles{
-		defaultSize: "100M",
+		defaultSize: "101M",
 
 		shouldTransfer: []interface{}{
-			f("test.txt", with{blobType: src}),
+			f("test.txt", with{blobType: dst}),
 		},
-	}, EAccountType.Standard(), EAccountType.Standard(), src.String()+"-"+dst.String())
+	}, EAccountType.Standard(), EAccountType.Standard(), "")
 }
 
 func TestBasic_CopyUploadLargeAppendBlobBlockSizeFlag(t *testing.T) {
 	dst := common.EBlobType.AppendBlob()
-	src := dst
 
 	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.BlobBlob(), common.EFromTo.LocalBlob()), eValidate.Auto(), anonymousAuthOnly, anonymousAuthOnly, params{
 		recursive:   true,
-		blobType:    src.String(),
+		blobType:    dst.String(),
 		blockSizeMB: 100, // 100 MB
 	}, &hooks{
-		beforeRunJob: func(h hookHelper) {
-			h.CreateFile(f("test.txt", with{blobType: dst}), false)
-		},
 		afterValidation: func(h hookHelper) {
 			props := h.GetDestination().getAllProperties(h.GetAsserter())
-			bprops, ok := props["test.txt"]
-			h.GetAsserter().Assert(ok, equals(), true)
-			if ok {
-				h.GetAsserter().Assert(bprops.blobType, equals(), dst)
+			h.GetAsserter().Assert(len(props), equals(), 1)
+			bprops := &objectProperties{}
+			for key, _ := range props {
+				// we try to match the test.txt substring because local test files have randomizing prefix to file names
+				if strings.Contains(key, "test.txt") {
+					bprops = props[key]
+				}
 			}
+			h.GetAsserter().Assert(bprops.blobType, equals(), dst)
 		},
 	}, testFiles{
-		defaultSize: "100M",
+		defaultSize: "101M",
 
 		shouldTransfer: []interface{}{
-			f("test.txt", with{blobType: src}),
+			f("test.txt", with{blobType: dst}),
 		},
-	}, EAccountType.Standard(), EAccountType.Standard(), src.String()+"-"+dst.String())
+	}, EAccountType.Standard(), EAccountType.Standard(), "")
 }
 
 func TestBasic_CopyDownloadSingleBlob(t *testing.T) {

--- a/ste/sender-appendBlob.go
+++ b/ste/sender-appendBlob.go
@@ -63,8 +63,8 @@ func newAppendBlobSenderBase(jptm IJobPartTransferMgr, destination string, pacer
 
 	// compute chunk count
 	chunkSize := transferInfo.BlockSize
-	// If the given chunk Size for the Job is greater than maximum append blob block size i.e 100 MB,
-	// then set chunkSize as 100 MB.
+	// If the given chunk Size for the Job is greater than maximum append blob block size i.e common.MaxAppendBlobBlockSize,
+	// then set chunkSize as common.MaxAppendBlobBlockSize.
 	chunkSize = common.Iff(
 		chunkSize > common.MaxAppendBlobBlockSize,
 		common.MaxAppendBlobBlockSize,

--- a/ste/sender-appendBlob.go
+++ b/ste/sender-appendBlob.go
@@ -63,8 +63,8 @@ func newAppendBlobSenderBase(jptm IJobPartTransferMgr, destination string, pacer
 
 	// compute chunk count
 	chunkSize := transferInfo.BlockSize
-	// If the given chunk Size for the Job is greater than maximum append blob block size i.e 4 MB,
-	// then set chunkSize as 4 MB.
+	// If the given chunk Size for the Job is greater than maximum append blob block size i.e 100 MB,
+	// then set chunkSize as 100 MB.
 	chunkSize = common.Iff(
 		chunkSize > common.MaxAppendBlobBlockSize,
 		common.MaxAppendBlobBlockSize,


### PR DESCRIPTION
The content length limit for `AppendBlob.AppendBlock()` and `AppendBlob.AppendBlockFromURL()` raised from 4 MB to 100 MB so this PR reflects the needed changes for this upgrade. 

- Hardcoded MaxAppendBlockSize value updated to  100 MB
- In copy.go, where we check the flag `block-size-mb` and blob  type has been updated to support this upgrade
- Included tests testing `block-size-mb` flag and large AppendBlobs (should these be skipped because of large size?)