### PR TITLE
Bug fix for double initiation of directory transfer

### DIFF
--- a/cmd/syncEnumerator.go
+++ b/cmd/syncEnumerator.go
@@ -76,27 +76,33 @@ func (cca *cookedSyncCmdArgs) InitEnumerator(ctx context.Context, errorChannel c
 	dest := cca.fromTo.To()
 
 	srcTraverserTemplate := ResourceTraverserTemplate{
-		location:                    cca.fromTo.From(),
-		credential:                  &srcCredInfo,
-		symlinkHandling:             common.ESymlinkHandlingType.Skip(),
-		listOfFilesChannel:          nil,
-		recursive:                   cca.recursive,
-		getProperties:               true,
-		includeDirectoryStubs:       includeDirStubs,
-		permanentDeleteOption:       common.EPermanentDeleteOption.None(),
-		incrementEnumerationCounter: func(entityType common.EntityType) {},
-		listOfVersionIds:            nil,
-		s2sPreserveBlobTags:         cca.s2sPreserveBlobTags,
-		syncHashType:                cca.compareHash,
-		preservePermissions:         cca.preservePermissions,
-		logLevel:                    AzcopyLogVerbosity,
-		cpkOptions:                  cca.cpkOptions,
-		errorChannel:                nil,
-		stripTopDir:                 false,
-		trailingDot:                 cca.trailingDot,
-		destination:                 &dest,
-		excludeContainerNames:       nil,
-		includeVersionsList:         false,
+		location:              cca.fromTo.From(),
+		credential:            &srcCredInfo,
+		symlinkHandling:       common.ESymlinkHandlingType.Skip(),
+		listOfFilesChannel:    nil,
+		recursive:             cca.recursive,
+		getProperties:         true,
+		includeDirectoryStubs: includeDirStubs,
+		permanentDeleteOption: common.EPermanentDeleteOption.None(),
+		incrementEnumerationCounter: func(entityType common.EntityType) {
+			if entityType == common.EEntityType.File() {
+				atomic.AddUint64(&cca.atomicSourceFilesScanned, 1)
+			} else if entityType == common.EEntityType.Folder() {
+				atomic.AddUint64(&cca.atomicSourceFoldersScanned, 1)
+			}
+		},
+		listOfVersionIds:      nil,
+		s2sPreserveBlobTags:   cca.s2sPreserveBlobTags,
+		syncHashType:          cca.compareHash,
+		preservePermissions:   cca.preservePermissions,
+		logLevel:              AzcopyLogVerbosity,
+		cpkOptions:            cca.cpkOptions,
+		errorChannel:          nil,
+		stripTopDir:           false,
+		trailingDot:           cca.trailingDot,
+		destination:           &dest,
+		excludeContainerNames: nil,
+		includeVersionsList:   false,
 	}
 
 	sourceTraverser, err := InitResourceTraverser(cca.Source, cca.fromTo.From(), &ctx, &srcCredInfo, common.ESymlinkHandlingType.Skip(), nil, cca.recursive, true, includeDirStubs, common.EPermanentDeleteOption.None(), func(entityType common.EntityType) {

--- a/cmd/syncOrchestrator.go
+++ b/cmd/syncOrchestrator.go
@@ -254,7 +254,7 @@ func syncMonitor() {
 		run = atomic.AddInt32(&syncMonitorRun, 0)
 	}
 
-	WarnStdoutAndScanningLog("Exiting SyncMonitor...\n")
+	//WarnStdoutAndScanningLog("Exiting SyncMonitor...\n")
 	atomic.AddInt32(&syncMonitorExited, 1)
 }
 
@@ -414,7 +414,7 @@ func (cca *cookedSyncCmdArgs) runSyncOrchestrator(ctx context.Context) (err erro
 		fi.ModTime(), fi.Size(), noContentProps, noBlobProps, noMetadata, "")
 
 	parallelism := 4
-		atomic.AddInt64(&syncQDepth, 1)
+	atomic.AddInt64(&syncQDepth, 1)
 	var _ = parallel.Crawl(ctx, root, syncOneDir, parallelism)
 
 	cca.waitUntilJobCompletion(false)
@@ -423,7 +423,7 @@ func (cca *cookedSyncCmdArgs) runSyncOrchestrator(ctx context.Context) (err erro
 	for {
 		qd := atomic.AddInt64(&syncQDepth, 0)
 		if qd == 0 {
-			WarnStdoutAndScanningLog("Sync traversers exited..\n")
+			// WarnStdoutAndScanningLog("Sync traversers exited..\n")
 			break
 		}
 		time.Sleep(1 * time.Second)
@@ -434,13 +434,13 @@ func (cca *cookedSyncCmdArgs) runSyncOrchestrator(ctx context.Context) (err erro
 	for {
 		exited := atomic.AddInt32(&syncMonitorExited, 0)
 		if exited == 1 {
-			WarnStdoutAndScanningLog("Sync monitor exited, quitting..\n")
+			// WarnStdoutAndScanningLog("Sync monitor exited, quitting..\n")
 			break
 		}
 		time.Sleep(1 * time.Second)
 	}
 
-	WarnStdoutAndScanningLog("Enumerator finalize running...\n")
+	//WarnStdoutAndScanningLog("Enumerator finalize running...\n")
 	err = enumerator.finalize()
 	if err != nil {
 		WarnStdoutAndScanningLog("Sync finalize failed!!\n")

--- a/cmd/zc_traverser_file.go
+++ b/cmd/zc_traverser_file.go
@@ -23,14 +23,15 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"runtime"
+	"strings"
+	"time"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/directory"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/file"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/service"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/share"
 	"github.com/Azure/azure-storage-azcopy/v10/common/parallel"
-	"runtime"
-	"strings"
-	"time"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
@@ -273,7 +274,7 @@ func (t *fileTraverser) Traverse(preprocessor objectMorpher, processor objectPro
 	// Our rule is that enumerators of folder-aware sources should include the root folder's properties.
 	// So include the root dir/share in the enumeration results, if it exists or is just the share root.
 	_, err = directoryClient.GetProperties(t.ctx, nil)
-	if err == nil || targetURLParts.DirectoryOrFilePath == "" {
+	if !UseSyncOrchestrator && (err == nil || targetURLParts.DirectoryOrFilePath == "") {
 		s, err := convertToStoredObject(newAzFileRootDirectoryEntity(directoryClient, ""))
 		if err != nil {
 			return err

--- a/cmd/zc_traverser_local.go
+++ b/cmd/zc_traverser_local.go
@@ -846,7 +846,7 @@ func (t *localTraverser) Traverse(preprocessor objectMorpher, processor objectPr
 
 		return finalizer(err)
 	} else {
-		if t.recursive || UseSyncOrchestrator {
+		if t.recursive {
 			processFile := func(filePath string, fileInfo os.FileInfo, fileError error) error {
 				if fileError != nil {
 					WarnStdoutAndScanningLog(fmt.Sprintf("Accessing %s failed with error: %s", filePath, fileError.Error()))


### PR DESCRIPTION
## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**: 

1. Remove UseSyncOrchestrator in local traverser. This caused enumeration in loop. If this is required to include directories without sub directories that needs to handled differently
2. In case of a directory tree update due to an addition of sub directory, there was double copy transfer triggered with sync orchestrator. 
3. Added source scan metrics counter to sync orchestrator

- **Related Links**:
- [Issues](<link>)
- [Team thread](<link>)
- [Documents](<link>)
- [Email Subject]

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

Thank you for your contribution to AzCopy!
