### PR TITLE
Local Resource Manager + Assorted bugfixes

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,12 +21,12 @@ jobs:
     name: lint
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: latest

--- a/e2etest/newe2e_account_registry.go
+++ b/e2etest/newe2e_account_registry.go
@@ -10,9 +10,7 @@ import (
 // AccountRegistry is a set of accounts that are intended to be initialized when the tests start running.
 // Suites and tests should not add to this pool.
 // todo: long-term, support flexible static configuration of accounts.
-var AccountRegistry = map[string]AccountResourceManager{
-	//PrimaryStandardAcct: &DummyAccountResourceManager{},
-} // For re-using accounts across testing
+var AccountRegistry = map[string]AccountResourceManager{} // For re-using accounts across testing
 
 func GetAccount(a Asserter, AccountName string) AccountResourceManager {
 	targetAccount, ok := AccountRegistry[AccountName]

--- a/e2etest/newe2e_resource_manager_getter.go
+++ b/e2etest/newe2e_resource_manager_getter.go
@@ -1,0 +1,30 @@
+package e2etest
+
+import (
+	"fmt"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+)
+
+type GetResourceOptions struct {
+	// Key for AccountRegistry when using account-based systems
+	PreferredAccount *string
+}
+
+// GetRootResource differs from CreateResource, in that GetRootResource obtains the lowest possible resource for a particular location
+// This eases the act of getting a base resource for tests that might utilize multiple "kinds" of resources (e.g. Local, Azure) interchangeably.
+// on *Local*, this inherently creates a container. But that's fine, because it's likely to be used.
+func GetRootResource(a Asserter, location common.Location, varOpts ...GetResourceOptions) ResourceManager {
+	opts := FirstOrZero(varOpts)
+
+	switch location {
+	case common.ELocation.Local():
+		return NewLocalContainer(a)
+	case common.ELocation.Blob(), common.ELocation.BlobFS(), common.ELocation.File():
+		// acct handles the dryrun case for us
+		acct := GetAccount(a, DerefOrDefault(opts.PreferredAccount, PrimaryStandardAcct))
+		return acct.GetService(a, location)
+	default:
+		a.Error(fmt.Sprintf("TODO: Location %s is not yet supported", location))
+		return nil
+	}
+}

--- a/e2etest/newe2e_resource_manager_interface.go
+++ b/e2etest/newe2e_resource_manager_interface.go
@@ -70,6 +70,14 @@ type RemoteResourceManager interface {
 	ResourceClient() any
 }
 
+func TryApplySpecificAuthType(rm ResourceManager, cred ExplicitCredentialTypes, a Asserter, opts ...CreateAzCopyTargetOptions) AzCopyTarget {
+	if rrm, ok := rm.(RemoteResourceManager); ok {
+		return rrm.WithSpecificAuthType(cred, a, opts...)
+	}
+
+	return CreateAzCopyTarget(rm, EExplicitCredentialType.None(), a)
+}
+
 // ExplicitCredentialTypes defines a more explicit enum for credential types as AzCopy's internal definition is very loose (e.g. Anonymous can be public or SAS); accepts the URI as-is.
 // ExplicitCredentialTypes is a set of bitflags indicating intended credential types for a test and available credential types for resources
 type ExplicitCredentialTypes uint8
@@ -275,9 +283,15 @@ type BlobFSProperties struct {
 }
 
 type FileProperties struct {
-	FileAttributes    *string
-	FileChangeTime    *time.Time
+	FileAttributes *string
+	// ChangeTime, though available on the Files service is not writeable locally, or queryable.
+	// We also just do not persist it, even on Files at the moment.
+	// Hence, we do not test ChangeTime.
 	FileCreationTime  *time.Time
 	FileLastWriteTime *time.Time
 	FilePermissions   *string
+}
+
+func (f FileProperties) hasCustomTimes() bool {
+	return f.FileCreationTime != nil || f.FileLastWriteTime != nil
 }

--- a/e2etest/newe2e_resource_manager_mock.go
+++ b/e2etest/newe2e_resource_manager_mock.go
@@ -209,7 +209,7 @@ func (m *MockContainerResourceManager) mockSignature() {
 }
 
 func (m *MockContainerResourceManager) Location() common.Location {
-	if m.overrideLocation != common.ELocation.Unknown() || m.parent != nil {
+	if m.overrideLocation != common.ELocation.Unknown() || m.parent == nil {
 		return m.overrideLocation
 	}
 
@@ -294,7 +294,7 @@ func (m *MockObjectResourceManager) mockSignature() {
 }
 
 func (m *MockObjectResourceManager) Location() common.Location {
-	if m.overrideLocation != common.ELocation.Unknown() || m.parent != nil {
+	if m.overrideLocation != common.ELocation.Unknown() || m.parent == nil {
 		return m.overrideLocation
 	}
 

--- a/e2etest/newe2e_resource_managers_blob.go
+++ b/e2etest/newe2e_resource_managers_blob.go
@@ -312,8 +312,8 @@ func (b *BlobContainerResourceManager) CreateWithOptions(a Asserter, options *Bl
 	}
 
 	a.NoError("create container", err)
-	if rt, ok := a.(ResourceTracker); ok && created {
-		rt.TrackCreatedResource(b)
+	if created {
+		TrackResourceCreation(a, b)
 	}
 }
 
@@ -577,9 +577,7 @@ func (b *BlobObjectResourceManager) CreateWithOptions(a Asserter, body ObjectCon
 		a.NoError("Upload append blob", msu.UploadContents(body))
 	}
 
-	if rt, ok := a.(ResourceTracker); ok {
-		rt.TrackCreatedResource(b)
-	}
+	TrackResourceCreation(a, b)
 }
 
 func (b *BlobObjectResourceManager) ListChildren(a Asserter, recursive bool) map[string]ObjectProperties {

--- a/e2etest/newe2e_resource_managers_blobfs.go
+++ b/e2etest/newe2e_resource_managers_blobfs.go
@@ -207,8 +207,8 @@ func (b *BlobFSFileSystemResourceManager) CreateWithOptions(a Asserter, opts *fi
 	}
 
 	a.NoError("Create filesystem", err)
-	if rt, ok := a.(ResourceTracker); ok && created {
-		rt.TrackCreatedResource(b)
+	if created {
+		TrackResourceCreation(a, b)
 	}
 }
 
@@ -375,9 +375,7 @@ func (b *BlobFSPathResourceProvider) Create(a Asserter, body ObjectContentContai
 		a.NoError("Set tier", err)
 	}
 
-	if rt, ok := a.(ResourceTracker); ok {
-		rt.TrackCreatedResource(b)
-	}
+	TrackResourceCreation(a, b)
 }
 
 func (b *BlobFSPathResourceProvider) Delete(a Asserter) {

--- a/e2etest/newe2e_resource_managers_file.go
+++ b/e2etest/newe2e_resource_managers_file.go
@@ -226,8 +226,8 @@ func (s *FileShareResourceManager) CreateWithOptions(a Asserter, options *FileSh
 	}
 
 	a.NoError("Create container", err)
-	if rt, ok := a.(ResourceTracker); ok && created {
-		rt.TrackCreatedResource(s)
+	if created {
+		TrackResourceCreation(a, s)
 	}
 }
 
@@ -284,7 +284,6 @@ func (s *FileShareResourceManager) ListObjects(a Asserter, targetDir string, rec
 					Metadata:   resp.Metadata,
 					FileProperties: FileProperties{
 						FileAttributes:    v.Attributes,
-						FileChangeTime:    v.Properties.ChangeTime,
 						FileCreationTime:  v.Properties.CreationTime,
 						FileLastWriteTime: v.Properties.LastWriteTime,
 						FilePermissions:   permissions,
@@ -320,7 +319,6 @@ func (s *FileShareResourceManager) ListObjects(a Asserter, targetDir string, rec
 					Metadata: resp.Metadata,
 					FileProperties: FileProperties{
 						FileAttributes:    v.Attributes,
-						FileChangeTime:    v.Properties.ChangeTime,
 						FileCreationTime:  v.Properties.CreationTime,
 						FileLastWriteTime: v.Properties.LastWriteTime,
 						FilePermissions:   permissions,
@@ -471,9 +469,7 @@ func (f *FileObjectResourceManager) Create(a Asserter, body ObjectContentContain
 		a.Error("File Objects only support Files and Folders")
 	}
 
-	if rt, ok := a.(ResourceTracker); ok {
-		rt.TrackCreatedResource(f)
-	}
+	TrackResourceCreation(a, f)
 }
 
 func (f *FileObjectResourceManager) Delete(a Asserter) {
@@ -519,7 +515,6 @@ func (f *FileObjectResourceManager) GetProperties(a Asserter) (out ObjectPropert
 			Metadata:   resp.Metadata,
 			FileProperties: FileProperties{
 				FileAttributes:    resp.FileAttributes,
-				FileChangeTime:    resp.FileChangeTime,
 				FileCreationTime:  resp.FileCreationTime,
 				FileLastWriteTime: resp.FileLastWriteTime,
 				FilePermissions:   permissions,
@@ -550,7 +545,6 @@ func (f *FileObjectResourceManager) GetProperties(a Asserter) (out ObjectPropert
 			Metadata: resp.Metadata,
 			FileProperties: FileProperties{
 				FileAttributes:    resp.FileAttributes,
-				FileChangeTime:    resp.FileChangeTime,
 				FileCreationTime:  resp.FileCreationTime,
 				FileLastWriteTime: resp.FileLastWriteTime,
 				FilePermissions:   permissions,

--- a/e2etest/newe2e_resource_managers_local.go
+++ b/e2etest/newe2e_resource_managers_local.go
@@ -138,6 +138,22 @@ type LocalObjectResourceManager struct {
 	rawPath    string
 }
 
+func (l *LocalObjectResourceManager) ContainerName() string {
+	if l.container != nil {
+		return filepath.Base(l.container.RootPath)
+	}
+
+	return "containerless"
+}
+
+func (l *LocalObjectResourceManager) ObjectName() string {
+	if l.objectPath != "" {
+		return l.objectPath
+	} else {
+		return filepath.Base(l.rawPath)
+	}
+}
+
 type localSMBPropertiesManager interface {
 	GetSDDL(Asserter) string
 	PutSDDL(sddlstr string, a Asserter)

--- a/e2etest/newe2e_resource_managers_local.go
+++ b/e2etest/newe2e_resource_managers_local.go
@@ -67,7 +67,7 @@ func (l *LocalContainerResourceManager) Account() AccountResourceManager {
 }
 
 func (l *LocalContainerResourceManager) Canon() string {
-	return fmt.Sprintf("acountless/local/%s", l.ContainerName())
+	return fmt.Sprintf("accountless/local/%s", l.ContainerName())
 }
 
 func (l *LocalContainerResourceManager) ContainerName() string {
@@ -213,7 +213,11 @@ func (l *LocalObjectResourceManager) Account() AccountResourceManager {
 }
 
 func (l *LocalObjectResourceManager) Canon() string {
-	return l.container.Canon() + "/" + l.objectPath
+	if l.container != nil {
+		return l.container.Canon() + "/" + l.objectPath
+	} else {
+		return fmt.Sprintf("accountless/local/containerless/%s", l.rawPath)
+	}
 }
 
 func (l *LocalObjectResourceManager) EntityType() common.EntityType {

--- a/e2etest/newe2e_resource_managers_local.go
+++ b/e2etest/newe2e_resource_managers_local.go
@@ -1,0 +1,328 @@
+package e2etest
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/Azure/azure-storage-azcopy/v10/cmd"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
+	"github.com/google/uuid"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"time"
+)
+
+// enforce interface compliance at compile time
+func init() {
+	void := func(_ ...any) {}
+
+	void(
+		ContainerResourceManager(&LocalContainerResourceManager{}),
+		ObjectResourceManager(&LocalObjectResourceManager{}),
+	)
+}
+
+func NewLocalContainer(a Asserter) ContainerResourceManager {
+	if d, ok := a.(DryrunAsserter); ok && d.Dryrun() {
+		return &MockContainerResourceManager{
+			containerName:    "mockContainer",
+			overrideLocation: common.ELocation.Local(),
+		}
+	}
+
+	tmp := os.TempDir()
+	dirName := uuid.NewString()
+
+	return &LocalContainerResourceManager{
+		RootPath: filepath.Join(tmp, dirName),
+	}
+}
+
+// LocalContainerResourceManager is effectively just the root temp folder for a transfer.
+type LocalContainerResourceManager struct {
+	RootPath string
+}
+
+func (l *LocalContainerResourceManager) Location() common.Location {
+	return common.ELocation.Local()
+}
+
+func (l *LocalContainerResourceManager) Level() cmd.LocationLevel {
+	return cmd.ELocationLevel.Container()
+}
+
+func (l *LocalContainerResourceManager) URI(opts ...GetURIOptions) string {
+	return l.RootPath
+}
+
+func (l *LocalContainerResourceManager) Parent() ResourceManager {
+	return nil
+}
+
+func (l *LocalContainerResourceManager) Account() AccountResourceManager {
+	return nil
+}
+
+func (l *LocalContainerResourceManager) Canon() string {
+	return fmt.Sprintf("acountless/local/%s", l.ContainerName())
+}
+
+func (l *LocalContainerResourceManager) ContainerName() string {
+	return filepath.Base(l.RootPath)
+}
+
+func (l *LocalContainerResourceManager) Create(a Asserter, props ContainerProperties) {
+	err := os.Mkdir(l.RootPath, 0777)
+	if !os.IsExist(err) {
+		a.NoError("Create local root directory", err)
+	}
+
+	TrackResourceCreation(a, l)
+}
+
+func (l *LocalContainerResourceManager) GetProperties(a Asserter) ContainerProperties {
+	return ContainerProperties{}
+}
+
+func (l *LocalContainerResourceManager) Delete(a Asserter) {
+	time.Sleep(time.Second)
+
+	err := os.RemoveAll(l.RootPath)
+	if !os.IsNotExist(err) {
+		a.NoError("Delete local root directory", err)
+	}
+}
+
+func (l *LocalContainerResourceManager) ListObjects(a Asserter, prefixOrDirectory string, recursive bool) map[string]ObjectProperties {
+	out := make(map[string]ObjectProperties)
+
+	root := l.GetObject(a, prefixOrDirectory, common.EEntityType.Folder()).(*LocalObjectResourceManager)
+
+	err := filepath.WalkDir(l.RootPath, func(path string, d fs.DirEntry, err error) error {
+		relPath, err := root.getRelPath(path)
+		if err != nil {
+			return err
+		}
+
+		out[relPath] = root.getChildObject(relPath, common.Iff(d.IsDir(), common.EEntityType.Folder(), common.EEntityType.File())).GetProperties(a)
+
+		return common.Iff(d.IsDir() && !recursive, filepath.SkipDir, nil)
+	})
+	a.NoError("failed to walk", err)
+
+	return out
+}
+
+func (l *LocalContainerResourceManager) GetObject(a Asserter, path string, eType common.EntityType) ObjectResourceManager {
+	return &LocalObjectResourceManager{
+		container:  l,
+		entityType: eType,
+		objectPath: path,
+	}
+}
+
+func (l *LocalContainerResourceManager) Exists() bool {
+	_, err := os.Stat(l.RootPath)
+	return err == nil
+}
+
+type LocalObjectResourceManager struct {
+	container  *LocalContainerResourceManager
+	entityType common.EntityType
+
+	// objectPath and rawPath are mutually exclusive fields.
+	objectPath string
+	rawPath    string
+}
+
+type localSMBPropertiesManager interface {
+	GetSDDL(Asserter) string
+	PutSDDL(sddlstr string, a Asserter)
+	GetSMBProperties(Asserter) ste.TypedSMBPropertyHolder
+	PutSMBProperties(Asserter, ste.TypedSMBPropertyHolder)
+}
+
+func (l *LocalObjectResourceManager) getChildObject(relPath string, entityType common.EntityType) *LocalObjectResourceManager {
+	if l.objectPath != "" { // We have a "container", this is relative
+		newPath := filepath.Join(l.objectPath, relPath)
+
+		return &LocalObjectResourceManager{
+			container:  l.container,
+			entityType: entityType,
+			objectPath: newPath,
+		}
+	} else {
+		newPath := filepath.Join(l.rawPath, relPath)
+
+		return &LocalObjectResourceManager{
+			entityType: entityType,
+			rawPath:    newPath,
+		}
+	}
+}
+
+func (l *LocalObjectResourceManager) getWorkingPath() string {
+	if l.objectPath != "" && l.rawPath != "" {
+		panic("objectPath and rawPath are mutually exclusive fields, and should never be filled at the same time.")
+	}
+
+	if l.rawPath != "" {
+		return l.rawPath
+	}
+
+	if l.container == nil {
+		panic("objectPath (relative) must have a container as a parent.")
+	}
+
+	// l.objectPath can be "", indicating it is the folder at the root of the container.
+	return path.Join(l.container.RootPath, l.objectPath)
+}
+
+func (l *LocalObjectResourceManager) getRelPath(fullPath string) (string, error) {
+	rootPath := ""
+	if l.objectPath != "" {
+		rootPath = filepath.Join(l.container.RootPath, l.objectPath)
+	} else {
+		rootPath = l.rawPath
+	}
+
+	return filepath.Rel(rootPath, fullPath)
+}
+
+func (l *LocalObjectResourceManager) Location() common.Location {
+	return common.ELocation.Local()
+}
+
+func (l *LocalObjectResourceManager) Level() cmd.LocationLevel {
+	return cmd.ELocationLevel.Object()
+}
+
+func (l *LocalObjectResourceManager) URI(opts ...GetURIOptions) string {
+	return filepath.Join(l.container.RootPath, l.objectPath)
+}
+
+func (l *LocalObjectResourceManager) Parent() ResourceManager {
+	return l.container
+}
+
+func (l *LocalObjectResourceManager) Account() AccountResourceManager {
+	return nil
+}
+
+func (l *LocalObjectResourceManager) Canon() string {
+	return l.container.Canon() + "/" + l.objectPath
+}
+
+func (l *LocalObjectResourceManager) EntityType() common.EntityType {
+	return l.entityType
+}
+
+func (l *LocalObjectResourceManager) Create(a Asserter, body ObjectContentContainer, properties ObjectProperties) {
+	a.AssertNow("Object must be file to have content", Equal{})
+
+	f, err := os.OpenFile(l.getWorkingPath(), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0774)
+	a.NoError("Open file", err)
+	defer func(f *os.File) {
+		err := f.Close()
+		a.NoError("Close file", err)
+	}(f)
+
+	_, err = io.Copy(f, body.Reader())
+	a.NoError("Write file", err)
+
+	l.SetObjectProperties(a, properties)
+
+	TrackResourceCreation(a, l)
+}
+
+func (l *LocalObjectResourceManager) Delete(a Asserter) {
+	err := os.RemoveAll(l.getWorkingPath())
+	if !os.IsNotExist(err) {
+		a.NoError("Could not remove local object "+l.getWorkingPath(), err)
+	}
+}
+
+func (l *LocalObjectResourceManager) ListChildren(a Asserter, recursive bool) map[string]ObjectProperties {
+	a.AssertNow("Entity type must be folder to have children", Equal{}, l.entityType, common.EEntityType.Folder())
+	out := make(map[string]ObjectProperties)
+
+	err := filepath.WalkDir(l.getWorkingPath(), func(path string, d fs.DirEntry, err error) error {
+		relPath, err := l.getRelPath(path)
+		if err != nil {
+			return err
+		}
+
+		out[relPath] = l.getChildObject(relPath, common.Iff(d.IsDir(), common.EEntityType.Folder(), common.EEntityType.File())).GetProperties(a)
+
+		return common.Iff(d.IsDir() && !recursive, filepath.SkipDir, nil)
+	})
+	a.NoError("failed to walk", err)
+
+	return out
+}
+
+func (l *LocalObjectResourceManager) GetProperties(a Asserter) ObjectProperties {
+	out := ObjectProperties{}
+
+	// OS-triggered code, implemented in newe2e_resource_managers_local_windows.go
+	if smb, ok := any(l).(localSMBPropertiesManager); ok {
+		props := smb.GetSMBProperties(a)
+
+		attr, err := props.FileAttributes()
+		a.NoError("get attributes", err)
+
+		perms := smb.GetSDDL(a)
+
+		out.FileProperties = FileProperties{
+			FileAttributes:    PtrOf(attr.String()),
+			FileCreationTime:  PtrOf(props.FileCreationTime()),
+			FileLastWriteTime: PtrOf(props.FileLastWriteTime()),
+			FilePermissions:   common.Iff(perms == "", nil, &perms),
+		}
+	}
+
+	return out
+}
+
+func (l *LocalObjectResourceManager) SetHTTPHeaders(a Asserter, h contentHeaders) {
+	// no-op on local
+}
+
+func (l *LocalObjectResourceManager) SetMetadata(a Asserter, metadata common.Metadata) {
+	// no-op on local
+	// todo: we could worry about xAttr on Linux, etc. but we don't officially support any of that outside of specific features (e.g. hash based sync)
+}
+
+func (l *LocalObjectResourceManager) SetObjectProperties(a Asserter, props ObjectProperties) {
+	// todo: set SMB properties
+	if smb, ok := any(l).(localSMBPropertiesManager); ok {
+		if props.FileProperties.FilePermissions != nil {
+			smb.PutSDDL(*props.FileProperties.FilePermissions, a)
+		}
+	}
+}
+
+func (l *LocalObjectResourceManager) Download(a Asserter) io.ReadSeeker {
+	a.AssertNow("Entity type must be file to have content to download", Equal{}, l.entityType, common.EEntityType.File())
+
+	f, err := os.Open(l.getWorkingPath())
+	a.NoError("open file", err)
+	defer func(f *os.File) {
+		err = f.Close()
+		a.NoError("Close file", err)
+	}(f)
+
+	buf := &bytes.Buffer{}
+	_, err = io.Copy(buf, f)
+	a.NoError("read file", err)
+
+	return bytes.NewReader(buf.Bytes())
+}
+
+func (l *LocalObjectResourceManager) Exists() bool {
+	_, err := os.Stat(l.getWorkingPath())
+	return err == nil
+}

--- a/e2etest/newe2e_resource_managers_local_windows.go
+++ b/e2etest/newe2e_resource_managers_local_windows.go
@@ -1,0 +1,199 @@
+//go:build windows
+
+package e2etest
+
+import (
+	"fmt"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/sddl"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
+	"github.com/hillu/go-ntdll"
+	"golang.org/x/sys/windows"
+	"strings"
+	"sync"
+	"syscall"
+	"unsafe"
+)
+
+// getHandle obtains a windows file handle with generic read permissions & backup semantics
+func (l LocalObjectResourceManager) getHandle(path string, a Asserter) ntdll.Handle {
+	srcPtr, err := syscall.UTF16PtrFromString(path)
+	a.NoError("Get UTF16 pointer", err)
+
+	// custom open call, because must specify FILE_FLAG_BACKUP_SEMANTICS to make --backup mode work properly (i.e. our use of SeBackupPrivilege)
+	fd, err := windows.CreateFile(srcPtr,
+		windows.GENERIC_READ, windows.FILE_SHARE_READ, nil,
+		windows.OPEN_EXISTING, windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
+	a.NoError("Get file descriptor", err)
+
+	return ntdll.Handle(fd)
+}
+
+func (l LocalObjectResourceManager) GetSDDL(a Asserter) string {
+	filePath := l.getWorkingPath()
+	fd := l.getHandle(filePath, a)
+
+	buf := make([]byte, 512)
+	bufLen := uint32(len(buf))
+	needValidate := false
+	status := ntdll.CallWithExpandingBuffer(func() ntdll.NtStatus {
+		status := ntdll.NtQuerySecurityObject(
+			fd,
+			windows.OWNER_SECURITY_INFORMATION|windows.GROUP_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION,
+			(*ntdll.SecurityDescriptor)(unsafe.Pointer(&buf[0])),
+			uint32(len(buf)),
+			&bufLen)
+
+		if status == ntdll.STATUS_SUCCESS {
+			sd := (*windows.SECURITY_DESCRIPTOR)(unsafe.Pointer(&buf[0]))
+
+			bufLen = sd.Length()
+			needValidate = true
+		}
+
+		return status
+	}, &buf, &bufLen)
+
+	if status != ntdll.STATUS_SUCCESS {
+		a.Error(fmt.Sprintf("failed to query security object %s (ntstatus: %s)", filePath, status.String()))
+	}
+
+	sd := (*windows.SECURITY_DESCRIPTOR)(unsafe.Pointer(&buf[0])) // ntdll.SecurityDescriptor is equivalent
+	if needValidate && !sd.IsValid() {
+		a.Error(fmt.Sprintf("failed to query security object %s (invalid descriptor returned with a successful status)", filePath))
+	}
+
+	fSDDL, err := sddl.ParseSDDL(sd.String())
+	if err != nil {
+		a.NoError(fmt.Sprintf("failed to parse SDDL for security object %s", filePath), err)
+	}
+
+	a.AssertNow("SDDL sanity check", Equal{}, fSDDL.String(), sd.String())
+
+	return fSDDL.PortableString()
+}
+
+func (l LocalObjectResourceManager) GetSMBProperties(a Asserter) ste.TypedSMBPropertyHolder {
+	info, err := common.GetFileInformation(l.getWorkingPath())
+	a.NoError("get file SMB props", err)
+
+	return ste.HandleInfo{ByHandleFileInformation: info}
+}
+
+func (l LocalObjectResourceManager) PutSMBProperties(a Asserter, properties FileProperties) {
+	filePath := l.getWorkingPath()
+	pathPtr, err := syscall.UTF16PtrFromString(filePath)
+	a.NoError("get UTF16 pointer for path", err)
+
+	if properties.FileAttributes != nil {
+		attr, err := ParseNTFSAttributes(*properties.FileAttributes)
+		a.NoError("Parse attributes", err)
+
+		err = windows.SetFileAttributes(pathPtr, uint32(attr))
+		a.NoError("Set file attributes", err)
+	}
+
+	if properties.hasCustomTimes() {
+		var sa windows.SecurityAttributes
+		sa.Length = uint32(unsafe.Sizeof(sa))
+		sa.InheritHandle = 1
+
+		var creation, lastWrite *windows.Filetime
+
+		if properties.FileCreationTime != nil {
+			c := windows.NsecToFiletime(properties.FileCreationTime.UnixNano())
+			creation = &c
+		}
+
+		if properties.FileLastWriteTime != nil {
+			lmt := windows.NsecToFiletime(properties.FileLastWriteTime.UnixNano())
+			lastWrite = &lmt
+		}
+
+		// need custom CreateFile call because need FILE_WRITE_ATTRIBUTES
+		fd, err := windows.CreateFile(pathPtr,
+			windows.FILE_WRITE_ATTRIBUTES, windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE, &sa,
+			windows.OPEN_EXISTING, windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
+		a.NoError(fmt.Sprintf("Get file descriptor %s", filePath), err)
+		defer a.NoError("close handle", windows.Close(fd))
+
+		err = windows.SetFileTime(fd, creation, nil, lastWrite)
+		a.NoError("Set file times", err)
+	}
+}
+
+// These syscalls are unfortunately, thread-sensitive.
+var globalSetAclMu = &sync.Mutex{}
+
+// PutSDDL sets SDDLs like AzCopy does for downloads
+func (l LocalObjectResourceManager) PutSDDL(sddlstr string, a Asserter) {
+	filePath := l.getWorkingPath()
+
+	sd, err := windows.SecurityDescriptorFromString(sddlstr)
+	a.NoError("parse security descriptor", err)
+
+	parsed, err := sddl.ParseSDDL(sddlstr)
+	a.NoError("parse security descriptor (internal lib)", err)
+
+	ctl, _, err := sd.Control()
+	a.NoError("Get control bits", err)
+
+	var securityInfoFlags windows.SECURITY_INFORMATION = windows.DACL_SECURITY_INFORMATION
+
+	parsedSDDL, err := sddl.ParseSDDL(sddlstr)
+
+	isProtectedAtSource := (ctl & windows.SE_DACL_PROTECTED) != 0
+	// treat rawpath like it's always the root
+	isAtTransferRoot := l.rawPath != "" || l.objectPath == ""
+
+	/*
+		via Jason Shay:
+		One exception is related to the "AI" flag.
+		If you provide a descriptor to NtSetSecurityObject with just AI (SE_DACL_AUTO_INHERITED), it will not be stored.
+		If you provide it with SE_DACL_AUTO_INHERITED AND SE_DACL_AUTO_INHERIT_REQ, then SE_DACL_AUTO_INHERITED will be stored (note the _REQ flag is never stored)
+
+		The REST API for Azure Files will see the "AI" in the SDDL, and will do the _REQ flag work in the background for you.
+	*/
+	if strings.Contains(parsedSDDL.DACL.Flags, "AI") {
+		// set the DACL auto-inherit flag, since Windows didn't pick it up for some reason...
+		err := sd.SetControl(windows.SE_DACL_AUTO_INHERITED|windows.SE_DACL_AUTO_INHERIT_REQ, windows.SE_DACL_AUTO_INHERITED|windows.SE_DACL_AUTO_INHERIT_REQ)
+		a.NoError("tried to persist auto-inherit bit", err)
+	}
+
+	// Protect the root so that we don't have parent ACLs affect the rest of the transfer
+	if isProtectedAtSource || isAtTransferRoot {
+		securityInfoFlags |= windows.PROTECTED_DACL_SECURITY_INFORMATION
+	}
+
+	if parsed.GroupSID != "" {
+		securityInfoFlags |= windows.GROUP_SECURITY_INFORMATION
+	}
+
+	if parsed.OwnerSID != "" {
+		securityInfoFlags |= windows.OWNER_SECURITY_INFORMATION
+	}
+
+	globalSetAclMu.Lock()
+	defer globalSetAclMu.Unlock()
+
+	destPtr, err := syscall.UTF16PtrFromString(filePath)
+	a.NoError("Get UTF16 ptr", err)
+
+	var sa windows.SecurityAttributes
+	sa.Length = uint32(unsafe.Sizeof(sa))
+	sa.InheritHandle = 1
+
+	// need WRITE_DAC and WRITE_OWNER for SDDL preservation, no need for ACCESS_SYSTEM_SECURITY, since we don't back up SACLs.
+	fd, err := windows.CreateFile(destPtr, windows.FILE_GENERIC_WRITE|windows.WRITE_DAC|windows.WRITE_OWNER, windows.FILE_SHARE_WRITE, &sa,
+		windows.OPEN_EXISTING, windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
+	a.NoError("Open file descriptor", err)
+	defer a.NoError("Close file descriptor", windows.Close(fd))
+
+	status := ntdll.NtSetSecurityObject(
+		ntdll.Handle(fd),
+		ntdll.SecurityInformationT(securityInfoFlags),
+		// unsafe but actually safe conversion
+		(*ntdll.SecurityDescriptor)(unsafe.Pointer(sd)),
+	)
+	a.Assert("Set ACLs status must be successful", Equal{}, status, ntdll.STATUS_SUCCESS)
+}

--- a/e2etest/zt_newe2e_basic_functionality_test.go
+++ b/e2etest/zt_newe2e_basic_functionality_test.go
@@ -1,0 +1,66 @@
+package e2etest
+
+import (
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"time"
+)
+
+func init() {
+	suiteManager.RegisterSuite(&BasicFunctionalitySuite{})
+}
+
+type BasicFunctionalitySuite struct{}
+
+func (s *BasicFunctionalitySuite) Scenario_SingleFileUploadDownload(svm *ScenarioVariationManager) {
+	azCopyVerb := ResolveVariation(svm, []AzCopyVerb{AzCopyVerbCopy, AzCopyVerbSync}) // Calculate verb early to create the destination object early
+	// Scale up from service to object
+	dstObj := CreateResource[ContainerResourceManager](svm, GetRootResource(svm, ResolveVariation(svm, []common.Location{common.ELocation.Local(), common.ELocation.Blob()})), ResourceDefinitionContainer{}).GetObject(svm, "test", common.EEntityType.File())
+	// The object must exist already if we're syncing.
+	if azCopyVerb == AzCopyVerbSync {
+		dstObj.Create(svm, NewZeroObjectContentContainer(0), ObjectProperties{})
+
+		if !svm.Dryrun() {
+			// Make sure the LMT is in the past
+			time.Sleep(time.Second)
+		}
+	}
+
+	body := NewRandomObjectContentContainer(svm, SizeFromString("10K"))
+	// Scale up from service to object
+	srcObj := CreateResource[ObjectResourceManager](svm, GetRootResource(svm, ResolveVariation(svm, []common.Location{common.ELocation.Local(), common.ELocation.Blob()})), ResourceDefinitionObject{
+		ObjectName: pointerTo("test"),
+		Body:       body,
+	})
+
+	// no s2s, no local->local
+	if srcObj.Location().IsRemote() == dstObj.Location().IsRemote() {
+		svm.InvalidateScenario()
+		return
+	}
+
+	sasOpts := GenericAccountSignatureValues{}
+
+	RunAzCopy(
+		svm,
+		AzCopyCommand{
+			// Sync is not included at this moment, because sync requires
+			Verb: azCopyVerb,
+			Targets: []ResourceManager{
+				TryApplySpecificAuthType(srcObj, EExplicitCredentialType.SASToken(), svm, CreateAzCopyTargetOptions{
+					SASTokenOptions: sasOpts,
+				}),
+				TryApplySpecificAuthType(dstObj, EExplicitCredentialType.SASToken(), svm, CreateAzCopyTargetOptions{
+					SASTokenOptions: sasOpts,
+				}),
+			},
+			Flags: CopyFlags{
+				CopySyncCommonFlags: CopySyncCommonFlags{
+					Recursive: pointerTo(true),
+				},
+			},
+		})
+
+	ValidateResource[ObjectResourceManager](svm, dstObj, ResourceDefinitionObject{
+		Body: body,
+	}, true)
+}

--- a/e2etest/zt_newe2e_example_test.go
+++ b/e2etest/zt_newe2e_example_test.go
@@ -1,12 +1,12 @@
 package e2etest
 
 import (
-	blobsas "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 func init() {
-	suiteManager.RegisterSuite(&ExampleSuite{})
+	// Deregistered the example suite so test doesn't run, re-enable for local test writing/usage of example
+	//suiteManager.RegisterSuite(&ExampleSuite{})
 }
 
 type ExampleSuite struct{}
@@ -21,43 +21,36 @@ func (s *ExampleSuite) TeardownSuite(a Asserter) {
 }
 
 func (s *ExampleSuite) Scenario_SingleFileCopySyncS2S(svm *ScenarioVariationManager) {
-	acct := GetAccount(svm, PrimaryStandardAcct)
-	srcService := acct.GetService(svm, ResolveVariation(svm, []common.Location{common.ELocation.Blob()}))
-	//svm.InsertVariationSeparator("->")
-	dstService := acct.GetService(svm, ResolveVariation(svm, []common.Location{common.ELocation.Blob()}))
-
 	svm.InsertVariationSeparator(":")
 	body := NewRandomObjectContentContainer(svm, SizeFromString("10K"))
 	// Scale up from service to object
-	srcObj := CreateResource[ObjectResourceManager](svm, srcService, ResourceDefinitionObject{
+	srcObj := CreateResource[ObjectResourceManager](svm, GetRootResource(svm, ResolveVariation(svm, []common.Location{common.ELocation.Local(), common.ELocation.Blob()})), ResourceDefinitionObject{
 		ObjectName: pointerTo("test"),
 		Body:       body,
 	}) // todo: generic CreateResource is something to pursue in another branch, but it's an interesting thought.
 	// Scale up from service to container
-	dstObj := CreateResource[ContainerResourceManager](svm, dstService, ResourceDefinitionContainer{})
+	dstContainer := CreateResource[ContainerResourceManager](svm, GetRootResource(svm, ResolveVariation(svm, []common.Location{common.ELocation.Local(), common.ELocation.Blob()})), ResourceDefinitionContainer{})
+
+	if srcObj.Location().IsRemote() == dstContainer.Location().IsRemote() {
+		svm.InvalidateScenario()
+	}
 
 	RunAzCopy(
 		svm,
 		AzCopyCommand{
 			Verb: ResolveVariation(svm, []AzCopyVerb{AzCopyVerbCopy}),
 			Targets: []ResourceManager{
-				srcObj.Parent().(RemoteResourceManager).WithSpecificAuthType(EExplicitCredentialType.SASToken(), svm, CreateAzCopyTargetOptions{
-					SASTokenOptions: GenericServiceSignatureValues{
-						Permissions: (&blobsas.BlobPermissions{Read: true, List: true}).String(),
-					},
-				}),
-				dstObj,
+				srcObj,
+				dstContainer,
 			},
 			Flags: CopyFlags{
 				CopySyncCommonFlags: CopySyncCommonFlags{
 					Recursive: pointerTo(true),
 				},
-
-				ListOfFiles: []string{"test"},
 			},
 		})
 
-	ValidateResource[ObjectResourceManager](svm, srcObj, ResourceDefinitionObject{
+	ValidateResource[ObjectResourceManager](svm, dstContainer.GetObject(svm, "test", common.EEntityType.File()), ResourceDefinitionObject{
 		Body: body,
 	}, true)
 }

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,8 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.9.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.4.0
 	github.com/Azure/go-autorest/autorest/date v0.3.0
+	golang.org/x/exp v0.0.0-20240213143201-ec583247a57a
+	golang.org/x/net v0.17.0
 )
 
 require (
@@ -64,7 +66,6 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -161,6 +161,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
 golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20240213143201-ec583247a57a h1:HinSgX1tJRX3KsL//Gxynpw5CTOAIPhgL4W8PNiIpVE=
+golang.org/x/exp v0.0.0-20240213143201-ec583247a57a/go.mod h1:CxmFvTBINI24O/j8iY7H1xHzx2i4OsyguNBmN/uPtqc=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=


### PR DESCRIPTION
A couple of things exist in this PR.

The primary one is that the New E2E framework now has a Local resource manager, a simple upload/download test, and sorts out some of the teething issues with grabbing a root resource in tests (since Local has no concept of an account)

In addition, there are a few bugfixes (for the e2e framework) around. Namely,
- CreateAzCopyTarget can now be called on any sort of ResourceManager, not just a RemoteResourceManager
- Flags structs that were zero-equivalents now have defaults filled in correctly
- Mock resource managers now correctly present their intended location/service type