### PR TITLE
Correct mariner preview binary location 

### DIFF
--- a/build-1es-pipeline.yaml
+++ b/build-1es-pipeline.yaml
@@ -1171,7 +1171,7 @@ extends:
                           echo "Skipping for ARM type on $distro"
                         else
                           if [[ $distro == *"Mariner-"* ]]; then
-                            if [ "$(is_preview)" = "true" ]; then
+                            if [ "$is_preview" = "true" ]; then
                               repoName=$(echo $repoName | sed 's/prod/preview/')
                             fi
                           fi

--- a/release-pipeline.yml
+++ b/release-pipeline.yml
@@ -2116,7 +2116,7 @@ stages:
                       echo "Skipping for ARM type on $distro"
                     else
                       if [[ $distro == *"Mariner-"* ]]; then
-                        if [ "$(is_preview)" = "true" ]; then
+                        if [ "$is_preview" = "true" ]; then
                           repoName=$(echo $repoName | sed 's/prod/preview/')
                         fi
                       fi


### PR DESCRIPTION
## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->


- **Feature / Bug Fix**: (Brief description of the feature or issue being addressed)
We encountered this issue in blobfuse2 where our latest preview binary for mariner/azure linux got pushed to prod folder instead of preview as our variable reference was incorrect. This PR fixes the issue by correcting the variable reference in the build-1es-pipeline.yaml and release-pipeline.yml files

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

Thank you for your contribution to AzCopy!
