### PR TITLE
 [RCA Repair Item] Retried deletes should ignore 404 errors

### DIFF
--- a/ste/sender-appendBlob_test.go
+++ b/ste/sender-appendBlob_test.go
@@ -110,15 +110,19 @@ func Test500FollowedBy412Logic(t *testing.T) {
 	a.Empty(errString)
 }
 
-func Test404DeleteLogic(t *testing.T) {
+// This function tests the scenario where we return a transfer success even when we receive a 404 response, indicating a resource not found error.
+// In this test, we create a container on an HNS enabled account but do not create any blob. This is done to simulate the 404 scenario when attempting to delete a non-existent blob.
+// The deletion operation won't find the blob to delete, resulting in a 404 error, and thus returning a transfer success.
+func Test404DeleteSuccessLogic(t *testing.T) {
 	a := assert.New(t)
-	//accountName, accountKey := getAccountAndKey()
-	accountName := "nakulkarhns4"
-	accountKey := "E9qRN+7QFREtSLAQB1w+vRrMt2/1bz4XVNqhnVOwdH7Gp8tfFpDGahVmzK6GxbIF34KX4uHOEena/8f24rfnHg=="
+
+	// Setup source and destination
+	accountName, accountKey := getAccountAndKey()
 	rawURL := fmt.Sprintf("https://%s.dfs.core.windows.net/", accountName)
 
 	credential, err := blob.NewSharedKeyCredential(accountName, accountKey)
 	a.Nil(err)
+
 	client, err := blobservice.NewClientWithSharedKeyCredential(rawURL, credential, &blobservice.ClientOptions{
 		ClientOptions: azcore.ClientOptions{
 			Transport: NewAzcopyHTTPClient(0),
@@ -131,6 +135,9 @@ func Test404DeleteLogic(t *testing.T) {
 	a.Nil(err)
 	defer cc.Delete(context.Background(), nil)
 
+	// Generating the name for a blob without actually creating it.
+	sourceName := generateBlobName()
+
 	sasURL, err := cc.NewBlobClient(cName).GetSASURL(
 		blobsas.BlobPermissions{Read: true},
 		time.Now().Add(1*time.Hour),
@@ -141,14 +148,14 @@ func Test404DeleteLogic(t *testing.T) {
 		info: to.Ptr(TransferInfo{
 			Source:       sasURL,
 			SrcContainer: cName,
-			SrcFilePath:  "azure",
+			SrcFilePath:  sourceName,
 		}),
 		fromTo: common.EFromTo.BlobFSTrash(),
 	}
+
 	jptm.SetStatus(common.ETransferStatus.Started())
 	doDeleteHNSResource(jptm)
 
 	a.Nil(err)
-	a.Equal(1, 1)
-
+	a.Equal(jptm.status, common.ETransferStatus.Success())
 }

--- a/ste/sender_blockBlob_test.go
+++ b/ste/sender_blockBlob_test.go
@@ -21,13 +21,14 @@
 package ste
 
 import (
+	"strings"
+	"testing"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/stretchr/testify/assert"
-	"strings"
-	"testing"
 )
 
 func TestGetVerifiedChunkParams(t *testing.T) {

--- a/ste/sourceInfoProvider_md5_test.go
+++ b/ste/sourceInfoProvider_md5_test.go
@@ -22,11 +22,20 @@ package ste
 
 import (
 	"bytes"
-	gcpUtils "cloud.google.com/go/storage"
 	"context"
 	"crypto/md5"
 	"errors"
 	"fmt"
+	"hash/crc64"
+	"io"
+	"math/rand"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	gcpUtils "cloud.google.com/go/storage"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
@@ -38,14 +47,6 @@ import (
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/minio/minio-go"
 	"github.com/stretchr/testify/assert"
-	"hash/crc64"
-	"io"
-	"math/rand"
-	"os"
-	"runtime"
-	"strings"
-	"testing"
-	"time"
 )
 
 // This file covers testing of the GetMD5() method in the various sourceInfoProvider implementations
@@ -174,7 +175,7 @@ func TestBenchmark(t *testing.T) {
 		info:   nil,
 		fromTo: common.EFromTo.BenchmarkBlob(),
 	}
-	benchSIP, err := newBenchmarkSourceInfoProvider(jptm)
+	benchSIP, err := newBenchmarkSourceInfoProvider(&jptm)
 	a.Nil(err)
 
 	_, err = benchSIP.GetMD5(0, 1)
@@ -220,7 +221,7 @@ func TestBlockBlob(t *testing.T) {
 		}),
 		fromTo: common.EFromTo.BlobBlob(),
 	}
-	blobSIP, err := newBlobSourceInfoProvider(jptm)
+	blobSIP, err := newBlobSourceInfoProvider(&jptm)
 	a.Nil(err)
 
 	// Get MD5 range within service calculation
@@ -288,7 +289,7 @@ func TestShareFile(t *testing.T) {
 		}),
 		fromTo: common.EFromTo.FileBlob(),
 	}
-	fileSIP, err := newFileSourceInfoProvider(jptm)
+	fileSIP, err := newFileSourceInfoProvider(&jptm)
 	a.Nil(err)
 
 	// Get MD5 range within service calculation
@@ -357,7 +358,7 @@ func TestShareDirectory(t *testing.T) {
 		}),
 		fromTo: common.EFromTo.FileBlob(),
 	}
-	fileSIP, err := newFileSourceInfoProvider(jptm)
+	fileSIP, err := newFileSourceInfoProvider(&jptm)
 	a.Nil(err)
 
 	_, err = fileSIP.GetMD5(0, 1)
@@ -398,7 +399,7 @@ func TestGCP(t *testing.T) {
 		}),
 		fromTo: common.EFromTo.GCPBlob(),
 	}
-	gcpSIP, err := newGCPSourceInfoProvider(jptm)
+	gcpSIP, err := newGCPSourceInfoProvider(&jptm)
 	a.Nil(err)
 
 	// Get MD5 range within service calculation
@@ -448,7 +449,7 @@ func TestLocal(t *testing.T) {
 		}),
 		fromTo: common.EFromTo.LocalBlob(),
 	}
-	localSIP, err := newLocalSourceInfoProvider(jptm)
+	localSIP, err := newLocalSourceInfoProvider(&jptm)
 	a.Nil(err)
 
 	// Get MD5 range within service calculation
@@ -504,7 +505,7 @@ func TestS3(t *testing.T) {
 		}),
 		fromTo: common.EFromTo.S3Blob(),
 	}
-	s3SIP, err := newS3SourceInfoProvider(jptm)
+	s3SIP, err := newS3SourceInfoProvider(&jptm)
 	a.Nil(err)
 
 	// Get MD5 range within service calculation

--- a/ste/testJobPartTransferManager_test.go
+++ b/ste/testJobPartTransferManager_test.go
@@ -22,32 +22,34 @@ package ste
 
 import (
 	"context"
+	"time"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
-	"time"
 )
 
-var _ IJobPartTransferMgr = testJobPartTransferManager{}
+var _ IJobPartTransferMgr = &testJobPartTransferManager{}
 
 type testJobPartTransferManager struct {
 	info       *TransferInfo
 	fromTo     common.FromTo
 	jobPartMgr jobPartMgr
 	ctx        context.Context
+	status     common.TransferStatus
 }
 
-func (t testJobPartTransferManager) DeleteDestinationFileIfNecessary() bool {
+func (t *testJobPartTransferManager) DeleteDestinationFileIfNecessary() bool {
 	return t.jobPartMgr.DeleteDestinationFileIfNecessary()
 }
 
-func (t testJobPartTransferManager) Info() *TransferInfo {
+func (t *testJobPartTransferManager) Info() *TransferInfo {
 	return t.info
 }
 
-func (t testJobPartTransferManager) SrcServiceClient() *common.ServiceClient {
+func (t *testJobPartTransferManager) SrcServiceClient() *common.ServiceClient {
 	options := t.S2SSourceClientOptions()
 	var azureFileSpecificOptions any
 	if t.fromTo.From() == common.ELocation.File() {
@@ -66,7 +68,7 @@ func (t testJobPartTransferManager) SrcServiceClient() *common.ServiceClient {
 	return client
 }
 
-func (t testJobPartTransferManager) DstServiceClient() *common.ServiceClient {
+func (t *testJobPartTransferManager) DstServiceClient() *common.ServiceClient {
 	options := t.ClientOptions()
 	var azureFileSpecificOptions any
 	if t.fromTo.To() == common.ELocation.File() {
@@ -86,186 +88,187 @@ func (t testJobPartTransferManager) DstServiceClient() *common.ServiceClient {
 	return client
 }
 
-func (t testJobPartTransferManager) SourceTrailingDot() *common.TrailingDotOption {
+func (t *testJobPartTransferManager) SourceTrailingDot() *common.TrailingDotOption {
 	if (t.fromTo.IsS2S() || t.fromTo.IsDownload()) && (t.fromTo.From() == common.ELocation.File()) {
 		return to.Ptr(common.ETrailingDotOption.Enable())
 	}
 	return nil
 }
 
-func (t testJobPartTransferManager) TrailingDot() *common.TrailingDotOption {
+func (t *testJobPartTransferManager) TrailingDot() *common.TrailingDotOption {
 	return to.Ptr(common.ETrailingDotOption.Enable())
 }
 
-func (t testJobPartTransferManager) From() *common.Location {
+func (t *testJobPartTransferManager) From() *common.Location {
 	return to.Ptr(t.fromTo.From())
 }
 
-func (t testJobPartTransferManager) FromTo() common.FromTo {
+func (t *testJobPartTransferManager) FromTo() common.FromTo {
 	return t.fromTo
 }
 
-func (t testJobPartTransferManager) ResourceDstData(dataFileToXfer []byte) (headers common.ResourceHTTPHeaders, metadata common.Metadata, blobTags common.BlobTags, cpkOptions common.CpkOptions) {
+func (t *testJobPartTransferManager) ResourceDstData(dataFileToXfer []byte) (headers common.ResourceHTTPHeaders, metadata common.Metadata, blobTags common.BlobTags, cpkOptions common.CpkOptions) {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) LastModifiedTime() time.Time {
+func (t *testJobPartTransferManager) LastModifiedTime() time.Time {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) PreserveLastModifiedTime() (time.Time, bool) {
+func (t *testJobPartTransferManager) PreserveLastModifiedTime() (time.Time, bool) {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) ShouldPutMd5() bool {
+func (t *testJobPartTransferManager) ShouldPutMd5() bool {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) MD5ValidationOption() common.HashValidationOption {
+func (t *testJobPartTransferManager) MD5ValidationOption() common.HashValidationOption {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) BlobTypeOverride() common.BlobType {
+func (t *testJobPartTransferManager) BlobTypeOverride() common.BlobType {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) BlobTiers() (blockBlobTier common.BlockBlobTier, pageBlobTier common.PageBlobTier) {
+func (t *testJobPartTransferManager) BlobTiers() (blockBlobTier common.BlockBlobTier, pageBlobTier common.PageBlobTier) {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) JobHasLowFileCount() bool {
+func (t *testJobPartTransferManager) JobHasLowFileCount() bool {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) Context() context.Context {
+func (t *testJobPartTransferManager) Context() context.Context {
 	return context.Background()
 }
 
-func (t testJobPartTransferManager) SlicePool() common.ByteSlicePooler {
+func (t *testJobPartTransferManager) SlicePool() common.ByteSlicePooler {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) CacheLimiter() common.CacheLimiter {
+func (t *testJobPartTransferManager) CacheLimiter() common.CacheLimiter {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) WaitUntilLockDestination(ctx context.Context) error {
+func (t *testJobPartTransferManager) WaitUntilLockDestination(ctx context.Context) error {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) EnsureDestinationUnlocked() {
+func (t *testJobPartTransferManager) EnsureDestinationUnlocked() {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) HoldsDestinationLock() bool {
+func (t *testJobPartTransferManager) HoldsDestinationLock() bool {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) StartJobXfer() {
+func (t *testJobPartTransferManager) StartJobXfer() {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) GetOverwriteOption() common.OverwriteOption {
+func (t *testJobPartTransferManager) GetOverwriteOption() common.OverwriteOption {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) GetForceIfReadOnly() bool {
+func (t *testJobPartTransferManager) GetForceIfReadOnly() bool {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) ShouldDecompress() bool {
+func (t *testJobPartTransferManager) ShouldDecompress() bool {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) GetSourceCompressionType() (common.CompressionType, error) {
+func (t *testJobPartTransferManager) GetSourceCompressionType() (common.CompressionType, error) {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) ReportChunkDone(id common.ChunkID) (lastChunk bool, chunksDone uint32) {
+func (t *testJobPartTransferManager) ReportChunkDone(id common.ChunkID) (lastChunk bool, chunksDone uint32) {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) TransferStatusIgnoringCancellation() common.TransferStatus {
+func (t *testJobPartTransferManager) TransferStatusIgnoringCancellation() common.TransferStatus {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) SetStatus(status common.TransferStatus) {
+func (t *testJobPartTransferManager) SetStatus(status common.TransferStatus) {
+	t.status = status
+}
+
+func (t *testJobPartTransferManager) SetErrorCode(errorCode int32) {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) SetErrorCode(errorCode int32) {
+func (t *testJobPartTransferManager) SetNumberOfChunks(numChunks uint32) {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) SetNumberOfChunks(numChunks uint32) {
+func (t *testJobPartTransferManager) SetActionAfterLastChunk(f func()) {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) SetActionAfterLastChunk(f func()) {
+func (t *testJobPartTransferManager) ReportTransferDone() uint32 {
+	// return value is the no of transfer's done for this job part.
+	return 1
+}
+
+func (t *testJobPartTransferManager) RescheduleTransfer() {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) ReportTransferDone() uint32 {
+func (t *testJobPartTransferManager) ScheduleChunks(chunkFunc chunkFunc) {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) RescheduleTransfer() {
+func (t *testJobPartTransferManager) SetDestinationIsModified() {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) ScheduleChunks(chunkFunc chunkFunc) {
+func (t *testJobPartTransferManager) Cancel() {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) SetDestinationIsModified() {
+func (t *testJobPartTransferManager) WasCanceled() bool {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) Cancel() {
+func (t *testJobPartTransferManager) IsLive() bool {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) WasCanceled() bool {
+func (t *testJobPartTransferManager) IsDeadBeforeStart() bool {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) IsLive() bool {
+func (t *testJobPartTransferManager) IsDeadInflight() bool {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) IsDeadBeforeStart() bool {
+func (t *testJobPartTransferManager) OccupyAConnection() {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) IsDeadInflight() bool {
+func (t *testJobPartTransferManager) ReleaseAConnection() {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) OccupyAConnection() {
+func (t *testJobPartTransferManager) CredentialInfo() common.CredentialInfo {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) ReleaseAConnection() {
+func (t *testJobPartTransferManager) ClientOptions() azcore.ClientOptions {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) CredentialInfo() common.CredentialInfo {
-	panic("implement me")
-}
-
-func (t testJobPartTransferManager) ClientOptions() azcore.ClientOptions {
-	panic("implement me")
-}
-
-func (t testJobPartTransferManager) S2SSourceCredentialInfo() common.CredentialInfo {
+func (t *testJobPartTransferManager) S2SSourceCredentialInfo() common.CredentialInfo {
 	return common.CredentialInfo{CredentialType: common.ECredentialType.Anonymous()}
 }
 
-func (t testJobPartTransferManager) GetS2SSourceTokenCredential(ctx context.Context) (token *string, err error) {
+func (t *testJobPartTransferManager) GetS2SSourceTokenCredential(ctx context.Context) (token *string, err error) {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) S2SSourceClientOptions() azcore.ClientOptions {
+func (t *testJobPartTransferManager) S2SSourceClientOptions() azcore.ClientOptions {
 	retryOptions := policy.RetryOptions{
 		MaxRetries:    UploadMaxTries,
 		TryTimeout:    UploadTryTimeout,
@@ -290,154 +293,150 @@ func (t testJobPartTransferManager) S2SSourceClientOptions() azcore.ClientOption
 	return NewClientOptions(retryOptions, telemetryOptions, httpClient, nil, LogOptions{})
 }
 
-func (t testJobPartTransferManager) CredentialOpOptions() *common.CredentialOpOptions {
+func (t *testJobPartTransferManager) CredentialOpOptions() *common.CredentialOpOptions {
 	return nil
 }
 
-func (t testJobPartTransferManager) FailActiveUpload(where string, err error) {
+func (t *testJobPartTransferManager) FailActiveUpload(where string, err error) {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) FailActiveDownload(where string, err error) {
+func (t *testJobPartTransferManager) FailActiveDownload(where string, err error) {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) FailActiveUploadWithStatus(where string, err error, failureStatus common.TransferStatus) {
+func (t *testJobPartTransferManager) FailActiveUploadWithStatus(where string, err error, failureStatus common.TransferStatus) {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) FailActiveDownloadWithStatus(where string, err error, failureStatus common.TransferStatus) {
+func (t *testJobPartTransferManager) FailActiveDownloadWithStatus(where string, err error, failureStatus common.TransferStatus) {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) FailActiveS2SCopy(where string, err error) {
+func (t *testJobPartTransferManager) FailActiveS2SCopy(where string, err error) {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) FailActiveS2SCopyWithStatus(where string, err error, failureStatus common.TransferStatus) {
+func (t *testJobPartTransferManager) FailActiveS2SCopyWithStatus(where string, err error, failureStatus common.TransferStatus) {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) FailActiveSend(where string, err error) {
+func (t *testJobPartTransferManager) FailActiveSend(where string, err error) {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) FailActiveSendWithStatus(where string, err error, failureStatus common.TransferStatus) {
+func (t *testJobPartTransferManager) FailActiveSendWithStatus(where string, err error, failureStatus common.TransferStatus) {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) LogUploadError(source, destination, errorMsg string, status int) {
+func (t *testJobPartTransferManager) LogUploadError(source, destination, errorMsg string, status int) {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) LogDownloadError(source, destination, errorMsg string, status int) {
+func (t *testJobPartTransferManager) LogDownloadError(source, destination, errorMsg string, status int) {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) LogS2SCopyError(source, destination, errorMsg string, status int) {
+func (t *testJobPartTransferManager) LogS2SCopyError(source, destination, errorMsg string, status int) {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) LogSendError(source, destination, errorMsg string, status int) {
+func (t *testJobPartTransferManager) LogSendError(source, destination, errorMsg string, status int) {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) LogError(resource, context string, err error) {
+func (t *testJobPartTransferManager) LogError(_, _ string, _ error) {}
+
+func (t *testJobPartTransferManager) LogTransferInfo(_ common.LogLevel, _, _, _ string) {}
+
+func (t *testJobPartTransferManager) LogTransferStart(source, destination, description string) {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) LogTransferInfo(level common.LogLevel, source, destination, msg string) {
+func (t *testJobPartTransferManager) LogChunkStatus(id common.ChunkID, reason common.WaitReason) {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) LogTransferStart(source, destination, description string) {
+func (t *testJobPartTransferManager) ChunkStatusLogger() common.ChunkStatusLogger {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) LogChunkStatus(id common.ChunkID, reason common.WaitReason) {
+func (t *testJobPartTransferManager) LogAtLevelForCurrentTransfer(level common.LogLevel, msg string) {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) ChunkStatusLogger() common.ChunkStatusLogger {
+func (t *testJobPartTransferManager) GetOverwritePrompter() *overwritePrompter {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) LogAtLevelForCurrentTransfer(level common.LogLevel, msg string) {
+func (t *testJobPartTransferManager) GetFolderCreationTracker() FolderCreationTracker {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) GetOverwritePrompter() *overwritePrompter {
-	panic("implement me")
-}
-
-func (t testJobPartTransferManager) GetFolderCreationTracker() FolderCreationTracker {
-	panic("implement me")
-}
-
-func (t testJobPartTransferManager) ShouldLog(level common.LogLevel) bool {
+func (t *testJobPartTransferManager) ShouldLog(level common.LogLevel) bool {
 	return false
 }
 
-func (t testJobPartTransferManager) Log(level common.LogLevel, msg string) {
+func (t *testJobPartTransferManager) Log(level common.LogLevel, msg string) {
 }
 
-func (t testJobPartTransferManager) Panic(err error) {
+func (t *testJobPartTransferManager) Panic(err error) {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) DeleteSnapshotsOption() common.DeleteSnapshotsOption {
+func (t *testJobPartTransferManager) DeleteSnapshotsOption() common.DeleteSnapshotsOption {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) PermanentDeleteOption() common.PermanentDeleteOption {
+func (t *testJobPartTransferManager) PermanentDeleteOption() common.PermanentDeleteOption {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) SecurityInfoPersistenceManager() *securityInfoPersistenceManager {
+func (t *testJobPartTransferManager) SecurityInfoPersistenceManager() *securityInfoPersistenceManager {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) FolderDeletionManager() common.FolderDeletionManager {
+func (t *testJobPartTransferManager) FolderDeletionManager() common.FolderDeletionManager {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) GetDestinationRoot() string {
+func (t *testJobPartTransferManager) GetDestinationRoot() string {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) ShouldInferContentType() bool {
+func (t *testJobPartTransferManager) ShouldInferContentType() bool {
 	fromTo := t.FromTo()
 	return fromTo.From() == common.ELocation.Local()
 }
 
-func (t testJobPartTransferManager) CpkInfo() *blob.CPKInfo {
+func (t *testJobPartTransferManager) CpkInfo() *blob.CPKInfo {
 	return nil
 }
 
-func (t testJobPartTransferManager) CpkScopeInfo() *blob.CPKScopeInfo {
+func (t *testJobPartTransferManager) CpkScopeInfo() *blob.CPKScopeInfo {
 	return nil
 }
 
-func (t testJobPartTransferManager) IsSourceEncrypted() bool {
+func (t *testJobPartTransferManager) IsSourceEncrypted() bool {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) PropertiesToTransfer() common.SetPropertiesFlags {
+func (t *testJobPartTransferManager) PropertiesToTransfer() common.SetPropertiesFlags {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) ResetSourceSize() {
+func (t *testJobPartTransferManager) ResetSourceSize() {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) SuccessfulBytesTransferred() int64 {
+func (t *testJobPartTransferManager) SuccessfulBytesTransferred() int64 {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) TransferIndex() (partNum, transferIndex uint32) {
+func (t *testJobPartTransferManager) TransferIndex() (partNum, transferIndex uint32) {
 	panic("implement me")
 }
 
-func (t testJobPartTransferManager) RestartedTransfer() bool {
+func (t *testJobPartTransferManager) RestartedTransfer() bool {
 	return false
 }

--- a/ste/xfer-deleteBlobFS.go
+++ b/ste/xfer-deleteBlobFS.go
@@ -59,6 +59,13 @@ func doDeleteHNSResource(jptm IJobPartTransferMgr) {
 				if respErr.StatusCode == http.StatusNotFound {
 					// if the delete failed with err 404, i.e resource not found, then mark the transfer as success.
 					status = common.ETransferStatus.Success()
+				}
+				// If the status code was 403, it means there was an authentication error and we exit.
+				// User can resume the job if completely ordered with a new sas.
+				if respErr.StatusCode == http.StatusForbidden {
+					errMsg := fmt.Sprintf("Authentication Failed. The SAS is not correct or expired or does not have the correct permission %s", err.Error())
+					jptm.Log(common.LogError, errMsg)
+					common.GetLifecycleMgr().Error(errMsg)
 				} else {
 					// in all other cases, make the transfer as failed
 					status = common.ETransferStatus.Failed()


### PR DESCRIPTION
**Description:**
This pull request aims to resolve the reported issue related to Azcopy, where it erroneously reports failures in cases of a 404 error, despite a successful background delete operation. The proposed fix involves disregarding 404 errors and treating them as successful operations.

**Changes:**
- Implemented a comprehensive fix to address the observed behavior, ensuring Azcopy operates correctly even when a 404 error is reported.
- Added validation checks to enhance the overall reliability of Azcopy.