### PR TITLE
Fix logger name without suffix

### DIFF
--- a/common/logger.go
+++ b/common/logger.go
@@ -82,7 +82,7 @@ func (jl *jobLogger) OpenLog() {
 		return
 	}
 
-	file, err := NewRotatingWriter(path.Join(jl.logFileFolder, jl.jobID.String()+jl.logFileNameSuffix), maxLogSize)
+	file, err := NewRotatingWriter(path.Join(jl.logFileFolder, jl.jobID.String()+jl.logFileNameSuffix+".log"), maxLogSize)
 	PanicIfErr(err)
 
 	jl.file = file

--- a/common/rotatingWriter.go
+++ b/common/rotatingWriter.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 )
@@ -68,8 +69,8 @@ func (w *rotatingWriter) rotate(suffix int32) error {
 		return err
 	}
 
-	suffixString := fmt.Sprintf(".%d.log", w.currentSuffix)
-	if err := os.Rename(w.filePath, w.filePath + suffixString); err != nil {
+	logFileName := strings.TrimSuffix(w.filePath, ".log") + fmt.Sprintf(".%d.log", w.currentSuffix)
+	if err := os.Rename(w.filePath, logFileName); err != nil {
 		return err
 	}
 	
@@ -89,9 +90,6 @@ func (w *rotatingWriter) rotate(suffix int32) error {
 
 func (w *rotatingWriter) Close() error {
 	if err := w.file.Close(); err != nil {
-		return err
-	}
-	if err := os.Rename(w.filePath, w.filePath + ".log"); err != nil {
 		return err
 	}
 	return nil

--- a/common/rotatingWriter_test.go
+++ b/common/rotatingWriter_test.go
@@ -40,17 +40,17 @@ func TestRotatingWriter(t *testing.T) {
 	}
 
 	a := assert.New(t)
-	logFileName := "logfile"
+	logFileNameWithoutSuffix := "logfile"
 	data := "This string is one hundred bytes. Also has some junk to make actually make it one hundred bytes. Bye"
 
 	tmpDir, err := os.MkdirTemp("", "")
 	defer os.RemoveAll(tmpDir)
 
 	a.Nil(err)
-	logFile := path.Join(tmpDir, logFileName)
+	logFile := path.Join(tmpDir, logFileNameWithoutSuffix)
 	
 	// 1. Create a rotating writer of size 100B
-	w, err := NewRotatingWriter(logFile, 100)
+	w, err := NewRotatingWriter(logFile + ".log", 100)
 	a.Nil(err)
 
 	// write 10 bytes and verify there is only one file in tmpDir
@@ -58,14 +58,14 @@ func TestRotatingWriter(t *testing.T) {
 	entries, err := os.ReadDir(tmpDir)
 	a.Nil(err)
 	a.Equal(1, len(entries))
-	a.Equal(logFileName, entries[0].Name())
+	a.Equal(logFileNameWithoutSuffix + ".log", entries[0].Name())
 
 	// write 90 more bytes and verify there is still only one file
 	w.Write([]byte(data[:90]))
 	entries, err = os.ReadDir(tmpDir)
 	a.Nil(err)
 	a.Equal(1, len(entries))
-	a.Equal(logFileName, entries[0].Name())
+	a.Equal(logFileNameWithoutSuffix + ".log", entries[0].Name())
 
 	// write 10 more bytes and verify a new log file is created
 	n, err := w.Write([]byte(data[:10]))
@@ -76,8 +76,8 @@ func TestRotatingWriter(t *testing.T) {
 	a.Nil(err)
 	a.Equal(2, len(entries))
 	f := convertToMap(entries)
-	a.Contains(f, logFileName)
-	a.Contains(f, logFileName + ".0.log")
+	a.Contains(f, logFileNameWithoutSuffix + ".log")
+	a.Contains(f, logFileNameWithoutSuffix + ".0.log")
 
 	// Write 80 bytes to prepare for next test
 	w.Write([]byte(data[:80]))
@@ -102,9 +102,9 @@ func TestRotatingWriter(t *testing.T) {
 	a.Nil(err)
 	a.Equal(3, len(entries))
 	f = convertToMap(entries)
-	a.Contains(f, logFileName)
-	a.Contains(f, logFileName + ".0.log")
-	a.Contains(f, logFileName + ".1.log")
+	a.Contains(f, logFileNameWithoutSuffix + ".log")
+	a.Contains(f, logFileNameWithoutSuffix + ".0.log")
+	a.Contains(f, logFileNameWithoutSuffix + ".1.log")
 	
 	// close and verify we've 3 log files
 	w.Close()
@@ -112,7 +112,7 @@ func TestRotatingWriter(t *testing.T) {
 	a.Nil(err)
 	a.Equal(3, len(entries))
 	f = convertToMap(entries)
-	a.Contains(f, logFileName + ".log")
-	a.Contains(f, logFileName + ".0.log")
-	a.Contains(f, logFileName + ".1.log")
+	a.Contains(f, logFileNameWithoutSuffix + ".log")
+	a.Contains(f, logFileNameWithoutSuffix + ".0.log")
+	a.Contains(f, logFileNameWithoutSuffix + ".1.log")
 }


### PR DESCRIPTION
Adds ".log" right when we create a log file, instead of adding it while rotation. KInd of like we used to do earlier.