### PR TITLE
Azcopy copy url-decodes slashes from directory names for windows

### DIFF
--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -559,9 +559,8 @@ func pathEncodeRules(path string, fromTo common.FromTo, disableAutoDecoding bool
 			}
 		}
 
-		// If uploading from Windows or downloading from files, decode unsafe chars if user enables decoding
-	} else if ((!source && fromTo.From() == common.ELocation.Local() && runtime.GOOS == "windows") || (!source && fromTo.From() == common.ELocation.File())) && !disableAutoDecoding {
-
+		// If downloading from files, decode unsafe chars if user enables decoding
+	} else if (!source && fromTo.From() == common.ELocation.File()) && !disableAutoDecoding {
 		for encoded, c := range reverseEncodedChars {
 			for k, p := range pathParts {
 				pathParts[k] = strings.ReplaceAll(p, encoded, string(c))


### PR DESCRIPTION
Issue: https://github.com/Azure/azure-storage-azcopy/issues/2753

When we do a copy operation from local to remote the path Encode Rules should not be applied on the source path.