### PR TITLE
Canonical resource cleanup

### DIFF
--- a/e2etest/newe2e_resource_manager_interface.go
+++ b/e2etest/newe2e_resource_manager_interface.go
@@ -27,6 +27,19 @@ type ResourceManager interface {
 	// Account specifies the parent account.
 	// Can return nil, indicating there is no associated account
 	Account() AccountResourceManager
+
+	/*Canon specifies an object's canonical location in the resource tree created by a test.
+
+	A Canon string is a `/` delimited list of parents up to the final element, representing the resource itself.
+	The format goes
+	<account>/<location>/<container>/<object>
+
+	For locations where an account does not exist (e.g. local), substitute account with "accountless".
+	e.g. accountless/Local/<tmpdirname>/<object>
+
+	For flat namespaces, e.g. raw blob, / is ignored past objects, as it gets no more granular.
+	*/
+	Canon() string
 }
 
 type RemoteResourceManager interface {

--- a/e2etest/newe2e_resource_manager_mock.go
+++ b/e2etest/newe2e_resource_manager_mock.go
@@ -69,6 +69,10 @@ type MockServiceResourceManager struct {
 	serviceType common.Location
 }
 
+func (m *MockServiceResourceManager) Canon() string {
+	return fmt.Sprintf("%s/%s", m.parent.accountName, m.serviceType.String())
+}
+
 func (m *MockServiceResourceManager) URI(a Asserter, withSas bool) string {
 	return ""
 }
@@ -123,6 +127,10 @@ type MockContainerResourceManager struct {
 	account          *MockAccountResourceManager
 	parent           *MockServiceResourceManager
 	containerName    string
+}
+
+func (m *MockContainerResourceManager) Canon() string {
+	return m.parent.Canon() + "/" + m.containerName
 }
 
 func (m *MockContainerResourceManager) Exists() bool {
@@ -191,6 +199,10 @@ type MockObjectResourceManager struct {
 	account    *MockAccountResourceManager
 	entityType common.EntityType
 	path       string
+}
+
+func (m *MockObjectResourceManager) Canon() string {
+	return m.parent.Canon() + "/" + m.path
 }
 
 func (m *MockObjectResourceManager) URI(a Asserter, withSas bool) string {

--- a/e2etest/newe2e_resource_managers_blobfs.go
+++ b/e2etest/newe2e_resource_managers_blobfs.go
@@ -46,6 +46,10 @@ type BlobFSServiceResourceManager struct {
 	internalClient  *service.Client
 }
 
+func (b *BlobFSServiceResourceManager) Canon() string {
+	return buildCanonForAzureResourceManager(b)
+}
+
 func (b *BlobFSServiceResourceManager) Parent() ResourceManager {
 	return nil
 }
@@ -119,6 +123,10 @@ type BlobFSFileSystemResourceManager struct {
 
 	containerName  string
 	internalClient *filesystem.Client
+}
+
+func (b *BlobFSFileSystemResourceManager) Canon() string {
+	return buildCanonForAzureResourceManager(b)
 }
 
 func (b *BlobFSFileSystemResourceManager) Exists() bool {
@@ -245,6 +253,10 @@ type BlobFSPathResourceProvider struct {
 
 	entityType common.EntityType
 	objectPath string
+}
+
+func (b *BlobFSPathResourceProvider) Canon() string {
+	return buildCanonForAzureResourceManager(b)
 }
 
 func (b *BlobFSPathResourceProvider) Parent() ResourceManager {

--- a/e2etest/newe2e_resource_managers_file.go
+++ b/e2etest/newe2e_resource_managers_file.go
@@ -51,6 +51,10 @@ type FileServiceResourceManager struct {
 	internalClient  *service.Client
 }
 
+func (s *FileServiceResourceManager) Canon() string {
+	return buildCanonForAzureResourceManager(s)
+}
+
 func (s *FileServiceResourceManager) Account() AccountResourceManager {
 	return s.internalAccount
 }
@@ -126,6 +130,10 @@ type FileShareResourceManager struct {
 
 	containerName  string
 	internalClient *share.Client
+}
+
+func (s *FileShareResourceManager) Canon() string {
+	return buildCanonForAzureResourceManager(s)
 }
 
 func (s *FileShareResourceManager) Exists() bool {
@@ -335,6 +343,10 @@ type FileObjectResourceManager struct {
 
 	path       string
 	entityType common.EntityType
+}
+
+func (f *FileObjectResourceManager) Canon() string {
+	return buildCanonForAzureResourceManager(f)
 }
 
 func (f *FileObjectResourceManager) Parent() ResourceManager {

--- a/e2etest/newe2e_resource_trie.go
+++ b/e2etest/newe2e_resource_trie.go
@@ -1,0 +1,111 @@
+package e2etest
+
+import "strings"
+
+type PathTrie[T any] struct {
+	Nodes *TrieNode[T]
+	Sep   rune
+}
+
+type TrieNode[T any] struct {
+	Parent   *TrieNode[T]
+	Children map[string]*TrieNode[T]
+	Segment  string
+
+	Data *T
+}
+
+func NewTrie[T any](Separator rune) *PathTrie[T] {
+	return &PathTrie[T]{Sep: Separator, Nodes: createNode[T]("", nil)}
+}
+
+func createNode[T any](Segment string, Parent *TrieNode[T]) *TrieNode[T] {
+	return &TrieNode[T]{Segment: Segment, Parent: Parent, Children: make(map[string]*TrieNode[T])}
+}
+
+func (t *PathTrie[T]) walk(path string, doCreate bool) *TrieNode[T] {
+	currentNode := t.Nodes
+	for len(path) > 0 {
+		segmentLength := strings.IndexRune(path, t.Sep)
+		if segmentLength == -1 {
+			segmentLength = len(path)
+		}
+
+		segment := path[:segmentLength]
+		newNode, OK := currentNode.Children[segment]
+		if !OK {
+			if doCreate {
+				newNode = createNode(segment, currentNode)
+				currentNode.Children[segment] = newNode
+			} else {
+				return nil
+			}
+		}
+
+		currentNode = newNode
+		if segmentLength == len(path) {
+			path = ""
+		} else {
+			path = path[segmentLength+1:]
+		}
+	}
+
+	return currentNode
+}
+
+func (t *PathTrie[T]) Insert(path string, data *T) {
+	newNode := t.walk(path, true)
+	newNode.Data = data
+}
+
+func (t *PathTrie[T]) Get(path string) *T {
+	node := t.walk(path, false)
+	if node == nil {
+		return nil
+	}
+
+	return node.Data
+}
+
+func (t *PathTrie[T]) Remove(path string) {
+	node := t.walk(path, false)
+
+	for node.Parent != nil && node.Data == nil {
+		childSegment := node.Segment
+		node = node.Parent
+
+		delete(node.Children, childSegment)
+	}
+}
+
+type TraversalOperation uint8
+
+const (
+	// TraversalOperationContinue continue traversing children
+	TraversalOperationContinue TraversalOperation = iota
+	// TraversalOperationStop stop traversing children
+	TraversalOperationStop
+	// TraversalOperationRemove remove this node from the tree and all children
+	TraversalOperationRemove
+)
+
+func (t *PathTrie[T]) Traverse(traversalFunc func(data *T) TraversalOperation) {
+	t.Nodes.Traverse(traversalFunc)
+}
+
+func (n *TrieNode[T]) Traverse(traversalFunc func(data *T) TraversalOperation) {
+	op := TraversalOperationContinue
+	if n.Data != nil {
+		op = traversalFunc(n.Data)
+	}
+
+	switch op {
+	case TraversalOperationContinue:
+		for _, v := range n.Children {
+			v.Traverse(traversalFunc)
+		}
+	case TraversalOperationRemove:
+		delete(n.Parent.Children, n.Segment)
+	default:
+	}
+}

--- a/e2etest/newe2e_scenario_manager.go
+++ b/e2etest/newe2e_scenario_manager.go
@@ -89,8 +89,6 @@ func (sm *ScenarioManager) RunScenario() {
 				})
 
 				sm.Func.Call([]reflect.Value{reflect.ValueOf(svm)})
-
-				t.Log(svm.VariationName())
 			})
 		}
 	}

--- a/e2etest/zt_newe2e_example_test.go
+++ b/e2etest/zt_newe2e_example_test.go
@@ -23,7 +23,7 @@ func (s *ExampleSuite) Scenario_SingleFileCopySyncS2S(svm *ScenarioVariationMana
 	acct := GetAccount(svm, PrimaryStandardAcct)
 	srcService := acct.GetService(svm, ResolveVariation(svm, []common.Location{common.ELocation.Blob()}))
 	//svm.InsertVariationSeparator("->")
-	//dstService := acct.GetService(svm, ResolveVariation(svm, []common.Location{common.ELocation.Blob()}))
+	dstService := acct.GetService(svm, ResolveVariation(svm, []common.Location{common.ELocation.Blob()}))
 
 	svm.InsertVariationSeparator(":")
 	body := NewRandomObjectContentContainer(svm, SizeFromString("10K"))
@@ -32,20 +32,19 @@ func (s *ExampleSuite) Scenario_SingleFileCopySyncS2S(svm *ScenarioVariationMana
 		Body: body,
 	}) // todo: generic CreateResource is something to pursue in another branch, but it's an interesting thought.
 	// Scale up from service to container
-	//dstObj := CreateResource[ContainerResourceManager](svm, dstService, ResourceDefinitionContainer{}).GetObject(svm, "foobar", common.EEntityType.File())
+	dstObj := CreateResource[ContainerResourceManager](svm, dstService, ResourceDefinitionContainer{})
 
-	//_, _ = srcObj, dstObj
 	RunAzCopy(
 		svm,
 		AzCopyCommand{
-			Verb: ResolveVariation(svm, []AzCopyVerb{AzCopyVerbRemove}),
+			Verb: ResolveVariation(svm, []AzCopyVerb{AzCopyVerbCopy}),
 			Targets: []ResourceManager{
 				srcObj,
+				dstObj,
 			},
 		})
 
 	ValidateResource[ObjectResourceManager](svm, srcObj, ResourceDefinitionObject{
-		Body:              body,
-		ObjectShouldExist: PtrOf(false),
+		Body: body,
 	}, true)
 }


### PR DESCRIPTION
This fixes up a prior issue with the testing framework where resource completion would sometimes not be aware of the actual tree due to a variety of reasons.

Instead of relying upon the objects itself, each resourcemanager now has a Canon() function that allows us to map it onto a trie.