### PR TITLE
Correct multi-run single-session issues with RunAzCopy

### DIFF
--- a/e2etest/newe2e_asserter.go
+++ b/e2etest/newe2e_asserter.go
@@ -38,10 +38,12 @@ type DryrunAsserter interface {
 	InvalidateScenario()
 }
 
+type CleanupFunc func(a Asserter)
+
 type ScenarioAsserter interface {
 	DryrunAsserter
 
-	Cleanup(func(a ScenarioAsserter))
+	Cleanup(CleanupFunc)
 }
 
 // HelperMarker handles the fact that testing.T can be sometimes nil, and that we can't indicate a depth to ignore with Helper()

--- a/e2etest/newe2e_scenario_manager.go
+++ b/e2etest/newe2e_scenario_manager.go
@@ -101,8 +101,14 @@ func (sm *ScenarioManager) RunScenario() {
 					t.Parallel()
 				}
 
-				svm.Cleanup(func(a ScenarioAsserter) {
-					svm.DeleteCreatedResources() // clean up after ourselves!
+				t.Cleanup(func() {
+					// cleanup steps FIFO
+					c := ScenarioVariationManagerCleanupAsserter{svm: svm}
+					for _, v := range svm.CleanupFuncs {
+						c.WrapCleanup(v)
+					}
+
+					svm.DeleteCreatedResources()
 				})
 
 				sm.Func.Call([]reflect.Value{reflect.ValueOf(svm)})

--- a/e2etest/newe2e_scenario_variation_manager.go
+++ b/e2etest/newe2e_scenario_variation_manager.go
@@ -1,6 +1,7 @@
 package e2etest
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 	"strings"
@@ -38,7 +39,7 @@ type ScenarioVariationManager struct {
 
 	// wetrun data
 	CreatedResources *PathTrie[createdResource]
-	CleanupFuncs     []func(a ScenarioAsserter)
+	CleanupFuncs     []func(a Asserter)
 }
 
 type createdResource struct {
@@ -325,16 +326,13 @@ func (svm *ScenarioVariationManager) InvalidateScenario() {
 	svm.isInvalid = true
 }
 
-func (svm *ScenarioVariationManager) Cleanup(cleanupFunc func(a ScenarioAsserter)) {
+func (svm *ScenarioVariationManager) Cleanup(cleanupFunc CleanupFunc) {
 	if svm.Dryrun() {
 		svm.Error("Sanity check: svm.Cleanup should not be called during a dry run. No real actions should be taken during a dry run.")
 		return
 	}
 
-	//svm.CleanupFuncs = append(svm.CleanupFuncs, cleanupFunc)
-	svm.t.Cleanup(func() {
-		cleanupFunc(svm)
-	})
+	svm.CleanupFuncs = append(svm.CleanupFuncs, cleanupFunc)
 }
 
 // ResolveVariation wraps ScenarioVariationManager.GetVariation, returning the variation as the user's requested type, and using the call stack as the ID
@@ -353,4 +351,97 @@ func NamedResolveVariation[T any](svm *ScenarioVariationManager, options map[str
 	variation := GetTypeOrZero[string](svm.GetVariation(svm.GetVariationCallerID(), AnyKeys(options)))
 
 	return options[variation]
+}
+
+var CleanupStepEarlyExit = errors.New("cleanupEarlyExit")
+
+type ScenarioVariationManagerCleanupAsserter struct {
+	svm *ScenarioVariationManager
+}
+
+func (s *ScenarioVariationManagerCleanupAsserter) WrapCleanup(cf CleanupFunc) {
+	defer func() {
+		if err := recover(); err != nil {
+			if err == CleanupStepEarlyExit {
+				return
+			}
+
+			s.Log("Cleanup step panicked: %v", err)
+		}
+	}()
+
+	cf(s)
+}
+
+func (s *ScenarioVariationManagerCleanupAsserter) NoError(comment string, err error, failNow ...bool) {
+	s.svm.t.Helper()
+
+	failFast := FirstOrZero(failNow)
+
+	//svm.AssertNow(comment, IsNil{}, err)
+	if err != nil {
+		s.Log("Error was not nil (%s): %v", comment, err)
+		s.svm.isInvalid = true // Flip the failed flag
+
+		s.svm.t.Fail()
+		if failFast {
+			panic(CleanupStepEarlyExit)
+		}
+	}
+}
+
+func (s *ScenarioVariationManagerCleanupAsserter) Assert(comment string, assertion Assertion, items ...any) {
+	s.svm.t.Helper()
+
+	if !assertion.Assert(items...) {
+		if fa, ok := assertion.(FormattedAssertion); ok {
+			s.Log("Assertion %s failed: %s (%s)", fa.Name(), fa.Format(items...), comment)
+		} else {
+			s.Log("Assertion %s failed with items %v (%s)", assertion.Name(), items, comment)
+		}
+
+		s.svm.isInvalid = true // We've now failed, so we flip the shared bad flag
+		s.svm.t.Fail()
+	}
+}
+
+func (s *ScenarioVariationManagerCleanupAsserter) AssertNow(comment string, assertion Assertion, items ...any) {
+	s.svm.t.Helper()
+
+	if !assertion.Assert(items...) {
+		if fa, ok := assertion.(FormattedAssertion); ok {
+			s.Log("Assertion %s failed: %s (%s)", fa.Name(), fa.Format(items...), comment)
+		} else {
+			s.Log("Assertion %s failed with items %v (%s)", assertion.Name(), items, comment)
+		}
+
+		s.svm.isInvalid = true // We've now failed, so we flip the shared bad flag
+		s.svm.t.Fail()
+		panic(CleanupStepEarlyExit)
+	}
+}
+
+func (s *ScenarioVariationManagerCleanupAsserter) Error(reason string) {
+	s.svm.t.Helper()
+	s.Log("Failed cleanup step: %v", reason)
+	panic(CleanupStepEarlyExit)
+}
+
+func (s *ScenarioVariationManagerCleanupAsserter) Skip(reason string) {
+	s.svm.t.Helper()
+	s.Log("Cleanup step skipped: %v", reason)
+	panic(CleanupStepEarlyExit)
+}
+
+func (s *ScenarioVariationManagerCleanupAsserter) Log(format string, a ...any) {
+	s.svm.t.Helper()
+	s.svm.Log(format, a...)
+}
+
+func (s *ScenarioVariationManagerCleanupAsserter) Failed() bool {
+	return s.svm.Failed()
+}
+
+func (s *ScenarioVariationManagerCleanupAsserter) HelperMarker() HelperMarker {
+	return s.svm.HelperMarker()
 }

--- a/e2etest/newe2e_task_runazcopy.go
+++ b/e2etest/newe2e_task_runazcopy.go
@@ -2,6 +2,7 @@ package e2etest
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -127,6 +128,12 @@ type AzCopyEnvironment struct {
 
 	InheritEnvironment bool
 	ManualLogin        bool
+
+	// If this is set, the logs have already been persisted.
+	// These should never be set by a test writer.
+	SessionId    *string
+	LogUploadDir *string
+	RunCount     *uint
 }
 
 func (env *AzCopyEnvironment) generateAzcopyDir(a ScenarioAsserter) {
@@ -134,7 +141,7 @@ func (env *AzCopyEnvironment) generateAzcopyDir(a ScenarioAsserter) {
 	a.NoError("create tempdir", err)
 	env.LogLocation = &dir
 	env.JobPlanLocation = &dir
-	a.Cleanup(func(a ScenarioAsserter) {
+	a.Cleanup(func(a Asserter) {
 		err := os.RemoveAll(dir)
 		a.NoError("remove tempdir", err)
 	})
@@ -363,17 +370,15 @@ func RunAzCopy(a ScenarioAsserter, commandSpec AzCopyCommand) (AzCopyStdout, *Az
 		ValidateLogFileRetention(a, *commandSpec.Environment.LogLocation, 1)
 	}
 
-	a.Cleanup(func(a ScenarioAsserter) {
-		if !commandSpec.Environment.ManualLogin {
-			UploadLogs(a, out, stderr, DerefOrZero(commandSpec.Environment.LogLocation))
-			_ = os.RemoveAll(DerefOrZero(commandSpec.Environment.LogLocation))
-		}
+	a.Cleanup(func(a Asserter) {
+		UploadLogs(a, out, stderr, commandSpec.Environment)
+		_ = os.RemoveAll(DerefOrZero(commandSpec.Environment.LogLocation))
 	})
 
 	return out, &AzCopyJobPlan{}
 }
 
-func UploadLogs(a ScenarioAsserter, stdout AzCopyStdout, stderr *bytes.Buffer, logDir string) {
+func UploadLogs(a Asserter, stdout AzCopyStdout, stderr *bytes.Buffer, env *AzCopyEnvironment) {
 	defer func() {
 		if err := recover(); err != nil {
 			fmt.Println("Log cleanup failed", err, "\n", string(debug.Stack()))
@@ -385,70 +390,66 @@ func UploadLogs(a ScenarioAsserter, stdout AzCopyStdout, stderr *bytes.Buffer, l
 		return
 	}
 
-	// sometimes, the log dir cannot be copied because the destination is on another drive. So, we'll copy the files instead by hand.
-	files, err := os.ReadDir(logDir)
-	a.NoError("Failed to read log dir", err)
-	jobId := ""
+	if env.LogUploadDir == nil {
+		logDir := DerefOrZero(env.LogLocation)
 
-	if jobStdout, ok := stdout.(*AzCopyParsedCopySyncRemoveStdout); ok {
-		if jobStdout.InitMsg.JobID != "" {
-			jobId = jobStdout.InitMsg.JobID
-		}
-	} else {
-		for _, file := range files { // first, find the job ID
-			if strings.HasSuffix(file.Name(), ".log") {
-				jobId = strings.TrimSuffix(strings.TrimSuffix(strings.TrimSuffix(file.Name(), "-chunks"), "-scanning"), ".log")
-				break
+		var err error
+		// Previously, we searched for a job ID to upload. Instead, we now treat shared environments as "sessions", and upload the logs all together.
+		sessionId := uuid.NewString()
+		env.SessionId = &sessionId
+
+		// Create the destination log directory
+		destLogDir := filepath.Join(logDropPath, sessionId)
+		err = os.MkdirAll(destLogDir, os.ModePerm|os.ModeDir)
+		a.NoError("Failed to create log dir", err)
+
+		// Copy the files by hand
+		err = filepath.WalkDir(logDir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
 			}
+			relPath := strings.TrimPrefix(path, logDir)
+			if d.IsDir() {
+				err = os.MkdirAll(filepath.Join(destLogDir, relPath), os.ModePerm|os.ModeDir)
+				return err
+			}
+
+			// copy the file
+			srcFile, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+
+			destFile, err := os.Create(filepath.Join(destLogDir, relPath))
+			if err != nil {
+				return err
+			}
+
+			defer srcFile.Close()
+			defer destFile.Close()
+
+			_, err = io.Copy(destFile, srcFile)
+			if err != nil {
+				return err
+			}
+
+			return err
+		})
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			a.NoError("Failed to copy log files", err)
 		}
+
+		env.LogUploadDir = &destLogDir
 	}
 
-	if jobId == "" {
-		// If we still don't have a job ID, let's make one up. Maybe the job never started, or this isn't a copy/sync/remove job anyway.
-		jobId = uuid.NewString()
-	}
-
-	// Create the destination log directory
-	destLogDir := filepath.Join(logDropPath, jobId)
-	err = os.MkdirAll(destLogDir, os.ModePerm|os.ModeDir)
-	a.NoError("Failed to create log dir", err)
-
-	// Copy the files by hand
-	err = filepath.WalkDir(logDir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		relPath := strings.TrimPrefix(path, logDir)
-		if d.IsDir() {
-			err = os.MkdirAll(filepath.Join(destLogDir, relPath), os.ModePerm|os.ModeDir)
-			return err
-		}
-
-		// copy the file
-		srcFile, err := os.Open(path)
-		if err != nil {
-			return err
-		}
-
-		destFile, err := os.Create(filepath.Join(destLogDir, relPath))
-		if err != nil {
-			return err
-		}
-
-		defer srcFile.Close()
-		defer destFile.Close()
-
-		_, err = io.Copy(destFile, srcFile)
-		if err != nil {
-			return err
-		}
-
-		return err
-	})
-	a.NoError("Failed to copy log files", err)
+	sessionId := *env.SessionId
+	destLogDir := *env.LogUploadDir
+	runCount := DerefOrZero(env.RunCount)
+	runCount++
+	env.RunCount = &runCount
 
 	// Write stdout to the folder instead of the job log
-	f, err := os.OpenFile(filepath.Join(destLogDir, "stdout.txt"), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0744)
+	f, err := os.OpenFile(filepath.Join(destLogDir, fmt.Sprintf("stdout-%03d.txt", runCount)), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0744)
 	a.NoError("Failed to create stdout file", err)
 	_, err = f.WriteString(stdout.String())
 	a.NoError("Failed to write stdout file", err)
@@ -457,7 +458,7 @@ func UploadLogs(a ScenarioAsserter, stdout AzCopyStdout, stderr *bytes.Buffer, l
 
 	// If stderr is non-zero, output that too!
 	if stderr != nil && stderr.Len() > 0 {
-		f, err := os.OpenFile(filepath.Join(destLogDir, "stderr.txt"), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0744)
+		f, err := os.OpenFile(filepath.Join(destLogDir, fmt.Sprintf("stderr-%03d.txt", runCount)), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0744)
 		a.NoError("Failed to create stdout file", err)
 		_, err = stderr.WriteTo(f)
 		a.NoError("Failed to write stdout file", err)
@@ -465,5 +466,7 @@ func UploadLogs(a ScenarioAsserter, stdout AzCopyStdout, stderr *bytes.Buffer, l
 		a.NoError("Failed to close stdout file", err)
 	}
 
-	a.Log("Uploaded failed run logs for job %s", jobId)
+	if runCount == 1 {
+		a.Log("Uploaded failed run logs for session %s", sessionId)
+	}
 }

--- a/e2etest/newe2e_task_runazcopy_parameters.go
+++ b/e2etest/newe2e_task_runazcopy_parameters.go
@@ -331,7 +331,7 @@ func (CopyFlags) SerializeListingFile(in any, a ScenarioAsserter) string {
 		_ = file.Close()
 	}(file)
 
-	a.Cleanup(func(a ScenarioAsserter) {
+	a.Cleanup(func(a Asserter) {
 		a.NoError("cleanup list file", os.Remove(path))
 	})
 

--- a/e2etest/zt_newe2e_sync_test.go
+++ b/e2etest/zt_newe2e_sync_test.go
@@ -86,7 +86,7 @@ func (s *SyncTestSuite) Scenario_TestSyncHashStorageModes(a *ScenarioVariationMa
 		customDir = pointerTo(f.URI())
 
 		if !a.Dryrun() {
-			a.Cleanup(func(a ScenarioAsserter) {
+			a.Cleanup(func(a Asserter) {
 				// Should be created by AzCopy, but, won't get tracked by the framework, because it's never actually created.
 				f.Delete(a)
 			})


### PR DESCRIPTION
## MERGE ORDER

#2958 (this PR) -> #2956 -> #2959

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**: 

Corrects some issues Wendi and others were encountering with RunAzCopy and UploadLogs in the new E2E framework. Fundamentally, the log upload function was designed intending one run per AzCopyEnvironment, patched over without understanding the root cause, and existed under the assumption all runs must produce a .azcopy folder-- This stops holding true when you re-use the same environment, try to perform a list, etc.

As such, this PR converts UploadLogs to act on "sessions" rather than one-off "jobs", no longer relying upon the job's UUID (conveniently reducing some awkward functionality and code bloat), prevents trying to re-copy logs after the first upload for a session, and makes it so that Cleanup steps happen FIFO, ensuring that run numbers are in-order with the job's execution.


## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [x] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

Manually tested against Wendi's PR, rebased #2956 atop and tested
