### PR TITLE
Don't panic if we fail to close the log

### DIFF
--- a/common/logger.go
+++ b/common/logger.go
@@ -116,8 +116,7 @@ func (jl *jobLogger) CloseLog() {
 	}
 
 	jl.logger.Println("Closing Log")
-	err := jl.file.Close()
-	PanicIfErr(err)
+	_ = jl.file.Close() // If it was already closed, that's alright. We wanted to close it, anyway.
 }
 
 func (jl jobLogger) Log(loglevel LogLevel, msg string) {


### PR DESCRIPTION
Was trying to search around for reasons we might double-close or re-create the case at hand, but had no luck. The simple solution is just to ignore the fact we've failed to close the log; after all, if we wanted it closed: It's already closed.