### PR TITLE
Use a different message when writing tags fails due to permissions issues, add test

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -1809,7 +1809,7 @@ func (cca *CookedCopyCmdArgs) ReportProgressOrExit(lcm common.LifecycleMgr) (tot
 
 	if jobDone {
 		exitCode := cca.getSuccessExitCode()
-		if summary.TransfersFailed > 0 {
+		if summary.TransfersFailed > 0 || summary.JobStatus == common.EJobStatus.Cancelled() || summary.JobStatus == common.EJobStatus.Cancelling() {
 			exitCode = common.EExitCode.Error()
 		}
 
@@ -2098,7 +2098,7 @@ func init() {
 	cpCmd.PersistentFlags().BoolVar(&raw.s2sSourceChangeValidation, "s2s-detect-source-changed", false, "False by default. Detect if the source file/blob changes while it is being read. This parameter only applies to service to service copies, because the corresponding check is permanently enabled for uploads and downloads.")
 	cpCmd.PersistentFlags().StringVar(&raw.s2sInvalidMetadataHandleOption, "s2s-handle-invalid-metadata", common.DefaultInvalidMetadataHandleOption.String(), "Specifies how invalid metadata keys are handled. Available options: ExcludeIfInvalid, FailIfInvalid, RenameIfInvalid (default 'ExcludeIfInvalid').")
 	cpCmd.PersistentFlags().StringVar(&raw.listOfVersionIDs, "list-of-versions", "", "Specifies a path to a text file where each version id is listed on a separate line. Ensure that the source must point to a single blob and all the version ids specified in the file using this flag must belong to the source blob only. AzCopy will download the specified versions in the destination folder provided.")
-	cpCmd.PersistentFlags().StringVar(&raw.blobTags, "blob-tags", "", "Set tags on blobs to categorize data in your storage account. Multiple blob tags should be separated by ';', i.e. 'foo=bar;some=thing'.")
+	cpCmd.PersistentFlags().StringVar(&raw.blobTags, "blob-tags", "", "Set tags on blobs to categorize data in your storage account. Multiple blob tags should be separated by '&', i.e. 'foo=bar&some=thing'.")
 	cpCmd.PersistentFlags().BoolVar(&raw.s2sPreserveBlobTags, "s2s-preserve-blob-tags", false, "False by default. Preserve blob tags during service to service transfer from one blob storage to another.")
 	cpCmd.PersistentFlags().BoolVar(&raw.includeDirectoryStubs, "include-directory-stub", false, "False by default to ignore directory stubs. Directory stubs are blobs with metadata 'hdi_isfolder:true'. Setting value to true will preserve directory stubs during transfers. Including this flag with no value defaults to true (e.g, azcopy copy --include-directory-stub is the same as azcopy copy --include-directory-stub=true).")
 	cpCmd.PersistentFlags().BoolVar(&raw.disableAutoDecoding, "disable-auto-decoding", false, "False by default to enable automatic decoding of illegal chars on Windows. Can be set to true to disable automatic decoding.")

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -621,7 +621,7 @@ func (cca *cookedSyncCmdArgs) ReportProgressOrExit(lcm common.LifecycleMgr) (tot
 
 	if jobDone {
 		exitCode := common.EExitCode.Success()
-		if summary.TransfersFailed > 0 {
+		if summary.TransfersFailed > 0 || summary.JobStatus == common.EJobStatus.Cancelled() || summary.JobStatus == common.EJobStatus.Cancelling() {
 			exitCode = common.EExitCode.Error()
 		}
 

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -858,7 +858,7 @@ func (jptm *jobPartTransferMgr) failActiveTransfer(typ transferErrorCode, descri
 			!jptm.jobPartMgr.(*jobPartMgr).jobMgr.IsDaemon() {
 			// quit right away, since without proper authentication no work can be done
 			// display a clear message
-			if strings.Index(descriptionOfWhereErrorOccurred, "tags") != -1 {
+			if strings.Contains(descriptionOfWhereErrorOccurred, "tags") {
 				common.GetLifecycleMgr().Info(fmt.Sprintf("Authorization failed during an attempt to set tags, please ensure you have the appropriate Tags permission %s", err.Error()))
 			} else {
 				common.GetLifecycleMgr().Info(fmt.Sprintf("Authentication failed, it is either not correct, or expired, or does not have the correct permission %s", err.Error()))

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -858,7 +858,12 @@ func (jptm *jobPartTransferMgr) failActiveTransfer(typ transferErrorCode, descri
 			!jptm.jobPartMgr.(*jobPartMgr).jobMgr.IsDaemon() {
 			// quit right away, since without proper authentication no work can be done
 			// display a clear message
-			common.GetLifecycleMgr().Info(fmt.Sprintf("Authentication failed, it is either not correct, or expired, or does not have the correct permission %s", err.Error()))
+			if strings.Index(descriptionOfWhereErrorOccurred, "tags") != -1 {
+				common.GetLifecycleMgr().Info(fmt.Sprintf("Authorization failed during an attempt to set tags, please ensure you have the appropriate Tags permission %s", err.Error()))
+			} else {
+				common.GetLifecycleMgr().Info(fmt.Sprintf("Authentication failed, it is either not correct, or expired, or does not have the correct permission %s", err.Error()))
+			}
+
 			// and use the normal cancelling mechanism so that we can exit in a clean and controlled way
 			jptm.jobPartMgr.(*jobPartMgr).jobMgr.CancelPauseJobOrder(common.EJobStatus.Cancelling())
 			// TODO: this results in the final job output line being: Final Job Status: Cancelled

--- a/ste/sender-appendBlob.go
+++ b/ste/sender-appendBlob.go
@@ -164,7 +164,7 @@ func (s *appendBlobSenderBase) Prologue(ps common.PrologueState) (destinationMod
 		CPKScopeInfo: s.jptm.CpkScopeInfo(),
 	})
 	if err != nil {
-		s.jptm.FailActiveSend("Creating blob", err)
+		s.jptm.FailActiveSend(common.Iff(len(blobTags) > 0, "Creating blob (with tags)", "Creating blob"), err)
 		return
 	}
 	destinationModified = true
@@ -172,7 +172,7 @@ func (s *appendBlobSenderBase) Prologue(ps common.PrologueState) (destinationMod
 	if setTags {
 		_, err = s.destAppendBlobClient.SetTags(s.jptm.Context(), s.blobTagsToApply, nil)
 		if err != nil {
-			s.jptm.Log(common.LogWarning, err.Error())
+			s.jptm.FailActiveSend("Set blob tags", err)
 		}
 	}
 	return

--- a/ste/sender-blobFolders.go
+++ b/ste/sender-blobFolders.go
@@ -199,17 +199,33 @@ func (b *blobFolderSender) EnsureFolderExists() error {
 	}
 
 	err = t.CreateFolder(b.DirUrlToString(), func() error {
+		blobTags := b.blobTagsToApply
+		setTags := separateSetTagsRequired(blobTags)
+		if setTags || len(blobTags) == 0 {
+			blobTags = nil
+		}
+
 		// It doesn't make sense to use a special access tier for a blob folder, the blob will be 0 bytes.
 		_, err := b.destinationClient.Upload(b.jptm.Context(), streaming.NopCloser(bytes.NewReader(nil)),
 			&blockblob.UploadOptions{
 				HTTPHeaders:  &b.headersToApply,
 				Metadata:     b.metadataToApply,
-				Tags:         b.blobTagsToApply,
+				Tags:         blobTags,
 				CPKInfo:      b.jptm.CpkInfo(),
 				CPKScopeInfo: b.jptm.CpkScopeInfo(),
 			})
+		if err != nil {
+			b.jptm.FailActiveSend(common.Iff(len(blobTags) > 0, "Upload symlink (with tags)", "Upload symlink"), err)
+		}
 
-		return err
+		if setTags {
+			if _, err := b.destinationClient.SetTags(b.jptm.Context(), b.blobTagsToApply, nil); err != nil {
+				b.jptm.FailActiveSend("Set tags", err)
+				return nil
+			}
+		}
+
+		return nil
 	})
 
 	if err != nil {

--- a/ste/sender-blobFolders.go
+++ b/ste/sender-blobFolders.go
@@ -215,7 +215,7 @@ func (b *blobFolderSender) EnsureFolderExists() error {
 				CPKScopeInfo: b.jptm.CpkScopeInfo(),
 			})
 		if err != nil {
-			b.jptm.FailActiveSend(common.Iff(len(blobTags) > 0, "Upload symlink (with tags)", "Upload symlink"), err)
+			b.jptm.FailActiveSend(common.Iff(len(blobTags) > 0, "Upload folder (with tags)", "Upload folder"), err)
 		}
 
 		if setTags {

--- a/ste/sender-blockBlob.go
+++ b/ste/sender-blockBlob.go
@@ -275,13 +275,13 @@ func (s *blockBlobSenderBase) Epilogue() {
 				CPKScopeInfo: s.jptm.CpkScopeInfo(),
 			})
 		if err != nil {
-			jptm.FailActiveSend("Committing block list", err)
+			jptm.FailActiveSend(common.Iff(blobTags != nil, "Committing block list (with tags)", "Committing block list"), err)
 			return
 		}
 
 		if setTags {
 			if _, err := s.destBlockBlobClient.SetTags(jptm.Context(), s.blobTagsToApply, nil); err != nil {
-				s.jptm.Log(common.LogWarning, err.Error())
+				jptm.FailActiveSend("Setting tags", err)
 			}
 		}
 	}

--- a/ste/sender-blockBlobFromLocal.go
+++ b/ste/sender-blockBlobFromLocal.go
@@ -178,7 +178,7 @@ func (u *blockBlobUploader) generatePutWholeBlob(id common.ChunkID, reader commo
 
 		// if the put blob is a failure, update the transfer status to failed
 		if err != nil {
-			jptm.FailActiveUpload("Uploading blob", err)
+			jptm.FailActiveSend(common.Iff(len(blobTags) > 0, "Committing block list (with tags)", "Committing block list"), err)
 			return
 		}
 
@@ -186,7 +186,7 @@ func (u *blockBlobUploader) generatePutWholeBlob(id common.ChunkID, reader commo
 
 		if setTags {
 			if _, err := u.destBlockBlobClient.SetTags(jptm.Context(), u.blobTagsToApply, nil); err != nil {
-				u.jptm.Log(common.LogWarning, err.Error())
+				jptm.FailActiveSend("Set blob tags", err)
 			}
 		}
 	})

--- a/ste/sender-blockBlobFromURL.go
+++ b/ste/sender-blockBlobFromURL.go
@@ -170,7 +170,7 @@ func (c *urlToBlockBlobCopier) generateStartPutBlobFromURL(id common.ChunkID, bl
 			})
 
 		if err != nil {
-			c.jptm.FailActiveSend("Put Blob from URL", err)
+			c.jptm.FailActiveSend(common.Iff(len(blobTags) > 0, "Committing block list (with tags)", "Committing block list"), err)
 			return
 		}
 
@@ -178,7 +178,7 @@ func (c *urlToBlockBlobCopier) generateStartPutBlobFromURL(id common.ChunkID, bl
 
 		if setTags {
 			if _, err := c.destBlockBlobClient.SetTags(c.jptm.Context(), c.blobTagsToApply, nil); err != nil {
-				c.jptm.Log(common.LogWarning, err.Error())
+				c.jptm.FailActiveSend("Set blob tags", err)
 			}
 		}
 	})

--- a/ste/sender-pageBlob.go
+++ b/ste/sender-pageBlob.go
@@ -260,7 +260,7 @@ func (s *pageBlobSenderBase) Prologue(ps common.PrologueState) (destinationModif
 			CPKScopeInfo:   s.jptm.CpkScopeInfo(),
 		})
 	if err != nil {
-		s.jptm.FailActiveSend("Creating blob", err)
+		s.jptm.FailActiveSend(common.Iff(len(blobTags) > 0, "Creating blob (with tags)", "Creating blob"), err)
 		return
 	}
 
@@ -268,7 +268,7 @@ func (s *pageBlobSenderBase) Prologue(ps common.PrologueState) (destinationModif
 
 	if setTags {
 		if _, err := s.destPageBlobClient.SetTags(s.jptm.Context(), s.blobTagsToApply, nil); err != nil {
-			s.jptm.Log(common.LogWarning, err.Error())
+			s.jptm.FailActiveSend("Set blob tags", err)
 		}
 	}
 


### PR DESCRIPTION
If the failure point includes data about tags, we now treat that as a failure writing tags, and log about needing tags permissions (per stgexp's request).

A single test case covers Upload & S2S cases for writing tags, as well as different blob types, hitting all code paths.