### PR TITLE
Fix AzCLI in tests/Make Autologin mode ephemeral in tests

### DIFF
--- a/cmd/credentialUtil.go
+++ b/cmd/credentialUtil.go
@@ -89,14 +89,9 @@ func GetOAuthTokenManagerInstance() (*common.UserOAuthTokenManager, error) {
 	var err error
 	autoOAuth.Do(func() {
 		var lca loginCmdArgs
-		autoLoginType := strings.ToUpper(glcm.GetEnvironmentVariable(common.EEnvironmentVariable.AutoLoginType()))
+		autoLoginType := strings.ToLower(glcm.GetEnvironmentVariable(common.EEnvironmentVariable.AutoLoginType()))
 		if autoLoginType == "" {
 			glcm.Info("Autologin not specified.")
-			return
-		}
-
-		if autoLoginType != "SPN" && autoLoginType != "MSI" && autoLoginType != "DEVICE" && autoLoginType != "AZCLI" && autoLoginType != "PSCRED" {
-			glcm.Error("Invalid Auto-login type specified.")
 			return
 		}
 
@@ -110,33 +105,37 @@ func GetOAuthTokenManagerInstance() (*common.UserOAuthTokenManager, error) {
 
 		// Fill up lca
 		switch autoLoginType {
-		case "SPN":
+		case common.AutologinTypeSPN:
 			lca.applicationID = glcm.GetEnvironmentVariable(common.EEnvironmentVariable.ApplicationID())
 			lca.certPath = glcm.GetEnvironmentVariable(common.EEnvironmentVariable.CertificatePath())
 			lca.certPass = glcm.GetEnvironmentVariable(common.EEnvironmentVariable.CertificatePassword())
 			lca.clientSecret = glcm.GetEnvironmentVariable(common.EEnvironmentVariable.ClientSecret())
 			lca.servicePrincipal = true
 
-		case "MSI":
+		case common.AutologinTypeMSI:
 			lca.identityClientID = glcm.GetEnvironmentVariable(common.EEnvironmentVariable.ManagedIdentityClientID())
 			lca.identityObjectID = glcm.GetEnvironmentVariable(common.EEnvironmentVariable.ManagedIdentityObjectID())
 			lca.identityResourceID = glcm.GetEnvironmentVariable(common.EEnvironmentVariable.ManagedIdentityResourceString())
 			lca.identity = true
 
-		case "DEVICE":
+		case common.AutologinTypeDevice:
 			lca.identity = false
 
-		case "AZCLI":
+		case common.AutologinTypeAzCLI:
 			lca.identity = false
 			lca.servicePrincipal = false
 			lca.psCred = false
 			lca.azCliCred = true
 
-		case "PSCRED":
+		case common.AutologinTypePsCred:
 			lca.identity = false
 			lca.servicePrincipal = false
 			lca.azCliCred = false
 			lca.psCred = true
+
+		default:
+			glcm.Error("Invalid Auto-login type specified: " + autoLoginType)
+			return
 		}
 
 		lca.persistToken = false

--- a/common/environment.go
+++ b/common/environment.go
@@ -82,6 +82,14 @@ func (EnvironmentVariable) UserDir() EnvironmentVariable {
 	}
 }
 
+const (
+	AutologinTypeSPN    = "spn"
+	AutologinTypeMSI    = "msi"
+	AutologinTypeDevice = "device"
+	AutologinTypeAzCLI  = "azcli"
+	AutologinTypePsCred = "pscred"
+)
+
 func (EnvironmentVariable) AutoLoginType() EnvironmentVariable {
 	return EnvironmentVariable{
 		Name:        "AZCOPY_AUTO_LOGIN_TYPE",

--- a/e2etest/declarativeHelpers.go
+++ b/e2etest/declarativeHelpers.go
@@ -193,6 +193,9 @@ type params struct {
 		INFO: source:  dest: /New Text Document.txt
 	*/
 
+	// OAuth params, "SPN" (default), "AZCLI", and "PSCRED" are currently supported
+	AutoLoginType string
+
 	// cancel params
 	ignoreErrorIfCompleted bool
 

--- a/e2etest/declarativeScenario.go
+++ b/e2etest/declarativeScenario.go
@@ -329,7 +329,8 @@ func (s *scenario) runAzCopy(logDirectory string) {
 		s.operation,
 		s.state.source.getParam(s.a, s.stripTopDir, needsSAS(s.credTypes[0]), tf.objectTarget),
 		s.state.dest.getParam(s.a, false, needsSAS(s.credTypes[1]), destObjTarget),
-		s.credTypes[0] == common.ECredentialType.OAuthToken() || s.credTypes[1] == common.ECredentialType.OAuthToken(), // needsOAuth
+		s.credTypes[0].IsAzureOAuth() || s.credTypes[1].IsAzureOAuth(), // needsOAuth
+		s.p.AutoLoginType,
 		needsFromTo,
 		s.fromTo,
 		afterStart, s.chToStdin, logDirectory)
@@ -361,6 +362,7 @@ func (s *scenario) cancelAzCopy(logDir string) {
 		s.state.result.jobID.String(),
 		"",
 		false,
+		"",
 		false,
 		s.fromTo,
 		afterStart,
@@ -403,7 +405,8 @@ func (s *scenario) resumeAzCopy(logDir string) {
 		eOperation.Resume(),
 		s.state.result.jobID.String(),
 		"",
-		false,
+		s.credTypes[0].IsAzureOAuth() || s.credTypes[1].IsAzureOAuth(),
+		s.p.AutoLoginType,
 		false,
 		s.fromTo,
 		afterStart,

--- a/e2etest/runner.go
+++ b/e2etest/runner.go
@@ -23,6 +23,7 @@ package e2etest
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -256,7 +257,7 @@ func (t *TestRunner) execDebuggableWithOutput(name string, args []string, env []
 	return stdout.Bytes(), runErr
 }
 
-func (t *TestRunner) ExecuteAzCopyCommand(operation Operation, src, dst string, needsOAuth bool, needsFromTo bool, fromTo common.FromTo, afterStart func() string, chToStdin <-chan string, logDir string) (CopyOrSyncCommandResult, bool, error) {
+func (t *TestRunner) ExecuteAzCopyCommand(operation Operation, src, dst string, needsOAuth bool, oauthMode string, needsFromTo bool, fromTo common.FromTo, afterStart func() string, chToStdin <-chan string, logDir string) (CopyOrSyncCommandResult, bool, error) {
 	capLen := func(b []byte) []byte {
 		if len(b) < 1024 {
 			return b
@@ -297,18 +298,66 @@ func (t *TestRunner) ExecuteAzCopyCommand(operation Operation, src, dst string, 
 	env := make([]string, len(os.Environ()))
 	copy(env, os.Environ())
 
-	// paste in OAuth environment variables if not specified
-	if needsOAuth && os.Getenv("AZCOPY_AUTO_LOGIN_TYPE") == "" {
+	if needsOAuth {
 		tenId, appId, clientSecret := GlobalInputManager{}.GetServicePrincipalAuth()
 
-		env = append(env,
-			"AZCOPY_AUTO_LOGIN_TYPE=SPN",
-			"AZCOPY_SPA_APPLICATION_ID="+appId,
-			"AZCOPY_SPA_CLIENT_SECRET="+clientSecret,
-		)
+		switch strings.ToLower(oauthMode) {
+		case "", common.AutologinTypeSPN:
+			env = append(env,
+				"AZCOPY_AUTO_LOGIN_TYPE="+common.Iff(oauthMode == "", common.AutologinTypeSPN, oauthMode),
+				"AZCOPY_SPA_APPLICATION_ID="+appId,
+				"AZCOPY_SPA_CLIENT_SECRET="+clientSecret,
+			)
 
-		if tenId != "" {
-			env = append(env, "AZCOPY_TENANT_ID="+tenId)
+			if tenId != "" {
+				env = append(env, "AZCOPY_TENANT_ID="+tenId)
+			}
+		case common.AutologinTypeAzCLI:
+			args := []string{
+				"login",
+				"--service-principal",
+				"-u=" + appId,
+				"-p=" + clientSecret,
+			}
+			if tenId != "" {
+				args = append(args, "--tenant="+tenId)
+				env = append(env, "AZCOPY_TENANT_ID="+tenId)
+			}
+
+			out, err := exec.Command("az", args...).Output()
+			if err != nil {
+				e, ok := err.(*exec.ExitError)
+				if ok {
+					return CopyOrSyncCommandResult{}, false, fmt.Errorf("%s\n%s\nfailed to login with AzCli: %s", e.Stderr, out, err.Error())
+				} else {
+					return CopyOrSyncCommandResult{}, false, fmt.Errorf("failed to login with AzCli: %s", err.Error())
+				}
+			}
+
+			env = append(env, "AZCOPY_AUTO_LOGIN_TYPE="+oauthMode)
+		case "pscred":
+			tenId, appId, clientSecret := GlobalInputManager{}.GetServicePrincipalAuth()
+			cmd := `$secret = ConvertTo-SecureString -String %s -AsPlainText -Force;
+				$cred = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList %s, $secret;
+				Connect-AzAccount -ServicePrincipal -Credential $cred`
+			if tenId != "" {
+				cmd += " -Tenant " + tenId
+			}
+
+			script := fmt.Sprintf(cmd, clientSecret, appId)
+			out, err := exec.Command("pwsh", "-Command", script).Output()
+			if err != nil {
+				e := err.(*exec.ExitError)
+				e, ok := err.(*exec.ExitError)
+				if ok {
+					return CopyOrSyncCommandResult{}, false, fmt.Errorf("%s\n%s\nfailed to login with Powershell: %s", e.Stderr, out, err.Error())
+				} else {
+					return CopyOrSyncCommandResult{}, false, fmt.Errorf("failed to login with Powershell: %s", err.Error())
+				}
+			}
+			env = append(env, "AZCOPY_AUTO_LOGIN_TYPE=PsCred")
+		default:
+			return CopyOrSyncCommandResult{}, false, errors.New("Unsupported OAuth mode " + oauthMode)
 		}
 	}
 

--- a/e2etest/zt_basic_cli_ps_auth_test.go
+++ b/e2etest/zt_basic_cli_ps_auth_test.go
@@ -21,9 +21,6 @@
 package e2etest
 
 import (
-	"fmt"
-	"os"
-	"os/exec"
 	"testing"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
@@ -33,31 +30,9 @@ import (
 
 func TestBasic_AzCLIAuth(t *testing.T) {
 	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.BlobBlob()), eValidate.Auto(), oAuthOnly, oAuthOnly, params{ // Pass flag values that the test requires. The params struct is a superset of Copy and Sync params
-		recursive: true,
-	}, &hooks{
-		beforeTestRun: func(h hookHelper) {
-			tenId, appId, clientSecret := GlobalInputManager{}.GetServicePrincipalAuth()
-			args := []string{
-				"login",
-				"--service-principal",
-				"-u=" + appId,
-				"-p=" + clientSecret,
-			}
-			if tenId != "" {
-				args = append(args, "--tenant="+tenId)
-			}
-
-			out, err := exec.Command("az", args...).Output()
-			if err != nil {
-				e := err.(*exec.ExitError)
-				t.Logf(string(e.Stderr))
-				t.Logf(string(out))
-				t.Logf("Failed to login with AzCLI " + err.Error())
-				t.FailNow()
-			}
-			os.Setenv("AZCOPY_AUTO_LOGIN_TYPE", "AZCLI")
-		},
-	}, testFiles{
+		recursive:     true,
+		AutoLoginType: common.AutologinTypeAzCLI,
+	}, nil, testFiles{
 		defaultSize: "1K",
 		shouldTransfer: []interface{}{
 			"wantedfile",
@@ -70,31 +45,9 @@ func TestBasic_AzCLIAuth(t *testing.T) {
 
 func TestBasic_AzCLIAuthLowerCase(t *testing.T) {
 	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.BlobBlob()), eValidate.Auto(), oAuthOnly, oAuthOnly, params{ // Pass flag values that the test requires. The params struct is a superset of Copy and Sync params
-		recursive: true,
-	}, &hooks{
-		beforeTestRun: func(h hookHelper) {
-			tenId, appId, clientSecret := GlobalInputManager{}.GetServicePrincipalAuth()
-			args := []string{
-				"login",
-				"--service-principal",
-				"-u=" + appId,
-				"-p=" + clientSecret,
-			}
-			if tenId != "" {
-				args = append(args, "--tenant="+tenId)
-			}
-
-			out, err := exec.Command("az", args...).Output()
-			if err != nil {
-				e := err.(*exec.ExitError)
-				t.Logf(string(e.Stderr))
-				t.Logf(string(out))
-				t.Logf("Failed to login with AzCLI " + err.Error())
-				t.FailNow()
-			}
-			os.Setenv("AZCOPY_AUTO_LOGIN_TYPE", "azcli")
-		},
-	}, testFiles{
+		recursive:     true,
+		AutoLoginType: "azCli", // the purpose of this test is to check whether our casing is working or not
+	}, nil, testFiles{
 		defaultSize: "1K",
 		shouldTransfer: []interface{}{
 			"wantedfile",
@@ -107,29 +60,9 @@ func TestBasic_AzCLIAuthLowerCase(t *testing.T) {
 
 func TestBasic_PSAuth(t *testing.T) {
 	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.BlobBlob()), eValidate.Auto(), oAuthOnly, oAuthOnly, params{ // Pass flag values that the test requires. The params struct is a superset of Copy and Sync params
-		recursive: true,
-	}, &hooks{
-		beforeTestRun: func(h hookHelper) {
-			tenId, appId, clientSecret := GlobalInputManager{}.GetServicePrincipalAuth()
-			cmd := `$secret = ConvertTo-SecureString -String %s -AsPlainText -Force;
-				$cred = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList %s, $secret;
-				Connect-AzAccount -ServicePrincipal -Credential $cred`
-			if tenId != "" {
-				cmd += " -Tenant " + tenId
-			}
-
-			script := fmt.Sprintf(cmd, clientSecret, appId)
-			out, err := exec.Command("pwsh", "-Command", script).Output()
-			if err != nil {
-				e := err.(*exec.ExitError)
-				t.Logf(string(e.Stderr))
-				t.Logf(string(out))
-				t.Logf("Failed to login with Powershell " + err.Error())
-				t.FailNow()
-			}
-			os.Setenv("AZCOPY_AUTO_LOGIN_TYPE", "PSCRED")
-		},
-	}, testFiles{
+		recursive:     true,
+		AutoLoginType: common.AutologinTypePsCred,
+	}, nil, testFiles{
 		defaultSize: "1K",
 		shouldTransfer: []interface{}{
 			"wantedfile",
@@ -142,29 +75,9 @@ func TestBasic_PSAuth(t *testing.T) {
 
 func TestBasic_PSAuthCamelCase(t *testing.T) {
 	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.BlobBlob()), eValidate.Auto(), oAuthOnly, oAuthOnly, params{ // Pass flag values that the test requires. The params struct is a superset of Copy and Sync params
-		recursive: true,
-	}, &hooks{
-		beforeTestRun: func(h hookHelper) {
-			tenId, appId, clientSecret := GlobalInputManager{}.GetServicePrincipalAuth()
-			cmd := `$secret = ConvertTo-SecureString -String %s -AsPlainText -Force;
-				$cred = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList %s, $secret;
-				Connect-AzAccount -ServicePrincipal -Credential $cred`
-			if tenId != "" {
-				cmd += " -Tenant " + tenId
-			}
-
-			script := fmt.Sprintf(cmd, clientSecret, appId)
-			out, err := exec.Command("pwsh", "-Command", script).Output()
-			if err != nil {
-				e := err.(*exec.ExitError)
-				t.Logf(string(e.Stderr))
-				t.Logf(string(out))
-				t.Logf("Failed to login with Powershell " + err.Error())
-				t.FailNow()
-			}
-			os.Setenv("AZCOPY_AUTO_LOGIN_TYPE", "PsCred")
-		},
-	}, testFiles{
+		recursive:     true,
+		AutoLoginType: "PSCred", // ditto
+	}, nil, testFiles{
 		defaultSize: "1K",
 		shouldTransfer: []interface{}{
 			"wantedfile",


### PR DESCRIPTION
This is a cherrypicked change from #2542 to get folks unblocked.

It serves two purposes
1) Specifying tenant ID to AzCopy (why did this suddenly become required? todo)
2) Make it so that AzCLI/PSCred isn't permanent across the test suite, because prior the env var never got cleared.