### PR TITLE
Fix for Azure Files transfer ParentNotFound error

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,11 @@
 
 # Change Log
 
+## Version 10.27.1
+
+### Bug Fixes
+1. Fixed an issue where file transfers would fail with ParentNotFound. ([#2858](https://github.com/Azure/azure-storage-azcopy/issues/2858))
+
 ## Version 10.27.0
 
 ### New Features

--- a/common/version.go
+++ b/common/version.go
@@ -1,6 +1,6 @@
 package common
 
-const AzcopyVersion = "10.27.0"
+const AzcopyVersion = "10.27.1"
 const UserAgent = "AzCopy/" + AzcopyVersion
 const S3ImportUserAgent = "S3Import " + UserAgent
 const GCPImportUserAgent = "GCPImport " + UserAgent

--- a/ste/folderCreationTracker.go
+++ b/ste/folderCreationTracker.go
@@ -82,8 +82,7 @@ func (f *jpptFolderTracker) CreateFolder(folder string, doCreation func() error)
 	// If the folder has already been created, then we don't need to create it again
 	fNode, addedToTrie := f.contents.InsertDirNode(folder)
 
-	if !addedToTrie && (f.plan.Transfer(fNode.TransferIndex).TransferStatus() == common.ETransferStatus.FolderCreated() ||
-		f.plan.Transfer(fNode.TransferIndex).TransferStatus() == common.ETransferStatus.Success()) {
+	if !addedToTrie && (f.plan.Transfer(fNode.TransferIndex).TransferStatus() == common.ETransferStatus.FolderCreated()) {
 		return nil
 	}
 
@@ -126,8 +125,7 @@ func (f *jpptFolderTracker) ShouldSetProperties(folder string, overwrite common.
 
 		var created bool
 		if fNode, ok := f.contents.GetDirNode(folder); ok {
-			created = f.plan.Transfer(fNode.TransferIndex).TransferStatus() == common.ETransferStatus.FolderCreated() ||
-				f.plan.Transfer(fNode.TransferIndex).TransferStatus() == common.ETransferStatus.Success()
+			created = f.plan.Transfer(fNode.TransferIndex).TransferStatus() == common.ETransferStatus.FolderCreated()
 		} else {
 			// This should not happen, ever.
 			// Folder property jobs register with the tracker before they start getting processed.


### PR DESCRIPTION
Note: The base branch was forked off of the 10.27 release branch




## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**: (Brief description of the feature or issue being addressed)
- Fixes a bug where Azure Files transfer would return ParentNotFound error

- **Related Links**:
- [Issues](#2858)
- Resolves #2858 
- [Email Subject] Failures with azcopy 10.27.0 version

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->
I did a manual test with a very large random structure of directories and ran azcopy copy with v10.27 and then with my fix. 

TODO: Repro the issue with a smaller test case and add to e2e framework



Thank you for your contribution to AzCopy!
