### PR TITLE
Added warning in case of shared key for datalake

### DIFF
--- a/cmd/credentialUtil.go
+++ b/cmd/credentialUtil.go
@@ -46,11 +46,11 @@ var once sync.Once
 var autoOAuth sync.Once
 
 var sharedKeyDeprecation sync.Once
-var sharedKeyDeprecationMessage = "*** Warning *** shared key authentication for datalake is deprecated and will be removed in a future release. Please use shared access signature (SAS) or OAuth for authentication."
+var sharedKeyDeprecationMessage = "*** WARNING *** shared key authentication for datalake is deprecated and will be removed in a future release. Please use shared access signature (SAS) or OAuth for authentication."
 
 func warnIfSharedKeyAuthForDatalake() {
 	sharedKeyDeprecation.Do(func() {
-		glcm.Info(sharedKeyDeprecationMessage)
+		glcm.Warn(sharedKeyDeprecationMessage)
 		jobsAdmin.JobsAdmin.LogToJobLog(sharedKeyDeprecationMessage, common.LogWarning)
 	})
 }

--- a/cmd/credentialUtil.go
+++ b/cmd/credentialUtil.go
@@ -45,6 +45,16 @@ import (
 var once sync.Once
 var autoOAuth sync.Once
 
+var sharedKeyDeprecation sync.Once
+var sharedKeyDeprecationMessage = "*** Warning *** shared key authentication for datalake is deprecated and will be removed in a future release. Please use shared access signature (SAS) or OAuth for authentication."
+
+func warnIfSharedKeyAuthForDatalake() {
+	sharedKeyDeprecation.Do(func() {
+		glcm.Info(sharedKeyDeprecationMessage)
+		jobsAdmin.JobsAdmin.LogToJobLog(sharedKeyDeprecationMessage, common.LogWarning)
+	})
+}
+
 // only one UserOAuthTokenManager should exists in azcopy-v2 process in cmd(FE) module for current user.
 // (given appAppPathFolder is mapped to current user)
 var currentUserOAuthTokenManager *common.UserOAuthTokenManager
@@ -352,7 +362,7 @@ var authMessagesAlreadyLogged = &sync.Map{}
 func isPublic(ctx context.Context, blobResourceURL string, cpkOptions common.CpkOptions) (isPublicResource bool) {
 	bURLParts, err := blob.ParseURL(blobResourceURL)
 	if err != nil {
-		return false;
+		return false
 	}
 
 	if bURLParts.ContainerName == "" || strings.Contains(bURLParts.ContainerName, "*") {
@@ -414,7 +424,7 @@ func mdAccountNeedsOAuth(ctx context.Context, blobResourceURL string, cpkOptions
 		if respErr.StatusCode == 401 || respErr.StatusCode == 403 { // *sometimes* the service can return 403s.
 			challenge := respErr.RawResponse.Header.Get("WWW-Authenticate")
 			if strings.Contains(challenge, common.MDResource) {
-				return true;
+				return true
 			}
 		}
 	}
@@ -433,9 +443,9 @@ func doGetCredentialTypeForLocation(ctx context.Context, location common.Locatio
 	case common.ELocation.Local(), common.ELocation.Benchmark(), common.ELocation.None(), common.ELocation.Pipe():
 		return common.ECredentialType.Anonymous(), false, nil
 	}
-	
-	defer func() { 
-		logAuthType(credType, location, isSource) 
+
+	defer func() {
+		logAuthType(credType, location, isSource)
 	}()
 
 	// caution: If auth-type is unsafe, below defer statement will change the return value credType
@@ -451,11 +461,11 @@ func doGetCredentialTypeForLocation(ctx context.Context, location common.Locatio
 	}()
 
 	if getForcedCredType() != common.ECredentialType.Unknown() &&
-			location != common.ELocation.S3() && location != common.ELocation.GCP() {
-				credType = getForcedCredType()
-				return
+		location != common.ELocation.S3() && location != common.ELocation.GCP() {
+		credType = getForcedCredType()
+		return
 	}
-	
+
 	if location == common.ELocation.S3() {
 		accessKeyID := glcm.GetEnvironmentVariable(common.EEnvironmentVariable.AWSAccessKeyID())
 		secretAccessKey := glcm.GetEnvironmentVariable(common.EEnvironmentVariable.AWSSecretAccessKey())
@@ -468,7 +478,7 @@ func doGetCredentialTypeForLocation(ctx context.Context, location common.Locatio
 		credType = common.ECredentialType.S3AccessKey()
 		return
 	}
-	
+
 	if location == common.ELocation.GCP() {
 		googleAppCredentials := glcm.GetEnvironmentVariable(common.EEnvironmentVariable.GoogleAppCredentials())
 		if googleAppCredentials == "" {
@@ -515,6 +525,7 @@ func doGetCredentialTypeForLocation(ctx context.Context, location common.Locatio
 		key := glcm.GetEnvironmentVariable(common.EEnvironmentVariable.AccountKey())
 		if name != "" && key != "" { // TODO: To remove, use for internal testing, SharedKey should not be supported from commandline
 			credType = common.ECredentialType.SharedKey()
+			warnIfSharedKeyAuthForDatalake()
 		}
 	}
 

--- a/cmd/zt_interceptors_for_test.go
+++ b/cmd/zt_interceptors_for_test.go
@@ -75,6 +75,7 @@ func (i *interceptor) reset() {
 // this lifecycle manager substitute does not perform any action
 type mockedLifecycleManager struct {
 	infoLog      chan string
+	warnLog      chan string
 	errorLog     chan string
 	progressLog  chan string
 	exitLog      chan string
@@ -102,6 +103,12 @@ func (*mockedLifecycleManager) Init(common.OutputBuilder) {}
 func (m *mockedLifecycleManager) Info(msg string) {
 	select {
 	case m.infoLog <- msg:
+	default:
+	}
+}
+func (m *mockedLifecycleManager) Warn(msg string) {
+	select {
+	case m.warnLog <- msg:
 	default:
 	}
 }

--- a/common/lifecyleMgr.go
+++ b/common/lifecyleMgr.go
@@ -53,6 +53,7 @@ type LifecycleMgr interface {
 	Progress(OutputBuilder)                                      // print on the same line over and over again, not allowed to float up
 	Exit(OutputBuilder, ExitCode)                                // indicates successful execution exit after printing, allow user to specify exit code
 	Info(string)                                                 // simple print, allowed to float up
+	Warn(string)                                                 // simple print, allowed to float up
 	Dryrun(OutputBuilder)                                        // print files for dry run mode
 	Error(string)                                                // indicates fatal error, exit after printing, exit code is always Failed (1)
 	Prompt(message string, details PromptDetails) ResponseOption // ask the user a question(after erasing the progress), then return the response
@@ -281,6 +282,18 @@ func (lcm *lifecycleMgr) Info(msg string) {
 	msg = lcm.logSanitizer.SanitizeLogMessage(msg) // sometimes error-like text comes through Info, before the final "we've failed, please stop now" signal comes to Error. So we sanitize in both places.
 
 	infoMsg := fmt.Sprintf("INFO: %v", msg)
+
+	lcm.msgQueue <- outputMessage{
+		msgContent: infoMsg,
+		msgType:    eOutputMessageType.Info(),
+	}
+}
+
+func (lcm *lifecycleMgr) Warn(msg string) {
+
+	msg = lcm.logSanitizer.SanitizeLogMessage(msg) // sometimes error-like text comes through Info, before the final "we've failed, please stop now" signal comes to Error. So we sanitize in both places.
+
+	infoMsg := fmt.Sprintf("WARN: %v", msg)
 
 	lcm.msgQueue <- outputMessage{
 		msgContent: infoMsg,


### PR DESCRIPTION
Console looks like

> INFO: Scanning...
> INFO: Autologin not specified.
> WARN: *** WARNING *** shared key authentication for datalake is deprecated and will be removed in a future release. Please use shared access signature (SAS) or OAuth for authentication.
> INFO: Authenticating to destination using SharedKey
> INFO: Any empty folders will be processed, because source and destination both support folders


Log file looks like

> 2024/02/05 21:18:53 AzcopyVersion  10.23.0
> 2024/02/05 21:18:53 OS-Environment  windows
> 2024/02/05 21:18:53 OS-Architecture  amd64
> 2024/02/05 21:18:53 Log times are in UTC. Local time is 5 Feb 2024 13:18:53
> 2024/02/05 21:18:53 ISO 8601 START TIME: to copy files that changed before or after this job started, use the parameter --include-before=2024-02-05T21:18:48Z or --include-after=2024-02-05T21:18:48Z
> 2024/02/05 21:18:53 WARN: *** WARNING *** shared key authentication for datalake is deprecated and will be removed in a future release. Please use shared access signature (SAS) or OAuth for authentication.
> 2024/02/05 21:18:53 Authenticating to destination using SharedKey
