### PR TITLE
Added totalBytesSkipped and using this in percentage complete calculation

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -1859,6 +1859,7 @@ Number of Folder Transfers Failed: %v
 Number of File Transfers Skipped: %v
 Number of Folder Transfers Skipped: %v
 Total Number of Bytes Transferred: %v
+Total Number of Bytes Skipped: %v
 Final Job Status: %v%s%s
 `,
 					summary.JobID.String(),
@@ -1874,6 +1875,7 @@ Final Job Status: %v%s%s
 					summary.TransfersSkipped-summary.FoldersSkipped,
 					summary.FoldersSkipped,
 					summary.TotalBytesTransferred,
+					summary.TotalBytesSkipped,
 					summary.JobStatus,
 					screenStats,
 					formatPerfAdvice(summary.PerformanceAdvice))

--- a/cmd/jobsResume.go
+++ b/cmd/jobsResume.go
@@ -169,6 +169,7 @@ Number of Folder Transfers Failed: %v
 Number of File Transfers Skipped: %v
 Number of Folder Transfers Skipped: %v
 Total Number of Bytes Transferred: %v
+Total Number of Bytes Skipped: %v
 Final Job Status: %v
 `,
 					summary.JobID.String(),
@@ -184,6 +185,7 @@ Final Job Status: %v
 					summary.TransfersSkipped-summary.FoldersSkipped,
 					summary.FoldersSkipped,
 					summary.TotalBytesTransferred,
+					summary.TotalBytesSkipped,
 					summary.JobStatus)
 			}
 		}, exitCode)

--- a/cmd/jobsShow.go
+++ b/cmd/jobsShow.go
@@ -159,6 +159,7 @@ Number of Folder Transfers Failed: %v
 Number of File Transfers Skipped: %v
 Number of Folder Transfers Skipped: %v
 Total Number of Bytes Transferred: %v
+Total Number of Bytes Skipped: %v
 Percent Complete (approx): %.1f
 Final Job Status: %v
 `,
@@ -174,6 +175,7 @@ Final Job Status: %v
 			summary.TransfersSkipped-summary.FoldersSkipped,
 			summary.FoldersSkipped,
 			summary.TotalBytesTransferred,
+			summary.TotalBytesSkipped,
 			summary.PercentComplete, // noted as approx in the format string because won't include in-flight files if this Show command is run from a different process
 			summary.JobStatus,
 		)

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -658,6 +658,7 @@ Number of Copy Transfers Completed: %v
 Number of Copy Transfers Failed: %v
 Number of Deletions at Destination: %v
 Total Number of Bytes Transferred: %v
+Total Number of Bytes Skipped: %v
 Total Number of Bytes Enumerated: %v
 Final Job Status: %v%s%s
 `,
@@ -672,6 +673,7 @@ Final Job Status: %v%s%s
 				summary.TransfersFailed,
 				cca.atomicDeletionCount,
 				summary.TotalBytesTransferred,
+				summary.TotalBytesSkipped,
 				summary.TotalBytesEnumerated,
 				summary.JobStatus,
 				screenStats,

--- a/common/rpc-models.go
+++ b/common/rpc-models.go
@@ -305,6 +305,9 @@ type ListJobSummaryResponse struct {
 	// does not include failed transfers or bytes sent in retries (i.e. no double counting). Includes successful transfers and transfers in progress
 	TotalBytesTransferred uint64 `json:",string"`
 
+	// Includes bytes of data skipped over (i.e. data already exists in blob)
+	TotalBytesSkipped uint64 `json:",string"`
+
 	// sum of the total transfer enumerated so far.
 	TotalBytesEnumerated uint64 `json:",string"`
 	// sum of total bytes expected in the job (i.e. based on our current expectation of which files will be successful)

--- a/jobsAdmin/init.go
+++ b/jobsAdmin/init.go
@@ -438,7 +438,7 @@ func GetJobSummary(jobID common.JobID) common.ListJobSummaryResponse {
 		// if no bytes expected, and we should avoid dividing by 0 (which results in NaN)
 		js.PercentComplete = 100
 	} else {
-		js.PercentComplete = 100 * (float32(js.TotalBytesTransferred) / float32(js.TotalBytesExpected))
+		js.PercentComplete = 100 * (float32(js.TotalBytesTransferred) + float32(js.TotalBytesSkipped)) / float32(js.TotalBytesExpected)
 	}
 
 	// This is added to let FE to continue fetching the Job Progress Summary
@@ -556,6 +556,7 @@ func resurrectJobSummary(jm ste.IJobMgr) common.ListJobSummaryResponse {
 			case common.ETransferStatus.SkippedEntityAlreadyExists(),
 				common.ETransferStatus.SkippedBlobHasSnapshots():
 				js.TransfersSkipped++
+				js.TotalBytesSkipped += uint64(jppt.SourceSize)
 				// getting the source and destination for skipped transfer at position - index
 				src, dst, isFolder := jpp.TransferSrcDstStrings(t)
 				js.SkippedTransfers = append(js.SkippedTransfers,
@@ -575,7 +576,7 @@ func resurrectJobSummary(jm ste.IJobMgr) common.ListJobSummaryResponse {
 		// if no bytes expected, and we should avoid dividing by 0 (which results in NaN)
 		js.PercentComplete = 100
 	} else {
-		js.PercentComplete = 100 * float32(js.TotalBytesTransferred) / float32(js.TotalBytesExpected)
+		js.PercentComplete = 100 * (float32(js.TotalBytesTransferred) + float32(js.TotalBytesSkipped)) / float32(js.TotalBytesExpected)
 	}
 
 	// This is added to let FE to continue fetching the Job Progress Summary

--- a/ste/jobStatusManager.go
+++ b/ste/jobStatusManager.go
@@ -171,6 +171,7 @@ func (jm *jobMgr) handleStatusUpdateMessage() {
 				}
 				js.TransfersSkipped++
 				js.SkippedTransfers = append(js.SkippedTransfers, msg)
+				js.TotalBytesSkipped += msg.TransferSize
 			}
 
 		case <-jstm.listReq:


### PR DESCRIPTION
## Description
Added a new object called "TotalBytesSkipped" which stores the amount of data skipped during file copying. This TotalBytesSkipped is added to all the summary messages as well as used in the "Percentage complete" calculation.

- **Bug Fix**: "Percentage complete" reporting does not take into account skipped files with --overwrite=ifSourceNewer

- **Related Links**:
- [[Issues](<link>)](https://github.com/Azure/azure-storage-azcopy/issues/2830)

## Type of Change
- [x ] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
**Tested on windows 11 only:**
Ran AzCopy with "--overwrite=ifSourceNewer" on a folder containing some new files and some files already in blob, output % was correctly measured with the skips included. 
Ran AzCopy with "--overwrite=ifSourceNewer" on a folder where **all** the data was already in the blob and all data was skipped and output was still displaying 100% done.

Thank you for your contribution to AzCopy!
