### PR TITLE
Add SNI authentication support for azcopy login

### DIFF
--- a/common/oauthTokenManager.go
+++ b/common/oauthTokenManager.go
@@ -25,7 +25,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache"
 	"net"
 	"net/http"
 	"net/url"
@@ -40,6 +39,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache"
 	"github.com/Azure/go-autorest/autorest/date"
 
 	// importing the cache module registers the cache implementation for the current platform
@@ -618,6 +618,7 @@ func (credInfo *OAuthTokenInfo) GetClientCertificateCredential() (azcore.TokenCr
 			Cloud:     cloud.Configuration{ActiveDirectoryAuthorityHost: authorityHost.String()},
 			Transport: newAzcopyHTTPClient(),
 		},
+		SendCertificateChain: true,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add SNI authentication support for azcopy login.

The parameter SendCertificateChain controls whether the credential sends the public certificate chain in the x5c header of each token request's JWT. This is required for Subject Name/Issuer (SNI) authentication.