### PR TITLE
[BugFix]FileShare and Resume Job fix

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,9 +22,8 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
-	"github.com/Azure/azure-storage-azcopy/v10/jobsAdmin"
 	"io"
 	"os"
 	"path/filepath"
@@ -32,6 +31,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-storage-azcopy/v10/jobsAdmin"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-azcopy/v10/ste"
@@ -117,6 +119,23 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
+		// If the command is for resuming a job with a specific JobID,
+		// use the provided JobID to resume the job; otherwise, create a new JobID.
+		if cmd.Use == "resume [jobID]" {
+			// If no argument is passed then it is not valid
+			if len(args) != 1 {
+				return errors.New("this command requires jobId to be passed as argument")
+			}
+
+			loggerInfo.jobID, err = common.ParseJobID(args[0])
+
+			if err != nil {
+				return err
+			}
+
+		}
+
 		common.AzcopyCurrentJobLogger = common.NewJobLogger(loggerInfo.jobID, azcopyLogVerbosity, loggerInfo.logFileFolder, "")
 		common.AzcopyCurrentJobLogger.OpenLog()
 

--- a/ste/sender-azureFile.go
+++ b/ste/sender-azureFile.go
@@ -465,11 +465,7 @@ func (u *azureFileSenderBase) SetFolderProperties() error {
 		u.fileOrDirClient,
 		u.jptm.GetForceIfReadOnly())
 
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func (u *azureFileSenderBase) DirUrlToString() string {

--- a/ste/sender-azureFile.go
+++ b/ste/sender-azureFile.go
@@ -24,16 +24,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/directory"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/file"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/fileerror"
 	filesas "github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/sas"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/share"
-	"net/http"
-	"net/url"
-	"strings"
-	"time"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
@@ -50,15 +51,15 @@ type FileClientStub interface {
 // (The alternative would be to have the likes of newAzureFilesUploader call sip.EntityType and return a different type
 // if the entity type is folder).
 type azureFileSenderBase struct {
-	jptm            IJobPartTransferMgr
+	jptm                 IJobPartTransferMgr
 	addFileRequestIntent bool
-	fileOrDirClient FileClientStub
-	shareClient     *share.Client
-	chunkSize       int64
-	numChunks       uint32
-	pacer           pacer
-	ctx             context.Context
-	sip             ISourceInfoProvider
+	fileOrDirClient      FileClientStub
+	shareClient          *share.Client
+	chunkSize            int64
+	numChunks            uint32
+	pacer                pacer
+	ctx                  context.Context
+	sip                  ISourceInfoProvider
 	// Headers and other info that we will apply to the destination
 	// object. For S2S, these come from the source service.
 	// When sending local data, they are computed based on
@@ -450,13 +451,12 @@ func (u *azureFileSenderBase) SetFolderProperties() error {
 		return err
 	}
 
-	_, err = u.getDirectoryClient().SetMetadata(u.ctx, &directory.SetMetadataOptions{Metadata: u.metadataToApply})
-	if err != nil {
-		return err
-	}
-
 	err = u.DoWithOverrideReadOnly(u.ctx,
 		func() (interface{}, error) {
+			_, err := u.getDirectoryClient().SetMetadata(u.ctx, &directory.SetMetadataOptions{Metadata: u.metadataToApply})
+			if err != nil {
+				return nil, err
+			}
 			return u.getDirectoryClient().SetProperties(u.ctx, &directory.SetPropertiesOptions{
 				FileSMBProperties: &u.smbPropertiesToApply,
 				FilePermissions:   &u.permissionsToApply,
@@ -464,7 +464,12 @@ func (u *azureFileSenderBase) SetFolderProperties() error {
 		},
 		u.fileOrDirClient,
 		u.jptm.GetForceIfReadOnly())
-	return err
+
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (u *azureFileSenderBase) DirUrlToString() string {


### PR DESCRIPTION
**Description**
- This pull request addresses the reported issue where Azcopy fails to function properly when the destination directory has the 'read-only' attribute set, even when utilizing the 'force-if-read-only' flag.
- Addressing the reported issue where job resumptions were leading to the creation of multiple log files within the Azure Storage AzCopy tool.


**Changes:**
- Implemented a comprehensive fix to rectify the observed behavior, ensuring Azcopy functions correctly even when encountering directories with the 'read-only' attribute.
- Added validation checks.
- Implemented a fix to ensure that log files are appropriately handled when jobs are resumed.
- Introduced validation checks to prevent the creation of redundant log files during job resumption scenarios.