### PR TITLE
Mildly refactor AzCopy runner

### DIFF
--- a/e2etest/newe2e_asserter.go
+++ b/e2etest/newe2e_asserter.go
@@ -33,10 +33,10 @@ type DryrunAsserter interface {
 	InvalidateScenario()
 }
 
-type CleanupAsserter interface {
-	Asserter
+type ScenarioAsserter interface {
+	DryrunAsserter
 
-	Cleanup(func())
+	Cleanup(func(a ScenarioAsserter))
 }
 
 // ====== Assertion ======

--- a/e2etest/newe2e_config.go
+++ b/e2etest/newe2e_config.go
@@ -32,11 +32,18 @@ type NewE2EConfig struct {
 	E2EAuthConfig struct { // mutually exclusive
 		SubscriptionLoginInfo struct {
 			SubscriptionID string `env:"NEW_E2E_SUBSCRIPTION_ID,required"`
-			TenantID       string `env:"NEW_E2E_TENANT_ID,required"`
 			ApplicationID  string `env:"NEW_E2E_APPLICATION_ID,required"`
 			ClientSecret   string `env:"NEW_E2E_CLIENT_SECRET,required"`
+			TenantID       string `env:"NEW_E2E_TENANT_ID"`
 		} `env:",required"`
+
 		StaticStgAcctInfo struct {
+			StaticOAuth struct {
+				TenantID      string `env:"NEW_E2E_STATIC_TENANT_ID"`
+				ApplicationID string `env:"NEW_E2E_STATIC_APPLICATION_ID,required"`
+				ClientSecret  string `env:"NEW_E2E_STATIC_CLIENT_SECRET,required"`
+			}
+
 			// todo: should we automate this somehow? Currently each of these accounts needs some marginal boilerplate.
 			// double todo: we should allow these to be missing.
 			Standard struct {

--- a/e2etest/newe2e_oauth_cache.go
+++ b/e2etest/newe2e_oauth_cache.go
@@ -50,6 +50,7 @@ type OAuthCache struct {
 func NewOAuthCache(cred azcore.TokenCredential, tenant string) *OAuthCache {
 	return &OAuthCache{
 		tc:     cred,
+		tenant: tenant,
 		tokens: make(map[string]*azcore.AccessToken),
 		mut:    &sync.RWMutex{},
 	}

--- a/e2etest/newe2e_resource_managers_blobfs.go
+++ b/e2etest/newe2e_resource_managers_blobfs.go
@@ -46,6 +46,19 @@ type BlobFSServiceResourceManager struct {
 	internalClient  *service.Client
 }
 
+func (b *BlobFSServiceResourceManager) DefaultAuthType() ExplicitCredentialTypes {
+	// This is what we primarily want to support, despite also supporting AcctKey.
+	return EExplicitCredentialType.SASToken()
+}
+
+func (b *BlobFSServiceResourceManager) WithSpecificAuthType(cred ExplicitCredentialTypes, a Asserter) AzCopyTarget {
+	return CreateAzCopyTarget(b, cred, a)
+}
+
+func (b *BlobFSServiceResourceManager) ValidAuthTypes() ExplicitCredentialTypes {
+	return EExplicitCredentialType.With(EExplicitCredentialType.OAuth(), EExplicitCredentialType.SASToken(), EExplicitCredentialType.AcctKey())
+}
+
 func (b *BlobFSServiceResourceManager) Canon() string {
 	return buildCanonForAzureResourceManager(b)
 }
@@ -74,10 +87,6 @@ func (b *BlobFSServiceResourceManager) URI(a Asserter, withSas bool) string {
 	}
 
 	return base
-}
-
-func (b *BlobFSServiceResourceManager) ValidAuthTypes() ExplicitCredentialTypes {
-	return EExplicitCredentialType.With(EExplicitCredentialType.OAuth(), EExplicitCredentialType.SASToken(), EExplicitCredentialType.AcctKey())
 }
 
 func (b *BlobFSServiceResourceManager) ResourceClient() any {
@@ -125,6 +134,18 @@ type BlobFSFileSystemResourceManager struct {
 	internalClient *filesystem.Client
 }
 
+func (b *BlobFSFileSystemResourceManager) DefaultAuthType() ExplicitCredentialTypes {
+	return (&BlobFSServiceResourceManager{}).DefaultAuthType()
+}
+
+func (b *BlobFSFileSystemResourceManager) WithSpecificAuthType(cred ExplicitCredentialTypes, a Asserter) AzCopyTarget {
+	return CreateAzCopyTarget(b, cred, a)
+}
+
+func (b *BlobFSFileSystemResourceManager) ValidAuthTypes() ExplicitCredentialTypes {
+	return (&BlobFSServiceResourceManager{}).ValidAuthTypes()
+}
+
 func (b *BlobFSFileSystemResourceManager) Canon() string {
 	return buildCanonForAzureResourceManager(b)
 }
@@ -141,10 +162,6 @@ func (b *BlobFSFileSystemResourceManager) Parent() ResourceManager {
 
 func (b *BlobFSFileSystemResourceManager) Account() AccountResourceManager {
 	return b.internalAccount
-}
-
-func (b *BlobFSFileSystemResourceManager) ValidAuthTypes() ExplicitCredentialTypes {
-	return b.Service.ValidAuthTypes()
 }
 
 func (b *BlobFSFileSystemResourceManager) ResourceClient() any {
@@ -255,6 +272,18 @@ type BlobFSPathResourceProvider struct {
 	objectPath string
 }
 
+func (b *BlobFSPathResourceProvider) DefaultAuthType() ExplicitCredentialTypes {
+	return (&BlobFSServiceResourceManager{}).DefaultAuthType()
+}
+
+func (b *BlobFSPathResourceProvider) WithSpecificAuthType(cred ExplicitCredentialTypes, a Asserter) AzCopyTarget {
+	return CreateAzCopyTarget(b, cred, a)
+}
+
+func (b *BlobFSPathResourceProvider) ValidAuthTypes() ExplicitCredentialTypes {
+	return (&BlobFSServiceResourceManager{}).ValidAuthTypes()
+}
+
 func (b *BlobFSPathResourceProvider) Canon() string {
 	return buildCanonForAzureResourceManager(b)
 }
@@ -265,10 +294,6 @@ func (b *BlobFSPathResourceProvider) Parent() ResourceManager {
 
 func (b *BlobFSPathResourceProvider) Account() AccountResourceManager {
 	return b.internalAccount
-}
-
-func (b *BlobFSPathResourceProvider) ValidAuthTypes() ExplicitCredentialTypes {
-	return b.Service.ValidAuthTypes()
 }
 
 func (b *BlobFSPathResourceProvider) ResourceClient() any {

--- a/e2etest/newe2e_task_runazcopy.go
+++ b/e2etest/newe2e_task_runazcopy.go
@@ -1,16 +1,34 @@
 package e2etest
 
 import (
-	"bytes"
 	"fmt"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"os"
 	"os/exec"
 	"reflect"
+	"strings"
 )
 
-// AzCopyJobPlan todo probably load the job plan directly?
+// AzCopyJobPlan todo probably load the job plan directly? WI#26418256
 type AzCopyJobPlan struct{}
+
+// AzCopyStdout shouldn't be used or relied upon right now! This will be fleshed out eventually. todo WI#26418258
+type AzCopyStdout struct {
+	RawOutput []string
+}
+
+func (a *AzCopyStdout) Write(p []byte) (n int, err error) {
+	str := string(p)
+	lines := strings.Split(str, "\n")
+
+	a.RawOutput = append(a.RawOutput, lines...)
+
+	return len(p), nil
+}
+
+func (a *AzCopyStdout) String() string {
+	return strings.Join(a.RawOutput, "\n")
+}
 
 type AzCopyVerb string
 
@@ -21,11 +39,20 @@ const ( // initially supporting a limited set of verbs
 )
 
 type AzCopyTarget struct {
-	ResourceManager
+	RemoteResourceManager
 	AuthType ExplicitCredentialTypes // Expects *one* credential type that the Resource supports. Assumes SAS (or GCP/S3) if not present.
 
 	// todo: SAS permissions
 	// todo: specific OAuth types (e.g. MSI, etc.)
+}
+
+func CreateAzCopyTarget(rm RemoteResourceManager, authType ExplicitCredentialTypes, a Asserter) AzCopyTarget {
+	validTypes := rm.ValidAuthTypes()
+
+	a.AssertNow(fmt.Sprintf("expected only one auth type, got %s", authType), Equal{}, authType.Count(), 1)
+	a.AssertNow(fmt.Sprintf("expected authType to be contained within valid types (got %s, needed %s)", authType, validTypes), Equal{}, validTypes.Includes(authType), true)
+
+	return AzCopyTarget{rm, authType}
 }
 
 type AzCopyCommand struct {
@@ -35,7 +62,7 @@ type AzCopyCommand struct {
 	// When OAuth, S3, GCP, AcctKey, etc. the appropriate env flags should auto-populate.
 	Targets     []ResourceManager
 	Flags       any // check SampleFlags
-	Environment AzCopyEnvironment
+	Environment *AzCopyEnvironment
 
 	ShouldFail bool
 }
@@ -43,12 +70,45 @@ type AzCopyCommand struct {
 type AzCopyEnvironment struct {
 	// `env:"XYZ"` is re-used but does not inherit the traits of config's env trait. Merely used for low-code mapping.
 
-	LogLocation                  *string `env:"AZCOPY_LOG_LOCATION"`
-	JobPlanLocation              *string `env:"AZCOPY_JOB_PLAN_LOCATION"`
+	LogLocation                  *string `env:"AZCOPY_LOG_LOCATION,defaultfunc:DefaultLogLoc"`
+	JobPlanLocation              *string `env:"AZCOPY_JOB_PLAN_LOCATION,defaultfunc:DefaultPlanLoc"`
+	AutoLoginMode                *string `env:"AZCOPY_AUTO_LOGIN_TYPE"`
+	AutoLoginTenantID            *string `env:"AZCOPY_TENANT_ID"`
 	ServicePrincipalAppID        *string `env:"AZCOPY_SPA_APPLICATION_ID"`
 	ServicePrincipalClientSecret *string `env:"AZCOPY_SPA_CLIENT_SECRET"`
 
 	InheritEnvironment bool
+}
+
+func (env *AzCopyEnvironment) generateAzcopyDir(a ScenarioAsserter) {
+	dir, err := os.MkdirTemp("", "azcopytests*")
+	a.NoError("create tempdir", err)
+	env.LogLocation = &dir
+	env.JobPlanLocation = &dir
+	a.Cleanup(func(a ScenarioAsserter) {
+		err := os.RemoveAll(dir)
+		a.NoError("remove tempdir", err)
+	})
+}
+
+func (env *AzCopyEnvironment) DefaultLogLoc(a ScenarioAsserter) string {
+	if env.JobPlanLocation != nil {
+		env.LogLocation = env.JobPlanLocation
+	} else if env.LogLocation == nil {
+		env.generateAzcopyDir(a)
+	}
+
+	return *env.LogLocation
+}
+
+func (env *AzCopyEnvironment) DefaultPlanLoc(a ScenarioAsserter) string {
+	if env.LogLocation != nil {
+		env.JobPlanLocation = env.LogLocation
+	} else if env.JobPlanLocation == nil {
+		env.generateAzcopyDir(a)
+	}
+
+	return *env.JobPlanLocation
 }
 
 func (c *AzCopyCommand) applyTargetAuth(a Asserter, target ResourceManager) string {
@@ -71,8 +131,28 @@ func (c *AzCopyCommand) applyTargetAuth(a Asserter, target ResourceManager) stri
 	case EExplicitCredentialType.SASToken():
 		return target.URI(a, true)
 	case EExplicitCredentialType.OAuth():
-		c.Environment.ServicePrincipalAppID = &GlobalConfig.E2EAuthConfig.SubscriptionLoginInfo.ApplicationID
-		c.Environment.ServicePrincipalClientSecret = &GlobalConfig.E2EAuthConfig.SubscriptionLoginInfo.ClientSecret
+		// Only set it if it wasn't already configured. If it was manually configured,
+		// special testing may be occurring, and this may be indicated to just get a SAS-less URI.
+		// Alternatively, we may have already configured it here once before.
+		if c.Environment.AutoLoginMode == nil && c.Environment.ServicePrincipalAppID == nil && c.Environment.ServicePrincipalClientSecret == nil && c.Environment.AutoLoginTenantID == nil {
+			c.Environment.AutoLoginMode = pointerTo("SPN") // TODO! There are two other modes for this. These probably can't apply in automated scenarios, but it's worth having tests for that we run before every release! WI#26625161
+
+			if GlobalConfig.StaticResources() {
+				oAuthInfo := GlobalConfig.E2EAuthConfig.StaticStgAcctInfo.StaticOAuth
+				a.AssertNow("At least NEW_E2E_STATIC_APPLICATION_ID and NEW_E2E_STATIC_CLIENT_SECRET must be specified to use OAuth.", Empty{true}, oAuthInfo.ApplicationID, oAuthInfo.ClientSecret)
+
+				c.Environment.ServicePrincipalAppID = &oAuthInfo.ApplicationID
+				c.Environment.ServicePrincipalClientSecret = &oAuthInfo.ClientSecret
+				c.Environment.AutoLoginTenantID = common.Iff(oAuthInfo.TenantID != "", &oAuthInfo.TenantID, nil)
+			} else {
+				// oauth should reliably work
+				oAuthInfo := GlobalConfig.E2EAuthConfig.SubscriptionLoginInfo
+				c.Environment.ServicePrincipalAppID = &oAuthInfo.ApplicationID
+				c.Environment.ServicePrincipalClientSecret = &oAuthInfo.ClientSecret
+				c.Environment.AutoLoginTenantID = common.Iff(oAuthInfo.TenantID != "", &oAuthInfo.TenantID, nil)
+			}
+		}
+
 		return target.URI(a, false)
 	default:
 		a.Error("unsupported credential type")
@@ -81,56 +161,67 @@ func (c *AzCopyCommand) applyTargetAuth(a Asserter, target ResourceManager) stri
 }
 
 // RunAzCopy todo define more cleanly, implement
-func RunAzCopy(a Asserter, commandSpec AzCopyCommand) *AzCopyJobPlan {
-	if dryrunner, ok := a.(DryrunAsserter); ok && dryrunner.Dryrun() {
-		return &AzCopyJobPlan{}
+func RunAzCopy(a ScenarioAsserter, commandSpec AzCopyCommand) (*AzCopyStdout, *AzCopyJobPlan) {
+	if a.Dryrun() {
+		return nil, &AzCopyJobPlan{}
 	}
 
-	env := MapFromTags(reflect.ValueOf(commandSpec.Environment), "env")
+	// separate these from the struct so their execution order is fixed
+	args := func() []string {
+		if commandSpec.Environment == nil {
+			commandSpec.Environment = &AzCopyEnvironment{}
+		}
 
-	out := &bytes.Buffer{}
+		out := []string{GlobalConfig.AzCopyExecutableConfig.ExecutablePath, string(commandSpec.Verb)}
+
+		for _, v := range commandSpec.Targets {
+			out = append(out, commandSpec.applyTargetAuth(a, v))
+		}
+
+		if commandSpec.Flags != nil {
+			flags := MapFromTags(reflect.ValueOf(commandSpec.Flags), "flag", a)
+			for k, v := range flags {
+				out = append(out, fmt.Sprintf("--%s=%s", k, v))
+			}
+		}
+
+		return out
+	}()
+	env := func() []string {
+		out := make([]string, 0)
+
+		env := MapFromTags(reflect.ValueOf(commandSpec.Environment), "env", a)
+
+		for k, v := range env {
+			out = append(out, fmt.Sprintf("%s=%s", k, v))
+		}
+
+		if commandSpec.Environment.InheritEnvironment {
+			out = append(out, os.Environ()...)
+		}
+
+		return out
+	}()
+
+	out := &AzCopyStdout{}
 	command := exec.Cmd{
 		Path: GlobalConfig.AzCopyExecutableConfig.ExecutablePath,
-		Args: func() []string {
-			out := []string{GlobalConfig.AzCopyExecutableConfig.ExecutablePath, string(commandSpec.Verb)}
-
-			for _, v := range commandSpec.Targets {
-				out = append(out, commandSpec.applyTargetAuth(a, v))
-			}
-
-			if commandSpec.Flags != nil {
-				flags := MapFromTags(reflect.ValueOf(commandSpec.Flags), "flag")
-				for k, v := range flags {
-					out = append(out, fmt.Sprintf("--%s=%s", k, v))
-				}
-			}
-
-			return out
-		}(),
-		Env: func() []string {
-			out := make([]string, 0)
-
-			for k, v := range env {
-				out = append(out, fmt.Sprintf("%s=%s", k, v))
-			}
-
-			if commandSpec.Environment.InheritEnvironment {
-				out = append(out, os.Environ()...)
-			}
-
-			return nil
-		}(),
+		Args: args,
+		Env:  env,
 
 		Stdout: out, // todo
 		Stdin:  nil, // todo
 	}
 
 	err := command.Run()
-	a.Log(out.String())
-	a.NoError("run command", err)
-	a.AssertNow("expected exit code",
+	a.Assert("run command", IsNil{}, err)
+	a.Assert("expected exit code",
 		common.Iff[Assertion](commandSpec.ShouldFail, Not{Equal{}}, Equal{}),
 		0, command.ProcessState.ExitCode())
 
-	return &AzCopyJobPlan{}
+	if err != nil {
+		a.Log("AzCopy output:\n%s", out.String())
+	}
+
+	return out, &AzCopyJobPlan{}
 }

--- a/e2etest/newe2e_task_runazcopy_parameters.go
+++ b/e2etest/newe2e_task_runazcopy_parameters.go
@@ -2,46 +2,93 @@ package e2etest
 
 import (
 	"fmt"
+	"github.com/Azure/azure-storage-azcopy/v10/cmd"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"os"
 	"reflect"
+	"strings"
+	"time"
 )
 
-///*
-//Initially, the intent was to opt for structs for each command (e.g. CopyParameters, SyncParameters),
-//but upon further thought that does not align with the way the framework will be calling AzCopy
-//(e.g. usually copy/sync multiple times in the same test)
-//
-//The goal of using structs to segregate the flags associated with different commands was to
-//make it easier to interpret which flags are compatible with which verbs.
-//
-//In an attempt to try to alleviate that and provide a versatile solution,
-//the verbs listed as constants below should be grouped by commonality.
-//*/
-//
-//type AzCopyFlag struct {
-//	Name           string
-//	SupportedVerbs AzCopyVerb
-//}
-//
-//var (
-//	AzCopyFlagRecursive = AzCopyFlag{Name: "recursive", SupportedVerbs: AzCopyVerbCopy | AzCopyVerbSync | AzCopyVerbRemove}
-//)
-
 // MapFromTags Recursively builds a map[string]string from a reflect.val
-func MapFromTags(val reflect.Value, tagName string) map[string]string {
-
+// As it searches recursively through the supplied struct,
+// The tag searched for is `flag:"name,extdata"`
+// All extra data is comma-separated.
+// All flags should be nillable, because zero is always a valid state, and must be distinguishable from unspecified.
+// available extdata:
+// - "default:xyz" Defaults to something non-standard for AzCopy-- E.g. always forcing debug logging
+// - "defaultfunc:SpecialDefault" Calls a `func Default*(a ScenarioAsserter) string` named SpecialDefault on the struct. Asserts if not found.
+// - "serializer:SerializerFunc" Calls a `func Serialize*(value any, a ScenarioAsserter) string` named SerializerFunc on the struct. Asserts if not found.
+// If special characters , or : are for some reason used, \ can be used as an escape.
+func MapFromTags(val reflect.Value, tagName string, a ScenarioAsserter) map[string]string {
 	queue := []reflect.Value{val}
 	out := make(map[string]string)
 
 	for len(queue) != 0 {
 		val := queue[0]
 		queue = queue[1:]
+
+		ptrVal := val
+		for val.Kind() == reflect.Pointer || val.Kind() == reflect.Interface { // deref pointers/interfaces
+			val = val.Elem()
+		}
+
+		if !val.IsValid() || val.IsZero() {
+			continue
+		}
+
 		t := val.Type()
 		numField := t.NumField()
 
 		for i := 0; i < numField; i++ {
 			key, ok := t.Field(i).Tag.Lookup(tagName)
 			if ok {
-				out[key] = fmt.Sprint(val.Field(i))
+				field := val.Field(i)
+				// break the key down
+				tag := parseFlagTag(key)
+
+				switch field.Kind() {
+				case reflect.Chan, reflect.Func, reflect.Map,
+					reflect.Pointer, reflect.UnsafePointer,
+					reflect.Slice, reflect.Interface:
+				default:
+					a.Error(fmt.Sprintf("Field %s of struct %s must be nillable", t.Field(i).Name, t.Name()))
+				}
+
+				tryFindMethod := func(name string) reflect.Value {
+					out := val.MethodByName(name) // First, target the real value, this catches non-pointer methods
+					if !out.IsValid() {
+						out = ptrVal.MethodByName(name) // If that fails, call the pointer version, we shouldn't be double pointering anyway.
+					}
+
+					if !out.IsValid() {
+						a.Error("could not find method " + name)
+					}
+					//a.AssertNow("could not find method "+name, Equal{}, out.IsValid(), true)
+					return out
+				}
+
+				// values should always be nillable
+				if field.IsNil() {
+					if tag.defaultData != nil { // if we have default data, it's easy.
+						out[tag.flagKey] = *tag.defaultData
+					} else if tag.defaultFunc != nil {
+						// find the function & call it
+						result := tryFindMethod(*tag.defaultFunc).Call([]reflect.Value{reflect.ValueOf(a)}) // todo: we could validate that we're getting what we expect, but no need to do that because reflect will panic for us, then the test will catch it.
+						out[tag.flagKey] = result[0].String()
+					}
+				} else {
+					if field.Kind() == reflect.Pointer {
+						field = field.Elem()
+					}
+
+					if tag.serializerFunc != nil {
+						result := tryFindMethod(*tag.serializerFunc).Call([]reflect.Value{field, reflect.ValueOf(a)})
+						out[tag.flagKey] = result[0].String()
+					} else {
+						out[tag.flagKey] = fmt.Sprint(field)
+					}
+				}
 			} else if val.Field(i).Kind() == reflect.Struct {
 				queue = append(queue, val.Field(i))
 			}
@@ -51,7 +98,299 @@ func MapFromTags(val reflect.Value, tagName string) map[string]string {
 	return out
 }
 
-// SampleFlags is a temporary stub to demonstrate how to create a flags struct
-type SampleFlags struct {
-	Recursive *bool `flag:"recursive"`
+type flagTag struct {
+	flagKey        string
+	defaultData    *string
+	defaultFunc    *string
+	serializerFunc *string
+}
+
+func parseFlagTag(tag string) flagTag {
+	//sections := make([]string, 0)
+	out := flagTag{}
+	var fieldTarget *string
+	token := make([]rune, 0)
+
+	var escapeNext bool
+	tagRunes := []rune(tag)
+
+	for char := 0; char < len(tagRunes); char++ {
+		finalize := func(targetField bool) {
+			defer func() { token = make([]rune, 0) }()
+
+			if fieldTarget != nil {
+				*fieldTarget = string(token)
+				fieldTarget = nil
+				return
+			}
+
+			if targetField {
+				var data string
+
+				switch strings.ToLower(string(token)) {
+				case "default":
+					out.defaultData = &data
+				case "defaultfunc":
+					out.defaultFunc = &data
+				case "serializer":
+					out.serializerFunc = &data
+				}
+
+				fieldTarget = &data
+			} else {
+				out.flagKey = string(token)
+			}
+		}
+
+		if escapeNext {
+			token = append(token, tagRunes[char])
+			escapeNext = false
+			continue
+		}
+
+		switch tag[char] {
+		case '\\':
+			escapeNext = true
+		case ',':
+			finalize(false)
+		case ':':
+			finalize(true)
+		case ' ':
+			// Space should always be ignored.
+			// If it is truly necessary for some sort of default,
+			// It should be manually escaped.
+			// That said, there are no cases (as of 1/26/2024) where a flag requires a space as any part of the flag
+			// as some part of enumeration or otherwise.
+		default:
+			token = append(token, tagRunes[char])
+		}
+
+		if char == len(tagRunes)-1 {
+			finalize(false)
+		}
+	}
+
+	return out
+}
+
+// The below structs are intended to be mixed and matched as much as possible,
+// such that a variety of verbs can be used with a single struct (e.g. copy and sync)
+// in a test, without rewriting all the flags for every use case.
+
+type GlobalFlags struct {
+	CapMbps          *float64 `flag:"cap-mbps"`
+	TrustedSuffixes  []string `flag:"trusted-microsoft-suffixes"`
+	SkipVersionCheck *bool    `flag:"skip-version-check"`
+
+	OutputType  *common.OutputFormat    `flag:"output-type,default:json"`
+	LogLevel    *common.LogLevel        `flag:"log-level,default:DEBUG"`
+	OutputLevel *common.OutputVerbosity `flag:"output-level,default:DEFAULT"`
+
+	// TODO: reconsider/reengineer this flag; WI#26475473
+	//DebugSkipFiles   []string                `flag:"debug-skip-files"`
+
+	// TODO: handle prompting and input; WI#26475441
+	//CancelFromStdin *bool `flag:"cancel-from-stdin"`
+	//AwaitContinue   *bool `flag:"await-continue"`
+	//AwaitOpen       *bool `flag:"await-open"`
+}
+
+type CommonFilterFlags struct {
+	IncludePattern []string `flag:"include-pattern,serializer:SerializeStrings"`
+	ExcludePattern []string `flag:"exclude-pattern,serializer:SerializeStrings"`
+
+	IncludeRegex []string `flag:"include-regex,serializer:SerializeStrings"`
+	ExcludeRegex []string `flag:"include-regex,serializer:SerializeStrings"`
+
+	IncludePath []string `flag:"include-path,serializer:SerializeStrings"`
+	ExcludePath []string `flag:"exclude-path,serializer:SerializeStrings"`
+
+	// Copy/remove only
+	IncludeBefore *time.Time `flag:"include-before,serializer:SerializeTime"`
+	IncludeAfter  *time.Time `flag:"include-after,serializer:SerializeTime"`
+
+	// primarily for testing errors, copy/sync only
+	LegacyInclude []string `flag:"include,serializer:SerializeStrings"`
+	LegacyExclude []string `flag:"exclude,serializer:SerializeStrings"`
+
+	IncludeAttributes []cmd.WindowsAttribute `flag:"include-attributes,serializer:SerializeAttributeList"`
+	ExcludeAttributes []cmd.WindowsAttribute `flag:"exclude-attributes,serializer:SerializeAttributeList"`
+}
+
+func (CommonFilterFlags) SerializeTime(t any, a ScenarioAsserter) string {
+	return GetTypeOrAssert[*time.Time](a, t).UTC().Format(time.RFC3339)
+}
+
+func (CommonFilterFlags) SerializeStrings(list any, a ScenarioAsserter) string {
+	return strings.Join(GetTypeOrAssert[[]string](a, list), ";")
+}
+
+func (CommonFilterFlags) SerializeAttributeList(list any, a ScenarioAsserter) string {
+	attrs := GetTypeOrAssert[[]cmd.WindowsAttribute](a, list)
+
+	out := ""
+	for _, v := range attrs {
+		if len(out) > 0 {
+			out += ";"
+		}
+
+		out += cmd.WindowsAttributeStrings[v]
+	}
+
+	return out
+}
+
+// CopySyncCommonFlags is a list of flags with feature parity across copy and sync.
+type CopySyncCommonFlags struct {
+	GlobalFlags
+	CommonFilterFlags
+
+	Recursive           *bool          `flag:"recursive"`
+	FromTo              *common.FromTo `flag:"from-to"`
+	BlockSizeMB         *float64       `flag:"block-size-mb"`
+	PreservePermissions *bool          `flag:"preserve-permissions"`
+	// PreserveSMBPermissions refers to explicitly using the classic, deprecated flag, in case we want to validate the warning is spat out.
+	PreserveSMBPermissions  *bool                        `flag:"preserve-smb-permissions"`
+	PreservePOSIXProperties *bool                        `flag:"preserve-posix-properties"`
+	ForceIfReadOnly         *bool                        `flag:"force-if-read-only"`
+	PutMD5                  *bool                        `flag:"put-md5"`
+	CheckMD5                *common.HashValidationOption `flag:"check-md5"`
+	S2SPreserveAccessTier   *bool                        `flag:"s2s-preserve-access-tier"`
+	S2SPreserveBlobTags     *bool                        `flag:"s2s-preserve-blob-tags"`
+	DryRun                  *bool                        `flag:"dry-run"`
+	TrailingDot             *common.TrailingDotOption    `flag:"trailing-dot"`
+	CPKByName               *string                      `flag:"cpk-by-name"`
+	CPKByValue              *bool                        `flag:"cpk-by-value"`
+}
+
+// CopyFlags is a more exclusive struct including flags exclusi
+type CopyFlags struct {
+	CopySyncCommonFlags
+
+	FollowSymlinks  *bool                 `flag:"follow-symlinks"`
+	ListOfFiles     []string              `flag:"list-of-files,serializer:SerializeListingFile"`
+	Overwrite       *bool                 `flag:"overwrite"`
+	Decompress      *bool                 `flag:"decompress"`
+	ExcludeBlobType *common.BlobType      `flag:"exclude-blob-type"`
+	BlobType        *common.BlobType      `flag:"blob-type"`
+	BlockBlobTier   *common.BlockBlobTier `flag:"block-blob-tier"`
+	PageBlobTier    *common.BlockBlobTier `flag:"page-blob-tier"`
+	Metadata        common.Metadata       `flag:"metadata,serializer:SerializeMetadata"`
+
+	ContentType        *string `flag:"content-type"`
+	ContentEncoding    *string `flag:"content-encoding"`
+	ContentDisposition *string `flag:"content-disposition"`
+	ContentLanguage    *string `flag:"content-language"`
+	CacheControl       *string `flag:"cache-control"`
+
+	NoGuessMimeType *bool `flag:"no-guess-mime-type"`
+	PreserveLMT     *bool `flag:"preserve-last-modified-time"`
+
+	AsSubdir         *bool `flag:"as-subdir"`
+	PreserveOwner    *bool `flag:"preserve-owner"`
+	PreserveSymlinks *bool `flag:"preserve-symlinks"`
+
+	// semi-related WIs for CheckLength present in GlobalFlags (WI#26475473, WI#26475441)
+	// goal would be to test the unhappy case of CheckLength=true by altering after enumeration time
+	CheckLength *bool `flag:"check-length"`
+
+	S2SPreserveProperties     *bool           `flag:"check-length"`
+	S2SDetectSourceChanged    *bool           `flag:"s2s-detect-source-changed"`
+	ListOfVersions            []string        `flag:"list-of-versions,serializer:SerializeListingFile"`
+	BlobTags                  common.Metadata `flag:"blob-tags,serializer:SerializeTags"`
+	IncludeDirectoryStubs     *bool           `flag:"include-directory-stubs"`
+	DisableAutoDecoding       *bool           `flag:"disable-auto-decoding"`
+	S2SGetPropertiesInBackend *bool           `flag:"s2s-get-properties-in-backend"`
+	ADLSFlushThreshold        *uint32         `flag:"flush-threshold"`
+
+	// todo: Privileged environment testing; WI#26542582
+	//BackupMode *bool `flag:"backup"`
+}
+
+func (CopyFlags) SerializeListingFile(in any, a ScenarioAsserter) string {
+	if a.Dryrun() {
+		// Dryruns won't actually run AzCopy, and dryruns shouldn't reach this code path, but just in case, we should cover it.
+		return "listingfile.txt"
+	}
+
+	list := GetTypeOrAssert[[]string](a, in)
+
+	file, err := os.CreateTemp("", "")
+	a.NoError("must create temp file", err)
+	path := file.Name()
+	defer func(file *os.File) {
+		_ = file.Close()
+	}(file)
+
+	a.Cleanup(func(a ScenarioAsserter) {
+		a.NoError("cleanup list file", os.Remove(path))
+	})
+
+	for _, v := range list {
+		_, err := file.WriteString(v + "\n")
+		a.NoError("must write line to temp file", err)
+	}
+
+	return path
+}
+
+// SerializeKeyValues
+// kvsep = what should be between a key and value
+// elemsep = what should be between two pairs
+func (CopyFlags) SerializeKeyValues(in any, a ScenarioAsserter, kvsep, elemsep string) string {
+	meta := GetTypeOrAssert[common.Metadata](a, in)
+	out := ""
+
+	for k, v := range meta {
+		if v == nil {
+			continue
+		}
+
+		if len(out) > 0 {
+			out += elemsep
+		}
+
+		out += fmt.Sprintf("%s%s%s", k, kvsep, *v)
+	}
+
+	return out
+}
+
+func (c CopyFlags) SerializeMetadata(meta any, a ScenarioAsserter) string {
+	return c.SerializeKeyValues(meta, a, "=", ";")
+}
+
+func (c CopyFlags) SerializeTags(tags any, a ScenarioAsserter) string {
+	return c.SerializeKeyValues(tags, a, "=", "&")
+}
+
+type SyncFlags struct {
+	CopySyncCommonFlags
+
+	DeleteDestination    *bool                   `flag:"delete-destination"`
+	MirrorMode           *bool                   `flag:"mirror-mode"`
+	CompareHash          *common.SyncHashType    `flag:"compare-hash"`
+	LocalHashDir         *string                 `flag:"hash-meta-dir"`
+	LocalHashStorageMode *common.HashStorageMode `flag:"local-hash-storage-mode"`
+}
+
+// RemoveFlags is not tiered like CopySyncCommonFlags is, because it is dissimilar in functionality, and would be hard to test in the same scenario.
+type RemoveFlags struct {
+	GlobalFlags
+	CommonFilterFlags
+
+	Recursive       *bool                         `flag:"recursive"`
+	ForceIfReadOnly *bool                         `flag:"force-if-read-only"`
+	ListOfFiles     []string                      `flag:"list-of-files"`
+	ListOfVersions  []string                      `flag:"list-of-versions"`
+	DryRun          *bool                         `flag:"dry-run"`
+	FromTo          *common.FromTo                `flag:"from-to"`
+	PermanentDelete *common.PermanentDeleteOption `flag:"permanent-delete"`
+	TrailingDot     *common.TrailingDotOption     `flag:"trailing-dot"`
+	CPKByName       *string                       `flag:"cpk-by-name"`
+	CPKByValue      *bool                         `flag:"cpk-by-value"`
+}
+
+func (r RemoveFlags) SerializeListingFile(in any, scenarioAsserter ScenarioAsserter) {
+	CopyFlags{}.SerializeListingFile(in, scenarioAsserter)
 }

--- a/e2etest/zt_newe2e_example_test.go
+++ b/e2etest/zt_newe2e_example_test.go
@@ -29,7 +29,8 @@ func (s *ExampleSuite) Scenario_SingleFileCopySyncS2S(svm *ScenarioVariationMana
 	body := NewRandomObjectContentContainer(svm, SizeFromString("10K"))
 	// Scale up from service to object
 	srcObj := CreateResource[ObjectResourceManager](svm, srcService, ResourceDefinitionObject{
-		Body: body,
+		ObjectName: pointerTo("test"),
+		Body:       body,
 	}) // todo: generic CreateResource is something to pursue in another branch, but it's an interesting thought.
 	// Scale up from service to container
 	dstObj := CreateResource[ContainerResourceManager](svm, dstService, ResourceDefinitionContainer{})
@@ -39,8 +40,15 @@ func (s *ExampleSuite) Scenario_SingleFileCopySyncS2S(svm *ScenarioVariationMana
 		AzCopyCommand{
 			Verb: ResolveVariation(svm, []AzCopyVerb{AzCopyVerbCopy}),
 			Targets: []ResourceManager{
-				srcObj,
+				srcObj.Parent().(RemoteResourceManager).WithSpecificAuthType(EExplicitCredentialType.OAuth(), svm),
 				dstObj,
+			},
+			Flags: CopyFlags{
+				CopySyncCommonFlags: CopySyncCommonFlags{
+					Recursive: pointerTo(true),
+				},
+
+				ListOfFiles: []string{"test"},
 			},
 		})
 


### PR DESCRIPTION
This mainly targets a few fields:

1) Flags. This is less a refactor, and more of a fleshing-out of the existing work.
2) Environment variables borrows some changes from the flags changes, namely auto-assigning work dirs.
3) Auth modes are a little cleaner, now. Using a RemoteResourceManager (todo: should we just merge RemoteResourceManager into the normal ResourceManager spec, and error out on the relevant fields when calling against local for ease-of-use?)