### PR TITLE
Add memory profiling into E2E tests, scenario generators, stress tests.

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -447,7 +447,7 @@ var megaSize = []string{
 	"EB",
 }
 
-func byteSizeToString(size int64) string {
+func ByteSizeToString(size int64) string {
 	units := []string{
 		"B",
 		"KiB",
@@ -488,5 +488,5 @@ func getPath(containerName, relativePath string, level LocationLevel, entityType
 }
 
 func sizeToString(size int64, machineReadable bool) string {
-	return common.Iff(machineReadable, strconv.Itoa(int(size)), byteSizeToString(size))
+	return common.Iff(machineReadable, strconv.Itoa(int(size)), ByteSizeToString(size))
 }

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -12,7 +12,7 @@ func TestBToString(t *testing.T) {
 	expects := []string{"50.00 B", "100.00 B", "125.00 B"}
 
 	for k, v := range inputs {
-		output := byteSizeToString(v)
+		output := ByteSizeToString(v)
 		a.Equal(expects[k], output)
 	}
 }
@@ -23,7 +23,7 @@ func TestKiBToString(t *testing.T) {
 	expects := []string{"1.00 KiB", "50.00 KiB", "125.00 KiB", "5.50 KiB", "5.25 KiB"}
 
 	for k, v := range inputs {
-		output := byteSizeToString(v)
+		output := ByteSizeToString(v)
 		a.Equal(expects[k], output)
 	}
 }
@@ -34,7 +34,7 @@ func TestMiBToString(t *testing.T) {
 	expects := []string{"1.00 MiB", "50.00 MiB", "125.00 MiB", "5.50 MiB", "5.25 MiB"}
 
 	for k, v := range inputs {
-		output := byteSizeToString(v)
+		output := ByteSizeToString(v)
 		a.Equal(expects[k], output)
 	}
 }
@@ -45,7 +45,7 @@ func TestGiBToString(t *testing.T) {
 	expects := []string{"1.00 GiB", "50.00 GiB", "125.00 GiB", "5.50 GiB", "5.25 GiB"}
 
 	for k, v := range inputs {
-		output := byteSizeToString(v)
+		output := ByteSizeToString(v)
 		a.Equal(expects[k], output)
 	}
 }
@@ -56,7 +56,7 @@ func TestTiBToString(t *testing.T) {
 	expects := []string{"1.00 TiB", "50.00 TiB", "125.00 TiB", "5.50 TiB", "5.25 TiB"}
 
 	for k, v := range inputs {
-		output := byteSizeToString(v)
+		output := ByteSizeToString(v)
 		a.Equal(expects[k], output)
 	}
 }
@@ -67,7 +67,7 @@ func TestPiBToString(t *testing.T) {
 	expects := []string{"1.00 PiB", "50.00 PiB", "125.00 PiB", "5.50 PiB", "5.25 PiB"}
 
 	for k, v := range inputs {
-		output := byteSizeToString(v)
+		output := ByteSizeToString(v)
 		a.Equal(expects[k], output)
 	}
 }
@@ -78,7 +78,7 @@ func TestEiBToString(t *testing.T) {
 	expects := []string{"1.00 EiB", "5.50 EiB", "5.25 EiB"} //50 & 125 aren't present Because they overflow int64
 
 	for k, v := range inputs {
-		output := byteSizeToString(v)
+		output := ByteSizeToString(v)
 		a.Equal(expects[k], output)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,12 +87,12 @@ var rootCmd = &cobra.Command{
 		glcm.RegisterCloseFunc(func() {
 			if debugMemoryProfile != "" {
 				memProfDir := filepath.Dir(debugMemoryProfile)
-				err := os.MkdirAll(memProfDir, 0644)
+				err := os.MkdirAll(memProfDir, 0777)
 				if err != nil {
 					panic(fmt.Sprintf("Failed to create memory profile parent dir: %v", err))
 				}
 
-				f, err := os.OpenFile(debugMemoryProfile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+				f, err := os.OpenFile(debugMemoryProfile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
 				if err != nil {
 					panic(fmt.Sprintf("Failed to open memory profile: %v", err))
 				}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,6 +86,12 @@ var rootCmd = &cobra.Command{
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		glcm.RegisterCloseFunc(func() {
 			if debugMemoryProfile != "" {
+				memProfDir := filepath.Dir(debugMemoryProfile)
+				err := os.MkdirAll(memProfDir, 0644)
+				if err != nil {
+					panic(fmt.Sprintf("Failed to create memory profile parent dir: %v", err))
+				}
+
 				f, err := os.OpenFile(debugMemoryProfile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 				if err != nil {
 					panic(fmt.Sprintf("Failed to open memory profile: %v", err))

--- a/common/lifecyleMgr.go
+++ b/common/lifecyleMgr.go
@@ -427,7 +427,16 @@ func (lcm *lifecycleMgr) SurrenderControl() {
 }
 
 func (lcm *lifecycleMgr) RegisterCloseFunc(closeFunc func()) {
-	lcm.closeFunc = closeFunc
+	if lcm.closeFunc != nil {
+		// "dereference" the function for later calling
+		orig := lcm.closeFunc
+		lcm.closeFunc = func() {
+			orig()
+			closeFunc()
+		}
+	} else {
+		lcm.closeFunc = closeFunc
+	}
 }
 
 func (lcm *lifecycleMgr) processOutputMessage() {

--- a/e2etest/newe2e_account_registry.go
+++ b/e2etest/newe2e_account_registry.go
@@ -131,20 +131,26 @@ func AccountRegistryInitHook(a Asserter) {
 	if GlobalConfig.StaticResources() {
 		acctInfo := GlobalConfig.E2EAuthConfig.StaticStgAcctInfo
 
-		AccountRegistry[PrimaryStandardAcct] = &AzureAccountResourceManager{
-			accountName: acctInfo.Standard.AccountName,
-			accountKey:  acctInfo.Standard.AccountKey,
-			accountType: EAccountType.Standard(),
+		if acctInfo.Standard.AccountName != "" {
+			AccountRegistry[PrimaryStandardAcct] = &AzureAccountResourceManager{
+				accountName: acctInfo.Standard.AccountName,
+				accountKey:  acctInfo.Standard.AccountKey,
+				accountType: EAccountType.Standard(),
+			}
 		}
-		AccountRegistry[PrimaryHNSAcct] = &AzureAccountResourceManager{
-			accountName: acctInfo.HNS.AccountName,
-			accountKey:  acctInfo.HNS.AccountKey,
-			accountType: EAccountType.HierarchicalNamespaceEnabled(),
+		if acctInfo.HNS.AccountName != "" {
+			AccountRegistry[PrimaryHNSAcct] = &AzureAccountResourceManager{
+				accountName: acctInfo.HNS.AccountName,
+				accountKey:  acctInfo.HNS.AccountKey,
+				accountType: EAccountType.HierarchicalNamespaceEnabled(),
+			}
 		}
-		AccountRegistry[PremiumPageBlobAcct] = &AzureAccountResourceManager{
-			accountName: acctInfo.PremiumPage.AccountName,
-			accountKey:  acctInfo.PremiumPage.AccountKey,
-			accountType: EAccountType.PremiumPageBlobs(),
+		if acctInfo.PremiumPage.AccountName != "" {
+			AccountRegistry[PremiumPageBlobAcct] = &AzureAccountResourceManager{
+				accountName: acctInfo.PremiumPage.AccountName,
+				accountKey:  acctInfo.PremiumPage.AccountKey,
+				accountType: EAccountType.PremiumPageBlobs(),
+			}
 		}
 	} else {
 		// Create standard accounts

--- a/e2etest/newe2e_account_registry.go
+++ b/e2etest/newe2e_account_registry.go
@@ -92,10 +92,10 @@ func CreateAccount(a Asserter, accountType AccountType, options *CreateAccountOp
 	a.NoError("ARM get keys call", err)
 
 	acct := &AzureAccountResourceManager{
-		accountName: accountARMClient.AccountName,
-		accountKey:  keys.Keys[0].Value, // todo find useful key
-		accountType: accountType,
-		armClient:   accountARMClient,
+		InternalAccountName: accountARMClient.AccountName,
+		InternalAccountKey:  keys.Keys[0].Value, // todo find useful key
+		InternalAccountType: accountType,
+		ArmClient:           accountARMClient,
 	}
 
 	if rt, ok := a.(ResourceTracker); ok {
@@ -133,23 +133,23 @@ func AccountRegistryInitHook(a Asserter) {
 
 		if acctInfo.Standard.AccountName != "" {
 			AccountRegistry[PrimaryStandardAcct] = &AzureAccountResourceManager{
-				accountName: acctInfo.Standard.AccountName,
-				accountKey:  acctInfo.Standard.AccountKey,
-				accountType: EAccountType.Standard(),
+				InternalAccountName: acctInfo.Standard.AccountName,
+				InternalAccountKey:  acctInfo.Standard.AccountKey,
+				InternalAccountType: EAccountType.Standard(),
 			}
 		}
 		if acctInfo.HNS.AccountName != "" {
 			AccountRegistry[PrimaryHNSAcct] = &AzureAccountResourceManager{
-				accountName: acctInfo.HNS.AccountName,
-				accountKey:  acctInfo.HNS.AccountKey,
-				accountType: EAccountType.HierarchicalNamespaceEnabled(),
+				InternalAccountName: acctInfo.HNS.AccountName,
+				InternalAccountKey:  acctInfo.HNS.AccountKey,
+				InternalAccountType: EAccountType.HierarchicalNamespaceEnabled(),
 			}
 		}
 		if acctInfo.PremiumPage.AccountName != "" {
 			AccountRegistry[PremiumPageBlobAcct] = &AzureAccountResourceManager{
-				accountName: acctInfo.PremiumPage.AccountName,
-				accountKey:  acctInfo.PremiumPage.AccountKey,
-				accountType: EAccountType.PremiumPageBlobs(),
+				InternalAccountName: acctInfo.PremiumPage.AccountName,
+				InternalAccountKey:  acctInfo.PremiumPage.AccountKey,
+				InternalAccountType: EAccountType.PremiumPageBlobs(),
 			}
 		}
 	} else {

--- a/e2etest/newe2e_arm_storage_account.go
+++ b/e2etest/newe2e_arm_storage_account.go
@@ -71,10 +71,10 @@ func (sa *ARMStorageAccount) GetResourceManager() (*AzureAccountResourceManager,
 	}
 
 	return &AzureAccountResourceManager{
-		accountName: sa.AccountName,
-		accountKey:  acctKey,
-		accountType: acctType,
-		armClient:   sa,
+		InternalAccountName: sa.AccountName,
+		InternalAccountKey:  acctKey,
+		InternalAccountType: acctType,
+		ArmClient:           sa,
 	}, nil
 }
 

--- a/e2etest/newe2e_asserter.go
+++ b/e2etest/newe2e_asserter.go
@@ -46,6 +46,7 @@ type CleanupFunc func(a Asserter)
 
 type ScenarioAsserter interface {
 	DryrunAsserter
+	ContextManager
 
 	Cleanup(CleanupFunc)
 	UUID() uuid.UUID

--- a/e2etest/newe2e_asserter.go
+++ b/e2etest/newe2e_asserter.go
@@ -46,34 +46,6 @@ type ScenarioAsserter interface {
 	Cleanup(CleanupFunc)
 }
 
-type ScenarioAsserterWrapper struct {
-	Asserter
-
-	CleanupFuncs []CleanupFunc
-}
-
-func (s *ScenarioAsserterWrapper) Dryrun() bool {
-	return false
-}
-
-func (s *ScenarioAsserterWrapper) Invalid() bool {
-	return false
-}
-
-func (s *ScenarioAsserterWrapper) InvalidateScenario() {
-	// noop
-}
-
-func (s *ScenarioAsserterWrapper) Cleanup(cleanupFunc CleanupFunc) {
-	if s.Dryrun() {
-		return
-	}
-}
-
-func (s *ScenarioAsserterWrapper) DoCleanup() {
-	
-}
-
 // HelperMarker handles the fact that testing.T can be sometimes nil, and that we can't indicate a depth to ignore with Helper()
 type HelperMarker interface {
 	Helper()

--- a/e2etest/newe2e_asserter.go
+++ b/e2etest/newe2e_asserter.go
@@ -46,6 +46,34 @@ type ScenarioAsserter interface {
 	Cleanup(CleanupFunc)
 }
 
+type ScenarioAsserterWrapper struct {
+	Asserter
+
+	CleanupFuncs []CleanupFunc
+}
+
+func (s *ScenarioAsserterWrapper) Dryrun() bool {
+	return false
+}
+
+func (s *ScenarioAsserterWrapper) Invalid() bool {
+	return false
+}
+
+func (s *ScenarioAsserterWrapper) InvalidateScenario() {
+	// noop
+}
+
+func (s *ScenarioAsserterWrapper) Cleanup(cleanupFunc CleanupFunc) {
+	if s.Dryrun() {
+		return
+	}
+}
+
+func (s *ScenarioAsserterWrapper) DoCleanup() {
+	
+}
+
 // HelperMarker handles the fact that testing.T can be sometimes nil, and that we can't indicate a depth to ignore with Helper()
 type HelperMarker interface {
 	Helper()

--- a/e2etest/newe2e_asserter.go
+++ b/e2etest/newe2e_asserter.go
@@ -1,7 +1,9 @@
 package e2etest
 
 import (
+	"context"
 	"fmt"
+	"github.com/google/uuid"
 	"strings"
 	"testing"
 )
@@ -28,6 +30,8 @@ type Asserter interface {
 	Failed() bool
 	// HelperMarker returns the associated *testing.T, and if there is none, a NilHelperMarker.
 	HelperMarker() HelperMarker
+
+	GetTestName() string
 }
 
 type DryrunAsserter interface {
@@ -44,6 +48,12 @@ type ScenarioAsserter interface {
 	DryrunAsserter
 
 	Cleanup(CleanupFunc)
+	UUID() uuid.UUID
+}
+
+type ContextManager interface {
+	Context() context.Context
+	SetContext(ctx context.Context)
 }
 
 // HelperMarker handles the fact that testing.T can be sometimes nil, and that we can't indicate a depth to ignore with Helper()

--- a/e2etest/newe2e_azcopy_environment_manager.go
+++ b/e2etest/newe2e_azcopy_environment_manager.go
@@ -1,0 +1,286 @@
+package e2etest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/google/uuid"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+type AzCopyEnvironmentManagerKey struct{}
+type AzCopyEnvironmentKey struct{}
+type AzCopyRunNumKey struct{}
+
+func FetchAzCopyEnvironmentContext(cm ScenarioAsserter) *AzCopyEnvironmentContext {
+	pCtx := cm.Context()
+	out := pCtx.Value(AzCopyEnvironmentManagerKey{})
+
+	if out == nil {
+		envCtx := &AzCopyEnvironmentContext{
+			ScenarioID:   uuid.New(),
+			Environments: make([]*AzCopyEnvironment, 0),
+
+			mu:          &sync.Mutex{},
+			cleanupOnce: &sync.Once{},
+
+			parent: pCtx,
+		}
+
+		cm.SetContext(envCtx)
+		return envCtx
+	}
+
+	return out.(*AzCopyEnvironmentContext)
+}
+
+type LogUpload struct {
+	EnvironmentID uint
+	RunID         uint
+
+	Stdout string
+	Stderr string
+}
+
+type AzCopyEnvironmentContext struct {
+	ScenarioID   uuid.UUID
+	Environments []*AzCopyEnvironment
+	LogUploads   []LogUpload
+
+	// let's just code defensively and assume there will be a test case that will run azcopy instances in parallel
+	mu          *sync.Mutex
+	cleanupOnce *sync.Once
+
+	parent context.Context
+}
+
+func (envCtx *AzCopyEnvironmentContext) Deadline() (deadline time.Time, ok bool) {
+	return envCtx.parent.Deadline()
+}
+
+func (envCtx *AzCopyEnvironmentContext) Done() <-chan struct{} {
+	return envCtx.parent.Done()
+}
+
+func (envCtx *AzCopyEnvironmentContext) Err() error {
+	return envCtx.parent.Err()
+}
+
+func (envCtx *AzCopyEnvironmentContext) Value(key any) any {
+	if key == (AzCopyEnvironmentManagerKey{}) {
+		return envCtx
+	}
+
+	return envCtx.parent.Value(key)
+}
+
+func (envCtx *AzCopyEnvironmentContext) GetEnvTempPath(env *AzCopyEnvironment) string {
+	return filepath.Join(os.TempDir(), envCtx.ScenarioID.String(), fmt.Sprintf("%03d", DerefOrZero(env.EnvironmentId)))
+}
+
+func (envCtx *AzCopyEnvironmentContext) GetEnvUploadPath(env *AzCopyEnvironment) string {
+	return filepath.Join(GlobalConfig.AzCopyExecutableConfig.LogDropPath, envCtx.ScenarioID.String(), fmt.Sprintf("%03d", DerefOrZero(env.EnvironmentId)))
+}
+
+const (
+	LogSubdir   = "log"
+	PlanSubdir  = "plan"
+	PprofSubdir = "pprof"
+	PprofMemFmt = "%03d.memory.pprof"
+	StdoutFmt   = "%03d.stdout.txt"
+	StderrFmt   = "%03d.stderr.txt"
+)
+
+// CreateEnvironment should be called in the event an AzCopyEnvironment wasn't specified, and should be presumed to be Run 0.
+func (envCtx *AzCopyEnvironmentContext) CreateEnvironment() *AzCopyEnvironment {
+	envCtx.mu.Lock()
+	defer envCtx.mu.Unlock()
+
+	out := &AzCopyEnvironment{
+		ParentContext: envCtx,
+		EnvironmentId: pointerTo(uint(len(envCtx.Environments))),
+		RunCount:      pointerTo[uint](1),
+	}
+
+	envCtx.Environments = append(envCtx.Environments, out)
+
+	return out
+}
+
+// RegisterEnvironment should be called if an AzCopyEnvironment is specified, and will no-op if the env already was registered.
+func (envCtx *AzCopyEnvironmentContext) RegisterEnvironment(env *AzCopyEnvironment) (runId uint) {
+	envCtx.mu.Lock()
+	defer envCtx.mu.Unlock()
+
+	rc := DerefOrZero(env.RunCount)
+	env.RunCount = pointerTo(rc + 1)
+
+	if env.EnvironmentId != nil {
+		return rc
+	}
+
+	env.EnvironmentId = pointerTo(uint(len(envCtx.Environments)))
+	env.ParentContext = envCtx
+
+	return rc
+}
+
+func (envCtx *AzCopyEnvironmentContext) RegisterLogUpload(upload LogUpload) {
+	envCtx.mu.Lock()
+	envCtx.mu.Unlock()
+
+	envCtx.LogUploads = append(envCtx.LogUploads, upload)
+}
+
+func (envCtx *AzCopyEnvironmentContext) SetupCleanup(a ScenarioAsserter) {
+	envCtx.cleanupOnce.Do(func() {
+		a.Cleanup(func(a Asserter) {
+			envCtx.DoCleanup(a)
+		})
+	})
+}
+
+func (envCtx *AzCopyEnvironmentContext) DoCleanup(a Asserter) {
+	envCtx.mu.Lock()
+	defer envCtx.mu.Unlock()
+
+	// defer deletion of the temp dir
+	defer func() {
+		_ = os.RemoveAll(filepath.Join(os.TempDir(), envCtx.ScenarioID.String()))
+	}()
+
+	// Upload all of the files on the disk that are needed
+	for _, v := range envCtx.Environments {
+		v.DoCleanup(a)
+	}
+
+	if a.Failed() && GlobalConfig.AzCopyExecutableConfig.LogDropPath != "" {
+		for _, logUpload := range envCtx.LogUploads {
+			env := envCtx.Environments[logUpload.EnvironmentID]
+			envUploadDir := envCtx.GetEnvUploadPath(env)
+
+			if len(logUpload.Stdout) > 0 {
+				logFile, err := os.Create(filepath.Join(envUploadDir, fmt.Sprintf(StdoutFmt, logUpload.RunID)))
+				a.NoError(fmt.Sprintf("create stdout file "+StdoutFmt, logUpload.RunID), err)
+				if err == nil {
+					_, err = logFile.WriteString(logUpload.Stdout)
+					a.NoError(fmt.Sprintf("write stdout file "+StdoutFmt, logUpload.RunID), err)
+				}
+			}
+
+			if len(logUpload.Stderr) > 0 {
+				logFile, err := os.Create(filepath.Join(envUploadDir, fmt.Sprintf(StderrFmt, logUpload.RunID)))
+				a.NoError(fmt.Sprintf("create stderr file "+StderrFmt, logUpload.RunID), err)
+				if err == nil {
+					_, err = logFile.WriteString(logUpload.Stderr)
+					a.NoError(fmt.Sprintf("write stderr file "+StderrFmt, logUpload.RunID), err)
+				}
+			}
+		}
+	}
+}
+
+func (env *AzCopyEnvironment) DoCleanup(a Asserter) {
+	p := env.ParentContext
+	envPath := p.GetEnvTempPath(env)
+
+	// Upload the memory profiles even if we didn't fail
+	for pprofRun := range *env.RunCount {
+		memProfLoc := filepath.Join(
+			envPath,
+			PprofSubdir,
+			fmt.Sprintf(PprofMemFmt, pprofRun))
+
+		UploadMemoryProfile(a, memProfLoc, pprofRun)
+	}
+
+	// set up the log drop path
+	logDropPath := GlobalConfig.AzCopyExecutableConfig.LogDropPath
+	if !a.Failed() || logDropPath == "" {
+		return
+	}
+	logDropPath = env.ParentContext.GetEnvUploadPath(env)
+
+	// DRY
+	CopyDir := func(source, dest string) error {
+		err := os.MkdirAll(dest, os.ModePerm|os.ModeDir)
+		if err != nil && !errors.Is(err, os.ErrExist) {
+			return fmt.Errorf("failed to create dest directory: %w", err)
+		}
+
+		var errList []error
+		err = filepath.WalkDir(source, func(path string, d fs.DirEntry, err error) error {
+			relPath := strings.TrimPrefix(path, source)
+			if err != nil {
+				errList = append(errList, fmt.Errorf("failed to read %s: %w", relPath, err))
+				return nil
+			}
+
+			if d.IsDir() {
+				err = os.MkdirAll(filepath.Join(dest, relPath), os.ModePerm|os.ModeDir)
+				if err != nil {
+					errList = append(errList, fmt.Errorf("failed to create dir %s: %w", relPath, err))
+				}
+				return nil
+			}
+
+			srcFile, err := os.Open(path)
+			if err != nil {
+				errList = append(errList, fmt.Errorf("failed to open file %s: %w", relPath, err))
+				return nil
+			}
+			defer func() {
+				_ = srcFile.Close()
+			}()
+
+			destFile, err := os.Create(filepath.Join(dest, relPath))
+			if err != nil {
+				errList = append(errList, fmt.Errorf("failed to create dest file %s: %w", relPath, err))
+				return nil
+			}
+			defer func() {
+				_ = destFile.Close()
+			}()
+
+			_, err = io.Copy(destFile, srcFile)
+			if err != nil {
+				errList = append(errList, fmt.Errorf(""))
+			}
+
+			return nil
+		})
+
+		if errCt := len(errList); errCt == 0 {
+			return nil
+		} else if errCt == 1 {
+			return errList[0]
+		} else {
+			out := "Encountered multiple errors copying directory: "
+
+			for _, v := range errList {
+				out += "\n"
+
+				out += v.Error()
+			}
+
+			return errors.New(out)
+		}
+	}
+
+	// Upload logs
+	err := CopyDir(*env.LogLocation, filepath.Join(logDropPath, LogSubdir))
+	a.NoError("failed to copy logs", err)
+
+	// Upload plans
+	err = CopyDir(*env.JobPlanLocation, filepath.Join(logDropPath, PlanSubdir))
+	a.NoError("failed to copy plans", err)
+
+	uploadRelPath := strings.TrimPrefix(logDropPath, GlobalConfig.AzCopyExecutableConfig.LogDropPath)
+	a.Log("Uploaded logs for session to %s", uploadRelPath)
+}

--- a/e2etest/newe2e_config.go
+++ b/e2etest/newe2e_config.go
@@ -4,10 +4,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	tableservice "github.com/Azure/azure-sdk-for-go/sdk/data/aztables"
+	blobservice "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/service"
 	"os"
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 )
 
 var GlobalConfig NewE2EConfig
@@ -23,6 +26,7 @@ The following options can be as follows:
 - mutually_exclusive: Only one field under this must be completely fulfilled. Multiple is unacceptable. Ignored on values and json structs.
 - minimum_required: How many required fields under this field must match, separated by an equal. Only numbers are accepted.
 - default: must be the final argument, separated with an equal. Everything that follows will be used, including commas.
+- defaultfunc: exactly like AzCopyEnvironment except `func() (T, error)` (as of this time)
 
 All immediate fields of a mutually exclusive struct will be treated as required, and all but one field will be expected to fail.
 Structs that are not marked "required" will present Environment errors from "required" fields when one or more options are successfully set
@@ -86,12 +90,26 @@ type NewE2EConfig struct {
 		} `env:",required,minimum_required=1"`
 	} `env:",required,mutually_exclusive"`
 
+	// Not required in any way-- Used in CI to record results regularly. SubscriptionLoginInfo should be used, or a static account key present here.
+	TelemetryConfig struct {
+		AccountName string `env:"NEW_E2E_TELEMETRY_ACCT_NAME"`
+		AccountKey  string `env:"NEW_E2E_TELEMETRY_ACCT_KEY"`
+		// The identifier in which all telemetry data will be added under this key. If nothing is specified, the present UNIX time will be used.
+		DataKey string `env:"NEW_E2E_TELEMETRY_DATA_KEY,defaultfunc=DefaultTelemetryDataKey"`
+
+		StressTestEnabled bool `env:"NEW_E2E_TELEMETRY_STRESS_TEST_ENABLED,default=false"`
+	}
+
 	AzCopyExecutableConfig struct {
 		ExecutablePath      string `env:"NEW_E2E_AZCOPY_PATH,required"`
 		AutobuildExecutable bool   `env:"NEW_E2E_AUTOBUILD_AZCOPY,default=true"` // todo: make this work. It does not as of 11-21-23
 
 		LogDropPath string `env:"AZCOPY_E2E_LOG_OUTPUT"`
 	} `env:",required"`
+}
+
+func (e NewE2EConfig) DefaultTelemetryDataKey() (string, error) {
+	return fmt.Sprint(time.Now().Unix()), nil
 }
 
 func (e NewE2EConfig) StaticResources() bool {
@@ -128,11 +146,104 @@ func (e NewE2EConfig) GetTenantID() string {
 	}
 }
 
+func (e NewE2EConfig) TelemetryConfigured() bool {
+	if e.TelemetryConfig.AccountName == "" { // we need to know where to put the data
+		return false
+	}
+
+	if e.StaticResources() && e.TelemetryConfig.AccountKey == "" { // Auth needed in some form
+		return false
+	}
+
+	return true
+}
+
+var telemetryServiceCache struct {
+	blob  *blobservice.Client
+	table *tableservice.Client
+}
+
+func (e NewE2EConfig) GetTelemetryBlobService() (*blobservice.Client, error) {
+	if telemetryServiceCache.blob != nil {
+		return telemetryServiceCache.blob, nil
+	}
+
+	if !e.TelemetryConfigured() {
+		return nil, errors.New("telemetry unconfigured")
+	}
+
+	uri := fmt.Sprintf("https://%s.blob.core.windows.net", e.TelemetryConfig.AccountName)
+
+	if e.StaticResources() {
+		sk, err := blobservice.NewSharedKeyCredential(e.TelemetryConfig.AccountName, e.TelemetryConfig.AccountKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to set up telemetry: invalid key: %w", err)
+		}
+
+		c, err := blobservice.NewClientWithSharedKeyCredential(
+			uri,
+			sk,
+			nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to set up telemetry: failed client creation: %w", err)
+		}
+
+		return c, nil
+	} else {
+		c, err := blobservice.NewClient(
+			uri,
+			PrimaryOAuthCache.tc,
+			nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to set up telemetry: failed client creation: %w", err)
+		}
+
+		return c, nil
+	}
+}
+
+func (e NewE2EConfig) GetTelemetryTableService() (*tableservice.ServiceClient, error) {
+
+	if !e.TelemetryConfigured() {
+		return nil, errors.New("telemetry unconfigured")
+	}
+
+	uri := fmt.Sprintf("https://%s.table.core.windows.net", e.TelemetryConfig.AccountName)
+
+	if e.StaticResources() {
+		sk, err := tableservice.NewSharedKeyCredential(e.TelemetryConfig.AccountName, e.TelemetryConfig.AccountKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to set up telemetry: invalid key: %w", err)
+		}
+
+		c, err := tableservice.NewServiceClientWithSharedKey(
+			uri,
+			sk,
+			nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to set up telemetry: failed client creation: %w", err)
+		}
+
+		return c, nil
+	} else {
+		c, err := tableservice.NewServiceClient(
+			uri,
+			PrimaryOAuthCache.tc,
+			nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to set up telemetry: failed client creation: %w", err)
+		}
+
+		return c, nil
+	}
+}
+
 // ========= Tag Definition ==========
 
 type EnvTag struct {
 	EnvName                     string
 	DefaultValue                string
+	DefaultFunc                 string
 	Required, MutuallyExclusive bool
 	MinimumRequired             uint
 }
@@ -154,6 +265,8 @@ func ParseEnvTag(tag string) EnvTag {
 			out.Required = true
 		case strings.EqualFold(v, "mutually_exclusive"):
 			out.MutuallyExclusive = true
+		case strings.HasPrefix(v, "defaultfunc="):
+			out.DefaultFunc = strings.TrimPrefix(v+strings.Join(parts[i+1:], ","), "defaultfunc=")
 		case strings.HasPrefix(v, "default="):
 			out.DefaultValue = strings.TrimPrefix(v+strings.Join(parts[i+1:], ","), "default=")
 		case strings.HasPrefix(v, "minimum_required="):
@@ -281,6 +394,7 @@ func (c *ConfigReaderError) Finalize() *ConfigReaderError {
 // ========== Config Reader ===========
 
 func SetValue(fieldName string, val reflect.Value, tag EnvTag) *ConfigReaderError {
+
 	res, ok := os.LookupEnv(tag.EnvName)
 	if !ok {
 		if tag.DefaultValue != "" {
@@ -289,6 +403,20 @@ func SetValue(fieldName string, val reflect.Value, tag EnvTag) *ConfigReaderErro
 
 			if res == "" {
 				return nil // defensively code against a zero-default, though it makes no sense.
+			}
+		} else if tag.DefaultFunc != "" {
+			out := reflect.ValueOf(GlobalConfig).MethodByName(tag.DefaultFunc) // First, target the real value, this catches non-pointer methods
+
+			if !out.IsValid() {
+				return NewConfigReaderErrorEnv(tag.EnvName, fieldName, fmt.Errorf("Could not locate function %s attached to NewE2EConfig", tag.DefaultFunc))
+			}
+
+			ret := out.Call([]reflect.Value{})
+			if !ret[1].IsNil() {
+				return NewConfigReaderErrorEnv(tag.EnvName, fieldName, ret[1].Interface().(error))
+			} else {
+				val.Set(ret[0])
+				return nil
 			}
 		} else if tag.Required {
 			return NewConfigReaderErrorEnv(tag.EnvName, fieldName, errors.New("environment variable not found"))

--- a/e2etest/newe2e_generic_wrangling.go
+++ b/e2etest/newe2e_generic_wrangling.go
@@ -3,6 +3,7 @@ package e2etest
 import (
 	"fmt"
 	"reflect"
+	"sync"
 )
 
 func FirstOrZero[T any](list []T) T {
@@ -171,4 +172,28 @@ func JoinMap[K comparable, V any](in ...map[K]V) map[K]V {
 	}
 
 	return out
+}
+
+type RWMutexResource[T any] struct {
+	res  T
+	rwmu *sync.RWMutex
+}
+
+func NewRWMutexResource[T any](res T) *RWMutexResource[T] {
+	return &RWMutexResource[T]{
+		res:  res,
+		rwmu: &sync.RWMutex{},
+	}
+}
+
+func (r *RWMutexResource[T]) DoRead(f func(res T)) {
+	r.rwmu.RLock()
+	defer r.rwmu.RUnlock()
+	f(r.res)
+}
+
+func (r *RWMutexResource[T]) DoWrite(f func(res T)) {
+	r.rwmu.Lock()
+	defer r.rwmu.Unlock()
+	f(r.res)
 }

--- a/e2etest/newe2e_resource_manager_azstorage.go
+++ b/e2etest/newe2e_resource_manager_azstorage.go
@@ -29,11 +29,11 @@ func addWildCard(uri string, optList ...GetURIOptions) string {
 }
 
 type AzureAccountResourceManager struct {
-	accountName string
-	accountKey  string
-	accountType AccountType
+	InternalAccountName string
+	InternalAccountKey  string
+	InternalAccountType AccountType
 
-	armClient *ARMStorageAccount
+	ArmClient *ARMStorageAccount
 }
 
 func (acct *AzureAccountResourceManager) ApplySAS(URI string, loc common.Location, optList ...GetURIOptions) string {
@@ -57,7 +57,7 @@ func (acct *AzureAccountResourceManager) ApplySAS(URI string, loc common.Locatio
 
 	switch loc {
 	case common.ELocation.Blob():
-		skc, err := blobservice.NewSharedKeyCredential(acct.accountName, acct.accountKey)
+		skc, err := blobservice.NewSharedKeyCredential(acct.InternalAccountName, acct.InternalAccountKey)
 		common.PanicIfErr(err)
 
 		p, err := sasVals.AsBlob().SignWithSharedKey(skc)
@@ -70,7 +70,7 @@ func (acct *AzureAccountResourceManager) ApplySAS(URI string, loc common.Locatio
 		parts.Scheme = common.Iff(opts.RemoteOpts.Scheme != "", opts.RemoteOpts.Scheme, "https")
 		return parts.String()
 	case common.ELocation.File():
-		skc, err := fileservice.NewSharedKeyCredential(acct.accountName, acct.accountKey)
+		skc, err := fileservice.NewSharedKeyCredential(acct.InternalAccountName, acct.InternalAccountKey)
 		common.PanicIfErr(err)
 
 		p, err := sasVals.AsFile().SignWithSharedKey(skc)
@@ -83,7 +83,7 @@ func (acct *AzureAccountResourceManager) ApplySAS(URI string, loc common.Locatio
 		parts.Scheme = common.Iff(opts.RemoteOpts.Scheme != "", opts.RemoteOpts.Scheme, "https")
 		return parts.String()
 	case common.ELocation.BlobFS():
-		skc, err := blobfscommon.NewSharedKeyCredential(acct.accountName, acct.accountKey)
+		skc, err := blobfscommon.NewSharedKeyCredential(acct.InternalAccountName, acct.InternalAccountKey)
 		common.PanicIfErr(err)
 
 		p, err := sasVals.AsDatalake().SignWithSharedKey(skc)
@@ -106,15 +106,15 @@ func (acct *AzureAccountResourceManager) ApplySAS(URI string, loc common.Locatio
 // If the account is a "modern" ARM storage account, ARMStorageAccount will be returned.
 // If the account is a "classic" storage account, ARMClassicStorageAccount (not yet implemented) will be returned.
 func (acct *AzureAccountResourceManager) ManagementClient() *ARMStorageAccount {
-	return acct.armClient
+	return acct.ArmClient
 }
 
 func (acct *AzureAccountResourceManager) AccountName() string {
-	return acct.accountName
+	return acct.InternalAccountName
 }
 
 func (acct *AzureAccountResourceManager) AccountType() AccountType {
-	return acct.accountType
+	return acct.InternalAccountType
 }
 
 func (acct *AzureAccountResourceManager) AvailableServices() []common.Location {
@@ -128,11 +128,11 @@ func (acct *AzureAccountResourceManager) AvailableServices() []common.Location {
 func (acct *AzureAccountResourceManager) getServiceURL(a Asserter, service common.Location) string {
 	switch service {
 	case common.ELocation.Blob():
-		return fmt.Sprintf("https://%s.blob.core.windows.net/", acct.accountName)
+		return fmt.Sprintf("https://%s.blob.core.windows.net/", acct.InternalAccountName)
 	case common.ELocation.File():
-		return fmt.Sprintf("https://%s.file.core.windows.net/", acct.accountName)
+		return fmt.Sprintf("https://%s.file.core.windows.net/", acct.InternalAccountName)
 	case common.ELocation.BlobFS():
-		return fmt.Sprintf("https://%s.dfs.core.windows.net/", acct.accountName)
+		return fmt.Sprintf("https://%s.dfs.core.windows.net/", acct.InternalAccountName)
 	default:
 		a.Error(fmt.Sprintf("Service %s is not supported by this resource manager.", service))
 		return ""
@@ -144,7 +144,7 @@ func (acct *AzureAccountResourceManager) GetService(a Asserter, location common.
 
 	switch location {
 	case common.ELocation.Blob():
-		sharedKey, err := blobservice.NewSharedKeyCredential(acct.accountName, acct.accountKey)
+		sharedKey, err := blobservice.NewSharedKeyCredential(acct.InternalAccountName, acct.InternalAccountKey)
 		a.NoError("Create shared key", err)
 		client, err := blobservice.NewClientWithSharedKeyCredential(uri, sharedKey, nil)
 		a.NoError("Create Blob client", err)
@@ -154,7 +154,7 @@ func (acct *AzureAccountResourceManager) GetService(a Asserter, location common.
 			InternalClient:  client,
 		}
 	case common.ELocation.File():
-		sharedKey, err := fileservice.NewSharedKeyCredential(acct.accountName, acct.accountKey)
+		sharedKey, err := fileservice.NewSharedKeyCredential(acct.InternalAccountName, acct.InternalAccountKey)
 		a.NoError("Create shared key", err)
 		client, err := fileservice.NewClientWithSharedKeyCredential(uri, sharedKey, &fileservice.ClientOptions{AllowTrailingDot: to.Ptr(true)})
 		a.NoError("Create File client", err)
@@ -164,13 +164,13 @@ func (acct *AzureAccountResourceManager) GetService(a Asserter, location common.
 			InternalClient:  client,
 		}
 	case common.ELocation.BlobFS():
-		sharedKey, err := blobfscommon.NewSharedKeyCredential(acct.accountName, acct.accountKey)
+		sharedKey, err := blobfscommon.NewSharedKeyCredential(acct.InternalAccountName, acct.InternalAccountKey)
 		client, err := blobfsservice.NewClientWithSharedKeyCredential(uri, sharedKey, nil)
 		a.NoError("Create BlobFS client", err)
 
 		return &BlobFSServiceResourceManager{
-			internalAccount: acct,
-			internalClient:  client,
+			InternalAccount: acct,
+			InternalClient:  client,
 		}
 	default:
 		return nil // GetServiceURL already covered the error

--- a/e2etest/newe2e_resource_manager_azstorage.go
+++ b/e2etest/newe2e_resource_manager_azstorage.go
@@ -150,8 +150,8 @@ func (acct *AzureAccountResourceManager) GetService(a Asserter, location common.
 		a.NoError("Create Blob client", err)
 
 		return &BlobServiceResourceManager{
-			internalAccount: acct,
-			internalClient:  client,
+			InternalAccount: acct,
+			InternalClient:  client,
 		}
 	case common.ELocation.File():
 		sharedKey, err := fileservice.NewSharedKeyCredential(acct.accountName, acct.accountKey)
@@ -160,8 +160,8 @@ func (acct *AzureAccountResourceManager) GetService(a Asserter, location common.
 		a.NoError("Create File client", err)
 
 		return &FileServiceResourceManager{
-			internalAccount: acct,
-			internalClient:  client,
+			InternalAccount: acct,
+			InternalClient:  client,
 		}
 	case common.ELocation.BlobFS():
 		sharedKey, err := blobfscommon.NewSharedKeyCredential(acct.accountName, acct.accountKey)

--- a/e2etest/newe2e_resource_manager_getter.go
+++ b/e2etest/newe2e_resource_manager_getter.go
@@ -25,10 +25,8 @@ func GetRootResource(a Asserter, location common.Location, varOpts ...GetResourc
 
 		return NewLocalContainer(a)
 	case common.ELocation.BlobFS():
-		// do we have a hns acct attached, if so, and we're requesting blobfs, let's use it
-		if _, ok := AccountRegistry[PrimaryHNSAcct]; ok {
-			defaultacct = PrimaryHNSAcct
-		}
+		// If we're trying to interact with blobfs we almost always want the hns account. test can specify if otherwise.
+		defaultacct = PrimaryHNSAcct
 
 		fallthrough // Continue to grab the account
 	case common.ELocation.Blob(), common.ELocation.File():

--- a/e2etest/newe2e_resource_managers_blobfs.go
+++ b/e2etest/newe2e_resource_managers_blobfs.go
@@ -554,7 +554,7 @@ func (b *BlobFSPathResourceProvider) getFileClient() *file.Client {
 func (b *BlobFSPathResourceProvider) getBlobClient(a Asserter) *blob.Client {
 	a.HelperMarker().Helper()
 	blobService := b.internalAccount.GetService(a, common.ELocation.Blob()).(*BlobServiceResourceManager) // Blob and BlobFS are synonymous, so simply getting the same path is fine.
-	container := blobService.internalClient.NewContainerClient(b.Container.containerName)
+	container := blobService.InternalClient.NewContainerClient(b.Container.containerName)
 	return container.NewBlobClient(b.objectPath) // Generic blob client for now, we can specialize if we want in the future.
 }
 

--- a/e2etest/newe2e_resource_managers_blobfs.go
+++ b/e2etest/newe2e_resource_managers_blobfs.go
@@ -44,8 +44,8 @@ func dfsStripSAS(uri string) string {
 }
 
 type BlobFSServiceResourceManager struct {
-	internalAccount *AzureAccountResourceManager
-	internalClient  *service.Client
+	InternalAccount *AzureAccountResourceManager
+	InternalClient  *service.Client
 }
 
 func (b *BlobFSServiceResourceManager) DefaultAuthType() ExplicitCredentialTypes {
@@ -70,7 +70,7 @@ func (b *BlobFSServiceResourceManager) Parent() ResourceManager {
 }
 
 func (b *BlobFSServiceResourceManager) Account() AccountResourceManager {
-	return b.internalAccount
+	return b.InternalAccount
 }
 
 func (b *BlobFSServiceResourceManager) Location() common.Location {
@@ -82,20 +82,20 @@ func (b *BlobFSServiceResourceManager) Level() cmd.LocationLevel {
 }
 
 func (b *BlobFSServiceResourceManager) URI(opts ...GetURIOptions) string {
-	base := dfsStripSAS(b.internalClient.DFSURL())
-	base = b.internalAccount.ApplySAS(base, b.Location(), opts...)
+	base := dfsStripSAS(b.InternalClient.DFSURL())
+	base = b.InternalAccount.ApplySAS(base, b.Location(), opts...)
 	base = addWildCard(base, opts...)
 
 	return base
 }
 
 func (b *BlobFSServiceResourceManager) ResourceClient() any {
-	return b.internalClient
+	return b.InternalClient
 }
 
 func (b *BlobFSServiceResourceManager) ListContainers(a Asserter) []string {
 	a.HelperMarker().Helper()
-	pager := b.internalClient.NewListFileSystemsPager(nil)
+	pager := b.InternalClient.NewListFileSystemsPager(nil)
 
 	out := make([]string, 0)
 
@@ -116,10 +116,10 @@ func (b *BlobFSServiceResourceManager) ListContainers(a Asserter) []string {
 
 func (b *BlobFSServiceResourceManager) GetContainer(containerName string) ContainerResourceManager {
 	return &BlobFSFileSystemResourceManager{
-		internalAccount: b.internalAccount,
+		internalAccount: b.InternalAccount,
 		Service:         b,
 		containerName:   containerName,
-		internalClient:  b.internalClient.NewFileSystemClient(containerName),
+		internalClient:  b.InternalClient.NewFileSystemClient(containerName),
 	}
 }
 

--- a/e2etest/newe2e_scenario_manager.go
+++ b/e2etest/newe2e_scenario_manager.go
@@ -1,6 +1,7 @@
 package e2etest
 
 import (
+	"github.com/google/uuid"
 	"reflect"
 	"runtime/debug"
 	"strings"
@@ -47,6 +48,7 @@ func (sm *ScenarioManager) NewVariation(origin *ScenarioVariationManager, id str
 		v := setting[i]
 		clone := &ScenarioVariationManager{
 			VariationData: origin.VariationData.Insert(id, v),
+			VariationUUID: uuid.New(),
 			Parent:        sm,
 			callcounts:    make(map[string]uint),
 		}
@@ -64,7 +66,7 @@ func (sm *ScenarioManager) RunScenario() {
 		Thus, we can retain good (read: brain happy) test ordering by doing FIFO. Engineering at its finest.
 	*/
 	sm.varStack = []*ScenarioVariationManager{
-		{Parent: sm, callcounts: make(map[string]uint)}, // Root svm, no variations, no nothing.
+		{Parent: sm, callcounts: make(map[string]uint), VariationUUID: uuid.New()}, // Root svm, no variations, no nothing.
 	}
 
 	for len(sm.varStack) > 0 {

--- a/e2etest/newe2e_scenario_variation_manager.go
+++ b/e2etest/newe2e_scenario_variation_manager.go
@@ -1,8 +1,8 @@
 package e2etest
 
 import (
-	"errors"
 	"context"
+	"errors"
 	"fmt"
 	"github.com/google/uuid"
 	"runtime"
@@ -389,6 +389,10 @@ var CleanupStepEarlyExit = errors.New("cleanupEarlyExit")
 
 type ScenarioVariationManagerCleanupAsserter struct {
 	svm *ScenarioVariationManager
+}
+
+func (s *ScenarioVariationManagerCleanupAsserter) GetTestName() string {
+	return s.svm.GetTestName()
 }
 
 func (s *ScenarioVariationManagerCleanupAsserter) WrapCleanup(cf CleanupFunc) {

--- a/e2etest/newe2e_scenario_variation_manager.go
+++ b/e2etest/newe2e_scenario_variation_manager.go
@@ -2,7 +2,9 @@ package e2etest
 
 import (
 	"errors"
+	"context"
 	"fmt"
+	"github.com/google/uuid"
 	"runtime"
 	"strings"
 	"testing"
@@ -36,10 +38,40 @@ type ScenarioVariationManager struct {
 	Parent *ScenarioManager
 	// VariationData is a mapping of IDs to values, in order.
 	VariationData *VariationDataContainer // todo call order, prepared options
+	VariationUUID uuid.UUID
 
 	// wetrun data
+	RunContext       context.Context
 	CreatedResources *PathTrie[createdResource]
 	CleanupFuncs     []func(a Asserter)
+}
+
+func (svm *ScenarioVariationManager) GetTestName() string {
+	if svm.t != nil {
+		return svm.t.Name()
+	} else {
+		return svm.Parent.testingT.Name() + "/" + svm.VariationName()
+	}
+}
+
+func (svm *ScenarioVariationManager) Context() context.Context {
+	if svm.RunContext == nil {
+		return context.Background()
+	}
+
+	return svm.RunContext
+}
+
+func (svm *ScenarioVariationManager) SetContext(ctx context.Context) {
+	svm.RunContext = ctx
+}
+
+func (svm *ScenarioVariationManager) UUID() uuid.UUID {
+	if svm.VariationUUID == uuid.Nil { // ensure we aren't handing back something empty
+		svm.VariationUUID = uuid.New()
+	}
+
+	return svm.VariationUUID
 }
 
 type createdResource struct {

--- a/e2etest/newe2e_synthetic_container_names.go
+++ b/e2etest/newe2e_synthetic_container_names.go
@@ -1,0 +1,8 @@
+package e2etest
+
+const (
+	SyntheticContainerManyFilesSource     = "many-objects"
+	SyntheticContainerManyFoldersSource   = "many-folders"
+	SyntheticContainerSyncWorstCaseSource = "sync-wc-source"
+	SyntheticContainerSyncWorstCaseDest   = "sync-wc-dest"
+)

--- a/e2etest/newe2e_task_runazcopy.go
+++ b/e2etest/newe2e_task_runazcopy.go
@@ -164,7 +164,7 @@ func (env *AzCopyEnvironment) InheritEnvVar(name string) {
 
 func (env *AzCopyEnvironment) EnsureInheritEnvironment() {
 	if env.InheritEnvironment == nil {
-		env.DefaultInheritEnvironment(nil)
+		env.DefaultInheritEnvironment(nil, context.TODO()) // context isn't important in this default yet
 	}
 }
 
@@ -177,7 +177,7 @@ var RunAzCopyDefaultInheritEnvironment = map[string]bool{
 	"azure_config_dir": true,
 }
 
-func (env *AzCopyEnvironment) DefaultInheritEnvironment(a ScenarioAsserter) map[string]bool {
+func (env *AzCopyEnvironment) DefaultInheritEnvironment(a ScenarioAsserter, ctx context.Context) map[string]bool {
 	env.InheritEnvironment = RunAzCopyDefaultInheritEnvironment
 
 	return env.InheritEnvironment
@@ -302,8 +302,6 @@ func (c *AzCopyCommand) applyTargetAuth(a Asserter, target ResourceManager) stri
 					c.Environment.AzureFederatedTokenFile = pointerTo(file.Name())
 					c.Environment.AzureTenantId = pointerTo(oAuthInfo.DynamicOAuth.Workload.TenantId)
 					c.Environment.AzureClientId = pointerTo(oAuthInfo.DynamicOAuth.Workload.ClientId)
-				} else if mode == common.EAutoLoginType.SPN().String() || mode == common.EAutoLoginType.MSI().String() {
-					c.Environment.InheritEnvironment = true
 				}
 
 			}

--- a/e2etest/newe2e_task_runazcopy.go
+++ b/e2etest/newe2e_task_runazcopy.go
@@ -23,6 +23,21 @@ type AzCopyStdout interface {
 	fmt.Stringer
 }
 
+type AzCopyDiscardStdout struct{}
+
+func (a *AzCopyDiscardStdout) RawStdout() []string {
+	return []string{}
+}
+
+func (a *AzCopyDiscardStdout) Write(p []byte) (n int, err error) {
+	// no-op
+	return len(p), nil
+}
+
+func (a *AzCopyDiscardStdout) String() string {
+	return ""
+}
+
 // AzCopyRawStdout shouldn't be used or relied upon right now! This will be fleshed out eventually. todo WI#26418258
 type AzCopyRawStdout struct {
 	RawOutput []string

--- a/e2etest/newe2e_task_runazcopy.go
+++ b/e2etest/newe2e_task_runazcopy.go
@@ -30,6 +30,8 @@ func (a *AzCopyDiscardStdout) RawStdout() []string {
 }
 
 func (a *AzCopyDiscardStdout) Write(p []byte) (n int, err error) {
+	fmt.Print(string(p))
+
 	// no-op
 	return len(p), nil
 }

--- a/e2etest/newe2e_task_runazcopy.go
+++ b/e2etest/newe2e_task_runazcopy.go
@@ -355,11 +355,28 @@ func RunAzCopy(a ScenarioAsserter, commandSpec AzCopyCommand) (AzCopyStdout, *Az
 			out = append(out, commandSpec.applyTargetAuth(a, v))
 		}
 
-		if commandSpec.Flags != nil {
-			flagMap = MapFromTags(reflect.ValueOf(commandSpec.Flags), "flag", a, ctx)
-			for k, v := range flagMap {
-				out = append(out, fmt.Sprintf("--%s=%s", k, v))
+		if commandSpec.Flags == nil {
+			switch commandSpec.Verb {
+			case AzCopyVerbCopy:
+				commandSpec.Flags = CopyFlags{}
+			case AzCopyVerbSync:
+				commandSpec.Flags = SyncFlags{}
+			case AzCopyVerbList:
+				commandSpec.Flags = ListFlags{}
+			case AzCopyVerbLogin:
+				commandSpec.Flags = LoginFlags{}
+			case AzCopyVerbLoginStatus:
+				commandSpec.Flags = LoginStatusFlags{}
+			case AzCopyVerbRemove:
+				commandSpec.Flags = RemoveFlags{}
+			default:
+				commandSpec.Flags = GlobalFlags{}
 			}
+		}
+
+		flagMap = MapFromTags(reflect.ValueOf(commandSpec.Flags), "flag", a, ctx)
+		for k, v := range flagMap {
+			out = append(out, fmt.Sprintf("--%s=%s", k, v))
 		}
 
 		return out

--- a/e2etest/newe2e_task_runazcopy.go
+++ b/e2etest/newe2e_task_runazcopy.go
@@ -290,7 +290,10 @@ func (c *AzCopyCommand) applyTargetAuth(a Asserter, target ResourceManager) stri
 					c.Environment.AzureFederatedTokenFile = pointerTo(file.Name())
 					c.Environment.AzureTenantId = pointerTo(oAuthInfo.DynamicOAuth.Workload.TenantId)
 					c.Environment.AzureClientId = pointerTo(oAuthInfo.DynamicOAuth.Workload.ClientId)
+				} else if mode == common.EAutoLoginType.SPN().String() || mode == common.EAutoLoginType.MSI().String() {
+					c.Environment.InheritEnvironment = true
 				}
+
 			}
 		}
 		return target.URI(opts) // Generate like public

--- a/e2etest/newe2e_task_runazcopy_parameters.go
+++ b/e2etest/newe2e_task_runazcopy_parameters.go
@@ -220,8 +220,17 @@ func (GlobalFlags) DefaultAwaitContinue(a ScenarioAsserter, ctx context.Context)
 }
 
 func (GlobalFlags) DefaultMemoryProfile(a ScenarioAsserter, ctx context.Context) string {
-	runName := ctx.Value(azcopyRunName{}).(string)
-	return filepath.Join(os.TempDir(), runName, "memoryprof.pprof")
+	envCtx := ctx.Value(AzCopyEnvironmentManagerKey{}).(*AzCopyEnvironmentContext)
+	env := ctx.Value(AzCopyEnvironmentKey{}).(*AzCopyEnvironment)
+	runNum := ctx.Value(AzCopyRunNumKey{}).(uint)
+
+	envTmpPath := envCtx.GetEnvTempPath(env)
+	memProfPath := filepath.Join(
+		envTmpPath,
+		PprofSubdir,
+		fmt.Sprintf(PprofMemFmt, runNum))
+
+	return memProfPath
 }
 
 type CommonFilterFlags struct {

--- a/e2etest/newe2e_task_runazcopy_parameters.go
+++ b/e2etest/newe2e_task_runazcopy_parameters.go
@@ -1,10 +1,12 @@
 package e2etest
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"time"
@@ -17,10 +19,10 @@ import (
 // All flags should be nillable, because zero is always a valid state, and must be distinguishable from unspecified.
 // available extdata:
 // - "default:xyz" Defaults to something non-standard for AzCopy-- E.g. always forcing debug logging
-// - "defaultfunc:SpecialDefault" Calls a `func Default*(a ScenarioAsserter) string` named SpecialDefault on the struct. Asserts if not found.
-// - "serializer:SerializerFunc" Calls a `func Serialize*(value any, a ScenarioAsserter) string` named SerializerFunc on the struct. Asserts if not found.
+// - "defaultfunc:SpecialDefault" Calls a `func Default*(a ScenarioAsserter, ctx context.Context) string` named SpecialDefault on the struct. Asserts if not found.
+// - "serializer:SerializerFunc" Calls a `func Serialize*(value any, a ScenarioAsserter, ctx context.Context) string` named SerializerFunc on the struct. Asserts if not found.
 // If special characters , or : are for some reason used, \ can be used as an escape.
-func MapFromTags(val reflect.Value, tagName string, a ScenarioAsserter) map[string]string {
+func MapFromTags(val reflect.Value, tagName string, a ScenarioAsserter, ctx context.Context) map[string]string {
 	queue := []reflect.Value{val}
 	out := make(map[string]string)
 
@@ -207,10 +209,19 @@ type GlobalFlags struct {
 	//CancelFromStdin *bool `flag:"cancel-from-stdin"`
 	AwaitContinue *bool `flag:"await-continue,defaultfunc:DefaultAwaitContinue"`
 	//AwaitOpen       *bool `flag:"await-open"`
+
+	// TODO: Ongoing performance profiling work
+	MemoryProfile *string `flag:"memory-profile,defaultfunc:DefaultMemoryProfile"`
+	//CpuProfile *string `flag:"cpu-profile"`
 }
 
-func (GlobalFlags) DefaultAwaitContinue(a ScenarioAsserter) string {
+func (GlobalFlags) DefaultAwaitContinue(a ScenarioAsserter, ctx context.Context) string {
 	return common.Iff(isLaunchedByDebugger, "true", "false")
+}
+
+func (GlobalFlags) DefaultMemoryProfile(a ScenarioAsserter, ctx context.Context) string {
+	runName := ctx.Value(azcopyRunName{}).(string)
+	return filepath.Join(os.TempDir(), runName, "memoryprof.pprof")
 }
 
 type CommonFilterFlags struct {
@@ -235,15 +246,15 @@ type CommonFilterFlags struct {
 	ExcludeAttributes []WindowsAttribute `flag:"exclude-attributes,serializer:SerializeAttributeList"`
 }
 
-func (CommonFilterFlags) SerializeTime(t any, a ScenarioAsserter) string {
+func (CommonFilterFlags) SerializeTime(t any, a ScenarioAsserter, ctx context.Context) string {
 	return GetTypeOrAssert[*time.Time](a, t).UTC().Format(time.RFC3339)
 }
 
-func (CommonFilterFlags) SerializeStrings(list any, a ScenarioAsserter) string {
+func (CommonFilterFlags) SerializeStrings(list any, a ScenarioAsserter, ctx context.Context) string {
 	return strings.Join(GetTypeOrAssert[[]string](a, list), ";")
 }
 
-func (CommonFilterFlags) SerializeAttributeList(list any, a ScenarioAsserter) string {
+func (CommonFilterFlags) SerializeAttributeList(list any, a ScenarioAsserter, ctx context.Context) string {
 	attrs := GetTypeOrAssert[[]WindowsAttribute](a, list)
 
 	out := ""
@@ -326,7 +337,7 @@ type CopyFlags struct {
 	//BackupMode *bool `flag:"backup"`
 }
 
-func (CopyFlags) SerializeListingFile(in any, a ScenarioAsserter) string {
+func (CopyFlags) SerializeListingFile(in any, a ScenarioAsserter, ctx context.Context) string {
 	if a.Dryrun() {
 		// Dryruns won't actually run AzCopy, and dryruns shouldn't reach this code path, but just in case, we should cover it.
 		return "listingfile.txt"
@@ -375,11 +386,11 @@ func (CopyFlags) SerializeKeyValues(in any, a ScenarioAsserter, kvsep, elemsep s
 	return out
 }
 
-func (c CopyFlags) SerializeMetadata(meta any, a ScenarioAsserter) string {
+func (c CopyFlags) SerializeMetadata(meta any, a ScenarioAsserter, ctx context.Context) string {
 	return c.SerializeKeyValues(meta, a, "=", ";")
 }
 
-func (c CopyFlags) SerializeTags(tags any, a ScenarioAsserter) string {
+func (c CopyFlags) SerializeTags(tags any, a ScenarioAsserter, ctx context.Context) string {
 	return c.SerializeKeyValues(tags, a, "=", "&")
 }
 
@@ -413,8 +424,8 @@ type RemoveFlags struct {
 	CPKByValue      *bool                         `flag:"cpk-by-value"`
 }
 
-func (r RemoveFlags) SerializeListingFile(in any, scenarioAsserter ScenarioAsserter) {
-	CopyFlags{}.SerializeListingFile(in, scenarioAsserter)
+func (r RemoveFlags) SerializeListingFile(in any, scenarioAsserter ScenarioAsserter, ctx context.Context) {
+	CopyFlags{}.SerializeListingFile(in, scenarioAsserter, ctx)
 }
 
 type ListFlags struct {

--- a/e2etest/newe2e_task_runazcopy_parameters.go
+++ b/e2etest/newe2e_task_runazcopy_parameters.go
@@ -85,7 +85,7 @@ func MapFromTags(val reflect.Value, tagName string, a ScenarioAsserter, ctx cont
 						out[tag.flagKey] = *tag.defaultData
 					} else if tag.defaultFunc != nil {
 						// find the function & call it
-						result := tryFindMethod(*tag.defaultFunc).Call([]reflect.Value{reflect.ValueOf(a)}) // todo: we could validate that we're getting what we expect, but no need to do that because reflect will panic for us, then the test will catch it.
+						result := tryFindMethod(*tag.defaultFunc).Call([]reflect.Value{reflect.ValueOf(a), reflect.ValueOf(ctx)}) // todo: we could validate that we're getting what we expect, but no need to do that because reflect will panic for us, then the test will catch it.
 
 						registerKey(tag.flagKey, result[0].String())
 					}
@@ -95,7 +95,7 @@ func MapFromTags(val reflect.Value, tagName string, a ScenarioAsserter, ctx cont
 					}
 
 					if tag.serializerFunc != nil {
-						result := tryFindMethod(*tag.serializerFunc).Call([]reflect.Value{field, reflect.ValueOf(a)})
+						result := tryFindMethod(*tag.serializerFunc).Call([]reflect.Value{field, reflect.ValueOf(a), reflect.ValueOf(ctx)})
 
 						registerKey(tag.flagKey, result[0].String())
 					} else {

--- a/e2etest/newe2e_telemetry.go
+++ b/e2etest/newe2e_telemetry.go
@@ -1,0 +1,116 @@
+package e2etest
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/aztables"
+	cmd2 "github.com/Azure/azure-storage-azcopy/v10/cmd"
+	"github.com/google/uuid"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync/atomic"
+)
+
+const (
+	MemoryProfileTable     = "memprofstats"
+	MemoryProfileContainer = "memprofdata"
+)
+
+func UploadMemoryProfile(a ScenarioAsserter, profilePath string, ctx context.Context) {
+	// We don't need telemetry configured to dump details on peak memory usage, and we need to grab these anyway.
+	cmd := exec.Command("go", "tool", "pprof", "-top", "-unit=bytes", profilePath)
+
+	stdout := &bytes.Buffer{}
+	cmd.Stdout = stdout
+	cmd.Stderr = &bytes.Buffer{}
+
+	err := cmd.Run()
+	if err != nil {
+		a.NoError("pprof run failed: "+cmd.Stderr.(*bytes.Buffer).String(), err)
+		return
+	}
+
+	// lazy, will inevitably snap like a twig if golang coughs. Unfortunately, you can't get json output. so that's not useful.
+	outStr := stdout.String()
+	outStr = outStr[strings.Index(outStr, "Showing nodes accounting for "):] // Locate the line we're really interested in
+	outStr = outStr[:strings.IndexRune(outStr, '\n')]                        // Trim down to the line
+	outStr = outStr[strings.Index(outStr, " of ")+4:]                        // grab the last total
+	outStr = outStr[:strings.Index(outStr, "B total")]                       // trim the excess, parse.
+	totalBytes, err := strconv.ParseInt(outStr, 10, 64)
+	if err != nil {
+		a.NoError("failed to parse "+outStr+" as an integer, original: "+stdout.String(), err)
+		return
+	}
+
+	// Output the data so that if the upload fails or the acct isn't configured, we're good to go.
+	a.Log("Test run sampled a heap size of %s", cmd2.ByteSizeToString(totalBytes))
+	if !GlobalConfig.TelemetryConfigured() {
+		return
+	}
+	a.Log("Uploading memory profile!")
+
+	// Fetch our run count for table key
+	var runCount *int64
+	runCount = ctx.Value(azCopyRunCounter{}).(*int64)
+
+	tableService, err := GlobalConfig.GetTelemetryTableService()
+	if err != nil {
+		a.NoError("failed to get telemetry table service", err)
+		return
+	}
+	blobService, err := GlobalConfig.GetTelemetryBlobService()
+	if err != nil {
+		a.NoError("failed to get telemetry blob service", err)
+		return
+	}
+
+	table := tableService.NewClient(MemoryProfileTable)
+	container := blobService.NewContainerClient(MemoryProfileContainer)
+	partitionKey := a.GetTestName() // We'll index the table by test, then select rows by the data key, doing the same on the blob front.
+
+	if runCount == nil {
+		partitionKey = a.GetTestName() + "/" + uuid.NewString()
+		a.Log("run counter not present, falling back to unique key")
+	} else {
+		partitionKey = a.GetTestName() + "/" + fmt.Sprintf("%05d", atomic.LoadInt64(runCount))
+	}
+
+	blobProfilePath := fmt.Sprintf(
+		"%s/%s",
+		partitionKey,
+		GlobalConfig.TelemetryConfig.DataKey,
+	)
+
+	buf, err := aztables.EDMEntity{
+		Entity: aztables.Entity{
+			PartitionKey: strings.ReplaceAll(partitionKey, "/", "-"),
+			RowKey:       GlobalConfig.TelemetryConfig.DataKey,
+		},
+		Properties: map[string]any{
+			"runDate":         "",
+			"bytesSampled":    totalBytes,
+			"blobProfilePath": blobProfilePath,
+		},
+	}.MarshalJSON()
+	a.NoError("serialize table entity", err)
+	if err == nil {
+		_, err = table.UpsertEntity(ctx, buf, nil)
+		a.NoError("upload table entity", err)
+	}
+
+	f, err := os.Open(profilePath)
+	if err != nil {
+		a.NoError("failed to open "+profilePath+" for reading", err)
+		return
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	bbClient := container.NewBlockBlobClient(blobProfilePath)
+	_, err = bbClient.UploadFile(ctx, f, nil)
+	a.NoError("uploading memory profile", err)
+}

--- a/e2etest/stress_generators/README.md
+++ b/e2etest/stress_generators/README.md
@@ -1,0 +1,2 @@
+# Synthetic stress test generators
+

--- a/e2etest/stress_generators/README.md
+++ b/e2etest/stress_generators/README.md
@@ -1,2 +1,7 @@
 # Synthetic stress test generators
 
+A base command, `all <service-url>` is provided to generate all cases on a target telemetry storage account.
+
+In addition, all generators are added as subcommands automatically. Review the `Generator` interface and register your generator in an `init()` command to implement a new one. Utilize the GenerationJobManager to assist with managing threading for your workload.
+
+Review `config.go` to adjust configuration-- it is implemented with the same configuration pioneered in the new E2E test framework, for familiarity.

--- a/e2etest/stress_generators/acct_rm.go
+++ b/e2etest/stress_generators/acct_rm.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	blobservice "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/service"
+	blobfsservice "github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/service"
+	fileservice "github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/service"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/e2etest"
+)
+
+// OAuthAccountResourceManager is jank incarnate, this isn't meant to be here long. if you're feeling the growing pains of it,
+// maybe looking at merging it into the new e2e tests, it's time to burn the building down.
+type OAuthAccountResourceManager struct {
+	serviceClientOptions azcore.ClientOptions
+	cred                 azcore.TokenCredential
+	accountName          string
+}
+
+func (a *OAuthAccountResourceManager) AccountName() string {
+	return a.accountName
+}
+
+func (a *OAuthAccountResourceManager) AccountType() e2etest.AccountType {
+	return e2etest.EAccountType.Standard() // this gets unused for the most part, it's ok if we return a possibly false value. it isn't used for most logic.
+}
+
+func (a *OAuthAccountResourceManager) AvailableServices() []common.Location {
+	return []common.Location{
+		common.ELocation.Blob(),
+		common.ELocation.BlobFS(),
+		common.ELocation.File(),
+	}
+}
+
+func (a *OAuthAccountResourceManager) GetService(asserter e2etest.Asserter, location common.Location) e2etest.ServiceResourceManager {
+	var serviceSuffix = map[common.Location]string{
+		common.ELocation.Blob():   ".blob.core.windows.net",
+		common.ELocation.File():   ".file.core.windows.net",
+		common.ELocation.BlobFS(): ".dfs.core.windows.net",
+	}
+
+	uri := fmt.Sprint("https://%s%s/", a.accountName, serviceSuffix)
+
+	var out e2etest.ServiceResourceManager
+	switch location {
+	case common.ELocation.Blob():
+		c, err := blobservice.NewClient(uri, a.cred, &blobservice.ClientOptions{
+			ClientOptions: a.serviceClientOptions,
+		})
+		if err != nil {
+			asserter.NoError("create blob service", err)
+			return nil
+		}
+
+		out = &e2etest.BlobServiceResourceManager{
+			InternalAccount: nil,
+			InternalClient:  c,
+		}
+	case common.ELocation.File():
+		c, err := fileservice.NewClient(uri, a.cred, &fileservice.ClientOptions{
+			ClientOptions: a.serviceClientOptions,
+		})
+		if err != nil {
+			asserter.NoError("create file service", err)
+			return nil
+		}
+
+		out = &e2etest.FileServiceResourceManager{
+			InternalAccount: nil,
+			InternalClient:  c,
+		}
+	case common.ELocation.BlobFS():
+		c, err := blobfsservice.NewClient(uri, a.cred, &blobfsservice.ClientOptions{
+			ClientOptions: a.serviceClientOptions,
+		})
+		if err != nil {
+			asserter.NoError("create blob service", err)
+			return nil
+		}
+
+		out = &e2etest.BlobFSServiceResourceManager{
+			InternalAccount: nil,
+			InternalClient:  c,
+		}
+	default:
+		asserter.Error("Invalid service specified: " + location.String())
+	}
+	return out
+}

--- a/e2etest/stress_generators/config.go
+++ b/e2etest/stress_generators/config.go
@@ -4,13 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	blobsas "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas"
-	blobservice "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/service"
-	filesas "github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/sas"
-	fileservice "github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/service"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-azcopy/v10/e2etest"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
+	"net/url"
 	"reflect"
 	"strings"
 )
@@ -18,91 +17,70 @@ import (
 type GeneratorConfig struct {
 	AuthInfo struct {
 		AuthSource struct {
-			PSInherit  bool   `env:"PS_INHERIT,required"`
-			CLIInherit bool   `env:"CLI_INHERIT,required"`
-			AcctKey    string `env:"ACCT_KEY,required"`
+			// Use the PS cred auth. Requires powershell 7 and Az Powershell installed.
+			PSInherit bool `env:"PS_INHERIT,required"`
+			// Use the AZ CLI auth. Requires Az CLI installed.
+			CLIInherit bool `env:"CLI_INHERIT,required"`
+			// Use an account key. Not recommended.
+			AcctKey string `env:"ACCT_KEY,required"`
 		} `env:",required,mutually_exclusive"`
-		TenantID string `env:"TENANT_ID,required"`
+		// Specify the tenant ID being used to authorize.
+		TenantID string `env:"TENANT_ID"`
+	} `env:",required"`
+
+	RetryOptions struct {
+		// An override switch similar to AzCopy's
+		HttpRetryCodes string `env:"HTTP_RETRY_CODES"`
 	}
 }
 
-func GetResourceManagerForURI(uri string) (e2etest.ServiceResourceManager, error) {
-	switch {
-	case strings.Contains(uri, "dfs.core.windows.net"):
-		strings.ReplaceAll(uri, "dfs.core.windows.net", "blob.core.windows.net")
-		fallthrough
-	case strings.Contains(uri, "blob.core.windows.net"):
-		blobUriParts, err := blobsas.ParseURL(uri)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse uri: %w", err)
-		} else if blobUriParts.ContainerName != "" || blobUriParts.BlobName != "" {
+var accountCache *e2etest.AzureAccountResourceManager
 
-		}
-
-		var client *blobservice.Client
-		if acctKey := genConfig.AuthInfo.AuthSource.AcctKey; acctKey != "" {
-			acctName := strings.TrimSuffix(blobUriParts.Host, ".blob.core.windows.net")
-			var skey *blobservice.SharedKeyCredential
-			skey, err = blobservice.NewSharedKeyCredential(acctName, acctKey)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse shared key: %w", err)
-			}
-
-			client, err = blobservice.NewClientWithSharedKeyCredential(uri, skey, nil)
-		} else {
-			var tCred azcore.TokenCredential
-			tCred, err = genConfig.GetTokenCredential()
-			if err != nil {
-				return nil, err
-			}
-
-			client, err = blobservice.NewClient(uri, tCred, nil)
-		}
-
-		if err != nil {
-			return nil, fmt.Errorf("failed to create client: %w", err)
-		}
-
-		return &e2etest.BlobServiceResourceManager{
-			InternalClient: client,
-		}, nil
-	case strings.Contains(uri, "file.core.windows.net"):
-		fUrlParts, err := filesas.ParseURL(uri)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse uri: %w", err)
-		} else if fUrlParts.ShareName != "" || fUrlParts.DirectoryOrFilePath != "" {
-			return nil, fmt.Errorf("target must be a service")
-		}
-
-		var client *fileservice.Client
-		if acctKey := genConfig.AuthInfo.AuthSource.AcctKey; acctKey != "" {
-			acctName := strings.TrimSuffix(fUrlParts.Host, ".file.core.windows.net")
-			var sKey *fileservice.SharedKeyCredential
-			sKey, err = fileservice.NewSharedKeyCredential(acctName, acctKey)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse shared key: %w", err)
-			}
-
-			client, err = fileservice.NewClientWithSharedKeyCredential(uri, sKey, nil)
-		} else {
-			var tCred azcore.TokenCredential
-			tCred, err = genConfig.GetTokenCredential()
-			if err != nil {
-				return nil, fmt.Errorf("failed to get token cred: %w", err)
-			}
-
-			client, err = fileservice.NewClient(uri, tCred, nil)
-		}
-		if err != nil {
-			return nil, fmt.Errorf("failed to create share client: %w", err)
-		}
-
-		return &e2etest.FileServiceResourceManager{
-			InternalClient: client,
-		}, nil
-	default:
-		return nil, errors.New("target URI did not match file or blob scheme")
+func GetAccountResourceManager(uri string) (e2etest.AccountResourceManager, error) {
+	if accountCache != nil {
+		return accountCache, nil
 	}
+
+	opts := azcore.ClientOptions{
+		Retry: policy.RetryOptions{
+			MaxRetries:    ste.UploadMaxTries,
+			TryTimeout:    ste.UploadTryTimeout,
+			RetryDelay:    ste.UploadRetryDelay,
+			MaxRetryDelay: ste.UploadMaxRetryDelay,
+			ShouldRetry:   ste.GetShouldRetry(),
+		},
+	}
+
+	var out e2etest.AccountResourceManager
+
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse uri: %w", err)
+	}
+
+	// gross and bad, do as I say not as I do
+	acctName := u.Host[:strings.IndexRune(u.Host, '.')]
+
+	if acctKey := genConfig.AuthInfo.AuthSource.AcctKey; acctKey != "" {
+		out = &e2etest.AzureAccountResourceManager{
+			InternalAccountName: acctName,
+			InternalAccountKey:  acctKey,
+			InternalAccountType: e2etest.EAccountType.Standard(),
+		}
+	} else {
+		tc, err := genConfig.GetTokenCredential()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get account resource manager: invalid tokencredential: %w", err)
+		}
+
+		out = &OAuthAccountResourceManager{
+			serviceClientOptions: opts,
+			cred:                 tc,
+			accountName:          acctName,
+		}
+	}
+
+	return out, nil
 }
 
 func (g GeneratorConfig) GetTokenCredential() (azcore.TokenCredential, error) {

--- a/e2etest/stress_generators/config.go
+++ b/e2etest/stress_generators/config.go
@@ -47,7 +47,7 @@ func GetAccountResourceManager(uri string) (e2etest.AccountResourceManager, erro
 			TryTimeout:    ste.UploadTryTimeout,
 			RetryDelay:    ste.UploadRetryDelay,
 			MaxRetryDelay: ste.UploadMaxRetryDelay,
-			ShouldRetry:   ste.GetShouldRetry(),
+			ShouldRetry:   ste.GetShouldRetry(nil),
 		},
 	}
 

--- a/e2etest/stress_generators/config.go
+++ b/e2etest/stress_generators/config.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	blobsas "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas"
+	blobservice "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/service"
+	filesas "github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/sas"
+	fileservice "github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/service"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/e2etest"
+	"reflect"
+	"strings"
+)
+
+type GeneratorConfig struct {
+	AuthInfo struct {
+		AuthSource struct {
+			PSInherit  bool   `env:"PS_INHERIT,required"`
+			CLIInherit bool   `env:"CLI_INHERIT,required"`
+			AcctKey    string `env:"ACCT_KEY,required"`
+		} `env:",required,mutually_exclusive"`
+		TenantID string `env:"TENANT_ID,required"`
+	}
+}
+
+func GetResourceManagerForURI(uri string) (e2etest.ServiceResourceManager, error) {
+	switch {
+	case strings.Contains(uri, "dfs.core.windows.net"):
+		strings.ReplaceAll(uri, "dfs.core.windows.net", "blob.core.windows.net")
+		fallthrough
+	case strings.Contains(uri, "blob.core.windows.net"):
+		blobUriParts, err := blobsas.ParseURL(uri)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse uri: %w", err)
+		} else if blobUriParts.ContainerName != "" || blobUriParts.BlobName != "" {
+
+		}
+
+		var client *blobservice.Client
+		if acctKey := genConfig.AuthInfo.AuthSource.AcctKey; acctKey != "" {
+			acctName := strings.TrimSuffix(blobUriParts.Host, ".blob.core.windows.net")
+			var skey *blobservice.SharedKeyCredential
+			skey, err = blobservice.NewSharedKeyCredential(acctName, acctKey)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse shared key: %w", err)
+			}
+
+			client, err = blobservice.NewClientWithSharedKeyCredential(uri, skey, nil)
+		} else {
+			var tCred azcore.TokenCredential
+			tCred, err = genConfig.GetTokenCredential()
+			if err != nil {
+				return nil, err
+			}
+
+			client, err = blobservice.NewClient(uri, tCred, nil)
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to create client: %w", err)
+		}
+
+		return &e2etest.BlobServiceResourceManager{
+			InternalClient: client,
+		}, nil
+	case strings.Contains(uri, "file.core.windows.net"):
+		fUrlParts, err := filesas.ParseURL(uri)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse uri: %w", err)
+		} else if fUrlParts.ShareName != "" || fUrlParts.DirectoryOrFilePath != "" {
+			return nil, fmt.Errorf("target must be a service")
+		}
+
+		var client *fileservice.Client
+		if acctKey := genConfig.AuthInfo.AuthSource.AcctKey; acctKey != "" {
+			acctName := strings.TrimSuffix(fUrlParts.Host, ".file.core.windows.net")
+			var sKey *fileservice.SharedKeyCredential
+			sKey, err = fileservice.NewSharedKeyCredential(acctName, acctKey)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse shared key: %w", err)
+			}
+
+			client, err = fileservice.NewClientWithSharedKeyCredential(uri, sKey, nil)
+		} else {
+			var tCred azcore.TokenCredential
+			tCred, err = genConfig.GetTokenCredential()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get token cred: %w", err)
+			}
+
+			client, err = fileservice.NewClient(uri, tCred, nil)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to create share client: %w", err)
+		}
+
+		return &e2etest.FileServiceResourceManager{
+			InternalClient: client,
+		}, nil
+	default:
+		return nil, errors.New("target URI did not match file or blob scheme")
+	}
+}
+
+func (g GeneratorConfig) GetTokenCredential() (azcore.TokenCredential, error) {
+	ai := g.AuthInfo
+	switch {
+	case ai.AuthSource.CLIInherit:
+		ret, err := azidentity.NewAzureCLICredential(&azidentity.AzureCLICredentialOptions{
+			TenantID: ai.TenantID,
+		})
+
+		return ret, err
+	case ai.AuthSource.PSInherit:
+		ret, err := common.NewPowershellContextCredential(&common.PowershellContextCredentialOptions{
+			TenantID: ai.TenantID,
+		})
+
+		return ret, err
+	default:
+		return nil, errors.New("invalid authSource")
+	}
+}
+
+var genConfig GeneratorConfig
+
+func init() {
+	err := e2etest.ReadConfig(reflect.ValueOf(&genConfig).Elem(), "GeneratorConfig", e2etest.EnvTag{Required: true})
+	if err != nil {
+		panic("failed reading config: " + err.Error())
+	}
+}

--- a/e2etest/stress_generators/dummyAsserter.go
+++ b/e2etest/stress_generators/dummyAsserter.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"github.com/Azure/azure-storage-azcopy/v10/e2etest"
+)
+
+type DummyAsserter struct {
+	CaughtError error
+}
+
+func (d *DummyAsserter) NoError(comment string, err error, failNow ...bool) {
+	if err != nil {
+		d.CaughtError = fmt.Errorf("%s: %w", comment, err)
+
+		if e2etest.FirstOrZero(failNow) {
+			panic(d.CaughtError)
+		}
+	}
+}
+
+func (d *DummyAsserter) Assert(comment string, assertion e2etest.Assertion, items ...any) {
+	if len(items) < assertion.MinArgs() || len(items) > assertion.MaxArgs() {
+		panic("assertion item count mismatch")
+	}
+
+	if !assertion.Assert(items...) {
+		var err error
+		if fa, ok := assertion.(e2etest.FormattedAssertion); ok {
+			err = fmt.Errorf("assertion %s failed: %s (%s)", fa.Name(), fa.Format(items...), comment)
+		} else {
+			err = fmt.Errorf("assertion %s failed with items %v (%s)", assertion.Name(), items, comment)
+		}
+
+		d.CaughtError = err
+	}
+}
+
+func (d *DummyAsserter) AssertNow(comment string, assertion e2etest.Assertion, items ...any) {
+	if len(items) < assertion.MinArgs() || len(items) > assertion.MaxArgs() {
+		panic("assertion item count mismatch")
+	}
+
+	if !assertion.Assert(items...) {
+		var err error
+		if fa, ok := assertion.(e2etest.FormattedAssertion); ok {
+			err = fmt.Errorf("assertion %s failed: %s (%s)", fa.Name(), fa.Format(items...), comment)
+		} else {
+			err = fmt.Errorf("assertion %s failed with items %v (%s)", assertion.Name(), items, comment)
+		}
+
+		d.CaughtError = err
+		panic(d.CaughtError)
+	}
+}
+
+func (d *DummyAsserter) Error(reason string) {
+	d.CaughtError = errors.New(reason)
+}
+
+func (d *DummyAsserter) Skip(reason string) {
+	// no-op
+}
+
+func (d *DummyAsserter) Log(format string, a ...any) {
+	fmt.Printf(format, a...)
+}
+
+func (d *DummyAsserter) Failed() bool {
+	return d.CaughtError != nil
+}
+
+func (d *DummyAsserter) HelperMarker() e2etest.HelperMarker {
+	return DummyHelper{}
+}
+
+func (d *DummyAsserter) GetTestName() string {
+	return ""
+}
+
+type DummyHelper struct{}
+
+func (d DummyHelper) Helper() {} // noop

--- a/e2etest/stress_generators/flags.go
+++ b/e2etest/stress_generators/flags.go
@@ -4,4 +4,6 @@ const (
 	FlagContainerName       = "container-name"
 	FlagSourceContainerName = "src-container-name"
 	FlagDestContainerName   = "dst-container-name"
+
+	FlagService = "service"
 )

--- a/e2etest/stress_generators/flags.go
+++ b/e2etest/stress_generators/flags.go
@@ -1,0 +1,7 @@
+package main
+
+const (
+	FlagContainerName       = "container-name"
+	FlagSourceContainerName = "src-container-name"
+	FlagDestContainerName   = "dst-container-name"
+)

--- a/e2etest/stress_generators/gen_all.go
+++ b/e2etest/stress_generators/gen_all.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"github.com/spf13/cobra"
+)
+
+var RequireValidTarget cobra.PositionalArgs = func(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return errors.New("expected target service as first positional arg")
+	}
+
+	_, err := GetResourceManagerForURI(args[0])
+	if err != nil {
+		return fmt.Errorf("invalid target: %w", err)
+	}
+
+	return nil
+}
+
+var GenAllCommand = &cobra.Command{
+	Use: "all <service-uri>",
+
+	RunE: func(cmd *cobra.Command, args []string) error {
+		svc, err := GetResourceManagerForURI(args[0])
+		if err != nil {
+			return fmt.Errorf("failed to create resource manager: %w", err)
+		}
+
+		for k, v := range GeneratorRegistry {
+			fmt.Println("Generating " + k)
+			err := v.Generate(svc)
+			if err != nil {
+				fmt.Printf("failed generating scenario %s: %v\n", k, err)
+			}
+		}
+		return nil
+	},
+
+	Args: RequireValidTarget,
+}
+
+func init() {
+	RootCmd.AddCommand(GenAllCommand)
+}

--- a/e2etest/stress_generators/gen_many_folders.go
+++ b/e2etest/stress_generators/gen_many_folders.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/Azure/azure-storage-azcopy/v10/e2etest"
+)
+
+const (
+	GenManyFoldersName = "many-folders"
+)
+
+func init() {
+	RegisterGenerator(&ManyFoldersGenerator{})
+}
+
+type ManyFoldersGenerator struct {
+	ContainerTarget string
+}
+
+func (m *ManyFoldersGenerator) Name() string {
+	return GenManyFoldersName
+}
+
+func (m *ManyFoldersGenerator) Generate(manager e2etest.ServiceResourceManager) error {
+	fmt.Println("asdf")
+	return nil
+}
+
+func (m *ManyFoldersGenerator) RegisterFlags(pFlags *flag.FlagSet) {
+	pFlags.StringVar(&m.ContainerTarget, FlagContainerName, e2etest.SyntheticContainerManyFoldersSource, "Set a custom container name")
+}

--- a/e2etest/stress_generators/gen_many_folders.go
+++ b/e2etest/stress_generators/gen_many_folders.go
@@ -1,9 +1,17 @@
 package main
 
 import (
-	"flag"
+	"context"
 	"fmt"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-azcopy/v10/e2etest"
+	"github.com/google/uuid"
+	"github.com/spf13/pflag"
+	"golang.org/x/sync/semaphore"
+	"math/rand/v2"
+	"strings"
+	"sync"
+	"sync/atomic"
 )
 
 const (
@@ -15,7 +23,18 @@ func init() {
 }
 
 type ManyFoldersGenerator struct {
-	ContainerTarget string
+	ContainerTarget  string
+	preferredService string
+}
+
+func (m *ManyFoldersGenerator) PreferredService() common.Location {
+	if m.preferredService != "" {
+		var out common.Location
+		_ = out.Parse(m.preferredService)
+		return out
+	}
+
+	return common.ELocation.File()
 }
 
 func (m *ManyFoldersGenerator) Name() string {
@@ -23,10 +42,162 @@ func (m *ManyFoldersGenerator) Name() string {
 }
 
 func (m *ManyFoldersGenerator) Generate(manager e2etest.ServiceResourceManager) error {
-	fmt.Println("asdf")
+	const (
+		FolderSize  = 5
+		MinDepth    = 5
+		MaxDepth    = 10
+		FolderCount = 1_000_000
+
+		// mostly unused but preserved for the IDE hint
+		TotalObjectCount = (FolderSize * FolderCount) + FolderCount
+	)
+
+	var depthMap = e2etest.NewRWMutexResource(make(map[int]int64))
+
+	a := &DummyAsserter{}
+
+	container := manager.GetContainer(m.ContainerTarget)
+
+	if container.Exists() {
+		return fmt.Errorf("please delete the container %s before re-running the generator", m.ContainerTarget)
+	}
+
+	container.Create(a, e2etest.ContainerProperties{})
+	if a.CaughtError != nil {
+		return fmt.Errorf("failed to create parent container %w", a.CaughtError)
+	}
+
+	gjm := NewGenerationJobManager(TotalObjectCount, CommonGenerateAnnouncementIncrement)
+	gjm.CustomAnnounce = func() string {
+		var out string
+
+		depthMap.DoRead(func(res map[int]int64) {
+			out = fmt.Sprint(res)
+		})
+
+		return "folder depths: " + out
+	}
+
+	// We limit the number of things we're trying to queue up at once so we don't casually use 64gb of memory for funsies
+	allocationCap := semaphore.NewWeighted(100_000)
+
+	genDirectoryName := func() string {
+		var out string
+		out = uuid.NewString()
+		out = out[:strings.IndexRune(out, '-')]
+
+		return out
+	}
+
+	cPath := make([]string, 0)
+
+	trieMu := &sync.Mutex{}
+	trie := e2etest.NewTrie[bool]('/')
+
+	// should have a lock before calling genDirectoryNameSafe
+	genDirectoryNameSafe := func() string {
+		root := strings.Join(cPath, "/")
+		var out string
+
+		for {
+			out = genDirectoryName()
+
+			if trie.Get(root+"/"+out) == nil {
+				break
+			}
+		}
+
+		return out
+	}
+
+	trie.Insert(strings.Join(cPath, "/"), e2etest.PtrOf(true))
+	for range FolderCount {
+		for len(cPath) < MinDepth {
+			cPath = append(cPath, genDirectoryNameSafe())
+			trie.Insert(strings.Join(cPath, "/"), e2etest.PtrOf(true))
+		}
+
+		// generate the path out here
+		folderPath := strings.Join(cPath, "/")
+
+		// schedule creation
+		gjm.ScheduleItem(func() error {
+			a := &DummyAsserter{}
+
+			depthMap.DoWrite(func(res map[int]int64) {
+				res[len(strings.Split(folderPath, "/"))]++
+			})
+
+			if folderPath != "" {
+				folder := container.GetObject(a, folderPath, common.EEntityType.Folder())
+				folder.Create(a, e2etest.NewZeroObjectContentContainer(0), e2etest.ObjectProperties{})
+				if a.CaughtError != nil {
+					return fmt.Errorf("failed to create parent folder: %w", a.CaughtError)
+				}
+			}
+
+			return nil
+		}, false)
+
+		for range FolderSize {
+			_ = allocationCap.Acquire(context.Background(), 1)
+
+			trieMu.Lock()
+			filePath := folderPath + "/" + genDirectoryName()
+
+			for e2etest.DerefOrZero(trie.Get(filePath)) {
+				filePath = folderPath + "/" + genDirectoryName()
+			}
+
+			trie.Insert(filePath, e2etest.PtrOf(true))
+			trieMu.Unlock()
+
+			gjm.ScheduleItem(func() error {
+				a := &DummyAsserter{}
+				defer allocationCap.Release(1)
+
+				file := container.GetObject(a, filePath, common.EEntityType.File())
+				file.Create(a, e2etest.NewRandomObjectContentContainer(50), e2etest.ObjectProperties{})
+				if a.CaughtError != nil {
+					return fmt.Errorf("failed to create child object: %w", a.CaughtError)
+				}
+
+				return nil
+			}, true) // create files with prio
+		}
+
+		trieMu.Lock()
+		// path traversal, ensure we always get a new directory, and ensure there's some complexity to our tree.
+		// random chance to ascend up the tree; or if we are at root we *must* ascend.
+		if rNum := rand.IntN(101); (len(cPath) < MaxDepth && rNum > 60) || len(cPath) <= MinDepth {
+			cPath = append(cPath, genDirectoryNameSafe())
+		} else if rNum > 25 { // if we're 25-60, stay level, but switch to a new dir.
+			cPath = cPath[:len(cPath)-1]
+		} else {
+			if len(cPath) == 1 {
+				// descend to root if we're at 1
+				cPath = []string{}
+			} else {
+				// if we are >=2, descend twice, then generate a new dir, putting us at n-1
+				cPath = cPath[:len(cPath)-2]
+				cPath = append(cPath, genDirectoryNameSafe())
+			}
+		}
+
+		trie.Insert(strings.Join(cPath, "/"), e2etest.PtrOf(true))
+		trieMu.Unlock()
+	}
+
+	gjm.Wait()
+
+	if fc := atomic.LoadInt64(gjm.failureCount); fc > 0 {
+		return fmt.Errorf("failed generating %d entries", fc)
+	}
+
 	return nil
 }
 
-func (m *ManyFoldersGenerator) RegisterFlags(pFlags *flag.FlagSet) {
+func (m *ManyFoldersGenerator) RegisterFlags(pFlags *pflag.FlagSet) {
 	pFlags.StringVar(&m.ContainerTarget, FlagContainerName, e2etest.SyntheticContainerManyFoldersSource, "Set a custom container name")
+	pFlags.StringVar(&m.preferredService, FlagService, "", "Generate against a service other than the default (file)")
 }

--- a/e2etest/stress_generators/gen_many_objects.go
+++ b/e2etest/stress_generators/gen_many_objects.go
@@ -2,19 +2,18 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-azcopy/v10/e2etest"
 	"github.com/google/uuid"
+	"github.com/spf13/pflag"
 	"golang.org/x/sync/semaphore"
-	"runtime"
-	"sync"
 	"sync/atomic"
 )
 
 const (
-	GenManyObjectsName = "many-objects"
+	GenManyObjectsCount       = 10_000_000
+	GenManyObjectsLogDivision = 10_000
 )
 
 func init() {
@@ -22,59 +21,70 @@ func init() {
 }
 
 type ManyObjectsGenerator struct {
-	ContainerTarget string
+	ContainerTarget  string
+	requestedService string
 }
 
-func (m ManyObjectsGenerator) RegisterFlags(pFlags *flag.FlagSet) {
+func (m *ManyObjectsGenerator) PreferredService() common.Location {
+	if m.requestedService != "" {
+		var out common.Location
+		_ = out.Parse(m.requestedService) // if this fails it'll be pretty obvious
+		return out
+	}
+
+	return common.ELocation.Blob()
+}
+
+func (m *ManyObjectsGenerator) RegisterFlags(pFlags *pflag.FlagSet) {
 	pFlags.StringVar(&m.ContainerTarget, FlagContainerName, e2etest.SyntheticContainerManyFilesSource, "Set a custom container name")
+	pflag.StringVar(&m.requestedService, FlagService, "", "Use a custom service instead of the default (blob)")
 }
 
-func (m ManyObjectsGenerator) Name() string {
-	return GenManyObjectsName
+func (m *ManyObjectsGenerator) Name() string {
+	return e2etest.SyntheticContainerManyFilesSource
 }
 
-func (m ManyObjectsGenerator) Generate(service e2etest.ServiceResourceManager) error {
+func (m *ManyObjectsGenerator) Generate(service e2etest.ServiceResourceManager) error {
 	a := &DummyAsserter{}
 
 	container := service.GetContainer(m.ContainerTarget)
+
+	if container.Exists() {
+		return fmt.Errorf("please delete the container %s before re-running the generator", m.ContainerTarget)
+	}
 
 	container.Create(a, e2etest.ContainerProperties{})
 	if a.CaughtError != nil {
 		return fmt.Errorf("failed to create container: %w", a.CaughtError)
 	}
 
-	threadPool := semaphore.NewWeighted(int64(runtime.NumCPU()))
-	waitGroup := &sync.WaitGroup{}
-	doneCount := e2etest.PtrOf[int64](0)
-	failures := e2etest.PtrOf[int64](0)
+	gjm := NewGenerationJobManager(GenManyObjectsCount, GenManyObjectsLogDivision)
+	// We limit the number of things we're trying to queue up at once so we don't casually use 64gb of memory for funsies
+	allocationCap := semaphore.NewWeighted(100_000)
 
-	// object count is not adjustable, this is generating a scenario for data purposes.
-	objCount := 10_000_000
-	waitGroup.Add(objCount)
-	for objNum := 0; objNum < 10_000_000; objNum++ {
-
-		_ = threadPool.Acquire(context.Background(), 1) // can't fail because there's no cancel
-		go func() {
-			defer waitGroup.Done()
-			defer threadPool.Release(1)
-
+	for range GenManyObjectsCount {
+		_ = allocationCap.Acquire(context.Background(), 1)
+		gjm.ScheduleItem(func() error {
 			// shadow the asserter
 			a := &DummyAsserter{}
+
+			defer allocationCap.Release(1)
 
 			// make the object
 			obj := container.GetObject(a, uuid.NewString(), common.EEntityType.File())
 			obj.Create(a, e2etest.NewRandomObjectContentContainer(1024), e2etest.ObjectProperties{})
 			if a.CaughtError != nil {
-				atomic.AddInt64(failures, 1)
-				fmt.Printf("failed to create object: %s", a.CaughtError)
+				return fmt.Errorf("failed to create object: %s\n", a.CaughtError)
 			}
 
-			counter := atomic.AddInt64(doneCount, 1)
-			if counter%10_000 == 0 {
-				// give the user some sorta useful output
-				fmt.Println("generated", objNum)
-			}
-		}()
+			return nil
+		}, true)
+	}
+
+	gjm.Wait()
+
+	if fc := atomic.LoadInt64(gjm.failureCount); fc > 0 {
+		return fmt.Errorf("failed generating %d entries", fc)
 	}
 
 	return nil

--- a/e2etest/stress_generators/gen_many_objects.go
+++ b/e2etest/stress_generators/gen_many_objects.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/e2etest"
+	"github.com/google/uuid"
+	"golang.org/x/sync/semaphore"
+	"runtime"
+	"sync"
+	"sync/atomic"
+)
+
+const (
+	GenManyObjectsName = "many-objects"
+)
+
+func init() {
+	RegisterGenerator(&ManyObjectsGenerator{})
+}
+
+type ManyObjectsGenerator struct {
+	ContainerTarget string
+}
+
+func (m ManyObjectsGenerator) RegisterFlags(pFlags *flag.FlagSet) {
+	pFlags.StringVar(&m.ContainerTarget, FlagContainerName, e2etest.SyntheticContainerManyFilesSource, "Set a custom container name")
+}
+
+func (m ManyObjectsGenerator) Name() string {
+	return GenManyObjectsName
+}
+
+func (m ManyObjectsGenerator) Generate(service e2etest.ServiceResourceManager) error {
+	a := &DummyAsserter{}
+
+	container := service.GetContainer(m.ContainerTarget)
+
+	container.Create(a, e2etest.ContainerProperties{})
+	if a.CaughtError != nil {
+		return fmt.Errorf("failed to create container: %w", a.CaughtError)
+	}
+
+	threadPool := semaphore.NewWeighted(int64(runtime.NumCPU()))
+	waitGroup := &sync.WaitGroup{}
+	doneCount := e2etest.PtrOf[int64](0)
+	failures := e2etest.PtrOf[int64](0)
+
+	// object count is not adjustable, this is generating a scenario for data purposes.
+	objCount := 10_000_000
+	waitGroup.Add(objCount)
+	for objNum := 0; objNum < 10_000_000; objNum++ {
+
+		_ = threadPool.Acquire(context.Background(), 1) // can't fail because there's no cancel
+		go func() {
+			defer waitGroup.Done()
+			defer threadPool.Release(1)
+
+			// shadow the asserter
+			a := &DummyAsserter{}
+
+			// make the object
+			obj := container.GetObject(a, uuid.NewString(), common.EEntityType.File())
+			obj.Create(a, e2etest.NewRandomObjectContentContainer(1024), e2etest.ObjectProperties{})
+			if a.CaughtError != nil {
+				atomic.AddInt64(failures, 1)
+				fmt.Printf("failed to create object: %s", a.CaughtError)
+			}
+
+			counter := atomic.AddInt64(doneCount, 1)
+			if counter%10_000 == 0 {
+				// give the user some sorta useful output
+				fmt.Println("generated", objNum)
+			}
+		}()
+	}
+
+	return nil
+}

--- a/e2etest/stress_generators/gen_sync_worst_case.go
+++ b/e2etest/stress_generators/gen_sync_worst_case.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/e2etest"
+	"github.com/google/uuid"
+	"github.com/spf13/pflag"
+	"golang.org/x/sync/semaphore"
+	"strings"
+	"sync/atomic"
+)
+
+const (
+	GenSyncWorstCaseName = "sync-worst-case"
+)
+
+func init() {
+	RegisterGenerator(&SyncWorstCaseGenerator{})
+}
+
+type SyncWorstCaseGenerator struct {
+	SourceContainerTarget string
+	DestContainerTarget   string
+	preferredService      string
+}
+
+func (s *SyncWorstCaseGenerator) PreferredService() common.Location {
+	if s.preferredService != "" {
+		var out common.Location
+		_ = out.Parse(s.preferredService)
+		return out
+	}
+
+	return common.ELocation.Blob()
+}
+
+func (s *SyncWorstCaseGenerator) Name() string {
+	return GenSyncWorstCaseName
+}
+
+func (s *SyncWorstCaseGenerator) Generate(manager e2etest.ServiceResourceManager) error {
+	a := &DummyAsserter{}
+
+	sourceCt := manager.GetContainer(s.SourceContainerTarget)
+	destCt := manager.GetContainer(s.DestContainerTarget)
+
+	if sourceCt.Exists() || destCt.Exists() {
+		return fmt.Errorf("please delete both containers %s and %s before re-running the generator", s.SourceContainerTarget, s.DestContainerTarget)
+	}
+
+	sourceCt.Create(a, e2etest.ContainerProperties{})
+	if a.CaughtError != nil {
+		return fmt.Errorf("failed to create source container: %w", a.CaughtError)
+	}
+
+	destCt.Create(a, e2etest.ContainerProperties{})
+	if a.CaughtError != nil {
+		return fmt.Errorf("failed to create source container: %w", a.CaughtError)
+	}
+
+	/*
+		The worst-case scenario for almost any implementation of sync's algorithm is "simple". A big, flat folder, deep in a tree, with no overlaps on either side.
+		However, for a real test of optimization, we actually want some overlap. Despite this being named "worst case", it's more intended to capture the "worst cases" of a real scenario.
+
+		We might see cases of deeply-nested folders filled with large numbers of unique items. But we might also see overlaps. We might see smaller directories.
+	*/
+	const (
+		MinDepth              = 2
+		MaxDepth              = 7
+		TotalFileCount        = 10_000_000
+		IncrementAnnouncement = TotalFileCount / 1_000
+
+		FilesPerDir = TotalFileCount / (MaxDepth - MinDepth)
+		// Our bottom directory will overlap 100%, but our top will overlap 1/nth, testing a good variety of cases.
+		OverlapIncrement = FilesPerDir / (MaxDepth - MinDepth)
+	)
+
+	gjm := NewGenerationJobManager(TotalFileCount+(MaxDepth), IncrementAnnouncement)
+
+	cDir := make([]string, 0)
+	currentOverlap := OverlapIncrement * (MaxDepth - MinDepth)
+
+	fileContent := e2etest.NewRandomObjectContentContainer(100)
+	// We limit the number of things we're trying to queue up at once so we don't casually use 64gb of memory for funsies
+	allocationCap := semaphore.NewWeighted(100_000)
+
+	createFiles := func(sourcePath, destPath string) {
+		_ = allocationCap.Acquire(context.Background(), 1)
+
+		gjm.ScheduleItem(func() error {
+			a := &DummyAsserter{}
+
+			defer allocationCap.Release(1)
+
+			sourceFile := sourceCt.GetObject(a, sourcePath, common.EEntityType.File())
+			if a.CaughtError != nil {
+				return fmt.Errorf("failed to get source file: %w", a.CaughtError)
+			}
+			destFile := destCt.GetObject(a, destPath, common.EEntityType.File())
+			if a.CaughtError != nil {
+				return fmt.Errorf("failed to get dest file: %w", a.CaughtError)
+			}
+
+			sourceFile.Create(a, fileContent, e2etest.ObjectProperties{})
+			if a.CaughtError != nil {
+				return fmt.Errorf("failed to create source file: %w", a.CaughtError)
+			}
+			destFile.Create(a, fileContent, e2etest.ObjectProperties{})
+			if a.CaughtError != nil {
+				return fmt.Errorf("failed to create source file: %w", a.CaughtError)
+			}
+
+			return nil
+		}, false)
+	}
+
+	for k := range MaxDepth {
+		dirPath := strings.Join(cDir, "/")
+
+		if len(cDir) > 0 {
+			gjm.ScheduleItem(func() error {
+				a := &DummyAsserter{}
+
+				srcFolder := sourceCt.GetObject(a, dirPath, common.EEntityType.Folder())
+				if a.CaughtError != nil {
+					return fmt.Errorf("failed to get source folder: %w", a.CaughtError)
+				}
+				srcFolder.Create(a, e2etest.NewZeroObjectContentContainer(0), e2etest.ObjectProperties{})
+				if a.CaughtError != nil {
+					return fmt.Errorf("failed to create source folder: %w", a.CaughtError)
+				}
+
+				dstFolder := destCt.GetObject(a, dirPath, common.EEntityType.Folder())
+				if a.CaughtError != nil {
+					return fmt.Errorf("failed to get dest folder: %w", a.CaughtError)
+				}
+				dstFolder.Create(a, e2etest.NewZeroObjectContentContainer(0), e2etest.ObjectProperties{})
+				if a.CaughtError != nil {
+					return fmt.Errorf("failed to create dest folder: %w", a.CaughtError)
+				}
+
+				return nil
+			}, true)
+		}
+
+		if k < MinDepth {
+			goto stepUp
+		}
+
+		// First, create the overlap files
+		for range currentOverlap {
+			f := uuid.NewString()
+			if len(dirPath) > 0 {
+				f = dirPath + "/" + f
+			}
+			createFiles(f, f)
+		}
+
+		// Then, if any remain, create the non-overlapping files
+		for range FilesPerDir - currentOverlap {
+			pfx := ""
+			if len(dirPath) > 0 {
+				pfx = dirPath + "/"
+			}
+
+			createFiles(pfx+uuid.NewString(), pfx+uuid.NewString())
+		}
+
+		// drop the overlap moving up
+		currentOverlap -= OverlapIncrement
+	stepUp:
+		cDir = append(cDir, uuid.NewString())
+	}
+
+	gjm.Wait()
+
+	if fc := atomic.LoadInt64(gjm.failureCount); fc > 0 {
+		return fmt.Errorf("failed generating %d entries", fc)
+	}
+
+	return nil
+}
+
+func (s *SyncWorstCaseGenerator) RegisterFlags(flags *pflag.FlagSet) {
+	flags.StringVar(&s.SourceContainerTarget, FlagSourceContainerName, e2etest.SyntheticContainerSyncWorstCaseSource, "Specify a target container for the source")
+	flags.StringVar(&s.DestContainerTarget, FlagDestContainerName, e2etest.SyntheticContainerSyncWorstCaseDest, "Specify a target container for the destination")
+	flags.StringVar(&s.preferredService, FlagService, "", "Generate against a service other than the default (blob)")
+}

--- a/e2etest/stress_generators/generator_reg.go
+++ b/e2etest/stress_generators/generator_reg.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/Azure/azure-storage-azcopy/v10/e2etest"
+	"github.com/spf13/cobra"
+)
+
+type Generator interface {
+	Name() string
+	Generate(manager e2etest.ServiceResourceManager) error
+	RegisterFlags(flags *flag.FlagSet)
+}
+
+var GeneratorRegistry = make(map[string]Generator)
+
+func RegisterGenerator(g Generator) {
+	_, ok := GeneratorRegistry[g.Name()]
+	if ok {
+		panic("Generator " + g.Name() + " re-registered")
+	}
+
+	GeneratorRegistry[g.Name()] = g
+	cmd := &cobra.Command{
+		Use: fmt.Sprintf("%s <service-uri>", g.Name()),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return RunGenerator(g.Name(), args[0])
+		},
+		Args: RequireValidTarget,
+	}
+
+	RootCmd.AddCommand(cmd)
+}
+
+func RunGenerator(name, target string) error {
+	svc, err := GetResourceManagerForURI(target)
+	if err != nil {
+		return fmt.Errorf("failed to get resource manager: %w", err)
+	}
+
+	gen, ok := GeneratorRegistry[name]
+	if !ok {
+		return fmt.Errorf("generator %s does not exist", name)
+	}
+
+	fmt.Printf("Generating scenario %s...", name)
+	err = gen.Generate(svc)
+	if err != nil {
+		return fmt.Errorf("failed generating scenario %s: %w", name, err)
+	}
+
+	return nil
+}

--- a/e2etest/stress_generators/main.go
+++ b/e2etest/stress_generators/main.go
@@ -1,0 +1,18 @@
+package main
+
+import "github.com/spf13/cobra"
+
+var RootCmd = &cobra.Command{
+	Use: "stress_gen",
+}
+
+func init() {
+
+}
+
+func main() {
+	err := RootCmd.Execute()
+	if err != nil {
+		panic(err)
+	}
+}

--- a/e2etest/stress_generators/main.go
+++ b/e2etest/stress_generators/main.go
@@ -1,18 +1,29 @@
 package main
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
+	"github.com/spf13/cobra"
+)
 
 var RootCmd = &cobra.Command{
 	Use: "stress_gen",
-}
 
-func init() {
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		var retryStatusCodes = "408;429;500;502;503;504"
+		if genConfig.RetryOptions.HttpRetryCodes != "" {
+			retryStatusCodes += ";" + genConfig.RetryOptions.HttpRetryCodes
+		}
 
+		rsc, err := ste.ParseRetryCodes(retryStatusCodes)
+		if err != nil {
+			return err
+		}
+		ste.RetryStatusCodes = rsc
+
+		return nil
+	},
 }
 
 func main() {
-	err := RootCmd.Execute()
-	if err != nil {
-		panic(err)
-	}
+	_ = RootCmd.Execute()
 }

--- a/e2etest/stress_generators/threading.go
+++ b/e2etest/stress_generators/threading.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"fmt"
+	"github.com/Azure/azure-storage-azcopy/v10/e2etest"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+/*
+This is really slapdash
+*/
+
+var (
+	ThreadCount = func() int64 {
+		threadCount := int64(runtime.NumCPU()) * 4
+
+		if threadCount > 64 {
+			return 64 // mirror AzCopy's thread count
+		}
+
+		return threadCount
+	}()
+
+	PriorityJobQueue = make(chan func(), ThreadCount)
+	JobQueue         = make(chan func(), ThreadCount)
+)
+
+func init() {
+	for range ThreadCount {
+		go func() {
+
+			var (
+				j  func()
+				ok bool
+			)
+
+			for {
+				select {
+				case j, ok = <-PriorityJobQueue:
+				case j, ok = <-JobQueue:
+				}
+
+				if j != nil {
+					j()
+					j = nil
+				}
+
+				if !ok {
+					return
+				}
+			}
+		}()
+	}
+}
+
+func NewGenerationJobManager(itemCount int, statusIncrement int64) *GenerationJobManager {
+	out := &GenerationJobManager{
+		wg:              &sync.WaitGroup{},
+		totalCount:      e2etest.PtrOf[int64](int64(itemCount)),
+		doneCount:       e2etest.PtrOf[int64](0),
+		failureCount:    e2etest.PtrOf[int64](0),
+		statusIncrement: statusIncrement,
+	}
+
+	out.wg.Add(itemCount)
+
+	return out
+}
+
+type GenerationJobManager struct {
+	wg              *sync.WaitGroup
+	totalCount      *int64
+	doneCount       *int64
+	failureCount    *int64
+	statusIncrement int64
+
+	CustomAnnounce func() string
+}
+
+func (gjm *GenerationJobManager) ScheduleAdditionalItems(n int) {
+	gjm.wg.Add(n)
+	atomic.AddInt64(gjm.totalCount, int64(n))
+}
+
+func (gjm *GenerationJobManager) ScheduleItem(f func() error, prio bool) {
+	go func() {
+		f := func() {
+			defer gjm.wg.Done()
+
+			err := f()
+			if err != nil {
+				atomic.AddInt64(gjm.failureCount, 1)
+				fmt.Printf("failed to create an object: %s\n", err)
+			} else {
+				done := atomic.AddInt64(gjm.doneCount, 1)
+				if done%gjm.statusIncrement == 0 {
+					cAnnounce := func() string {
+						if gjm.CustomAnnounce == nil {
+							return ""
+						}
+
+						return " " + gjm.CustomAnnounce()
+					}
+
+					fmt.Printf("%v: generated %d items of %d!%v\n", time.Now().Format(time.Stamp), done, atomic.LoadInt64(gjm.totalCount), cAnnounce())
+				}
+			}
+		}
+
+		if prio {
+			PriorityJobQueue <- f
+		} else {
+			JobQueue <- f
+		}
+	}()
+}
+
+func (gjm *GenerationJobManager) Wait() {
+	gjm.wg.Wait()
+}

--- a/e2etest/zt_aanewe2e_testmain_test.go
+++ b/e2etest/zt_aanewe2e_testmain_test.go
@@ -22,6 +22,7 @@ var FrameworkHooks = []TestFrameworkHook{
 	{HookName: "OAuth Cache", SetupHook: SetupOAuthCache},
 	{HookName: "ARM Client", SetupHook: SetupArmClient, TeardownHook: TeardownArmClient},
 	{HookName: "Default accts", SetupHook: AccountRegistryInitHook, TeardownHook: AccountRegistryCleanupHook},
+	{HookName: "Synthetic Test Suite Registration", SetupHook: RegisterSyntheticStressTestHook},
 }
 
 type TestFrameworkHook struct {

--- a/e2etest/zt_newe2e_file_test.go
+++ b/e2etest/zt_newe2e_file_test.go
@@ -567,7 +567,7 @@ func (s *FileTestSuite) Scenario_UploadFilesWithQuota(svm *ScenarioVariationMana
 
 	// Fill the share up
 	if !svm.Dryrun() {
-		shareClient := shareResource.(*FileShareResourceManager).internalClient
+		shareClient := shareResource.(*FileShareResourceManager).InternalClient
 		fileClient := shareClient.NewRootDirectoryClient().NewFileClient("big.txt")
 		_, err := fileClient.Create(ctx, 990*common.MegaByte, nil)
 		svm.NoError("Create large file", err)

--- a/e2etest/zt_newe2e_sync_test.go
+++ b/e2etest/zt_newe2e_sync_test.go
@@ -126,13 +126,15 @@ func (s *SyncTestSuite) Scenario_TestSyncHashStorageModes(a *ScenarioVariationMa
 	data, err := adapter.GetHashData(dupeBodyPath)
 	a.NoError("Poll hash data", err)
 	a.Assert("Data must not be nil", Not{IsNil{}}, data)
-	a.Assert("Data must match target hash mode", Equal{}, data.Mode, common.ESyncHashType.MD5()) // for now, we only have MD5. In the future, CRC64 may be available.
+	if data != nil {
+		a.Assert("Data must match target hash mode", Equal{}, data.Mode, common.ESyncHashType.MD5()) // for now, we only have MD5. In the future, CRC64 may be available.
 
-	fi, err := os.Stat(filepath.Join(source.URI(), dupeBodyPath))
-	a.NoError("Stat file at source", err)
-	a.Assert("LMTs must match between hash data and file", Equal{}, data.LMT.Equal(fi.ModTime()), true)
+		fi, err := os.Stat(filepath.Join(source.URI(), dupeBodyPath))
+		a.NoError("Stat file at source", err)
+		a.Assert("LMTs must match between hash data and file", Equal{}, data.LMT.Equal(fi.ModTime()), true)
 
-	a.Assert("hashes must match", Equal{}, data.Data, base64.StdEncoding.EncodeToString(md5[:]))
+		a.Assert("hashes must match", Equal{}, data.Data, base64.StdEncoding.EncodeToString(md5[:]))
+	}
 }
 
 func (s *SyncTestSuite) Scenario_TestSyncRemoveDestination(svm *ScenarioVariationManager) {
@@ -199,7 +201,7 @@ func (s *SyncTestSuite) Scenario_TestSyncDeleteDestinationIfNecessary(svm *Scena
 
 		switch dstRes.Location() {
 		case common.ELocation.Blob(): // In this case, we want to submit a block ID with a different length.
-			ctClient := dstRes.(*BlobContainerResourceManager).internalClient
+			ctClient := dstRes.(*BlobContainerResourceManager).InternalClient
 			blobClient := ctClient.NewBlockBlobClient(overwriteName)
 
 			_, err := blobClient.StageBlock(ctx, base64.StdEncoding.EncodeToString([]byte("foobar")), buf, nil)

--- a/e2etest/zt_newe2e_synthetic_memory_stress_test.go
+++ b/e2etest/zt_newe2e_synthetic_memory_stress_test.go
@@ -53,6 +53,7 @@ func (s *SyntheticMemoryStressTestSuite) Scenario_CopyManyFiles(a *ScenarioVaria
 
 			AsSubdir: PtrOf(false),
 		},
+		Stdout: &AzCopyDiscardStdout{},
 	})
 }
 
@@ -78,6 +79,7 @@ func (s *SyntheticMemoryStressTestSuite) Scenario_CopyFolders(a *ScenarioVariati
 
 			AsSubdir: PtrOf(false),
 		},
+		Stdout: &AzCopyDiscardStdout{},
 	})
 }
 

--- a/e2etest/zt_newe2e_synthetic_memory_stress_test.go
+++ b/e2etest/zt_newe2e_synthetic_memory_stress_test.go
@@ -1,0 +1,32 @@
+package e2etest
+
+type SyntheticMemoryStressTestSuite struct{}
+
+/*
+This test suite requires three things
+
+1) The telemetry account is configured
+2) Stress test data is generated and present in the expected containers (run the generators in stress_generators)
+3) Stress testing is enabled-- this is not enabled for every run, and should be flipped on for release PRs.
+
+Currently, this suite (and it's scenarios) are designed to target highly memory intensive operations,
+(e.g. massive sync cases, many folder properties transfers, etc.)
+as well as some common intensive operations (e.g. millions of files, several gigantic files, etc.) in S2S.
+
+
+*/
+
+func RegisterSyntheticStressTestHook(a Asserter) {
+	// Why a hook instead of init? We want to check that conditions are set, which is reliant upon the config.
+	if !GlobalConfig.TelemetryConfigured() {
+		return // don't register if we don't have the account set up
+	}
+
+	if !GlobalConfig.TelemetryConfig.StressTestEnabled {
+		return // don't register if we haven't enabled the stress tests.
+	}
+
+	// todo: validate stress test data is present
+
+	suiteManager.RegisterSuite(&SyntheticMemoryStressTestSuite{})
+}

--- a/e2etest/zt_newe2e_token_persist_test.go
+++ b/e2etest/zt_newe2e_token_persist_test.go
@@ -1,6 +1,7 @@
 package e2etest
 
 import (
+	"flag"
 	"fmt"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
@@ -68,5 +69,64 @@ func (*TokenPersistenceSuite) Scenario_InheritCred_Persist(a *ScenarioVariationM
 		AzCopyCommand{
 			Verb:        AzCopyVerbLogout,
 			Environment: azcopyEnv,
+		})
+}
+
+var runDeviceCodeTest = flag.Bool("device-code", false, "Whether or not to run device code tests. These must be run manually due to interactive nature.")
+
+func (*TokenPersistenceSuite) Scenario_DeviceCode_Persist(a *ScenarioVariationManager) {
+	if runDeviceCodeTest == nil || !*runDeviceCodeTest {
+		a.Skip("device code disabled")
+	}
+
+	env := &AzCopyEnvironment{
+		LoginCacheName: pointerTo("AzCopyDeviceCodeTest"),
+		ManualLogin:    true,
+	}
+
+	cfgTenantID := GlobalConfig.GetTenantID()
+	_, _ = RunAzCopy(a,
+		AzCopyCommand{
+			Verb: AzCopyVerbLogin,
+			Flags: LoginFlags{
+				LoginType: pointerTo(common.EAutoLoginType.Device()),
+				TenantID:  common.Iff(cfgTenantID != "", &cfgTenantID, nil),
+			},
+			Environment: env,
+		})
+
+	loginStatus, _ := RunAzCopy(a,
+		AzCopyCommand{
+			Verb: AzCopyVerbLoginStatus,
+			Flags: LoginStatusFlags{
+				Method:   pointerTo(true),
+				Endpoint: pointerTo(true),
+				Tenant:   pointerTo(true),
+			},
+			Environment: env,
+		})
+
+	parsedStdout, ok := loginStatus.(*AzCopyParsedLoginStatusStdout)
+	a.AssertNow("must be AzCopyParsedLoginStatusStdout", Equal{}, ok, true)
+
+	if !a.Dryrun() {
+		status := parsedStdout.status
+		a.Assert("Login check failed", Equal{}, true, status.Valid)
+
+		a.Assert("Tenant not returned", Not{IsNil{}}, status.TenantID) // Let's just do a little extra testing while we're at it, kill two birds with one stone.
+		if status.TenantID != nil && cfgTenantID != "" {
+			a.Assert("Tenant does not match", Equal{}, cfgTenantID, *status.TenantID)
+		}
+		a.Assert("Endpoint not returned", Not{IsNil{}}, status.AADEndpoint)
+		a.Assert("Auth mechanism not returned", Not{IsNil{}}, status.AuthMethod)
+		if status.AuthMethod != nil {
+			a.Assert("Incorrect auth mechanism", Equal{}, *status.AuthMethod, common.EAutoLoginType.Device().String())
+		}
+	}
+
+	_, _ = RunAzCopy(a,
+		AzCopyCommand{
+			Verb:        AzCopyVerbLogout,
+			Environment: env,
 		})
 }

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.5.2 // indirect
 	cloud.google.com/go/iam v1.2.1 // indirect
 	cloud.google.com/go/monitoring v1.21.1 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/data/aztables v1.3.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -31,8 +31,10 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.16.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.1
+	github.com/Azure/azure-sdk-for-go/sdk/data/aztables v1.3.0
 	github.com/Azure/go-autorest/autorest/date v0.3.0
 	github.com/keybase/go-keychain v0.0.0-20231219164618-57a3676c3af6
+	github.com/spf13/pflag v1.0.5
 	golang.org/x/net v0.36.0
 )
 
@@ -44,7 +46,6 @@ require (
 	cloud.google.com/go/compute/metadata v0.5.2 // indirect
 	cloud.google.com/go/iam v1.2.1 // indirect
 	cloud.google.com/go/monitoring v1.21.1 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/data/aztables v1.3.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 // indirect
@@ -76,7 +77,6 @@ require (
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.29.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.54.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.0 h1:B/dfvscEQtew9dVuoxqxr
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.0/go.mod h1:fiPSssYvltE08HJchL04dOy+RD4hgrjph0cwGGMntdI=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.1 h1:Bk5uOhSAenHyR5P61D/NzeQCv+4fEVV8mOkJ82NqpWw=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.1/go.mod h1:QZ4pw3or1WPmRBxf0cHd1tknzrT54WPBOQoGutCPvSU=
+github.com/Azure/azure-sdk-for-go/sdk/data/aztables v1.3.0 h1:NnE8y/opvxowwNcSNHubQUiSSEhfk3dmooLGAOmPuKs=
+github.com/Azure/azure-sdk-for-go/sdk/data/aztables v1.3.0/go.mod h1:GhHzPHiiHxZloo6WvKu9X7krmSAKTyGoIwoKMbrKTTA=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 h1:ywEEhmNahHBihViHepv3xPBn1663uRv2t2q/ESv9seY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkYRNWPENUnqx6bJ2xnSDFI2tjwZNuY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.6.0 h1:PiSrjRPpkQNjrM8H0WwKMnZUdu1RGMtd/LdGKUrOo+c=

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -110,7 +110,7 @@ func NewClientOptions(retry policy.RetryOptions, telemetry policy.TelemetryOptio
 	if srcCred != nil {
 		perRetryPolicies = append(perRetryPolicies, NewSourceAuthPolicy(srcCred))
 	}
-	retry.ShouldRetry = getShouldRetry(&log)
+	retry.ShouldRetry = GetShouldRetry(&log)
 
 	return azcore.ClientOptions{
 		//APIVersion: ,

--- a/ste/xferRetryHelper.go
+++ b/ste/xferRetryHelper.go
@@ -35,7 +35,7 @@ var platformRetryPolicy func(response *http.Response, err error) bool
 
 type RetryFunc = func(*http.Response, error) bool
 
-func getShouldRetry(log *LogOptions) RetryFunc {
+func GetShouldRetry(log *LogOptions) RetryFunc {
 	if len(RetryStatusCodes) == 0 {
 		return nil
 	}
@@ -52,9 +52,9 @@ func getShouldRetry(log *LogOptions) RetryFunc {
 								fmt.Sprintf("Request %s retried on custom condition %s", resp.Header.Get("x-ms-client-request-id"), errorCode))
 						}
 
-                        if policy {
-						    return policy
-                        }
+						if policy {
+							return policy
+						}
 					} else if !ok && storageErrorCodes["*"] {
 						return true
 					}

--- a/ste/xferRetryHelper.go
+++ b/ste/xferRetryHelper.go
@@ -42,16 +42,6 @@ func getShouldRetry(log *LogOptions) RetryFunc {
 	return func(resp *http.Response, err error) bool {
 		if resp != nil {
 			if storageErrorCodes, ok := RetryStatusCodes[resp.StatusCode]; ok {
-				// no status codes specified to compare to
-				if len(storageErrorCodes) == 0 {
-					if log != nil && log.ShouldLog(common.ELogLevel.Debug()) {
-						log.Log(
-							common.ELogLevel.Debug(),
-							fmt.Sprintf("Request %s retried on custom condition %d", resp.Header.Get("x-ms-client-request-id"), resp.StatusCode))
-					}
-
-					return true
-				}
 				// compare to status codes
 				errorCode := getErrorCode(resp)
 				if errorCode != "" {
@@ -62,7 +52,9 @@ func getShouldRetry(log *LogOptions) RetryFunc {
 								fmt.Sprintf("Request %s retried on custom condition %s", resp.Header.Get("x-ms-client-request-id"), errorCode))
 						}
 
-						return policy
+                        if policy {
+						    return policy
+                        }
 					} else if !ok && storageErrorCodes["*"] {
 						return true
 					}

--- a/ste/xferRetryHelper_test.go
+++ b/ste/xferRetryHelper_test.go
@@ -108,7 +108,7 @@ func TestGetShouldRetry(t *testing.T) {
 		}
 
 		RetryStatusCodes = v.Rules
-		shouldRetry := getShouldRetry(nil)
+		shouldRetry := GetShouldRetry(nil)
 
 		if v.CustomTest != nil {
 			v.CustomTest(t, shouldRetry)

--- a/ste/xferRetryHelper_windows.go
+++ b/ste/xferRetryHelper_windows.go
@@ -17,7 +17,13 @@ func init() {
 
 		// It's entirely possible something in between closed our connection.
 		if errors.Is(err, windows.WSAECONNRESET) || // Catch it in the idiomatic way
-			strings.Contains(strings.ToLower(err.Error()), "an existing connection was forcibly closed by the remote host.") { // But just in case something funny happened along the line, let's listen for the string we expect.
+			strings.Contains(strings.ToLower(err.Error()), strings.ToLower(windows.WSAECONNRESET.Error())) { // But just in case something funny happened along the line, let's listen for the string we expect.
+			return true
+		}
+
+		// This can sometimes happen if we're trying too many connections. It usually resolves itself quickly.
+		if errors.Is(err, windows.WSAEADDRINUSE) ||
+			strings.Contains(strings.ToLower(err.Error()), strings.ToLower(windows.WSAEADDRINUSE.Error())) {
 			return true
 		}
 


### PR DESCRIPTION
This requires some infra setup, and some prior PRs merged to get this one in.

#2956 -> #2959 -> #2962 ->this PR

A storage account will need to be created for storing telemetry data, and the data for the stress tests will need to be generated before they can be ran. Stress tests will need to be manually run, since they are... quite hefty, but the data only needs to be generated once.