### PR TITLE
Invalid block list log

### DIFF
--- a/ste/sender-blockBlob.go
+++ b/ste/sender-blockBlob.go
@@ -25,6 +25,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 	"strconv"
 	"strings"
 	"sync"
@@ -248,8 +249,6 @@ func (s *blockBlobSenderBase) Epilogue() {
 
 	// commit block list if necessary
 	if jptm.IsLive() && shouldPutBlockList == putListNeeded {
-		jptm.Log(common.LogDebug, fmt.Sprintf("Conclude Transfer with BlockList %s", blockIDs))
-
 		// commit the blocks.
 		if !ValidateTier(jptm, s.destBlobTier, s.destBlockBlobClient.BlobClient(), s.jptm.Context(), false) {
 			s.destBlobTier = nil
@@ -278,6 +277,57 @@ func (s *blockBlobSenderBase) Epilogue() {
 			})
 		if err != nil {
 			jptm.FailActiveSend(common.Iff(blobTags != nil, "Committing block list (with tags)", "Committing block list"), err)
+
+			/*
+				If we get an invalid block list, it's likely one of our blocks was deleted, or GC'd mid-job or something.
+				Knowing which blocks are missing is useful, as up to 50k blocks can exist in a single object.
+
+				This info could *potentially* be used to just re-upload the missing blocks later, but for now we want to discover the why.
+			*/
+			if bloberror.HasCode(err, bloberror.InvalidBlockList) {
+				blockList, err := s.destBlockBlobClient.GetBlockList(jptm.Context(), blockblob.BlockListTypeAll, nil)
+				if err != nil {
+					jptm.Log(common.LogWarning, fmt.Sprintf("Failed to get block list to provide delta: %v", err))
+				} else {
+					blockSet := map[string]bool{}
+					extraBlocks := map[string]bool{} // any blocks the service has but we don't
+					for _, v := range s.blockIDs {
+						blockSet[v] = true
+					}
+
+					recordBlock := func(blockId string) {
+						if blockSet[blockId] {
+							delete(blockSet, blockId)
+						} else {
+							extraBlocks[blockId] = true
+						}
+					}
+
+					for _, v := range blockList.UncommittedBlocks {
+						recordBlock(*v.Name)
+					}
+					for _, v := range blockList.CommittedBlocks { // For the sake of thoroughness, we'll include blocks that already were present.
+						recordBlock(*v.Name)
+					}
+
+					formatBlocklist := func(dict map[string]bool) string {
+						out := ""
+
+						out += fmt.Sprintf("%d blocks: ", len(dict))
+						out += "["
+						for k := range dict {
+							out += k + ", "
+						}
+						out = out[:len(out)-2] + "]"
+
+						return out
+					}
+
+					jptm.Log(common.LogError, fmt.Sprintf("Missing blocks: %s", formatBlocklist(blockSet)))
+					jptm.Log(common.LogError, fmt.Sprintf("Unrecognized blocks: %s", formatBlocklist(extraBlocks)))
+				}
+			}
+
 			return
 		}
 


### PR DESCRIPTION
In response to current IcMs/stgexp issues, as a supportability measure, output the block list, any missing blocks, and any unrecognized blocks. With any hope, we can look up the failed blocks in the log or ask for help from the service to figure out why we're failing this way.