### PR TITLE
Fixed an issue where failure to rename a file from the temp prefix to the file name would not be considered a Failed transfer

### DIFF
--- a/e2etest/zt_basic_copy_sync_remove_test.go
+++ b/e2etest/zt_basic_copy_sync_remove_test.go
@@ -89,6 +89,20 @@ func TestBasic_CopyDownloadSingleBlob(t *testing.T) {
 	}, EAccountType.Standard(), EAccountType.Standard(), "")
 }
 
+func TestBasic_CopyDownloadSingleBlobEmptyDir(t *testing.T) {
+	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.BlobLocal()), eValidate.Auto(), allCredentialTypes, anonymousAuthOnly, params{
+		recursive: true,
+	}, nil, testFiles{
+		defaultSize: "1K",
+		shouldTransfer: []interface{}{
+			folder(""),
+		},
+		shouldFail: []interface{}{
+			f("dir1//dir3/file1.txt"),
+		},
+	}, EAccountType.Standard(), EAccountType.Standard(), "")
+}
+
 func TestBasic_CopyDownloadEmptyBlob(t *testing.T) {
 	RunScenarios(t, eOperation.CopyAndSync(), eTestFromTo.AllDownloads(), eValidate.Auto(), anonymousAuthOnly, anonymousAuthOnly, params{
 		recursive: true,

--- a/e2etest/zt_basic_copy_sync_remove_test.go
+++ b/e2etest/zt_basic_copy_sync_remove_test.go
@@ -90,6 +90,10 @@ func TestBasic_CopyDownloadSingleBlob(t *testing.T) {
 }
 
 func TestBasic_CopyDownloadSingleBlobEmptyDir(t *testing.T) {
+	// Only Windows fails to rename if there is an empty dir name in the path
+	if runtime.GOOS != "windows" {
+		return
+	}
 	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.BlobLocal()), eValidate.Auto(), allCredentialTypes, anonymousAuthOnly, params{
 		recursive: true,
 	}, nil, testFiles{

--- a/ste/xfer-remoteToLocal-file.go
+++ b/ste/xfer-remoteToLocal-file.go
@@ -421,15 +421,13 @@ func epilogueWithCleanupDownload(jptm IJobPartTransferMgr, dl downloader, active
 			}
 
 			// check if we need to rename back to original name. At this point, we're sure the file is completely
-			// downloaded and not corrupt. In fact, post this point we should only log errors and
-			// not fail the transfer.
+			// downloaded and not corrupt.
 			renameNecessary := !strings.EqualFold(info.getDownloadPath(), info.Destination) &&
 				!strings.EqualFold(info.Destination, common.Dev_Null)
 			if err == nil && renameNecessary {
 				renameErr := os.Rename(info.getDownloadPath(), info.Destination)
 				if renameErr != nil {
-					jptm.LogError(info.Destination, fmt.Sprintf(
-						"Failed to rename. File at %s", info.getDownloadPath()), renameErr)
+					jptm.FailActiveDownload("Download rename", renameErr)
 				}
 			}
 		}


### PR DESCRIPTION
Customer was trying to download (from the blob service) a path with an empty directory and was seeing a successful transfer, but all affected files had the .azDownload temp prefix, which is unexpected.

Windows does not support empty directory names, and different APIs behave differently. Create/Delete will trim the extra / but Rename considers it to be an invalid path name. 

This fix makes failure to rename the file be considered a Failed transfer. 