### PR TITLE
Replace powershell with pwsh in Powershell Login

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -154,10 +154,10 @@ jobs:
 
     steps:
       - task: PowerShell@2
-        condition: eq(variables.type, 'windows' )
         inputs: 
           targetType: 'inline'
           script: 'Install-Module -Name Az -Scope CurrentUser -Repository PSGallery -AllowClobber -Force'
+          pwsh: 'true'
         displayName: 'Install Powershell Az Module'
       - task: GoTool@0
         inputs:

--- a/common/azure_ps_context_credential.go
+++ b/common/azure_ps_context_credential.go
@@ -15,7 +15,6 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
-	"strings"
 	"sync"
 	"time"
 
@@ -155,9 +154,9 @@ func (c *PowershellContextCredential) createAccessToken(tk []byte) (azcore.Acces
 		ExpiresOn   string `json:"ExpiresOn"`
 	}{}
 
-	err := json.Unmarshal([]byte(strings.TrimSpace(string(tk))), &t)
+	err := json.Unmarshal(tk, &t)
 	if err != nil {
-		return azcore.AccessToken{}, errors.New(err.Error() + string(tk))
+		return azcore.AccessToken{}, errors.New(err.Error())
 	}
 	
 	parseErr := "error parsing token expiration time %q: %v"

--- a/e2etest/zt_basic_cli_ps_auth_test.go
+++ b/e2etest/zt_basic_cli_ps_auth_test.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"runtime"
 	"testing"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
@@ -111,9 +110,6 @@ func TestBasic_PSAuth(t *testing.T) {
 		recursive: true,
 	}, &hooks{
 		beforeTestRun: func(h hookHelper) {
-			if runtime.GOOS != "windows" {
-				h.SkipTest()
-			}
 			tenId, appId, clientSecret := GlobalInputManager{}.GetServicePrincipalAuth()
 			cmd := `$secret = ConvertTo-SecureString -String %s -AsPlainText -Force;
 				$cred = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList %s, $secret;
@@ -123,7 +119,7 @@ func TestBasic_PSAuth(t *testing.T) {
 			}
 
 			script := fmt.Sprintf(cmd, clientSecret, appId)
-			out, err := exec.Command("powershell", script).Output()
+			out, err := exec.Command("pwsh", "-Command", script).Output()
 			if err != nil {
 				e := err.(*exec.ExitError)
 				t.Logf(string(e.Stderr))
@@ -149,9 +145,6 @@ func TestBasic_PSAuthCamelCase(t *testing.T) {
 		recursive: true,
 	}, &hooks{
 		beforeTestRun: func(h hookHelper) {
-			if runtime.GOOS != "windows" {
-				h.SkipTest()
-			}
 			tenId, appId, clientSecret := GlobalInputManager{}.GetServicePrincipalAuth()
 			cmd := `$secret = ConvertTo-SecureString -String %s -AsPlainText -Force;
 				$cred = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList %s, $secret;
@@ -161,7 +154,7 @@ func TestBasic_PSAuthCamelCase(t *testing.T) {
 			}
 
 			script := fmt.Sprintf(cmd, clientSecret, appId)
-			out, err := exec.Command("powershell", script).Output()
+			out, err := exec.Command("pwsh", "-Command", script).Output()
 			if err != nil {
 				e := err.(*exec.ExitError)
 				t.Logf(string(e.Stderr))


### PR DESCRIPTION
This PR replaces the usage of powershell in Powershell login with pwsh. pwsh is supported on linux and mac additionally.

The existing tests have been enabled to run on linux/mac as well. Also, the azure-pipelines is changed to use pwsh instead of powershell.