### PR TITLE
[BugFix]LogFileLocation in JSON output is invalid when job is resumed 

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -124,21 +125,19 @@ var rootCmd = &cobra.Command{
 		if cmd.Use == "resume [jobID]" {
 			// If no argument is passed then it is not valid
 			if len(args) != 1 {
-				return err
+				return errors.New("this command requires jobId to be passed as argument")
 			}
 
-			parsedJobID, err := common.ParseJobID(args[0])
+			loggerInfo.jobID, err = common.ParseJobID(args[0])
 
 			if err != nil {
 				return err
 			}
 
-			common.AzcopyCurrentJobLogger = common.NewJobLogger(parsedJobID, azcopyLogVerbosity, loggerInfo.logFileFolder, "")
-			common.AzcopyCurrentJobLogger.OpenLog()
-		} else {
-			common.AzcopyCurrentJobLogger = common.NewJobLogger(loggerInfo.jobID, azcopyLogVerbosity, loggerInfo.logFileFolder, "")
-			common.AzcopyCurrentJobLogger.OpenLog()
 		}
+
+		common.AzcopyCurrentJobLogger = common.NewJobLogger(loggerInfo.jobID, azcopyLogVerbosity, loggerInfo.logFileFolder, "")
+		common.AzcopyCurrentJobLogger.OpenLog()
 
 		glcm.SetForceLogging()
 


### PR DESCRIPTION
**Description:**
Addressing the reported issue where job resumptions were leading to the creation of multiple log files (#2466)[https://github.com/Azure/azure-storage-azcopy/issues/2466] within the Azure Storage AzCopy tool.


**Changes:**
- Implemented a fix to ensure that log files are appropriately handled when jobs are resumed.
- Introduced validation checks to prevent the creation of redundant log files during job resumption scenarios.
- This fix aims to rectify the problem highlighted in issue #2466 by ensuring that log file creation remains consistent and singular during job resumptions.