### PR TITLE
Catch an object named after the root with a trailing `/` & carefully handle trailing `/` files on sync

### DIFF
--- a/cmd/syncProcessor.go
+++ b/cmd/syncProcessor.go
@@ -278,10 +278,13 @@ func (b *remoteResourceDeleter) delete(object StoredObject) error {
 		b.clientOptions.PerCallPolicies = append([]policy.Policy{common.NewRecursivePolicy()}, b.clientOptions.PerCallPolicies...)
 	}
 	*/
-	if object.relativePath == "\x00" {
-		return nil // Do nothing, we don't want to accidentally delete the root.
-	}
 	objectPath := path.Join(b.rootPath, object.relativePath)
+	if object.relativePath == "\x00" && b.targetLocation != common.ELocation.Blob() {
+		return nil // Do nothing, we don't want to accidentally delete the root.
+	} else if object.relativePath == "\x00" { // this is acceptable on blob, though. Dir stubs are a thing, and they aren't necessary for normal function.
+		objectPath = b.rootPath
+	}
+
 	if strings.HasSuffix(object.relativePath, "/") && !strings.HasSuffix(objectPath, "/") && b.targetLocation == common.ELocation.Blob() {
 		// If we were targeting a directory, we still need to be. path.join breaks that.
 		// We also want to defensively code around this, and make sure we are not putting folder// or trying to put a weird URI in to an endpoint that can't do this.

--- a/cmd/zc_traverser_blob.go
+++ b/cmd/zc_traverser_blob.go
@@ -559,6 +559,11 @@ func (t *blobTraverser) serialList(containerClient *container.Client, containerN
 
 			storedObject := t.createStoredObjectForBlob(preprocessor, blobInfo, relativePath, containerName)
 
+			// edge case, blob name happens to be the same as root and ends in /
+			if storedObject.relativePath == "" && strings.HasSuffix(storedObject.name, "/") {
+				storedObject.relativePath = "\x00" // Short circuit, letting the backend know we *really* meant root/.
+			}
+
 			// Setting blob tags
 			if t.s2sPreserveSourceTags && blobInfo.BlobTags != nil {
 				blobTagsMap := common.BlobTags{}

--- a/cmd/zc_traverser_blob.go
+++ b/cmd/zc_traverser_blob.go
@@ -419,6 +419,11 @@ func (t *blobTraverser) parallelList(containerClient *container.Client, containe
 
 				storedObject := t.createStoredObjectForBlob(preprocessor, blobInfo, strings.TrimPrefix(*blobInfo.Name, searchPrefix), containerName)
 
+				// edge case, blob name happens to be the same as root and ends in /
+				if storedObject.relativePath == "" && strings.HasSuffix(storedObject.name, "/") {
+					storedObject.relativePath = "\x00" // Short circuit, letting the backend know we *really* meant root/.
+				}
+
 				if t.s2sPreserveSourceTags && blobInfo.BlobTags != nil {
 					blobTagsMap := common.BlobTags{}
 					for _, blobTag := range blobInfo.BlobTags.BlobTagSet {


### PR DESCRIPTION
Two issues still existed following the folder naming PR.

1) Sync with `--delete-destination-files`; files ending with `/` were not caught properly.
2) Root directories ending with `/`, when not containing the `hdi_isfolder` meta were caught, but not properly put into the plan file.