### PR TITLE
Commands lagging for ~8 seconds due to version-check

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -276,7 +276,7 @@ func beginDetectNewVersion() chan struct{} {
 		cachedVersion, err := ValidateCachedVersion(filePath) // same as the remote version
 		if err == nil {
 			PrintOlderVersion(*cachedVersion, *localVersion)
-			close(completionChannel) // let caller know that we have finished early
+			// close(completionChannel) // let caller know that we have finished early
 		}
 
 		// step 2: initialize pipeline

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -276,7 +276,7 @@ func beginDetectNewVersion() chan struct{} {
 		cachedVersion, err := ValidateCachedVersion(filePath) // same as the remote version
 		if err == nil {
 			PrintOlderVersion(*cachedVersion, *localVersion)
-			return
+			close(completionChannel) // let caller know that we have finished early
 		}
 
 		// step 2: initialize pipeline
@@ -296,6 +296,7 @@ func beginDetectNewVersion() chan struct{} {
 		// step 4: read newest version str
 		data := make([]byte, *downloadBlobResp.ContentLength)
 		_, err = downloadBlobResp.Body.Read(data)
+		defer downloadBlobResp.Body.Close()
 		if err != nil && err != io.EOF {
 			return
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -276,42 +276,41 @@ func beginDetectNewVersion() chan struct{} {
 		cachedVersion, err := ValidateCachedVersion(filePath) // same as the remote version
 		if err == nil {
 			PrintOlderVersion(*cachedVersion, *localVersion)
-			// close(completionChannel) // let caller know that we have finished early
-		}
+		} else {
+			// step 2: initialize pipeline
+			options := createClientOptions(nil)
 
-		// step 2: initialize pipeline
-		options := createClientOptions(nil)
+			// step 3: start download
+			blobClient, err := blob.NewClientWithNoCredential(versionMetadataUrl, &blob.ClientOptions{ClientOptions: options})
+			if err != nil {
+				return
+			}
 
-		// step 3: start download
-		blobClient, err := blob.NewClientWithNoCredential(versionMetadataUrl, &blob.ClientOptions{ClientOptions: options})
-		if err != nil {
-			return
-		}
+			downloadBlobResp, err := blobClient.DownloadStream(context.TODO(), nil)
+			if err != nil {
+				return
+			}
 
-		downloadBlobResp, err := blobClient.DownloadStream(context.TODO(), nil)
-		if err != nil {
-			return
-		}
+			// step 4: read newest version str
+			data := make([]byte, *downloadBlobResp.ContentLength)
+			_, err = downloadBlobResp.Body.Read(data)
+			defer downloadBlobResp.Body.Close()
+			if err != nil && err != io.EOF {
+				return
+			}
 
-		// step 4: read newest version str
-		data := make([]byte, *downloadBlobResp.ContentLength)
-		_, err = downloadBlobResp.Body.Read(data)
-		defer downloadBlobResp.Body.Close()
-		if err != nil && err != io.EOF {
-			return
-		}
+			remoteVersion, err := NewVersion(string(data))
+			if err != nil {
+				return
+			}
 
-		remoteVersion, err := NewVersion(string(data))
-		if err != nil {
-			return
-		}
+			PrintOlderVersion(*remoteVersion, *localVersion)
 
-		PrintOlderVersion(*remoteVersion, *localVersion)
-
-		// step 5: persist remote version in local
-		err = localVersion.CacheRemoteVersion(*remoteVersion, filePath)
-		if err != nil {
-			return
+			// step 5: persist remote version in local
+			err = localVersion.CacheRemoteVersion(*remoteVersion, filePath)
+			if err != nil {
+				return
+			}
 		}
 
 		// let caller know we have finished, if they want to know


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-storage-azcopy/issues/2482

Version check command lags for 8 seconds due to channel not being closed. This change ensures that whether the version is cached or not, the beginDetectNewVersion method exits properly allowing the channel to be closed at the end (line 317).