### PR TITLE
Default to using the customized retry policy

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -89,14 +89,16 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
+		// referencing https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/azcore/policy/policy.go#L114
+		rscList := "408;429;500;502;503;504"
 		if retryStatusCodes != "" {
-			retryStatusCodes = retryStatusCodes + ";408;429;500;502;503;504"
-			rsc, err := ste.ParseRetryCodes(retryStatusCodes)
-			if err != nil {
-				return err
-			}
-			ste.RetryStatusCodes = rsc
+			rscList += ";" + retryStatusCodes
 		}
+		rsc, err := ste.ParseRetryCodes(rscList)
+		if err != nil {
+			return fmt.Errorf("failed to parse requested retry status code list: %w", err)
+		}
+		ste.RetryStatusCodes = rsc
 
 		glcm.E2EEnableAwaitAllowOpenFiles(azcopyAwaitAllowOpenFiles)
 		if azcopyAwaitContinue {
@@ -105,7 +107,7 @@ var rootCmd = &cobra.Command{
 
 		timeAtPrestart := time.Now()
 
-		err := azcopyOutputFormat.Parse(outputFormatRaw)
+		err = azcopyOutputFormat.Parse(outputFormatRaw)
 		glcm.SetOutputFormat(azcopyOutputFormat)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**: The extra platform-specific check for the wsarecv error does not occur if no special retry policy is specified.

- **Related Links**:
- Resolves an issue I noticed with #2916 while writing scenario generators for memory testing

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

