### PR TITLE
Fix ignoring of S3 Glacier type errors bug (#2834)

### DIFF
--- a/cmd/zc_traverser_s3.go
+++ b/cmd/zc_traverser_s3.go
@@ -72,7 +72,28 @@ func (t *s3Traverser) Traverse(preprocessor objectMorpher, processor objectProce
 		return strings.HasSuffix(objectKey, ".") ||
 			strings.Contains(objectKey, "./")
 	}
+
+	const (
+		storageClassKey  = "X-Amz-Storage-Class"
+		deepArchiveClass = "DEEP_ARCHIVE"
+	)
+
+	invalidAwsStorageClass := func(minioObject minio.ObjectInfo) bool {
+		/* S3 object's storage class "DEEP_ARCHIVE" is invalid.
+		   Because S3 Glacier Archive objects cannot be copied to Azure Storage.
+		*/
+		storageClasses, ok := minioObject.Metadata[storageClassKey]
+		if !ok || len(storageClasses) == 0 {
+			return false
+		}
+
+		storageClass := storageClasses[0]
+
+		return storageClass == deepArchiveClass
+	}
+
 	invalidNameErrorMsg := "Skipping S3 object %s, as it is not a valid Blob name. Rename the object and retry the transfer"
+	invalidAwsStorageClassMsg := "Skipping S3 object %s, as it is not a valid AWS storage class: %s"
 	// Check if resource is a single object.
 	if t.s3URLParts.IsObjectSyntactically() && !t.s3URLParts.IsDirectorySyntactically() && !t.s3URLParts.IsBucketSyntactically() {
 		objectPath := strings.Split(t.s3URLParts.ObjectKey, "/")
@@ -82,6 +103,12 @@ func (t *s3Traverser) Traverse(preprocessor objectMorpher, processor objectProce
 		if invalidAzureBlobName(t.s3URLParts.ObjectKey) {
 			WarnStdoutAndScanningLog(fmt.Sprintf(invalidNameErrorMsg, t.s3URLParts.ObjectKey))
 			return common.EAzError.InvalidBlobName()
+		}
+
+		if invalidAwsStorageClass(oi) {
+
+			WarnStdoutAndScanningLog(fmt.Sprintf(invalidAwsStorageClassMsg, t.s3URLParts.ObjectKey, deepArchiveClass))
+			return common.EAzError.InvalidAWSStorageClass()
 		}
 
 		// If we actually got object properties, process them.

--- a/common/azError.go
+++ b/common/azError.go
@@ -49,6 +49,9 @@ func (err AzError) Error() string {
 
 var EAzError AzError
 
+func (err AzError) InvalidAWSStorageClass() AzError {
+	return AzError{uint64(2), "Invalid AWS Storage Class: ", "DEEP_ARCHIVE"}
+}
 func (err AzError) LoginCredMissing() AzError {
 	return AzError{uint64(1), "Login Credentials missing. ", ""}
 }


### PR DESCRIPTION
### INFO: Skipping S3 object launch.json, as it is not a valid AWS storage class: DEEP_ARCHIVE

### failed to perform copy command due to error: cannot start job due to error: Invalid AWS Storage Class: DEEP_ARCHIVE.

The above is the output message after fixing the bug.

