### PR TITLE
Remove --nfs flag and add NFS combinations in --from-to flag

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -373,7 +373,7 @@ func (raw *rawCopyCmdArgs) toOptions() (cooked CookedCopyCmdArgs, err error) {
 	}
 
 	if common.IsNFSCopy() {
-		cooked.preserveInfo = raw.preserveInfo
+		cooked.preserveInfo = raw.preserveInfo && areBothLocationsNFSAware(cooked.FromTo)
 		cooked.preservePermissions = common.NewPreservePermissionsOption(raw.preservePermissions,
 			true,
 			cooked.FromTo)

--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -53,7 +53,6 @@ func (cca *CookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 		TrailingDot: cca.trailingDot,
 	}
 	jobPartOrder.CpkOptions = cca.CpkOptions
-	jobPartOrder.IsNFSCopy = cca.isNFSCopy
 	jobPartOrder.PreservePermissions = cca.preservePermissions
 	jobPartOrder.PreserveInfo = cca.preserveInfo
 	// We set preservePOSIXProperties if the customer has explicitly asked for this in transfer or if it is just a Posix-property only transfer
@@ -67,7 +66,7 @@ func (cca *CookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 		(cca.FromTo.From() == common.ELocation.File() && !cca.FromTo.To().IsRemote()) || // If it's a download, we still need LMT and MD5 from files.
 		(cca.FromTo.From() == common.ELocation.File() && cca.FromTo.To().IsRemote() && (cca.s2sSourceChangeValidation || cca.IncludeAfter != nil || cca.IncludeBefore != nil)) || // If S2S from File to *, and sourceChangeValidation is enabled, we get properties so that we have LMTs. Likewise, if we are using includeAfter or includeBefore, which require LMTs.
 		(cca.FromTo.From().IsRemote() && cca.FromTo.To().IsRemote() && cca.s2sPreserveProperties.Value() && !cca.s2sGetPropertiesInBackend) // If S2S and preserve properties AND get properties in backend is on, turn this off, as properties will be obtained in the backend.
-	jobPartOrder.S2SGetPropertiesInBackend = cca.s2sPreserveProperties.Value() && !getRemoteProperties && cca.s2sGetPropertiesInBackend     // Infer GetProperties if GetPropertiesInBackend is enabled.
+	jobPartOrder.S2SGetPropertiesInBackend = cca.s2sPreserveProperties.Value() && !getRemoteProperties && cca.s2sGetPropertiesInBackend // Infer GetProperties if GetPropertiesInBackend is enabled.
 	jobPartOrder.S2SSourceChangeValidation = cca.s2sSourceChangeValidation
 	jobPartOrder.DestLengthValidation = cca.CheckLength
 	jobPartOrder.S2SInvalidMetadataHandleOption = cca.s2sInvalidMetadataHandleOption
@@ -98,7 +97,7 @@ func (cca *CookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 
 		ExcludeContainers: cca.excludeContainer,
 		IncrementEnumeration: func(entityType common.EntityType) {
-			if isNFSCopy {
+			if common.IsNFSCopy() {
 				if entityType == common.EEntityType.Other() {
 					atomic.AddUint32(&cca.atomicSkippedSpecialFileCount, 1)
 				} else if entityType == common.EEntityType.Symlink() {

--- a/cmd/copyProcess.go
+++ b/cmd/copyProcess.go
@@ -3,9 +3,10 @@ package cmd
 import (
 	"bufio"
 	"fmt"
-	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"os"
 	"strings"
+
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 func (cooked *CookedCopyCmdArgs) processArgs() (err error) {
@@ -164,9 +165,8 @@ func (cooked *CookedCopyCmdArgs) processArgs() (err error) {
 		}
 	}
 
-	SetNFSFlag(cooked.isNFSCopy)
 	if cooked.preserveInfo && !cooked.preservePermissions.IsTruthy() {
-		if cooked.isNFSCopy {
+		if common.IsNFSCopy() {
 			glcm.Info(PreserveNFSPermissionsDisabledMsg)
 		} else {
 			glcm.Info(PreservePermissionsDisabledMsg)

--- a/cmd/copyValidation.go
+++ b/cmd/copyValidation.go
@@ -3,9 +3,10 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"net/url"
 	"strings"
+
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 // Note: blockSize, blobTagsMap is set here
@@ -90,7 +91,7 @@ func (cooked *CookedCopyCmdArgs) validate() (err error) {
 		}
 	}
 
-	if cooked.isNFSCopy {
+	if common.IsNFSCopy() {
 		if err := performNFSSpecificValidation(
 			cooked.FromTo, cooked.preservePermissions, cooked.preserveInfo,
 			cooked.SymlinkHandling, cooked.hardlinks); err != nil {

--- a/cmd/syncEnumerator.go
+++ b/cmd/syncEnumerator.go
@@ -75,7 +75,7 @@ func (cca *cookedSyncCmdArgs) initEnumerator(ctx context.Context) (enumerator *s
 			if entityType == common.EEntityType.File() {
 				atomic.AddUint64(&cca.atomicSourceFilesScanned, 1)
 			}
-			if isNFSCopy {
+			if common.IsNFSCopy() {
 				if entityType == common.EEntityType.Other() {
 					atomic.AddUint32(&cca.atomicSkippedSpecialFileCount, 1)
 				} else if entityType == common.EEntityType.Symlink() {
@@ -262,7 +262,6 @@ func (cca *cookedSyncCmdArgs) initEnumerator(ctx context.Context) (enumerator *s
 		FileAttributes: common.FileTransferAttributes{
 			TrailingDot: cca.trailingDot,
 		},
-		IsNFSCopy: cca.isNFSCopy,
 	}
 
 	var srcReauthTok *common.ScopedAuthenticator
@@ -327,10 +326,10 @@ func (cca *cookedSyncCmdArgs) initEnumerator(ctx context.Context) (enumerator *s
 	if cca.fromTo.IsS2S() {
 		if cca.fromTo.From() == common.ELocation.File() {
 			if err := validateShareProtocolCompatibility(ctx,
-				cca.fromTo, cca.source, copyJobTemplate.SrcServiceClient, cca.isNFSCopy, true); err != nil {
+				cca.fromTo, cca.source, copyJobTemplate.SrcServiceClient, common.IsNFSCopy(), true); err != nil {
 				return nil, err
 			}
-		} else if isNFSCopy {
+		} else if common.IsNFSCopy() {
 			return nil, errors.New("NFS copy is not supported for source location " + cca.fromTo.From().String())
 		}
 	}
@@ -340,13 +339,13 @@ func (cca *cookedSyncCmdArgs) initEnumerator(ctx context.Context) (enumerator *s
 		if err := validateShareProtocolCompatibility(ctx, cca.fromTo,
 			cca.destination,
 			copyJobTemplate.DstServiceClient,
-			cca.isNFSCopy, false); err != nil {
+			common.IsNFSCopy(), false); err != nil {
 			return nil, err
 		}
 	} else if cca.fromTo.IsDownload() && cca.fromTo.From() == common.ELocation.File() {
 		if err := validateShareProtocolCompatibility(ctx, cca.fromTo,
 			cca.source, copyJobTemplate.SrcServiceClient,
-			cca.isNFSCopy, true); err != nil {
+			common.IsNFSCopy(), true); err != nil {
 			return nil, err
 		}
 	}

--- a/cmd/validators.go
+++ b/cmd/validators.go
@@ -85,7 +85,7 @@ var fromToHelp = func() string {
 
 var fromToHelpText = fromToHelp
 
-const locationHelpFormat = "Specified to nudge AzCopy when resource detection may not work (e.g. emulator/azure stack); Valid Location are Source words (e.g. Blob, File) that specify the source resource type. All valid Locations are: %s"
+const locationHelpFormat = "Specified to nudge AzCopy when resource detection may not work (e.g. emulator/azure stack); Required for NFS transfers; optional for SMB. Valid Location are Source words (e.g. Blob, File) that specify the source resource type. All valid Locations are: %s"
 
 var locationHelp = func() string {
 	validLocations := ""
@@ -218,8 +218,8 @@ func InferArgumentLocation(arg string) common.Location {
 			if common.IsGCPURL(*u) {
 				return common.ELocation.GCP()
 			}
-      
-			// If none of the above conditions match, return Unknown 
+
+			// If none of the above conditions match, return Unknown
 			return common.ELocation.Unknown()
 		}
 	}

--- a/cmd/zc_traverser_file.go
+++ b/cmd/zc_traverser_file.go
@@ -203,7 +203,7 @@ func (t *fileTraverser) Traverse(preprocessor objectMorpher, processor objectPro
 				targetURLParts.ShareName,
 			)
 			// NFS handling for different file types
-			if isNFSCopy {
+			if common.IsNFSCopy() {
 				if skip, err := evaluateAndLogNFSFileType(t.ctx, NFSFileMeta{
 					Name:        storedObject.name,
 					NFSFileType: *fileProperties.NFSFileType,
@@ -262,7 +262,7 @@ func (t *fileTraverser) Traverse(preprocessor objectMorpher, processor objectPro
 		// Check if the file is a symlink and should be skipped in case of NFS
 		// We don't want to skip the file if we are not using NFS
 		// Check if the file is a hard link and should be logged with proper message in case of NFS
-		if isNFSCopy {
+		if common.IsNFSCopy() {
 			if skip, err := evaluateAndLogNFSFileType(t.ctx, NFSFileMeta{
 				Name:        f.name,
 				NFSFileType: file.NFSFileType(fullProperties.NFSFileType()),

--- a/cmd/zc_traverser_local.go
+++ b/cmd/zc_traverser_local.go
@@ -281,7 +281,7 @@ func WalkWithSymlinks(appCtx context.Context,
 				}
 
 				if symlinkHandling.None() {
-					if isNFSCopy {
+					if common.IsNFSCopy() {
 						if incrementEnumerationCounter != nil {
 							incrementEnumerationCounter(common.EEntityType.Symlink())
 						}
@@ -363,7 +363,7 @@ func WalkWithSymlinks(appCtx context.Context,
 				}
 				return nil
 			} else {
-				if isNFSCopy {
+				if common.IsNFSCopy() {
 					LogHardLinkIfDefaultPolicy(fileInfo, hardlinkHandling)
 					if !IsRegularFile(fileInfo) && !fileInfo.IsDir() {
 						// We don't want to process other non-regular files here.
@@ -677,7 +677,7 @@ func (t *localTraverser) Traverse(preprocessor objectMorpher, processor objectPr
 	if isSingleFile {
 
 		entityType := common.EEntityType.File()
-		if isNFSCopy {
+		if common.IsNFSCopy() {
 			if IsSymbolicLink(singleFileInfo) {
 				entityType = common.EEntityType.Symlink()
 				logSpecialFileWarning(singleFileInfo.Name())
@@ -748,7 +748,7 @@ func (t *localTraverser) Traverse(preprocessor objectMorpher, processor objectPr
 				}
 
 				// NFS Handling
-				if isNFSCopy {
+				if common.IsNFSCopy() {
 					if IsHardlink(fileInfo) {
 						entityType = common.EEntityType.Hardlink()
 					}
@@ -803,7 +803,7 @@ func (t *localTraverser) Traverse(preprocessor objectMorpher, processor objectPr
 				fileInfo, _ := entry.Info()
 				if fileInfo.Mode()&os.ModeSymlink != 0 {
 					if t.symlinkHandling.None() {
-						if isNFSCopy && t.incrementEnumerationCounter != nil {
+						if common.IsNFSCopy() && t.incrementEnumerationCounter != nil {
 							t.incrementEnumerationCounter(common.EEntityType.Symlink())
 						}
 						continue
@@ -835,7 +835,7 @@ func (t *localTraverser) Traverse(preprocessor objectMorpher, processor objectPr
 					}
 				}
 				// NFS handling
-				if isNFSCopy {
+				if common.IsNFSCopy() {
 					if IsHardlink(fileInfo) {
 						entityType = common.EEntityType.Hardlink()
 					} else if !IsRegularFile(fileInfo) {

--- a/common/fe-ste-models.go
+++ b/common/fe-ste-models.go
@@ -598,6 +598,8 @@ func (Location) S3() Location        { return Location(6) }
 func (Location) Benchmark() Location { return Location(7) }
 func (Location) GCP() Location       { return Location(8) }
 func (Location) None() Location      { return Location(9) } // None is used in case we're transferring properties
+func (Location) SMB() Location       { return Location(10) }
+func (Location) NFS() Location       { return Location(11) }
 
 func (Location) AzureAccount() Location { return Location(100) } // AzureAccount is never used within AzCopy, and won't be detected, (for now)
 
@@ -633,7 +635,7 @@ func FromToValue(from Location, to Location) FromTo {
 
 func (l Location) IsRemote() bool {
 	switch l {
-	case ELocation.BlobFS(), ELocation.Blob(), ELocation.File(), ELocation.S3(), ELocation.GCP():
+	case ELocation.BlobFS(), ELocation.Blob(), ELocation.File(), ELocation.S3(), ELocation.GCP(), ELocation.SMB(), ELocation.NFS():
 		return true
 	case ELocation.Local(), ELocation.Benchmark(), ELocation.Pipe(), ELocation.Unknown(), ELocation.None():
 		return false
@@ -652,7 +654,7 @@ func (l Location) IsLocal() bool {
 
 // IsAzure checks if location is Azure (BlobFS, Blob, File)
 func (l Location) IsAzure() bool {
-	return l == ELocation.BlobFS() || l == ELocation.Blob() || l == ELocation.File()
+	return l == ELocation.BlobFS() || l == ELocation.Blob() || l == ELocation.File() || l == ELocation.SMB() || l == ELocation.NFS()
 }
 
 // IsFolderAware returns true if the location has real folders (e.g. there's such a thing as an empty folder,
@@ -721,6 +723,11 @@ func (FromTo) GCPBlob() FromTo      { return FromToValue(ELocation.GCP(), ELocat
 func (FromTo) BlobNone() FromTo     { return FromToValue(ELocation.Blob(), ELocation.None()) }
 func (FromTo) BlobFSNone() FromTo   { return FromToValue(ELocation.BlobFS(), ELocation.None()) }
 func (FromTo) FileNone() FromTo     { return FromToValue(ELocation.File(), ELocation.None()) }
+func (FromTo) LocalNFS() FromTo     { return FromToValue(ELocation.Local(), ELocation.NFS()) }
+func (FromTo) NFSLocal() FromTo     { return FromToValue(ELocation.NFS(), ELocation.Local()) }
+func (FromTo) NFSNFS() FromTo       { return FromToValue(ELocation.NFS(), ELocation.NFS()) }
+func (FromTo) SMBNFS() FromTo       { return FromToValue(ELocation.SMB(), ELocation.NFS()) }
+func (FromTo) NFSSMB() FromTo       { return FromToValue(ELocation.NFS(), ELocation.SMB()) }
 
 // todo: to we really want these?  Starts to look like a bit of a combinatorial explosion
 func (FromTo) BenchmarkBlob() FromTo {

--- a/common/rpc-models.go
+++ b/common/rpc-models.go
@@ -180,7 +180,6 @@ type CopyJobPartOrderRequest struct {
 	// This may not always be the case (for instance, if we opt to use multiple OAuth tokens). At that point, this will likely be it's own CredentialInfo.
 	S2SSourceCredentialType CredentialType // Only Anonymous and OAuth will really be used in response to this, but S3 and GCP will come along too...
 	FileAttributes          FileTransferAttributes
-	IsNFSCopy               bool
 }
 
 // CredentialInfo contains essential credential info which need be transited between modules,

--- a/common/util.go
+++ b/common/util.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"net"
 	"net/url"
 	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -411,4 +412,16 @@ func IsSystemContainer(containerName string) bool {
 		}
 	}
 	return false
+}
+
+// this is a global variable so that we can use it in traversal phase
+var isNFSCopy bool
+
+func SetNFSFlag(isNFS bool) {
+	// SetNFSFlag sets the global isNFSCopy variable to the given value
+	isNFSCopy = isNFS
+}
+
+func IsNFSCopy() bool {
+	return isNFSCopy
 }

--- a/ste/JobPartPlan.go
+++ b/ste/JobPartPlan.go
@@ -107,7 +107,6 @@ type JobPartPlanHeader struct {
 	PermanentDeleteOption common.PermanentDeleteOption
 
 	RehydratePriority common.RehydratePriorityType
-	IsNFSCopy         bool
 }
 
 // Status returns the job status stored in JobPartPlanHeader in thread-safe manner

--- a/ste/JobPartPlanFileName.go
+++ b/ste/JobPartPlanFileName.go
@@ -230,7 +230,6 @@ func (jpfn JobPartPlanFileName) Create(order common.CopyJobPartOrderRequest) {
 		DstFileData: JobPartPlanDstFile{
 			TrailingDot: order.FileAttributes.TrailingDot,
 		},
-		IsNFSCopy: order.IsNFSCopy,
 	}
 
 	// Copy any strings into their respective fields

--- a/ste/downloader-azureFiles.go
+++ b/ste/downloader-azureFiles.go
@@ -87,7 +87,7 @@ func (bd *azureFilesDownloader) preserveAttributes() (stage string, err error) {
 		// If PreservePermissions is false and the source is an NFS share,
 		// apply default NFS permissions (mode, owner, group) to the destination file.
 		// This ensures the destination has valid permissions when none are preserved.
-		if info.IsNFSCopy {
+		if common.IsNFSCopy() {
 			if spdl, ok := interface{}(bd).(nfsPermissionsAwareDownloader); ok {
 				// Azure Files sources always implement INFSPropertyBearingSourceInfoProvider,
 				// so the type assertion below is guaranteed to succeed.
@@ -178,7 +178,7 @@ func (bd *azureFilesDownloader) SetFolderProperties(jptm IJobPartTransferMgr) er
 // Return - It returns a string message and an error if an issue occurs.
 func (bd *azureFilesDownloader) preservePermissions(info *TransferInfo) (string, error) {
 
-	if info.IsNFSCopy {
+	if common.IsNFSCopy() {
 		if spdl, ok := interface{}(bd).(nfsPermissionsAwareDownloader); ok {
 			// We don't need to worry about the sip not being a INFSPropertyBearingSourceInfoProvider as Azure Files always is.
 			err := spdl.PutNFSPermissions(bd.sip.(INFSPropertyBearingSourceInfoProvider), bd.txInfo)
@@ -215,7 +215,7 @@ func (bd *azureFilesDownloader) preservePermissions(info *TransferInfo) (string,
 // It ensures the properties are preserved after the permissions have been set.
 // Return - It returns a string message and an error if an issue occurs.
 func (bd *azureFilesDownloader) preserveProperties(info *TransferInfo) (string, error) {
-	if info.IsNFSCopy {
+	if common.IsNFSCopy() {
 		// must be done AFTER we preserve the permissions (else some of the flags/dates set here may be lost)
 		if spdl, ok := interface{}(bd).(nfsPropertyAwareDownloader); ok {
 			// We don't need to worry about the sip not being a ISMBPropertyBearingSourceInfoProvider as Azure Files always is.

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -143,7 +143,6 @@ type TransferInfo struct {
 
 	VersionID  string
 	SnapshotID string
-	IsNFSCopy  bool
 }
 
 func (i *TransferInfo) IsFilePropertiesTransfer() bool {
@@ -439,7 +438,6 @@ func (jptm *jobPartTransferMgr) Info() *TransferInfo {
 		RehydratePriority: plan.RehydratePriority.ToRehydratePriorityType(),
 		VersionID:         versionID,
 		SnapshotID:        snapshotID,
-		IsNFSCopy:         plan.IsNFSCopy,
 	}
 }
 

--- a/ste/sender-azureFile.go
+++ b/ste/sender-azureFile.go
@@ -194,7 +194,7 @@ func (u *azureFileSenderBase) Prologue(state common.PrologueState) (destinationM
 		Metadata:    u.metadataToApply,
 	}
 
-	if info.IsNFSCopy {
+	if common.IsNFSCopy() {
 
 		stage, err := u.addNFSPropertiesToHeaders(info)
 		if err != nil {
@@ -434,7 +434,7 @@ func (u *azureFileSenderBase) Epilogue() {
 	//      So when we uploaded the ranges, we've unintentionally changed the last-write-time.
 	if u.jptm.IsLive() && u.jptm.Info().PreserveInfo {
 		// This is an extra round trip, but we can live with that for these relatively rare cases
-		if u.jptm.Info().IsNFSCopy {
+		if common.IsNFSCopy() {
 			_, err := u.getFileClient().SetHTTPHeaders(u.ctx, &file.SetHTTPHeadersOptions{
 				HTTPHeaders: &u.headersToApply,
 				NFSProperties: &file.NFSProperties{
@@ -499,7 +499,7 @@ func (u *azureFileSenderBase) SetFolderProperties() (err error) {
 	info := u.jptm.Info()
 
 	setPropertiesOptions := &directory.SetPropertiesOptions{}
-	if info.IsNFSCopy {
+	if common.IsNFSCopy() {
 
 		_, err = u.addNFSPropertiesToHeaders(info)
 		if err != nil {


### PR DESCRIPTION
## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->
In Phase-1, we introduced the --nfs flag to indicate when an NFS share was involved in the transfer. This flag helped us decide which properties and permissions to preserve.
However, with the introduction of heterogeneous source and destination combinations in Phase-2, we are facing additional challenges in validating the shares. We cannot rely solely on the --nfs flag anymore; instead, we need to validate both the source and destination protocols. AzCopy already provides a flag named --from-to that specifies the source and destination combination. We propose to leverage this flag for protocol validation in these scenarios and depricate --nfs flag.

- **Feature / Bug Fix**: (Brief description of the feature or issue being addressed)

- **Related Links**:
- [Issues](<link>)
- [Team thread](<link>)
- [Documents](<link>)
- [Email Subject] Phase-2 NFS Support for AzCopy Callout

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

Thank you for your contribution to AzCopy!
