### PR TITLE
Track request lifetimes, add it as a scaling parameter in the concurrency tuner, default to always tuning.

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -1432,10 +1432,6 @@ func (cca *CookedCopyCmdArgs) getSrcCredential(ctx context.Context, jpo *common.
 // dispatches the job order (in parts) to the storage engine
 func (cca *CookedCopyCmdArgs) processCopyJobPartOrders() (err error) {
 	ctx := context.WithValue(context.TODO(), ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
-	// Make AUTO default for Azure Files since Azure Files throttles too easily unless user specified concurrency value
-	if jobsAdmin.JobsAdmin != nil && (cca.FromTo.From() == common.ELocation.File() || cca.FromTo.To() == common.ELocation.File()) && common.GetEnvironmentVariable(common.EEnvironmentVariable.ConcurrencyValue()) == "" {
-		jobsAdmin.JobsAdmin.SetConcurrencySettingsToAuto()
-	}
 
 	if err := common.VerifyIsURLResolvable(cca.Source.Value); cca.FromTo.From().IsRemote() && err != nil {
 		return fmt.Errorf("failed to resolve source: %w", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -196,8 +196,9 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
-		// currently, we only automatically do auto-tuning when benchmarking
-		preferToAutoTuneGRs := cmd == benchCmd // TODO: do we have a better way to do this than making benchCmd global?
+		// We want to auto-tune by default now, with the log message.
+		// By default, tuning for CPU cores can be a bit overzealous when the network is limited (e.g. via cap-mbps)
+		preferToAutoTuneGRs := true
 		providePerformanceAdvice := cmd == benchCmd
 
 		// startup of the STE happens here, so that the startup can access the values of command line parameters that are defined for "root" command

--- a/common/linkedList.go
+++ b/common/linkedList.go
@@ -37,6 +37,14 @@ func (l *LinkedList[T]) PopRear() {
 	}
 }
 
+func (l *LinkedList[T]) Front() T {
+	return l.front.data
+}
+
+func (l *LinkedList[T]) Back() T {
+	return l.back.data
+}
+
 func (l *LinkedList[T]) Insert(data T) {
 	if l.front == nil {
 		l.front = &linkedListElement[T]{

--- a/common/linkedList.go
+++ b/common/linkedList.go
@@ -1,0 +1,74 @@
+package common
+
+// Singly linked list intended for buckets for ste.RequestLifetimeTracker
+
+type LinkedList[T any] struct {
+	front *linkedListElement[T]
+	back  *linkedListElement[T]
+	len   int64
+}
+
+type linkedListElement[T any] struct {
+	next *linkedListElement[T]
+	data T
+}
+
+func (l *LinkedList[T]) Enum() *LinkedListEnumerator[T] {
+	return &LinkedListEnumerator[T]{
+		index:  0,
+		target: l.back,
+	}
+}
+
+func (l *LinkedList[T]) Len() int64 {
+	return l.len
+}
+
+func (l *LinkedList[T]) PopRear() {
+	if l.back == nil {
+		return
+	}
+
+	l.back = l.back.next
+	l.len--
+
+	if l.back == nil {
+		l.back = l.front
+	}
+}
+
+func (l *LinkedList[T]) Insert(data T) {
+	if l.front == nil {
+		l.front = &linkedListElement[T]{
+			data: data,
+		}
+		l.back = l.front
+	} else {
+		l.front.next = &linkedListElement[T]{
+			data: data,
+		}
+		l.front = l.front.next
+	}
+
+	l.len++
+}
+
+type LinkedListEnumerator[T any] struct {
+	index  int64
+	target *linkedListElement[T]
+}
+
+func (l *LinkedListEnumerator[T]) HasData() bool {
+	return l.target != nil
+}
+
+func (l *LinkedListEnumerator[T]) Next() {
+	if l.target != nil {
+		l.target = l.target.next
+		l.index++
+	}
+}
+
+func (l *LinkedListEnumerator[T]) Data() T {
+	return l.target.data
+}

--- a/ste/concurrencyTuner.go
+++ b/ste/concurrencyTuner.go
@@ -125,15 +125,16 @@ func (t *autoConcurrencyTuner) recordRetry() {
 }
 
 const (
-	ConcurrencyReasonNone          = ""
-	ConcurrencyReasonTunerDisabled = "tuner disabled" // used as the final (non-finished) state for null tuner
-	concurrencyReasonInitial       = "initial starting point"
-	concurrencyReasonSeeking       = "seeking optimum"
-	concurrencyReasonBackoff       = "backing off"
-	concurrencyReasonHitMax        = "hit max concurrency limit"
-	concurrencyReasonHighCpu       = "at optimum, but may be limited by CPU"
-	concurrencyReasonAtOptimum     = "at optimum"
-	concurrencyReasonFinished      = "tuning already finished (or never started)"
+	ConcurrencyReasonNone                = ""
+	ConcurrencyReasonTunerDisabled       = "tuner disabled" // used as the final (non-finished) state for null tuner
+	concurrencyReasonInitial             = "initial starting point"
+	concurrencyReasonSeeking             = "seeking optimum"
+	concurrencyReasonBackoff             = "backing off"
+	concurrencyReasonHitMax              = "hit max concurrency limit"
+	concurrencyReasonHighCpu             = "at optimum, but may be limited by CPU"
+	concurrencyReasonAtOptimum           = "at optimum"
+	concurrencyReasonFinished            = "tuning already finished (or never started)"
+	concurrencyReasonHighRequestLifetime = "atypical request lifetime"
 )
 
 func (t *autoConcurrencyTuner) worker() {
@@ -154,6 +155,8 @@ func (t *autoConcurrencyTuner) worker() {
 	dontBackoffRegardless := false
 	multiplierReductionCount := 0
 	lastReason := ConcurrencyReasonNone
+
+	requestLifetimeTracker := GetRequestLifetimeTracker()
 
 	// get initial baseline throughput
 	lastSpeed, _ := t.getCurrentSpeed()

--- a/ste/concurrencyTuner.go
+++ b/ste/concurrencyTuner.go
@@ -23,6 +23,7 @@ package ste
 import (
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 type ConcurrencyTuner interface {
@@ -70,6 +71,9 @@ type autoConcurrencyTuner struct {
 		value  int
 		reason string
 	}
+	// atomicCurrentConcurrency should never be written to, it is a read only reference to the job manager
+	atomicCurrentConcurrency *int32
+
 	initialConcurrency  int
 	maxConcurrency      int
 	callbacksWhenStable chan func()
@@ -79,7 +83,7 @@ type autoConcurrencyTuner struct {
 	isBenchmarking      bool
 }
 
-func NewAutoConcurrencyTuner(initial, max int, isBenchmarking bool) ConcurrencyTuner {
+func NewAutoConcurrencyTuner(initial, max int, atomicCurrentConcurrency *int32, isBenchmarking bool) ConcurrencyTuner {
 	t := &autoConcurrencyTuner{
 		observations: make(chan struct {
 			mbps      int
@@ -89,11 +93,12 @@ func NewAutoConcurrencyTuner(initial, max int, isBenchmarking bool) ConcurrencyT
 			value  int
 			reason string
 		}),
-		initialConcurrency:  initial,
-		maxConcurrency:      max,
-		callbacksWhenStable: make(chan func(), 1000),
-		lockFinal:           sync.Mutex{},
-		isBenchmarking:      isBenchmarking,
+		initialConcurrency:       initial,
+		maxConcurrency:           max,
+		callbacksWhenStable:      make(chan func(), 1000),
+		lockFinal:                sync.Mutex{},
+		isBenchmarking:           isBenchmarking,
+		atomicCurrentConcurrency: atomicCurrentConcurrency,
 	}
 	go t.worker()
 	return t
@@ -144,6 +149,7 @@ func (t *autoConcurrencyTuner) worker() {
 	const slowdownFactor = 5
 	const minMulitplier = 1.19 // really this is 1.2, but use a little less to make the floating point comparisons robust
 	const fudgeFactor = 0.2
+	const requestLifetimeBackoffMultiplier = 0.5 // Aggressively back off
 
 	multiplier := float32(boostedMultiplier)
 	concurrency := float32(t.initialConcurrency)
@@ -175,10 +181,45 @@ func (t *autoConcurrencyTuner) worker() {
 			rateChangeReason = concurrencyReasonHitMax
 		}
 
+		var desiredNewSpeed float32
+		if requestLifetimeTracker.UnusualRequestLifetime() {
+			// We're seeing extremely high request lifetimes start popping up. Let's scale down a bit, and see if that helps our case. We'll need to wait for the next bucket, and try again.
+			concurrency = concurrency * requestLifetimeBackoffMultiplier
+			if concurrency <= 4 { // 4 should be bare minimum
+				concurrency = 4
+			}
+			rateChangeReason = concurrencyReasonHighRequestLifetime
+
+			lastReason = t.setConcurrency(concurrency, rateChangeReason)
+			exitChannel := make(chan bool)
+			go func() {
+				for {
+					if requestLifetimeTracker.SimultaneousLiveRequests() < int64(concurrency) {
+						exitChannel <- true
+					}
+
+					time.Sleep(requestBucketLifetime) // Sleep for the duration of the tracking window to give us time to scale down.
+				}
+			}()
+
+			for {
+				select {
+				case <-exitChannel:
+					close(exitChannel)
+					goto escape
+				case ob := <-t.observations:
+					lastSpeed, highCpu = float32(ob.mbps), ob.isHighCpu
+					t.setConcurrency(concurrency, rateChangeReason)
+				}
+			}
+		escape:
+			continue
+		}
+
 		// compute increase
 		concurrency = concurrency * multiplier
-		desiredSpeedIncrease := lastSpeed * (multiplier - 1) * fudgeFactor // we'd like it to speed up linearly, but we'll accept a _lot_ less, according to fudge factor in the interests of finding best possible speed
-		desiredNewSpeed := lastSpeed + desiredSpeedIncrease
+		desiredSpeedIncrease := lastSpeed * (multiplier - 1) * fudgeFactor // we'd like it to speed up linearly, but we'll accept a _lot_ less, according to fudge factor in the interests of finding the best possible speed
+		desiredNewSpeed = lastSpeed + desiredSpeedIncrease
 
 		// action the increase and measure its effect
 		lastReason = t.setConcurrency(concurrency, rateChangeReason)

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -103,7 +103,7 @@ func NewClientOptions(retry policy.RetryOptions, telemetry policy.TelemetryOptio
 	// [includeResponsePolicy, newAPIVersionPolicy (ignored), NewTelemetryPolicy, perCall, NewRetryPolicy, perRetry, NewLogPolicy, httpHeaderPolicy, bodyDownloadPolicy]
 	perCallPolicies := []policy.Policy{azruntime.NewRequestIDPolicy(), NewVersionPolicy(), newFileUploadRangeFromURLFixPolicy()}
 	// TODO : Default logging policy is not equivalent to old one. tracing HTTP request
-	perRetryPolicies := []policy.Policy{newRetryNotificationPolicy(), newLogPolicy(log), newStatsPolicy()}
+	perRetryPolicies := []policy.Policy{newRetryNotificationPolicy(), newLogPolicy(log), newStatsPolicy(), GetRequestLifetimeTracker().GetPolicy()}
 	if dstCred != nil {
 		perCallPolicies = append(perRetryPolicies, NewDestReauthPolicy(dstCred))
 	}

--- a/ste/pacer-tokenBucketPacer.go
+++ b/ste/pacer-tokenBucketPacer.go
@@ -121,7 +121,7 @@ func (p *tokenBucketPacer) RequestTrafficAllocation(ctx context.Context, byteCou
 		case <-time.After(modifiedSleepDuration):
 			// keep looping
 		}
-		
+
 		// If we've updated target to a NULL pacer, we'll return immediately
 		if p.targetBytesPerSecond() == 0 {
 			atomic.AddInt64(&p.atomicGrandTotal, byteCount)
@@ -159,7 +159,7 @@ func (p *tokenBucketPacer) pacerBody() {
 		select {
 		case <-p.done:
 			return
-		case newTarget = <- p.newTargetBytesPerSecond:
+		case newTarget = <-p.newTargetBytesPerSecond:
 		default:
 		}
 

--- a/ste/xferLifetimeTracker.go
+++ b/ste/xferLifetimeTracker.go
@@ -1,0 +1,129 @@
+package ste
+
+import (
+	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"time"
+)
+
+/*
+In some cases, an extremely high number of threads with an extremely low throughput
+can cause requests to remain live, but idle for an extended period of time.
+
+This is sometimes long enough for the service, or AzCopy to simply outright drop the request.
+
+RequestLifetimeTracker tracks requests over (count * lifetime), and keeps a running average.
+*/
+
+const (
+	requestBucketCount    = 6 * 10 // 10 minutes of buckets
+	requestBucketLifetime = time.Second * 10
+
+	requestActionInitiate uint = iota - 2
+	requestActionCancel
+	requestActionFinalize
+)
+
+var _requestLifetimeTrackerSingleton *RequestLifetimeTracker
+
+// GetRequestLifetimeTracker returns the singleton *RequestLifetimeTracker which stems off into RequestLifetimeTrackerPolicy.
+
+func GetRequestLifetimeTracker() (tracker *RequestLifetimeTracker) {
+	if _requestLifetimeTrackerSingleton == nil {
+
+		_requestLifetimeTrackerSingleton = &RequestLifetimeTracker{
+			requestActionQueue:         make(chan requestAction, 600), // 2x our max number of threads, that way the queue should never block up.
+			liveRequestInitiationTimes: make(map[string]time.Time),
+			requestLifetimeBuckets:     &requestLifetimeBucket{},
+			bucketSwapTicker:           time.NewTicker(requestBucketLifetime),
+		}
+
+		go _requestLifetimeTrackerSingleton.queueWorker()
+	}
+
+	return _requestLifetimeTrackerSingleton
+}
+
+type requestLifetimeBucket = common.LinkedList[*common.LinkedList[time.Duration]]
+type requestAction struct {
+	ID     string
+	Action uint
+
+	Init     time.Time
+	Duration time.Duration
+}
+
+type RequestLifetimeTracker struct {
+	atomicSimultaneousLiveRequestCount int64
+
+	// Keeping track of a total average, for debug purposes.
+	atomicTotalRequestLifetime        int64
+	atomicCompletedRequestCount       int64
+	atomicTotalAverageRequestLifetime int64
+
+	// This is the useful bit. Keep track of in-flight requests and recent historical data.
+	requestActionQueue         chan requestAction
+	liveRequestInitiationTimes map[string]time.Time
+	requestLifetimeBuckets     *requestLifetimeBucket // Divided into n buckets of duration
+	bucketSwapTicker           *time.Ticker
+
+	// more atomic values for read-only
+	atomicRunningRequestAverageLifetime int64
+	atomicRunningRequestTotalLifetime   int64
+	atomicRunningRequestCount           int64
+}
+
+// workers sit in the background and manage the running averages and buckets, ticking with the bucket ticker.
+
+func (r *RequestLifetimeTracker) queueWorker() {
+	for {
+		select { // This thread should die with the program to prevent any hangups
+		case <-r.bucketSwapTicker.C:
+			// todo
+			panic("swap")
+
+			// Add the latest bucket on
+			// Remove the oldest bucket
+			// Average and find 99th percentile
+		case act := <-r.requestActionQueue:
+			switch act.Action {
+			case requestActionInitiate:
+
+			case requestActionFinalize:
+				fallthrough
+			case requestActionCancel:
+
+				break
+			default:
+				panic(fmt.Sprintf("unrecognized action %d", act.Action))
+			}
+		}
+	}
+}
+
+func (r *RequestLifetimeTracker) InitiateRequest(clientRequestID string) {
+	r.requestActionQueue <- requestAction{
+		ID:     clientRequestID,
+		Action: requestActionInitiate,
+	}
+}
+
+func (r *RequestLifetimeTracker) CancelRequest(clientRequestID string) {
+	r.requestActionQueue <- requestAction{
+		ID:     clientRequestID,
+		Action: requestActionCancel,
+	}
+}
+
+func (r *RequestLifetimeTracker) FinishRequest(clientRequestID string, duration time.Duration) {
+	r.requestActionQueue <- requestAction{
+		ID:       clientRequestID,
+		Action:   requestActionFinalize,
+		Duration: duration,
+	}
+}
+
+func (r *RequestLifetimeTracker) GetPolicy() policy.Policy {
+	panic("todo policy")
+}

--- a/ste/xferLifetimeTracker.go
+++ b/ste/xferLifetimeTracker.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/google/uuid"
+	"net/http"
+	"sync/atomic"
 	"time"
 )
 
@@ -14,6 +17,8 @@ can cause requests to remain live, but idle for an extended period of time.
 This is sometimes long enough for the service, or AzCopy to simply outright drop the request.
 
 RequestLifetimeTracker tracks requests over (count * lifetime), and keeps a running average.
+
+Below a certain length, say, a couple seconds, this isn't particularly useful.
 */
 
 const (
@@ -31,13 +36,31 @@ var _requestLifetimeTrackerSingleton *RequestLifetimeTracker
 
 func GetRequestLifetimeTracker() (tracker *RequestLifetimeTracker) {
 	if _requestLifetimeTrackerSingleton == nil {
+		newAtomicInt := func() *int64 {
+			var n int64
+			return &n
+		}
 
 		_requestLifetimeTrackerSingleton = &RequestLifetimeTracker{
 			requestActionQueue:         make(chan requestAction, 600), // 2x our max number of threads, that way the queue should never block up.
-			liveRequestInitiationTimes: make(map[string]time.Time),
+			liveRequestInitiationTimes: make(map[uuid.UUID]time.Time),
 			requestLifetimeBuckets:     &requestLifetimeBucket{},
 			bucketSwapTicker:           time.NewTicker(requestBucketLifetime),
+
+			atomicSimultaneousLiveRequestCount: newAtomicInt(),
+			atomicUnexpectedRequestLifetime:    newAtomicInt(),
+
+			atomicRequestLifetimeSum:     newAtomicInt(),
+			atomicRequestCompletionCount: newAtomicInt(),
+			atomicRequestMaxLifetime:     newAtomicInt(),
+			atomicRequestAvgLifetime:     newAtomicInt(),
+
+			atomicRunningRequestAverageLifetime: newAtomicInt(),
+			atomicRunningRequestCount:           newAtomicInt(),
+			atomicRunningRequestMaxLifetime:     newAtomicInt(),
 		}
+
+		_requestLifetimeTrackerSingleton.requestLifetimeBuckets.Insert(&common.LinkedList[time.Duration]{})
 
 		go _requestLifetimeTrackerSingleton.queueWorker()
 	}
@@ -47,31 +70,32 @@ func GetRequestLifetimeTracker() (tracker *RequestLifetimeTracker) {
 
 type requestLifetimeBucket = common.LinkedList[*common.LinkedList[time.Duration]]
 type requestAction struct {
-	ID     string
+	ID     uuid.UUID
 	Action uint
 
-	Init     time.Time
-	Duration time.Duration
+	SubmitTime time.Time
 }
 
 type RequestLifetimeTracker struct {
-	atomicSimultaneousLiveRequestCount int64
+	atomicSimultaneousLiveRequestCount *int64 // how many requests are currently live
+	atomicUnexpectedRequestLifetime    *int64 // Are our longest-living requests alive too long?
 
 	// Keeping track of a total average, for debug purposes.
-	atomicTotalRequestLifetime        int64
-	atomicCompletedRequestCount       int64
-	atomicTotalAverageRequestLifetime int64
+	atomicRequestLifetimeSum     *int64 // the sum of all requests' lifetime
+	atomicRequestMaxLifetime     *int64 // The highest lifetime we've *ever* seen.
+	atomicRequestCompletionCount *int64 // how many requests have been completed
+	atomicRequestAvgLifetime     *int64 // the average of all requests' lifetime
 
 	// This is the useful bit. Keep track of in-flight requests and recent historical data.
 	requestActionQueue         chan requestAction
-	liveRequestInitiationTimes map[string]time.Time
+	liveRequestInitiationTimes map[uuid.UUID]time.Time
 	requestLifetimeBuckets     *requestLifetimeBucket // Divided into n buckets of duration
 	bucketSwapTicker           *time.Ticker
 
 	// more atomic values for read-only
-	atomicRunningRequestAverageLifetime int64
-	atomicRunningRequestTotalLifetime   int64
-	atomicRunningRequestCount           int64
+	atomicRunningRequestAverageLifetime *int64
+	atomicRunningRequestMaxLifetime     *int64
+	atomicRunningRequestCount           *int64
 }
 
 // workers sit in the background and manage the running averages and buckets, ticking with the bucket ticker.
@@ -80,20 +104,69 @@ func (r *RequestLifetimeTracker) queueWorker() {
 	for {
 		select { // This thread should die with the program to prevent any hangups
 		case <-r.bucketSwapTicker.C:
-			// todo
-			panic("swap")
+			var rCount int64
+			var rSum, rAvg, rMax time.Duration
+
+			// Average and find peak
+			for bucketEnum := r.requestLifetimeBuckets.Enum(); bucketEnum.HasData(); bucketEnum.Next() {
+				bucket := bucketEnum.Data()
+				rCount += bucket.Len()
+
+				for durationEnum := bucket.Enum(); durationEnum.HasData(); durationEnum.Next() {
+					duration := durationEnum.Data()
+
+					rSum += duration
+					if rMax < duration {
+						rMax = duration
+					}
+				}
+			}
+			rAvg = rSum / time.Duration(rCount)
+
+			atomic.StoreInt64(r.atomicRunningRequestAverageLifetime, int64(rAvg))
+			atomic.StoreInt64(r.atomicRunningRequestCount, rCount)
+			atomic.StoreInt64(r.atomicRunningRequestMaxLifetime, int64(rMax))
 
 			// Add the latest bucket on
+			r.requestLifetimeBuckets.Insert(&common.LinkedList[time.Duration]{})
+
 			// Remove the oldest bucket
-			// Average and find 99th percentile
+			r.requestLifetimeBuckets.PopRear()
+
+			// Log the current statistic
+			if common.AzcopyCurrentJobLogger != nil {
+				common.AzcopyCurrentJobLogger.Log(common.ELogLevel.Debug(), fmt.Sprintf(
+					"Request lifetime statistics: Job lifetime: (avg: %v max: %v requests: %v) Recent window: (Avg: %v Max: %v Requests: %v"))
+			}
+
+			// Indicate that we're seeing routine exhaustion
+			if rAvg < time.Second*40 { // For requests only say, a few seconds long, this isn't going to be a useful measure.
+				rAvg = time.Second * 40 // At higher avg lifetimes though, we do start being interested.
+			}
+			maxDiff := float64(rMax) / float64(rAvg) // If the max request lifetime significantly exceeds the average,
+			if maxDiff > 3 {                         // We should probably start to slow down a little.
+				atomic.StoreInt64(r.atomicUnexpectedRequestLifetime, 1)
+			} else {
+				atomic.StoreInt64(r.atomicUnexpectedRequestLifetime, 0)
+			}
 		case act := <-r.requestActionQueue:
 			switch act.Action {
 			case requestActionInitiate:
-
+				r.liveRequestInitiationTimes[act.ID] = act.SubmitTime
 			case requestActionFinalize:
+				startTime := r.liveRequestInitiationTimes[act.ID]
+				duration := act.SubmitTime.Sub(startTime)
+
+				sum := atomic.AddInt64(r.atomicRequestLifetimeSum, int64(duration))
+				count := atomic.AddInt64(r.atomicRequestCompletionCount, 1)
+				atomic.StoreInt64(r.atomicRequestAvgLifetime, sum/count) // we're the only writer here so this is OK
+				atomic.AddInt64(r.atomicSimultaneousLiveRequestCount, -1)
+
+				r.requestLifetimeBuckets.Front().Insert(duration)
+
 				fallthrough
 			case requestActionCancel:
-
+				delete(r.liveRequestInitiationTimes, act.ID)
 				break
 			default:
 				panic(fmt.Sprintf("unrecognized action %d", act.Action))
@@ -102,28 +175,66 @@ func (r *RequestLifetimeTracker) queueWorker() {
 	}
 }
 
-func (r *RequestLifetimeTracker) InitiateRequest(clientRequestID string) {
+func (r *RequestLifetimeTracker) InitiateRequest(clientRequestID uuid.UUID) {
 	r.requestActionQueue <- requestAction{
-		ID:     clientRequestID,
-		Action: requestActionInitiate,
+		ID:         clientRequestID,
+		Action:     requestActionInitiate,
+		SubmitTime: time.Now(),
 	}
 }
 
-func (r *RequestLifetimeTracker) CancelRequest(clientRequestID string) {
+func (r *RequestLifetimeTracker) FinishRequest(clientRequestID uuid.UUID) {
 	r.requestActionQueue <- requestAction{
-		ID:     clientRequestID,
-		Action: requestActionCancel,
+		ID:         clientRequestID,
+		Action:     requestActionFinalize,
+		SubmitTime: time.Now(),
 	}
 }
 
-func (r *RequestLifetimeTracker) FinishRequest(clientRequestID string, duration time.Duration) {
-	r.requestActionQueue <- requestAction{
-		ID:       clientRequestID,
-		Action:   requestActionFinalize,
-		Duration: duration,
-	}
+func (r *RequestLifetimeTracker) SimultaneousLiveRequests() int64 {
+	return atomic.LoadInt64(r.atomicSimultaneousLiveRequestCount)
+}
+
+func (r *RequestLifetimeTracker) LifetimeTotalRequests() int64 {
+	return atomic.LoadInt64(r.atomicRequestCompletionCount)
+}
+
+func (r *RequestLifetimeTracker) LifetimeAverageRequestLifetime() time.Duration {
+	return time.Duration(atomic.LoadInt64(r.atomicRequestAvgLifetime))
+}
+
+func (r *RequestLifetimeTracker) WindowTotalRequests() int64 {
+	return atomic.LoadInt64(r.atomicRunningRequestCount)
+}
+
+func (r *RequestLifetimeTracker) WindowAverageRequestLifetime() time.Duration {
+	return time.Duration(atomic.LoadInt64(r.atomicRunningRequestAverageLifetime))
+}
+
+func (r *RequestLifetimeTracker) WindowMaxRequestLifetime() time.Duration {
+	return time.Duration(atomic.LoadInt64(r.atomicRunningRequestMaxLifetime))
+}
+
+func (r *RequestLifetimeTracker) UnexpectedMaxRequestLifetime() bool {
+	return atomic.LoadInt64(r.atomicUnexpectedRequestLifetime) == 1
 }
 
 func (r *RequestLifetimeTracker) GetPolicy() policy.Policy {
-	panic("todo policy")
+	return &RequestLifetimeTrackerPolicy{
+		parent: r,
+	}
+}
+
+type RequestLifetimeTrackerPolicy struct {
+	parent *RequestLifetimeTracker
+}
+
+func (r *RequestLifetimeTrackerPolicy) Do(req *policy.Request) (*http.Response, error) {
+	reqId := uuid.New()
+
+	r.parent.InitiateRequest(reqId)
+	resp, err := req.Next()
+	r.parent.FinishRequest(reqId)
+
+	return resp, err
 }


### PR DESCRIPTION
## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**: 

This half-fixes a bug that's evoked in situations where the number of goroutines we initialize far out-scales the available network bandwidth. It can be evoked by setting `AZCOPY_CONCURRENCY_VALUE` super high and `--cap-mbps` super low.

The janky fix present in this PR is to default the auto-scaler to on. Because it's seeking the optimal output, and trying to not over-scale, scaling past the network's capabilities will cause it to scale down as throughput didn't increase as expected. This _does not_ fix the problem, but it does work around it for the grand and wide majority of users. More PRs are to come of this.

- **Related Links**: StgExp Sync chat

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

Manual testing, set benchmark with a 100gb upload and 5mbps cap-mbps. Request lifetime stabilizes out to around a minute max after the concurrency tuner settles. This still isn't great, it's a really severe issue, but it does mean the job _works_, which is way better than it _not working_.

A user manually specifying both could still trigger the underlying behavior.
