### PR TITLE
Added the --nfs flag missing check while download from Azure Files NFS

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -1557,11 +1557,20 @@ func (cca *CookedCopyCmdArgs) processCopyJobPartOrders() (err error) {
 		}
 	}
 
-	if err := validateProtocolCompatibility(ctx, cca.FromTo,
-		cca.Destination,
-		jobPartOrder.DstServiceClient,
-		cca.isNFSCopy); err != nil {
-		return err
+	if (cca.FromTo.IsUpload() || cca.FromTo.IsS2S()) && cca.FromTo.To() == common.ELocation.File() {
+		if err := validateProtocolCompatibility(ctx, cca.FromTo,
+			cca.Destination,
+			jobPartOrder.DstServiceClient,
+			cca.isNFSCopy); err != nil {
+			return err
+		}
+	} else if cca.FromTo.IsDownload() && cca.FromTo.From() == common.ELocation.File() {
+		if err := validateProtocolCompatibility(ctx, cca.FromTo,
+			cca.Source,
+			jobPartOrder.SrcServiceClient,
+			cca.isNFSCopy); err != nil {
+			return err
+		}
 	}
 
 	switch {


### PR DESCRIPTION
## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->
If --nfs flag is not provided while downloading to local from Azure Files NFS azcopy should fail the command with proper error message.

- **Feature / Bug Fix**: (Brief description of the feature or issue being addressed)

- **Related Links**:
- [Issues](<link>)
- [Team thread](<link>)
- [Documents](<link>)
- [Email Subject]

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

Thank you for your contribution to AzCopy!
