### PR TITLE
Entirely remove create container log

### DIFF
--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -447,7 +447,7 @@ func (cca *CookedCopyCmdArgs) createDstContainer(containerName string, dstWithSA
 	options := createClientOptions(
 		common.LogLevelOverrideLogger{ // override our log level here
 			ILoggerResetable:  common.AzcopyCurrentJobLogger,
-			MinimumLevelToLog: logLevel,
+			MinimumLevelToLog: common.Iff(azcopyLogVerbosity == common.ELogLevel.Debug(), common.ELogLevel.Debug(), common.ELogLevel.None()),
 		}, nil, reauthTok)
 
 	sc, err := common.GetServiceClientForLocation(

--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -65,7 +65,7 @@ func (cca *CookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 		(cca.FromTo.From() == common.ELocation.File() && !cca.FromTo.To().IsRemote()) || // If it's a download, we still need LMT and MD5 from files.
 		(cca.FromTo.From() == common.ELocation.File() && cca.FromTo.To().IsRemote() && (cca.s2sSourceChangeValidation || cca.IncludeAfter != nil || cca.IncludeBefore != nil)) || // If S2S from File to *, and sourceChangeValidation is enabled, we get properties so that we have LMTs. Likewise, if we are using includeAfter or includeBefore, which require LMTs.
 		(cca.FromTo.From().IsRemote() && cca.FromTo.To().IsRemote() && cca.s2sPreserveProperties && !cca.s2sGetPropertiesInBackend) // If S2S and preserve properties AND get properties in backend is on, turn this off, as properties will be obtained in the backend.
-	jobPartOrder.S2SGetPropertiesInBackend = cca.s2sPreserveProperties && !getRemoteProperties && cca.s2sGetPropertiesInBackend // Infer GetProperties if GetPropertiesInBackend is enabled.
+	jobPartOrder.S2SGetPropertiesInBackend = cca.s2sPreserveProperties && !getRemoteProperties && cca.s2sGetPropertiesInBackend     // Infer GetProperties if GetPropertiesInBackend is enabled.
 	jobPartOrder.S2SSourceChangeValidation = cca.s2sSourceChangeValidation
 	jobPartOrder.DestLengthValidation = cca.CheckLength
 	jobPartOrder.S2SInvalidMetadataHandleOption = cca.s2sInvalidMetadataHandleOption
@@ -156,11 +156,7 @@ func (cca *CookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 
 			// check against seenFailedContainers so we don't spam the job log with initialization failed errors
 			if _, ok := seenFailedContainers[dstContainerName]; err != nil && jobsAdmin.JobsAdmin != nil && !ok {
-				logDstContainerCreateFailureOnce.Do(func() {
-					glcm.Warn("Failed to create one or more destination container(s). Your transfers may still succeed if the container already exists.")
-				})
-				jobsAdmin.JobsAdmin.LogToJobLog(fmt.Sprintf("Failed to create destination container %s. The transfer will continue if the container exists", dstContainerName), common.LogWarning)
-				jobsAdmin.JobsAdmin.LogToJobLog(fmt.Sprintf("Error %s", err), common.LogDebug)
+				jobsAdmin.JobsAdmin.LogToJobLog(fmt.Sprintf("Failed attempt to create destination container (this is not blocking): %s", err), common.LogDebug)
 				seenFailedContainers[dstContainerName] = true
 			}
 		} else if cca.FromTo.From().IsRemote() { // if the destination has implicit container names
@@ -448,7 +444,11 @@ func (cca *CookedCopyCmdArgs) createDstContainer(containerName string, dstWithSA
 		reauthTok = (*common.ScopedAuthenticator)(common.NewScopedCredential(at, common.ECredentialType.OAuthToken()))
 	}
 
-	options := createClientOptions(common.AzcopyCurrentJobLogger, nil, reauthTok)
+	options := createClientOptions(
+		common.LogLevelOverrideLogger{ // override our log level here
+			ILoggerResetable:  common.AzcopyCurrentJobLogger,
+			MinimumLevelToLog: logLevel,
+		}, nil, reauthTok)
 
 	sc, err := common.GetServiceClientForLocation(
 		cca.FromTo.To(),

--- a/common/logger.go
+++ b/common/logger.go
@@ -53,6 +53,24 @@ type ILoggerResetable interface {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+type LogLevelOverrideLogger struct {
+	ILoggerResetable
+	MinimumLevelToLog LogLevel
+}
+
+func (l LogLevelOverrideLogger) MinimumLogLevel() LogLevel {
+	return l.MinimumLevelToLog
+}
+
+func (l LogLevelOverrideLogger) ShouldLog(level LogLevel) bool {
+	if level == LogNone {
+		return false
+	}
+	return level <= l.MinimumLevelToLog
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 const maxLogSize = 500 * 1024 * 1024
 
 type jobLogger struct {


### PR DESCRIPTION
## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**: The log for failing to create a container is entirely removed. In 5+ years, I've never seen a customer actually use this log to debug AzCopy; only to get hung up on it trying to debug some other issue. This log is needlessly confusing to a customer.

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [x] Other (describe): Supportability change

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

Manually tested
