### PR TITLE
Mover/feature/otendolkar/custom s3 credential provider

### DIFF
--- a/cmd/credentialUtil.go
+++ b/cmd/credentialUtil.go
@@ -454,13 +454,16 @@ func doGetCredentialTypeForLocation(ctx context.Context, location common.Locatio
 	}
 
 	if location == common.ELocation.S3() {
-		accessKeyID := common.GetEnvironmentVariable(common.EEnvironmentVariable.AWSAccessKeyID())
-		secretAccessKey := common.GetEnvironmentVariable(common.EEnvironmentVariable.AWSSecretAccessKey())
-		if accessKeyID == "" || secretAccessKey == "" {
-			credType = common.ECredentialType.S3PublicBucket()
-			public = true
-			return
-		}
+		//Commenting this block out because checkAuthSafeForTarget has no case to handle public. Copy defaults S3 to access key, so similar functionality should be present for sync
+		/*
+			accessKeyID := common.GetEnvironmentVariable(common.EEnvironmentVariable.AWSAccessKeyID())
+			secretAccessKey := common.GetEnvironmentVariable(common.EEnvironmentVariable.AWSSecretAccessKey())
+			if accessKeyID == "" || secretAccessKey == "" {
+				credType = common.ECredentialType.S3PublicBucket()
+				public = true
+				return
+			}
+		*/
 
 		credType = common.ECredentialType.S3AccessKey()
 		return

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -209,7 +209,7 @@ func (raw *RawSyncCmdArgs) Cook() (cookedSyncCmdArgs, error) {
 	case common.EFromTo.BlobLocal(), common.EFromTo.FileLocal(), common.EFromTo.BlobFSLocal():
 		cooked.Source, err = SplitResourceString(raw.Src, cooked.fromTo.From())
 		common.PanicIfErr(err)
-	case common.EFromTo.BlobBlob(), common.EFromTo.FileFile(), common.EFromTo.BlobFile(), common.EFromTo.FileBlob(), common.EFromTo.BlobFSBlobFS(), common.EFromTo.BlobFSBlob(), common.EFromTo.BlobFSFile(), common.EFromTo.BlobBlobFS(), common.EFromTo.FileBlobFS():
+	case common.EFromTo.BlobBlob(), common.EFromTo.FileFile(), common.EFromTo.BlobFile(), common.EFromTo.FileBlob(), common.EFromTo.BlobFSBlobFS(), common.EFromTo.BlobFSBlob(), common.EFromTo.BlobFSFile(), common.EFromTo.BlobBlobFS(), common.EFromTo.FileBlobFS(), common.EFromTo.S3Blob():
 		cooked.Destination, err = SplitResourceString(raw.Dst, cooked.fromTo.To())
 		common.PanicIfErr(err)
 		cooked.Source, err = SplitResourceString(raw.Src, cooked.fromTo.From())

--- a/cmd/zc_traverser_s3.go
+++ b/cmd/zc_traverser_s3.go
@@ -28,9 +28,12 @@ import (
 	"sync"
 
 	"github.com/minio/minio-go"
+	"github.com/minio/minio-go/pkg/credentials"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
+
+const customCreds string = "customS3Creds" //key for custom credentials in stored in context
 
 type s3Traverser struct {
 	rawURL        *url.URL // No pipeline needed for S3
@@ -202,11 +205,19 @@ func newS3Traverser(credentialType common.CredentialType, rawURL *url.URL, ctx c
 
 	showS3UrlTypeWarning(s3URLParts)
 
+	//Optional check for custom credential provider
+	var credProvider credentials.Provider = nil
+	creds := ctx.Value(customCreds)
+	if creds != nil {
+		credProvider = creds.(credentials.Provider) //if passed through context, use custom provider
+	}
+
 	t.s3Client, err = common.CreateS3Client(t.ctx, common.CredentialInfo{
 		CredentialType: credentialType,
 		S3CredentialInfo: common.S3CredentialInfo{
 			Endpoint: t.s3URLParts.Endpoint,
 			Region:   t.s3URLParts.Region,
+			Provider: credProvider, //will pass nil in most cases, but if provider is implemented and passed explicitly, it will be used
 		},
 	}, common.CredentialOpOptions{
 		LogError: glcm.Error,

--- a/common/rpc-models.go
+++ b/common/rpc-models.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	datalake "github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/service"
+	"github.com/minio/minio-go/pkg/credentials"
 
 	"github.com/JeffreyRichter/enum/enum"
 )
@@ -180,6 +181,7 @@ type CopyJobPartOrderRequest struct {
 	// This may not always be the case (for instance, if we opt to use multiple OAuth tokens). At that point, this will likely be it's own CredentialInfo.
 	S2SSourceCredentialType CredentialType // Only Anonymous and OAuth will really be used in response to this, but S3 and GCP will come along too...
 	FileAttributes          FileTransferAttributes
+	Provider                credentials.Provider //credential provider implementation for custom credential management
 }
 
 // CredentialInfo contains essential credential info which need be transited between modules,
@@ -204,6 +206,7 @@ type GCPCredentialInfo struct {
 type S3CredentialInfo struct {
 	Endpoint string
 	Region   string
+	Provider credentials.Provider //credential provider implementation for custom credential management
 }
 
 type CopyJobPartOrderErrorType string

--- a/common/rpc-models.go
+++ b/common/rpc-models.go
@@ -355,6 +355,7 @@ type ResumeJobRequest struct {
 	IncludeTransfer  map[string]int
 	ExcludeTransfer  map[string]int
 	CredentialInfo   CredentialInfo
+	Provider         credentials.Provider
 }
 
 // represents the Details and details of a single transfer

--- a/jobsAdmin/init.go
+++ b/jobsAdmin/init.go
@@ -176,6 +176,7 @@ func ExecuteNewCopyJobPartOrder(order common.CopyJobPartOrderRequest) common.Cop
 		ste.InMemoryTransitJobState{
 			CredentialInfo:          order.CredentialInfo,
 			S2SSourceCredentialType: order.S2SSourceCredentialType,
+			Provider:                order.Provider,
 		})
 	// Supply no plan MMF because we don't have one, and AddJobPart will create one on its own.
 	// Add this part to the Job and schedule its transfers

--- a/jobsAdmin/init.go
+++ b/jobsAdmin/init.go
@@ -355,6 +355,7 @@ func ResumeJobOrder(req common.ResumeJobRequest) common.CancelPauseResumeRespons
 		jm.SetInMemoryTransitJobState(
 			ste.InMemoryTransitJobState{
 				CredentialInfo: req.CredentialInfo,
+				Provider:       req.Provider,
 			})
 
 		jpp0.SetJobStatus(common.EJobStatus.InProgress())

--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/minio/minio-go/pkg/credentials"
 )
 
 var _ IJobMgr = &jobMgr{}
@@ -46,6 +47,7 @@ type InMemoryTransitJobState struct {
 	CredentialInfo common.CredentialInfo
 	// S2SSourceCredentialType can override the CredentialInfo.CredentialType when being used for the source (e.g. Source Info Provider and when using GetS2SSourceBlobTokenCredential)
 	S2SSourceCredentialType common.CredentialType
+	Provider                credentials.Provider
 }
 
 type IJobMgr interface {
@@ -1008,7 +1010,11 @@ func (jm *jobMgr) scheduleJobParts() {
 				go jm.poolSizer()
 				startedPoolSizer = true
 			}
-			jobPart.ScheduleTransfers(jm.Context())
+			inMemoryState := jm.getInMemoryTransitJobState()
+			s3provider := inMemoryState.Provider
+			jmctx := jm.Context()
+			ctx := context.WithValue(jmctx, "customS3Creds", s3provider)
+			jobPart.ScheduleTransfers(ctx)
 		}
 	}
 }

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/minio/minio-go/pkg/credentials"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"golang.org/x/sync/semaphore"
@@ -381,6 +382,13 @@ func (jpm *jobPartMgr) ScheduleTransfers(jobCtx context.Context) {
 
 		//build transferInfo after we've set transferIndex
 		jptm.transferInfo = jptm.Info()
+		//populate transfer info with the provider for custom s3 credential provider
+		var credProvider credentials.Provider = nil
+		creds := jobCtx.Value("customS3Creds")
+		if creds != nil {
+			credProvider = creds.(credentials.Provider) //if passed through context, use custom provider
+		}
+		jptm.transferInfo.Provider = credProvider
 		jpm.Log(common.LogDebug, fmt.Sprintf("scheduling JobID=%v, Part#=%d, Transfer#=%d, priority=%v", plan.JobID, plan.PartNum, t, plan.Priority))
 
 		// ===== TEST KNOB

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/fileerror"
+	"github.com/minio/minio-go/pkg/credentials"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
@@ -144,6 +145,7 @@ type TransferInfo struct {
 
 	VersionID  string
 	SnapshotID string
+	Provider   credentials.Provider //custom Provider
 }
 
 func (i *TransferInfo) IsFilePropertiesTransfer() bool {

--- a/ste/sourceInfoProvider-S3.go
+++ b/ste/sourceInfoProvider-S3.go
@@ -64,7 +64,9 @@ func newS3SourceInfoProvider(jptm IJobPartTransferMgr) (ISourceInfoProvider, err
 		return nil, err
 	}
 
-	if os.Getenv("AWS_ACCESS_KEY_ID") == "" && os.Getenv("AWS_SECRET_ACCESS_KEY") == "" {
+	if p.transferInfo.Provider != nil { //add check for if we want to use provider case
+		p.credType = common.ECredentialType.S3AccessKey()
+	} else if os.Getenv("AWS_ACCESS_KEY_ID") == "" && os.Getenv("AWS_SECRET_ACCESS_KEY") == "" {
 		p.credType = common.ECredentialType.S3PublicBucket()
 	} else {
 		p.credType = common.ECredentialType.S3AccessKey()
@@ -76,6 +78,7 @@ func newS3SourceInfoProvider(jptm IJobPartTransferMgr) (ISourceInfoProvider, err
 		S3CredentialInfo: common.S3CredentialInfo{
 			Endpoint: p.s3URLPart.Endpoint,
 			Region:   p.s3URLPart.Region,
+			Provider: p.transferInfo.Provider,
 		},
 	}, common.CredentialOpOptions{
 		LogInfo:  func(str string) { p.jptm.Log(common.LogInfo, str) },


### PR DESCRIPTION
To ensure uninterrupted job execution, we propose enabling the dynamic fetching of S3 credentials. For long-running migration tasks, this allows credentials to be retrieved on the fly, preventing unnecessary pauses or interruptions.
A new field, "Provider", will be added within the s3credinfo structure. This field will interface with the MinIO library to enable dynamic credential retrieval. This change is backward compatible and will not impact the existing AzCopy functionality; the new field will only be utilized if the consumer of AzCopy specifically implements the provider interface.