### PR TITLE
Add a test for list-of-versions flag

### DIFF
--- a/e2etest/declarativeResourceManagers.go
+++ b/e2etest/declarativeResourceManagers.go
@@ -21,17 +21,21 @@
 package e2etest
 
 import (
+	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/datalakeerror"
 	datalakedirectory "github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/directory"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/file"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/share"
+	"github.com/Azure/azure-storage-azcopy/v10/cmd"
 	"net/url"
 	"os"
 	"path"
 	"runtime"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
@@ -85,7 +89,7 @@ type resourceManager interface {
 	cleanup(a asserter)
 
 	// gets the azCopy command line param that represents the resource.  withSas is ignored when not applicable
-	getParam(stripTopDir bool, withSas bool, withFile objectTarget) string
+	getParam(a asserter, stripTopDir, withSas bool, withFile objectTarget) string
 
 	getSAS() string
 
@@ -155,7 +159,7 @@ func (r *resourceLocal) cleanup(_ asserter) {
 	}
 }
 
-func (r *resourceLocal) getParam(stripTopDir bool, withSas bool, withFile objectTarget) string {
+func (r *resourceLocal) getParam(a asserter, stripTopDir, withSas bool, withFile objectTarget) string {
 	if r.dirPath == common.Dev_Null {
 		return common.Dev_Null
 	}
@@ -288,7 +292,64 @@ func (r *resourceBlobContainer) cleanup(a asserter) {
 	}
 }
 
-func (r *resourceBlobContainer) getParam(stripTopDir bool, withSas bool, withFile objectTarget) string {
+type timestampSortable struct {
+	timestamps []string
+	format     string
+	a          asserter
+}
+
+func (t *timestampSortable) Len() int {
+	return len(t.timestamps)
+}
+
+func (t *timestampSortable) Less(i, j int) bool {
+	it, err := time.Parse(t.format, t.timestamps[i])
+	t.a.AssertNoErr(err, "failed to parse timestamp "+t.timestamps[i])
+
+	jt, err := time.Parse(t.format, t.timestamps[j])
+	t.a.AssertNoErr(err, "failed to parse timestamp "+t.timestamps[j])
+
+	return it.Before(jt)
+}
+
+func (t *timestampSortable) Swap(i, j int) {
+	t.timestamps[i], t.timestamps[j] = t.timestamps[j], t.timestamps[i]
+}
+
+// getVersions returns an ordered list of versions
+func (r *resourceBlobContainer) getVersions(a asserter, objectName string) []string {
+	p := r.containerClient.NewListBlobsFlatPager(&container.ListBlobsFlatOptions{
+		Include: container.ListBlobsInclude{Versions: true},
+		Prefix:  &objectName,
+	})
+
+	versions := &timestampSortable{
+		timestamps: make([]string, 0),
+		format:     cmd.ISO8601,
+		a:          a,
+	}
+
+	for p.More() {
+		page, err := p.NextPage(ctx)
+		a.AssertNoErr(err, "listing versions")
+
+		for _, v := range page.Segment.BlobItems {
+			if v.Name != nil && *v.Name == objectName && v.VersionID != nil {
+				_, err := time.Parse(cmd.ISO8601, *v.VersionID) // Make sure we can parse it
+				a.AssertNoErr(err, "parsing timestamp "+*v.VersionID)
+
+				versions.timestamps = append(versions.timestamps, *v.VersionID)
+			}
+		}
+	}
+
+	// Sort it
+	sort.Sort(versions)
+
+	return versions.timestamps
+}
+
+func (r *resourceBlobContainer) getParam(a asserter, stripTopDir, withSas bool, withFile objectTarget) string {
 	var uri string
 	if withSas {
 		uri = r.rawSasURL.String()
@@ -302,10 +363,18 @@ func (r *resourceBlobContainer) getParam(stripTopDir bool, withSas bool, withFil
 		bURLParts.BlobName = withFile.objectName
 
 		bURLParts.BlobName = withFile.objectName
-		if withFile.snapshotid {
+
+		if !withFile.singleVersionList && len(withFile.versions) == 1 {
+			versions := r.getVersions(a, withFile.objectName)
+			a.Assert(len(versions) > 0, equals(), true, "blob was expected to have versions!")
+			a.Assert(int(withFile.versions[0]) < len(versions), equals(), true, fmt.Sprintf("Not enough versions are present! (needed version %d of %d)", withFile.versions[0], len(versions)))
+
+			bURLParts.VersionID = versions[withFile.versions[0]]
+		} else if withFile.snapshotid {
 			// Get latest snapshot
 			blobClient := r.containerClient.NewBlobClient(withFile.objectName)
-			resp, _ := blobClient.CreateSnapshot(ctx, nil)
+			resp, err := blobClient.CreateSnapshot(ctx, nil)
+			a.AssertNoErr(err, "creating snapshot")
 			bURLParts.Snapshot = *resp.Snapshot
 		}
 
@@ -407,7 +476,7 @@ func (r *resourceAzureFileShare) cleanup(a asserter) {
 	}
 }
 
-func (r *resourceAzureFileShare) getParam(stripTopDir bool, withSas bool, withFile objectTarget) string {
+func (r *resourceAzureFileShare) getParam(a asserter, stripTopDir, withSas bool, withFile objectTarget) string {
 	assertNoStripTopDir(stripTopDir)
 	var uri string
 	if withSas {
@@ -503,7 +572,7 @@ func (r *resourceManagedDisk) cleanup(a asserter) {
 }
 
 // getParam works functionally different because resourceManagerDisk inherently only targets a single file.
-func (r *resourceManagedDisk) getParam(stripTopDir bool, withSas bool, withFile objectTarget) string {
+func (r *resourceManagedDisk) getParam(a asserter, stripTopDir, withSas bool, withFile objectTarget) string {
 	out := *r.accessURI // clone the URI
 
 	if !withSas {
@@ -550,7 +619,7 @@ func (r *resourceDummy) createFile(a asserter, o *testObject, s *scenario, isSou
 func (r *resourceDummy) cleanup(_ asserter) {
 }
 
-func (r *resourceDummy) getParam(stripTopDir bool, withSas bool, withFile objectTarget) string {
+func (r *resourceDummy) getParam(a asserter, stripTopDir, withSas bool, withFile objectTarget) string {
 	assertNoStripTopDir(stripTopDir)
 	return ""
 }

--- a/e2etest/declarativeScenario.go
+++ b/e2etest/declarativeScenario.go
@@ -248,7 +248,7 @@ func (s *scenario) assignSourceAndDest() {
 		// TODO: handle account to account (multi-container) scenarios
 		switch loc {
 		case common.ELocation.Local():
-			return &resourceLocal{common.Iff(s.p.destNull && !isSourceAcc, common.Dev_Null, "")}
+			return &resourceLocal{common.Iff[string](s.p.destNull && !isSourceAcc, common.Dev_Null, "")}
 		case common.ELocation.File():
 			return &resourceAzureFileShare{accountType: accType}
 		case common.ELocation.Blob():
@@ -282,8 +282,10 @@ func (s *scenario) runAzCopy(logDirectory string) {
 	s.chToStdin = make(chan string) // unubuffered seems the most predictable for our usages
 	defer close(s.chToStdin)
 
+	tf := s.GetTestFiles()
+
 	r := newTestRunner()
-	r.SetAllFlags(s.p, s.operation)
+	r.SetAllFlags(s)
 
 	// use the general-purpose "after start" mechanism, provided by execDebuggableWithOutput,
 	// for the _specific_ purpose of running beforeOpenFirstFile, if that hook exists.
@@ -303,12 +305,20 @@ func (s *scenario) runAzCopy(logDirectory string) {
 
 	needsFromTo := s.destAccountType == EAccountType.Azurite() || s.srcAccountType == EAccountType.Azurite()
 
-	tf := s.GetTestFiles()
+	var destObjTarget objectTarget
+	if tf.destTarget != "" {
+		destObjTarget.objectName = tf.destTarget
+	} else if tf.objectTarget.objectName != "" &&
+		// Object target must have no list of versions.
+		(len(tf.objectTarget.versions) == 0 || (len(tf.objectTarget.versions) == 1 && !tf.objectTarget.singleVersionList)) {
+		destObjTarget.objectName = tf.objectTarget.objectName
+	}
+
 	// run AzCopy
 	result, wasClean, err := r.ExecuteAzCopyCommand(
 		s.operation,
-		s.state.source.getParam(s.stripTopDir, needsSAS(s.credTypes[0]), tf.objectTarget),
-		s.state.dest.getParam(false, needsSAS(s.credTypes[1]), objectTarget{objectName: common.Iff(tf.destTarget != "", tf.destTarget, tf.objectTarget.objectName)}),
+		s.state.source.getParam(s.a, s.stripTopDir, needsSAS(s.credTypes[0]), tf.objectTarget),
+		s.state.dest.getParam(s.a, false, needsSAS(s.credTypes[1]), destObjTarget),
 		s.credTypes[0] == common.ECredentialType.OAuthToken() || s.credTypes[1] == common.ECredentialType.OAuthToken(), // needsOAuth
 		needsFromTo,
 		s.fromTo,
@@ -402,11 +412,11 @@ func (s *scenario) validateTransferStates(azcopyDir string) {
 		// TODO: testing of skipped is implicit, in that they are created at the source, but don't exist in Success or Failed lists
 		//       Is that OK? (Not sure what to do if it's not, because azcopy jobs show, apparently doesn't offer us a way to get the skipped list)
 	} {
-		expectedTransfers := s.fs.getForStatus(statusToTest, expectFolders, expectRootFolder)
+		expectedTransfers := s.fs.getForStatus(s, statusToTest, expectFolders, expectRootFolder)
 		actualTransfers, err := s.state.result.GetTransferList(statusToTest, azcopyDir)
 		s.a.AssertNoErr(err)
 
-		Validator{}.ValidateCopyTransfersAreScheduled(s.a, isSrcEncoded, isDstEncoded, srcRoot, dstRoot, expectedTransfers, actualTransfers, statusToTest, expectFolders)
+		Validator{}.ValidateCopyTransfersAreScheduled(s, isSrcEncoded, isDstEncoded, srcRoot, dstRoot, expectedTransfers, actualTransfers, statusToTest, expectFolders)
 		// TODO: how are we going to validate folder transfers????
 	}
 
@@ -415,8 +425,8 @@ func (s *scenario) validateTransferStates(azcopyDir string) {
 }
 
 func (s *scenario) getTransferInfo() (srcRoot string, dstRoot string, expectFolders bool, expectedRootFolder bool, addedDirAtDest string) {
-	srcRoot = s.state.source.getParam(false, false, objectTarget{})
-	dstRoot = s.state.dest.getParam(false, false, objectTarget{})
+	srcRoot = s.state.source.getParam(s.a, false, false, objectTarget{})
+	dstRoot = s.state.dest.getParam(s.a, false, false, objectTarget{})
 
 	srcBase := filepath.Base(srcRoot)
 	srcRootURL, err := url.Parse(srcRoot)
@@ -491,7 +501,7 @@ func (s *scenario) validateProperties() {
 	_, _, expectFolders, expectRootFolder, addedDirAtDest := s.getTransferInfo()
 
 	// for everything that should have been transferred, verify that any expected properties have been transferred to the destination
-	expectedFilesAndFolders := s.fs.getForStatus(common.ETransferStatus.Success(), expectFolders, expectRootFolder)
+	expectedFilesAndFolders := s.fs.getForStatus(s, common.ETransferStatus.Success(), expectFolders, expectRootFolder)
 	for _, f := range expectedFilesAndFolders {
 		expected := f.verificationProperties // use verificationProperties (i.e. what we expect) NOT creationProperties (what we made at the source). They won't ALWAYS be the same
 		if expected == nil {
@@ -562,7 +572,7 @@ func (s *scenario) validateContent() {
 	_, _, expectFolders, expectRootFolder, addedDirAtDest := s.getTransferInfo()
 
 	// for everything that should have been transferred, verify that any expected properties have been transferred to the destination
-	expectedFilesAndFolders := s.fs.getForStatus(common.ETransferStatus.Success(), expectFolders, expectRootFolder)
+	expectedFilesAndFolders := s.fs.getForStatus(s, common.ETransferStatus.Success(), expectFolders, expectRootFolder)
 	for _, f := range expectedFilesAndFolders {
 		if f.creationProperties.contentHeaders == nil {
 			s.a.Failed()

--- a/e2etest/declarativeScenario.go
+++ b/e2etest/declarativeScenario.go
@@ -30,6 +30,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -73,7 +74,7 @@ type scenarioState struct {
 func (s *scenario) Run() {
 	defer func() { // catch a test panicking
 		if err := recover(); err != nil {
-			s.a.Error(fmt.Sprintf("Test panicked: %v", err))
+			s.a.Error(fmt.Sprintf("Test panicked: %v\n%s", err, debug.Stack()))
 		}
 	}()
 	defer s.cleanup()

--- a/e2etest/declarativeWithPropertyProviders.go
+++ b/e2etest/declarativeWithPropertyProviders.go
@@ -48,9 +48,12 @@ type with struct {
 	contentType        string
 	contentMD5         []byte
 
-	nameValueMetadata  map[string]*string
-	blobTags           string
-	blobType           common.BlobType
+	nameValueMetadata map[string]*string
+	blobTags          string
+	blobType          common.BlobType
+	// blobVersions is a list of strings defining the data stored inside the object's body.
+	// These versions are treated as a key, as well, and correspond to the version IDs Azure assigns.
+	blobVersions       uint
 	lastWriteTime      time.Time
 	creationTime       time.Time
 	smbAttributes      uint32
@@ -136,6 +139,10 @@ func (w with) createObjectProperties() *objectProperties {
 	if w.blobType != common.EBlobType.Detect() {
 		populated = true
 		result.blobType = w.blobType
+	}
+	if w.blobVersions > 0 {
+		populated = true
+		result.blobVersions = &w.blobVersions
 	}
 	if w.lastWriteTime != (time.Time{}) {
 		populated = true
@@ -235,7 +242,8 @@ func (withDirStubMetadata) createObjectProperties() *objectProperties {
 // use withError ONLY on files in the shouldFail section.
 // It allows you to say what the error should be
 // TODO: as at 1 July 2020, we are not actually validating these.  Should we? It could be nice.  If we don't,
-//   remove this type and its usages, and the expectedFailureProvider interface
+//
+//	remove this type and its usages, and the expectedFailureProvider interface
 type withError struct {
 	msg string
 }

--- a/e2etest/runner.go
+++ b/e2etest/runner.go
@@ -54,7 +54,10 @@ var isLaunchedByDebugger = func() bool {
 	return false
 }()
 
-func (t *TestRunner) SetAllFlags(p params, o Operation) {
+func (t *TestRunner) SetAllFlags(s *scenario) {
+	p := s.p
+	o := s.operation
+
 	set := func(key string, value interface{}, dflt interface{}, formats ...string) {
 		if value == dflt {
 			return // nothing to do. The flag is not supposed to be set
@@ -118,6 +121,33 @@ func (t *TestRunner) SetAllFlags(p params, o Operation) {
 			set("follow-symlinks", true, nil)
 		case common.ESymlinkHandlingType.Preserve():
 			set("preserve-symlinks", true, nil)
+		}
+
+		target := s.GetTestFiles().objectTarget
+		if s.fromTo.From() == common.ELocation.Blob() && s.fs.isListOfVersions() { // Otherwise, it must be a list.
+			s.a.Assert(s.fromTo.From(), equals(), common.ELocation.Blob(), "list of files can only be used in blob.")
+
+			versions := s.GetSource().(*resourceBlobContainer).getVersions(s.a, target.objectName)
+			s.a.Assert(len(versions) > 0, equals(), true, "blob was expected to have versions!")
+			listOfVersions := make([]string, len(target.versions))
+
+			for idx, val := range target.versions {
+				s.a.Assert(int(val) < len(versions), equals(), true, fmt.Sprintf("Not enough versions are present! (needed version %d of %d)", val, len(versions)))
+				listOfVersions[idx] = versions[val]
+			}
+
+			file, err := os.CreateTemp("", "listofversions*.json")
+			defer func(file *os.File) {
+				_ = file.Close()
+			}(file)
+			s.a.AssertNoErr(err, "create temp list of versions file")
+
+			for _, v := range listOfVersions {
+				_, err = file.WriteString(v + "\n")
+				s.a.AssertNoErr(err, "write to list of versions file")
+			}
+
+			set("list-of-versions", file.Name(), "")
 		}
 	} else if o == eOperation.Sync() {
 		set("delete-destination", p.deleteDestination.String(), "False")

--- a/e2etest/scenario_helpers.go
+++ b/e2etest/scenario_helpers.go
@@ -460,7 +460,7 @@ func (scenarioHelper) generateBlobsFromList(c asserter, options *generateBlobFro
 		}
 
 		blobHadBody := b.body != nil
-		versionsRequested := common.Iff[uint](b.creationProperties.blobVersions != nil, *b.creationProperties.blobVersions, 1)
+		versionsRequested := common.IffNotNil[uint](b.creationProperties.blobVersions, 1)
 		versionsCreated := uint(0)
 
 		for versionsCreated < versionsRequested {

--- a/e2etest/zt_blob_versioning_test.go
+++ b/e2etest/zt_blob_versioning_test.go
@@ -19,3 +19,32 @@
 // THE SOFTWARE.
 
 package e2etest
+
+import (
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"testing"
+)
+
+func TestBlobVersioning_ListOfVersions(t *testing.T) {
+	RunScenarios(t,
+		eOperation.Copy(),
+		eTestFromTo.Other(common.EFromTo.BlobLocal()),
+		eValidate.Auto(),
+		anonymousAuthOnly,
+		anonymousAuthOnly,
+		params{},
+		&hooks{},
+		testFiles{
+			defaultSize: "1k",
+			objectTarget: objectTarget{
+				objectName: "versioned",
+				versions:   []uint{0, 2},
+			},
+			shouldTransfer: []any{
+				f("versioned", with{
+					blobVersions: 3, // create 3 unique versions to read from
+				}),
+			},
+		},
+		EAccountType.Standard(), EAccountType.Standard(), "")
+}


### PR DESCRIPTION
Adds it to the (old) e2e testing framework, this is just to ship a production ready test now for a patch release. I will add this functionality to the new e2e testing framework ere long.