### PR TITLE
--cap-mbps refactor

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -446,44 +446,6 @@ func (cooked cookedListCmdArgs) newListSummary(fileCount, totalFileSize int64) A
 	}
 }
 
-var megaSize = []string{
-	"B",
-	"KB",
-	"MB",
-	"GB",
-	"TB",
-	"PB",
-	"EB",
-}
-
-func ByteSizeToString(size int64) string {
-	units := []string{
-		"B",
-		"KiB",
-		"MiB",
-		"GiB",
-		"TiB",
-		"PiB",
-		"EiB", // Let's face it, a file, account, or container probably won't be more than 1000 exabytes in YEARS.
-		// (and int64 literally isn't large enough to handle too many exbibytes. 128 bit processors when)
-	}
-	unit := 0
-	floatSize := float64(size)
-	gigSize := 1024
-
-	if cooked.MegaUnits {
-		gigSize = 1000
-		units = megaSize
-	}
-
-	for floatSize/float64(gigSize) >= 1 {
-		unit++
-		floatSize /= float64(gigSize)
-	}
-
-	return strconv.FormatFloat(floatSize, 'f', 2, 64) + " " + units[unit]
-}
-
 func getPath(containerName, relativePath string, level LocationLevel, entityType common.EntityType) string {
 	builder := strings.Builder{}
 	if level == level.Service() {
@@ -497,5 +459,5 @@ func getPath(containerName, relativePath string, level LocationLevel, entityType
 }
 
 func sizeToString(size int64, machineReadable bool) string {
-	return common.Iff(machineReadable, strconv.Itoa(int(size)), ByteSizeToString(size))
+	return common.Iff(machineReadable, strconv.Itoa(int(size)), common.ByteSizeToString(size, cooked.MegaUnits))
 }

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -12,7 +12,7 @@ func TestBToString(t *testing.T) {
 	expects := []string{"50.00 B", "100.00 B", "125.00 B"}
 
 	for k, v := range inputs {
-		output := ByteSizeToString(v)
+		output := common.ByteSizeToString(v)
 		a.Equal(expects[k], output)
 	}
 }
@@ -23,7 +23,7 @@ func TestKiBToString(t *testing.T) {
 	expects := []string{"1.00 KiB", "50.00 KiB", "125.00 KiB", "5.50 KiB", "5.25 KiB"}
 
 	for k, v := range inputs {
-		output := ByteSizeToString(v)
+		output := common.ByteSizeToString(v)
 		a.Equal(expects[k], output)
 	}
 }
@@ -34,7 +34,7 @@ func TestMiBToString(t *testing.T) {
 	expects := []string{"1.00 MiB", "50.00 MiB", "125.00 MiB", "5.50 MiB", "5.25 MiB"}
 
 	for k, v := range inputs {
-		output := ByteSizeToString(v)
+		output := common.ByteSizeToString(v)
 		a.Equal(expects[k], output)
 	}
 }
@@ -45,7 +45,7 @@ func TestGiBToString(t *testing.T) {
 	expects := []string{"1.00 GiB", "50.00 GiB", "125.00 GiB", "5.50 GiB", "5.25 GiB"}
 
 	for k, v := range inputs {
-		output := ByteSizeToString(v)
+		output := common.ByteSizeToString(v)
 		a.Equal(expects[k], output)
 	}
 }
@@ -56,7 +56,7 @@ func TestTiBToString(t *testing.T) {
 	expects := []string{"1.00 TiB", "50.00 TiB", "125.00 TiB", "5.50 TiB", "5.25 TiB"}
 
 	for k, v := range inputs {
-		output := ByteSizeToString(v)
+		output := common.ByteSizeToString(v)
 		a.Equal(expects[k], output)
 	}
 }
@@ -67,7 +67,7 @@ func TestPiBToString(t *testing.T) {
 	expects := []string{"1.00 PiB", "50.00 PiB", "125.00 PiB", "5.50 PiB", "5.25 PiB"}
 
 	for k, v := range inputs {
-		output := ByteSizeToString(v)
+		output := common.ByteSizeToString(v)
 		a.Equal(expects[k], output)
 	}
 }
@@ -78,7 +78,7 @@ func TestEiBToString(t *testing.T) {
 	expects := []string{"1.00 EiB", "5.50 EiB", "5.25 EiB"} //50 & 125 aren't present Because they overflow int64
 
 	for k, v := range inputs {
-		output := ByteSizeToString(v)
+		output := common.ByteSizeToString(v)
 		a.Equal(expects[k], output)
 	}
 }

--- a/common/atomic_operations.go
+++ b/common/atomic_operations.go
@@ -1,0 +1,25 @@
+package common
+
+import (
+	"golang.org/x/exp/constraints"
+)
+
+type Atomic[T any] interface {
+	Store(x T)
+	Load() T
+	CompareAndSwap(old T, new T) (swapped bool)
+}
+
+type AtomicNumeric[T constraints.Integer] interface {
+	Atomic[T]
+	Add(n T) T
+	And(n T) T
+	Or(n T) T
+}
+
+func AtomicSubtract[T constraints.Integer](left AtomicNumeric[T], right T) T {
+	return AtomicMorph(left, func(startVal T) (val T, res T) {
+		out := startVal - right
+		return out, out
+	})
+}

--- a/common/byteSizeString.go
+++ b/common/byteSizeString.go
@@ -1,0 +1,44 @@
+package common
+
+import (
+	"golang.org/x/exp/constraints"
+	"strconv"
+)
+
+var MegaSize = []string{
+	"B",
+	"KB",
+	"MB",
+	"GB",
+	"TB",
+	"PB",
+	"EB",
+}
+
+func ByteSizeToString[T constraints.Integer](size T, megaUnits bool) string {
+	units := []string{
+		"B",
+		"KiB",
+		"MiB",
+		"GiB",
+		"TiB",
+		"PiB",
+		"EiB", // Let's face it, a file, account, or container probably won't be more than 1000 exabytes in YEARS.
+		// (and int64 literally isn't large enough to handle too many exbibytes. 128 bit processors when)
+	}
+	unit := 0
+	floatSize := float64(size)
+	gigSize := 1024
+
+	if megaUnits {
+		gigSize = 1000
+		units = MegaSize
+	}
+
+	for floatSize/float64(gigSize) >= 1 {
+		unit++
+		floatSize /= float64(gigSize)
+	}
+
+	return strconv.FormatFloat(floatSize, 'f', 2, 64) + " " + units[unit]
+}

--- a/common/yield_send.go
+++ b/common/yield_send.go
@@ -1,0 +1,37 @@
+package common
+
+// NonBlockingSafeSend implements a channel send that is guaranteed to not panic, and may be either instantaneous or waiting.
+// Instantaneous returns false if a panic occurred, or if
+func NonBlockingSafeSend[T any](target chan<- T, value T, instant ...bool) <-chan bool {
+	out := make(chan bool, 1)
+
+	sendInstant := func() bool {
+		select {
+		case target <- value:
+			return true
+		default:
+			return false
+		}
+	}
+
+	sendWaiting := func() bool {
+		target <- value
+		return true
+	}
+
+	go func() {
+		defer func() { // Catch in case this send causes issues.
+			if err := recover(); err != nil {
+				out <- false
+				close(out)
+			}
+		}()
+
+		// Then try to send down the channel
+		result := Iff(FirstOrZero(instant), sendInstant, sendWaiting)()
+		out <- result
+		close(out)
+	}()
+
+	return out
+}

--- a/e2etest/newe2e_telemetry.go
+++ b/e2etest/newe2e_telemetry.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/aztables"
-	cmd2 "github.com/Azure/azure-storage-azcopy/v10/cmd"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"os"
 	"os/exec"
 	"strconv"
@@ -43,7 +43,7 @@ func UploadMemoryProfile(a Asserter, profilePath string, runCount uint) {
 	}
 
 	// Output the data so that if the upload fails or the acct isn't configured, we're good to go.
-	a.Log("Test run sampled a heap size of %s", cmd2.ByteSizeToString(totalBytes))
+	a.Log("Test run sampled a heap size of %s", common.ByteSizeToString(totalBytes))
 	if !GlobalConfig.TelemetryConfigured() {
 		return
 	}

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/wastore/keyctl v0.3.1
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/oauth2 v0.27.0
-	golang.org/x/sync v0.12.0
+	golang.org/x/sync v0.15.0
 	golang.org/x/sys v0.31.0
 	google.golang.org/api v0.202.0
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
@@ -86,6 +86,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.29.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.29.0 // indirect
 	go.opentelemetry.io/otel/trace v1.29.0 // indirect
+	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
 	golang.org/x/text v0.23.0 // indirect
 	golang.org/x/time v0.7.0 // indirect
 	google.golang.org/genproto v0.0.0-20241015192408-796eee8c2d53 // indirect

--- a/go.sum
+++ b/go.sum
@@ -212,6 +212,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
 golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b h1:M2rDM6z3Fhozi9O7NWsxAkg/yqS/lQJ6PmkyIV3YP+o=
+golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b/go.mod h1:3//PLf8L/X+8b4vuAfHzxeRUl04Adcb341+IGKfnqS8=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
@@ -233,6 +235,8 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
 golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/sync v0.15.0 h1:KWH3jNZsfyT6xfAfKiz6MRNmd46ByHDYaZ7KSkCtdW8=
+golang.org/x/sync v0.15.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/jobsAdmin/JobsAdmin.go
+++ b/jobsAdmin/JobsAdmin.go
@@ -119,9 +119,8 @@ func initJobsAdmin(appCtx context.Context, concurrency ste.ConcurrencySettings, 
 	maxRamBytesToUse := getMaxRamForChunks()
 
 	// use the "networking mega" (based on powers of 10, not powers of 2, since that's what mega means in networking context)
-	targetRateInBytesPerSec := int64(targetRateInMegaBitsPerSec * 1000 * 1000 / 8)
-	unusedExpectedCoarseRequestByteCount := int64(0)
-	pacer := ste.NewTokenBucketPacer(targetRateInBytesPerSec, unusedExpectedCoarseRequestByteCount)
+	targetRateInBytesPerSec := uint64(targetRateInMegaBitsPerSec * 1000 * 1000 / 8)
+	pacer := ste.NewRequestPolicyPacer(targetRateInBytesPerSec)
 	// Note: as at July 2019, we don't currently have a shutdown method/event on JobsAdmin where this pacer
 	// could be shut down. But, it's global anyway, so we just leave it running until application exit.
 
@@ -245,7 +244,7 @@ type jobsAdmin struct {
 	logDir                  string // Where log files are stored
 	planDir                 string // Initialize to directory where Job Part Plans are stored
 	appCtx                  context.Context
-	pacer                   ste.PacerAdmin
+	pacer                   ste.RequestPolicyPacer
 	slicePool               common.ByteSlicePooler
 	cacheLimiter            common.CacheLimiter
 	fileCountLimiter        common.CacheLimiter

--- a/ste/downloader-blobFS.go
+++ b/ste/downloader-blobFS.go
@@ -23,15 +23,15 @@ package ste
 import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/file"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"os"
 	"time"
-	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 type blobFSDownloader struct {
-	jptm IJobPartTransferMgr
-	txInfo *TransferInfo
-	srcFileClient   *file.Client
+	jptm          IJobPartTransferMgr
+	txInfo        *TransferInfo
+	srcFileClient *file.Client
 }
 
 func newBlobFSDownloader(jptm IJobPartTransferMgr) (downloader, error) {
@@ -75,7 +75,7 @@ func (bd *blobFSDownloader) Epilogue() {
 
 // Returns a chunk-func for ADLS gen2 downloads
 
-func (bd *blobFSDownloader) GenerateDownloadFunc(jptm IJobPartTransferMgr, destWriter common.ChunkedFileWriter, id common.ChunkID, length int64, pacer pacer) chunkFunc {
+func (bd *blobFSDownloader) GenerateDownloadFunc(jptm IJobPartTransferMgr, destWriter common.ChunkedFileWriter, id common.ChunkID, length int64) chunkFunc {
 	return createDownloadChunkFunc(jptm, id, func() {
 
 		srcFileClient := bd.srcFileClient
@@ -101,11 +101,11 @@ func (bd *blobFSDownloader) GenerateDownloadFunc(jptm IJobPartTransferMgr, destW
 		// The retryReader encapsulates any retries that may be necessary while downloading the body
 		jptm.LogChunkStatus(id, common.EWaitReason.Body())
 		retryReader := get.NewRetryReader(jptm.Context(), &file.RetryReaderOptions{
-			MaxRetries: MaxRetryPerDownloadBody,
+			MaxRetries:   MaxRetryPerDownloadBody,
 			OnFailedRead: common.NewDatalakeReadLogFunc(jptm, srcFileClient.DFSURL()),
 		})
 		defer retryReader.Close()
-		err = destWriter.EnqueueChunk(jptm.Context(), id, length, newPacedResponseBody(jptm.Context(), retryReader, pacer), true)
+		err = destWriter.EnqueueChunk(jptm.Context(), id, length, retryReader, true)
 		if err != nil {
 			jptm.FailActiveDownload("Enqueuing chunk", err)
 			return

--- a/ste/downloader.go
+++ b/ste/downloader.go
@@ -33,7 +33,7 @@ type downloader interface {
 	// GenerateDownloadFunc returns a func() that will download the specified portion of the remote file into dstFile
 	// Instead of taking destination file as a parameter, it takes a helper that will write to the file. That keeps details of
 	// file IO out out the download func, and lets that func concentrate only on the details of the remote endpoint
-	GenerateDownloadFunc(jptm IJobPartTransferMgr, writer common.ChunkedFileWriter, id common.ChunkID, length int64, pacer pacer) chunkFunc
+	GenerateDownloadFunc(jptm IJobPartTransferMgr, writer common.ChunkedFileWriter, id common.ChunkID, length int64) chunkFunc
 
 	// Epilogue does cleanup. MAY be the only method that gets called (in error cases). So must not fail simply because
 	// Prologue has not yet been called

--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -109,7 +109,7 @@ type IJobMgr interface {
 
 func NewJobMgr(concurrency ConcurrencySettings, jobID common.JobID, appCtx context.Context, cpuMon common.CPUMonitor, level common.LogLevel,
 	commandString string, logFileFolder string, tuner ConcurrencyTuner,
-	pacer PacerAdmin, slicePool common.ByteSlicePooler, cacheLimiter common.CacheLimiter, fileCountLimiter common.CacheLimiter,
+	pacer RequestPolicyPacer, slicePool common.ByteSlicePooler, cacheLimiter common.CacheLimiter, fileCountLimiter common.CacheLimiter,
 	jobLogger common.ILoggerResetable, daemonMode bool) IJobMgr {
 	const channelSize = 100000
 	// PartsChannelSize defines the number of JobParts which can be placed into the
@@ -328,7 +328,7 @@ type jobMgr struct {
 	poolSizingChannels  poolSizingChannels
 	concurrencyTuner    ConcurrencyTuner
 	cpuMon              common.CPUMonitor
-	pacer               PacerAdmin
+	pacer               RequestPolicyPacer
 	slicePool           common.ByteSlicePooler
 	cacheLimiter        common.CacheLimiter
 	fileCountLimiter    common.CacheLimiter
@@ -926,7 +926,7 @@ func (jm *jobMgr) poolSizer() {
 
 	nextWorkerId := 0
 	actualConcurrency := 0
-	lastBytesOnWire := int64(0)
+	lastBytesOnWire := uint64(0)
 	lastBytesTime := time.Now()
 	hasHadTimeToStablize := false
 	initialMonitoringInterval := time.Duration(4 * time.Second)

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -103,7 +103,7 @@ func NewClientOptions(retry policy.RetryOptions, telemetry policy.TelemetryOptio
 	// [includeResponsePolicy, newAPIVersionPolicy (ignored), NewTelemetryPolicy, perCall, NewRetryPolicy, perRetry, NewLogPolicy, httpHeaderPolicy, bodyDownloadPolicy]
 	perCallPolicies := []policy.Policy{azruntime.NewRequestIDPolicy(), NewVersionPolicy(), newFileUploadRangeFromURLFixPolicy()}
 	// TODO : Default logging policy is not equivalent to old one. tracing HTTP request
-	perRetryPolicies := []policy.Policy{newRetryNotificationPolicy(), newLogPolicy(log), newStatsPolicy()}
+	perRetryPolicies := []policy.Policy{todoRequestPolicyPacer, NewPolicyInjector(PolicyAutoPacerKey), newRetryNotificationPolicy(), newLogPolicy(log), newStatsPolicy()}
 	if dstCred != nil {
 		perCallPolicies = append(perRetryPolicies, NewDestReauthPolicy(dstCred))
 	}
@@ -188,7 +188,7 @@ type jobPartMgr struct {
 
 	priority common.JobPriority
 
-	pacer pacer // Pacer is used to cap throughput
+	pacer RequestPolicyPacer // Pacer is used to cap throughput
 
 	slicePool common.ByteSlicePooler
 
@@ -446,7 +446,7 @@ func (jpm *jobPartMgr) ExclusiveDestinationMap() *common.ExclusiveStringMap {
 }
 
 func (jpm *jobPartMgr) StartJobXfer(jptm IJobPartTransferMgr) {
-	jpm.newJobXfer(jptm, jpm.pacer)
+	jpm.newJobXfer(jptm)
 }
 
 func (jpm *jobPartMgr) GetOverwriteOption() common.OverwriteOption {

--- a/ste/mockResponder_test.go
+++ b/ste/mockResponder_test.go
@@ -1,0 +1,22 @@
+package ste
+
+import (
+	"bytes"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"io"
+	"net/http"
+)
+
+type MockResponder struct {
+	resp http.Response
+	body []byte
+}
+
+func (m MockResponder) Do(req *policy.Request) (*http.Response, error) {
+	r := m.resp
+	r.Header = m.resp.Header.Clone()
+	r.Body = io.NopCloser(bytes.NewReader(m.body))
+
+	r.Request = req.Raw()
+	return &r, nil
+}

--- a/ste/pacedReadSeeker.go
+++ b/ste/pacedReadSeeker.go
@@ -1,85 +1,85 @@
-// Copyright © 2017 Microsoft <wastore@microsoft.com>
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-
+// // Copyright © 2017 Microsoft <wastore@microsoft.com>
+// //
+// // Permission is hereby granted, free of charge, to any person obtaining a copy
+// // of this software and associated documentation files (the "Software"), to deal
+// // in the Software without restriction, including without limitation the rights
+// // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// // copies of the Software, and to permit persons to whom the Software is
+// // furnished to do so, subject to the following conditions:
+// //
+// // The above copyright notice and this permission notice shall be included in
+// // all copies or substantial portions of the Software.
+// //
+// // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// // THE SOFTWARE.
 package ste
 
-import (
-	"context"
-	"io"
-)
-
-// pacedReadSeeker implements read/seek/close with pacing. (Formerly in file pacer-lite)
-type pacedReadSeeker struct {
-
-	// Although storing ctx in a struct is generally considered an anti-patten, this particular
-	// struct happens to be fairly-short lived (from its users point of view). Basically just for
-	// as long as a takes to read or send a request body.  That's not terribly long, but it is
-	// long enough that we might need to cancel during it, hence the ctx.
-	ctx context.Context
-
-	body io.Reader // Seeking is required to support retries
-	p    pacer
-}
-
-func newPacedRequestBody(ctx context.Context, requestBody io.ReadSeeker, p pacer) io.ReadSeekCloser {
-	if p == nil {
-		panic("p must not be nil")
-	}
-	return &pacedReadSeeker{ctx: ctx, body: requestBody, p: p}
-}
-
-func newPacedResponseBody(ctx context.Context, responseBody io.ReadCloser, p pacer) io.ReadCloser {
-	if p == nil {
-		panic("p must not be nil")
-	}
-	return &pacedReadSeeker{ctx: ctx, body: responseBody, p: p}
-}
-
-func (prs *pacedReadSeeker) Read(p []byte) (int, error) {
-	requestedCount := len(p)
-
-	// blocks until we are allowed to process the bytes
-	err := prs.p.RequestTrafficAllocation(prs.ctx, int64(requestedCount))
-	if err != nil {
-		return 0, err
-	}
-
-	// process them
-	n, err := prs.body.Read(p)
-
-	// "return" any unused tokens to the pacer (e.g. if we hit eof before the end of our buffer p)
-	excess := requestedCount - n
-	prs.p.UndoRequest(int64(excess))
-
-	return n, err
-}
-
-// Seeking is required to support retries
-func (prs *pacedReadSeeker) Seek(offset int64, whence int) (offsetFromStart int64, err error) {
-	return prs.body.(io.ReadSeeker).Seek(offset, whence)
-}
-
-// pacedReadSeeker supports Close but the underlying stream may not; if it does, Close will close it.
-func (prs *pacedReadSeeker) Close() error {
-	if c, ok := prs.body.(io.Closer); ok {
-		return c.Close()
-	}
-	return nil
-}
+//
+//import (
+//	"context"
+//	"io"
+//)
+//
+//// pacedReadSeeker implements read/seek/close with pacing. (Formerly in file pacer-lite)
+//type pacedReadSeeker struct {
+//
+//	// Although storing ctx in a struct is generally considered an anti-patten, this particular
+//	// struct happens to be fairly-short lived (from its users point of view). Basically just for
+//	// as long as a takes to read or send a request body.  That's not terribly long, but it is
+//	// long enough that we might need to cancel during it, hence the ctx.
+//	ctx context.Context
+//
+//	body io.Reader // Seeking is required to support retries
+//	p    pacer
+//}
+//
+//func newPacedRequestBody(ctx context.Context, requestBody io.ReadSeeker, p pacer) io.ReadSeekCloser {
+//	if p == nil {
+//		panic("p must not be nil")
+//	}
+//	return &pacedReadSeeker{ctx: ctx, body: requestBody, p: p}
+//}
+//
+//func newPacedResponseBody(ctx context.Context, responseBody io.ReadCloser, p pacer) io.ReadCloser {
+//	if p == nil {
+//		panic("p must not be nil")
+//	}
+//	return &pacedReadSeeker{ctx: ctx, body: responseBody, p: p}
+//}
+//
+//func (prs *pacedReadSeeker) Read(p []byte) (int, error) {
+//	requestedCount := len(p)
+//
+//	// blocks until we are allowed to process the bytes
+//	err := prs.p.RequestTrafficAllocation(prs.ctx, int64(requestedCount))
+//	if err != nil {
+//		return 0, err
+//	}
+//
+//	// process them
+//	n, err := prs.body.Read(p)
+//
+//	// "return" any unused tokens to the pacer (e.g. if we hit eof before the end of our buffer p)
+//	excess := requestedCount - n
+//	prs.p.UndoRequest(int64(excess))
+//
+//	return n, err
+//}
+//
+//// Seeking is required to support retries
+//func (prs *pacedReadSeeker) Seek(offset int64, whence int) (offsetFromStart int64, err error) {
+//	return prs.body.(io.ReadSeeker).Seek(offset, whence)
+//}
+//
+//// pacedReadSeeker supports Close but the underlying stream may not; if it does, Close will close it.
+//func (prs *pacedReadSeeker) Close() error {
+//	if c, ok := prs.body.(io.Closer); ok {
+//		return c.Close()
+//	}
+//	return nil
+//}

--- a/ste/pacer-NullRequestPolicyPacer.go
+++ b/ste/pacer-NullRequestPolicyPacer.go
@@ -1,0 +1,22 @@
+package ste
+
+import (
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"io"
+)
+
+type NullRequestPolicyPacer struct {
+}
+
+func (n NullRequestPolicyPacer) GetPacedBody(body io.ReadSeekCloser) (io.ReadSeekCloser, error) {
+	return body, nil
+}
+
+func (n NullRequestPolicyPacer) ReturnBytes(returned uint64) {
+	panic("implement me")
+}
+
+func (n NullRequestPolicyPacer) GetPolicy() policy.Policy {
+	//TODO implement me
+	panic("implement me")
+}

--- a/ste/pacer-RequestPolicyPacer-interface.go
+++ b/ste/pacer-RequestPolicyPacer-interface.go
@@ -6,13 +6,16 @@ import (
 )
 
 type RequestPolicyPacer interface {
-	GetPacedRequestBody(body io.ReadSeekCloser) (io.ReadSeekCloser, error)
-	GetPacedResponseBody(body io.ReadCloser, contentLength uint64) (io.ReadCloser, error)
+	GetPacedRequestBody(body io.ReadSeekCloser, contentLength uint64) io.ReadSeekCloser
+	GetPacedResponseBody(body io.ReadCloser, contentLength uint64) io.ReadCloser
 	UpdateTargetBytesPerSecond(bytesPerSecond uint64)
+
 	ProcessBytes(uint64)
-	ReturnBytes(uint64)
+	UndoBytes(uint64)
+
 	GetPolicy() policy.Policy
 	GetTotalTraffic() uint64
+	Cleanup()
 }
 
 type PolicyPacerBody interface {

--- a/ste/pacer-RequestPolicyPacer-interface.go
+++ b/ste/pacer-RequestPolicyPacer-interface.go
@@ -1,0 +1,28 @@
+package ste
+
+import (
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"io"
+)
+
+type RequestPolicyPacer interface {
+	GetPacedRequestBody(body io.ReadSeekCloser) (io.ReadSeekCloser, error)
+	GetPacedResponseBody(body io.ReadCloser, contentLength uint64) (io.ReadCloser, error)
+	UpdateTargetBytesPerSecond(bytesPerSecond uint64)
+	ProcessBytes(uint64)
+	ReturnBytes(uint64)
+	GetPolicy() policy.Policy
+	GetTotalTraffic() uint64
+}
+
+type PolicyPacerBody interface {
+	io.ReadCloser
+	Deallocate()
+	AwaitFlight()
+}
+
+type PolicyPacerRequestBody interface {
+	PolicyPacerBody
+	io.Seeker
+	DeallocateResponse()
+}

--- a/ste/pacer-RequestPolicyPacer-pacer.go
+++ b/ste/pacer-RequestPolicyPacer-pacer.go
@@ -1,0 +1,335 @@
+package ste
+
+import (
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/google/uuid"
+	"sync/atomic"
+	"time"
+)
+
+/*
+A couple problems must be solved here.
+
+1. Requests _larger_ than the throughput window must be allowed through. This means a large request must be able to start and then gradually be paced.
+2. Requests
+*/
+
+const (
+	// RequestMinimumBytesPerSecond is the bare minimum bytes per second we're allowed to allocate to a request.
+	RequestMinimumBytesPerSecond = common.MegaByte / 60 // 1 minute per megabyte
+
+	// PacerTickrate defines how frequently we provide bytes to requests in flight. This must be less than or equal to a second.
+	PacerTickrate = time.Second / 10
+
+	// PacerMaxOverflow defines how much the "bucket", per PacerTickrate, can overflow, as a multiple.
+	PacerMaxOverflow = 2.5
+
+	// PacerRedlinePercentage defines what portion of the max mbps should be filled before halting the acceptance of further additional requests
+	// Effectively, the remainder should get distributed to live requests.
+	PacerRedlinePercentage = 0.75
+	// RealBandwidthRedlinePercentage defines what portion of our actually hit bandwidth, if it is dissimilar to our ideal cap
+	RealBandwidthRedlinePercentage = 0.6
+	// RealBandwidthPacerSimilarityError defines how much of a gap we will accept before falling back to RealBandwidthRedlinePercentage if a cap is enabled
+	RealBandwidthPacerSimilarityError = 0.1
+)
+
+func NewRequestPolicyPacer(bytesPerSecond uint64) RequestPolicyPacer {
+	p := &requestPolicyPacer{
+		processedBytes:          &atomic.Uint64{},
+		maxBytesPerSecond:       &atomic.Uint64{},
+		allocatedBytesPerSecond: &atomic.Uint64{},
+		maxAvailableBytes:       &atomic.Uint64{},
+		availableBytes:          &atomic.Uint64{},
+		isLive:                  &atomic.Pointer[bool]{},
+
+		liveBodies:         make(map[uuid.UUID]*policyPacerBody),
+		requestInitChannel: make(chan *policyPacerBody, 300),
+		respInitChannel:    make(chan *policyPacerBody, 300),
+		pacerExitChannel:   make(chan *policyPacerBody, 300),
+		allocationRequests: make(map[uuid.UUID]uint64),
+		allocationRequestchannel: make(chan struct {
+			pacerID uuid.UUID
+			size    uint64
+		}),
+		ticker: time.NewTicker(PacerTickrate),
+	}
+
+	p.isLive.Store(to.Ptr(true))
+
+	p.UpdateTargetBytesPerSecond(bytesPerSecond)
+	go p.pacerBody()
+
+	return p
+}
+
+type requestPolicyPacer struct {
+	processedBytes *atomic.Uint64
+
+	maxBytesPerSecond       *atomic.Uint64
+	allocatedBytesPerSecond *atomic.Uint64
+
+	bytesPerTick      *atomic.Uint64
+	maxAvailableBytes *atomic.Uint64
+	availableBytes    *atomic.Uint64
+
+	isLive *atomic.Pointer[bool]
+
+	requestInitChannel       chan *policyPacerBody // Requests are paced
+	respInitChannel          chan *policyPacerBody // Responses come as a part of the req/resp package and are processed instantly, with priority.
+	pacerExitChannel         chan *policyPacerBody // Requests *and* responses exit here
+	allocationRequestchannel chan struct {
+		pacerID uuid.UUID
+		size    uint64
+	}
+
+	shutdownCh chan bool
+
+	liveBodies         map[uuid.UUID]*policyPacerBody
+	allocationRequests map[uuid.UUID]uint64
+
+	// testing harness stuff
+	ticker     *time.Ticker
+	manualTick bool // With manualTick enabled, requests will flight themselves to prevent a chicken and egg problem.
+}
+
+func (r *requestPolicyPacer) pacerBody() {
+	for {
+		select {
+		case <-r.shutdownCh:
+			r.isLive.Store(to.Ptr(false))
+			r.ticker.Stop()
+			r.shutdownCh <- true
+			close(r.shutdownCh)
+			return
+		case <-r.ticker.C:
+			r.refillBucket()               // Refill the bucket
+			r.deallocateFinishedRequests() // Deallocate what we can
+			r.allocateNewRequests()        // Add new requests
+			r.allocateNewResponses()       // Add new responses
+			r.feedRequests()               // Use the bytes in the bucket
+		}
+	}
+}
+
+func (r *requestPolicyPacer) refillBucket() {
+	if refillRate := r.bytesPerTick.Load(); refillRate != 0 {
+		r.availableBytes.Store(min(r.maxAvailableBytes.Load(), r.availableBytes.Load()+refillRate))
+	}
+}
+
+func (r *requestPolicyPacer) deallocateFinishedRequests() {
+	// Discount closed requests
+	for {
+		escape := false
+		select {
+		case req := <-r.pacerExitChannel:
+			delete(r.liveBodies, req.id)
+			common.AtomicSubtract(r.allocatedBytesPerSecond, RequestMinimumBytesPerSecond)
+		default:
+			escape = true // break doesn't work in here
+		}
+
+		if escape {
+			break
+		}
+	}
+}
+
+func (r *requestPolicyPacer) allocateNewRequests() {
+	// Allow new requests
+	// todo try to keep in flight requests to a certain percentage of our "actual" hit bandwidth.
+	maxBytesPerSecond := r.maxBytesPerSecond.Load()
+	reqRespAllocation := uint64(RequestMinimumBytesPerSecond * 2)
+
+	if maxBytesPerSecond != 0 { // If we have a throughput limit, trickle in requests up to our redline.
+		redlineBytesPerSecond := uint64(float64(maxBytesPerSecond) * PacerRedlinePercentage)
+
+		condition := func() bool {
+			return r.allocatedBytesPerSecond.Load()+reqRespAllocation < redlineBytesPerSecond
+		}
+
+		// If we can't allocate the bare minimum, we just have to allocate a single request at a time, and give it what we can.
+		if maxBytesPerSecond < reqRespAllocation {
+			condition = func() bool {
+				return len(r.liveBodies) == 0
+			}
+		}
+
+		for condition() {
+			escape := false
+			select {
+			case newRequest := <-r.requestInitChannel:
+				r.liveBodies[newRequest.id] = newRequest         // Register the request
+				r.allocatedBytesPerSecond.Add(reqRespAllocation) // Allocate the bytes
+
+				// Inform the body that it is allocated
+				newRequest.bodyStatus.Store(to.Ptr(BodyStatusAllocated))
+			default: // there's nothing new, so let's use what we have.
+				escape = true
+			}
+
+			if escape {
+				break
+			}
+		}
+	} else {
+		// todo: placeholder.
+		// Currently, we blindly accept all requests. However, instead, we should be watching for our current throughput and
+
+		for {
+			escape := false
+			select {
+			case newRequest := <-r.requestInitChannel:
+				r.liveBodies[newRequest.id] = newRequest         // Register the request
+				r.allocatedBytesPerSecond.Add(reqRespAllocation) // Allocate the bytes
+
+				// Inform the body that it is allocated
+				newRequest.bodyStatus.Store(to.Ptr(BodyStatusAllocated))
+			default: // there's nothing new, so let's use what we have.
+				escape = true
+			}
+
+			if escape {
+				break
+			}
+		}
+	}
+}
+
+func (r *requestPolicyPacer) allocateNewResponses() {
+	// We already included the response in our allocation for the request, so any responses in the queue can freely join in.
+	for {
+		escape := false
+		select {
+		case newResponse := <-r.respInitChannel:
+			r.liveBodies[newResponse.id] = newResponse
+
+			// Inform the body that it is allocated
+			newResponse.bodyStatus.Store(to.Ptr(BodyStatusAllocated))
+		default:
+			escape = true
+		}
+
+		if escape {
+			break
+		}
+	}
+}
+
+func (r *requestPolicyPacer) feedRequests() {
+	/*
+		We ideally want to repeat this process as little as possible, and want to give
+		each request as much bandwidth as we can.
+
+		To do this, we start with seeding what we can, and re-iterate until we've exhausted the pool, or we can't allocate anything more.
+	*/
+
+	// First, receive requests.
+	func() { // Enter a closure so we can cleanly exit the loop without special tricks
+		for {
+			select {
+			case req := <-r.allocationRequestchannel: // A body should never be requesting more than one read at a time.
+				if _, ok := r.allocationRequests[req.pacerID]; req.size <= 0 && ok {
+					delete(r.allocationRequests, req.pacerID)
+				} else if req.size > 0 {
+					r.allocationRequests[req.pacerID] = req.size
+				}
+			default:
+				return
+			}
+		}
+	}()
+
+	// If we are in standard allocation mode, do our rounds.
+	if bytesPerTick := r.bytesPerTick.Load(); bytesPerTick != 0 {
+		availableBytes := r.availableBytes.Load()
+		usedBytes := uint64(0)
+		allocations := make(map[uuid.UUID]uint64)
+
+		allocateBytes := func(id uuid.UUID, n uint64) {
+			// defensively check in case we try to submit a request larger than what's needed or possible
+			if availableBytes < n {
+				n = availableBytes
+			}
+			if req := r.allocationRequests[id]; req < n {
+				n = req
+			}
+
+			usedBytes += n // Keep track of allocated byte count
+			availableBytes -= n
+
+			allocations[id] += n // Prepare the allocation
+			r.allocationRequests[id] -= n
+
+			if r.allocationRequests[id] == 0 { // Trim it from the list if it doesn't need anything else.
+				delete(r.allocationRequests, id)
+			}
+		}
+
+		func() { // Cycle and try to use the entire pool
+			for availableBytes > 0 && len(r.allocationRequests) > 0 {
+				avgAllocation := availableBytes / uint64(len(r.allocationRequests))
+
+				if avgAllocation == 0 {
+					avgAllocation = availableBytes
+				}
+
+				for k, v := range r.allocationRequests {
+					allocSize := min(v, avgAllocation)
+
+					allocateBytes(k, allocSize)
+
+					if availableBytes == 0 { // We have allocated all we can. There's no need to allocate anything else.
+						return
+					}
+				}
+			}
+		}()
+
+		common.AtomicSubtract(r.availableBytes, usedBytes)
+
+		for k, v := range allocations {
+			common.NonBlockingSafeSend(r.liveBodies[k].allocationChannel, v)
+		}
+	}
+}
+
+func (r *requestPolicyPacer) UpdateTargetBytesPerSecond(bytesPerSecond uint64) {
+	maxBytesPerSecond := bytesPerSecond
+	ticksPerSecond := uint64(time.Second / PacerTickrate) // Find how many ticks per second
+	if ticksPerSecond < 1 {
+		panic("invalid specification for policy pacer tickrate")
+	}
+	bytesPerTick := maxBytesPerSecond / ticksPerSecond                   // So we can break our cap-mbps into mb/tick
+	maxOverflowBytes := uint64(float64(bytesPerTick) * PacerMaxOverflow) // Then, extend our overage window
+
+	r.maxBytesPerSecond.Store(maxBytesPerSecond)
+	r.bytesPerTick.Store(bytesPerTick)
+	r.maxAvailableBytes.Store(maxOverflowBytes)
+}
+
+func (r *requestPolicyPacer) ReturnBytes(returned uint64) {
+	common.AtomicMorph(r.availableBytes, func(startVal uint64) (val uint64, res uint64) {
+		maxAvailable := r.maxAvailableBytes.Load()
+		val = startVal + returned
+		if val > maxAvailable {
+			val = maxAvailable
+		}
+
+		return
+	})
+}
+
+func (r *requestPolicyPacer) ProcessBytes(processed uint64) {
+	r.processedBytes.Add(processed)
+}
+
+func (r *requestPolicyPacer) GetTotalTraffic() uint64 {
+	return r.processedBytes.Load()
+}
+
+func (r *requestPolicyPacer) Cleanup() {
+	r.shutdownCh <- true
+	<-r.shutdownCh // Wait for the "true shutdown" response.
+}

--- a/ste/pacer-RequestPolicyPacer-pacer_test.go
+++ b/ste/pacer-RequestPolicyPacer-pacer_test.go
@@ -1,0 +1,438 @@
+package ste
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"math/rand"
+	"net/http"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func NewTestPolicyPacer(target uint64, manualTick bool) (pacer RequestPolicyPacer, tickFunc func()) {
+	var ticker *time.Ticker
+	if manualTick {
+		t := make(chan time.Time, 1)
+		ticker = &time.Ticker{
+			C: t,
+		}
+
+		tickFunc = func() {
+			t <- time.Now()
+		}
+	} else {
+		ticker = time.NewTicker(PacerTickrate)
+	}
+
+	pacer = &requestPolicyPacer{
+		processedBytes:          &atomic.Uint64{},
+		maxBytesPerSecond:       &atomic.Uint64{},
+		allocatedBytesPerSecond: &atomic.Uint64{},
+		bytesPerTick:            &atomic.Uint64{},
+		maxAvailableBytes:       &atomic.Uint64{},
+		availableBytes:          &atomic.Uint64{},
+		requestInitChannel:      make(chan *policyPacerBody, 300),
+		respInitChannel:         make(chan *policyPacerBody, 300),
+		pacerExitChannel:        make(chan *policyPacerBody, 300),
+		allocationRequestchannel: make(chan struct {
+			pacerID uuid.UUID
+			size    uint64
+		}, 300),
+		shutdownCh:         make(chan bool, 300),
+		liveBodies:         make(map[uuid.UUID]*policyPacerBody),
+		allocationRequests: make(map[uuid.UUID]uint64),
+		ticker:             ticker,
+		manualTick:         manualTick,
+	}
+
+	pacer.UpdateTargetBytesPerSecond(target)
+	go pacer.(*requestPolicyPacer).pacerBody()
+
+	return
+}
+
+func NewRandomBytes(size uint64) []byte {
+	buf := make([]byte, size)
+
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	r.Read(buf)
+
+	return buf
+}
+
+func NewRandomBody(size uint64) io.ReadSeekCloser {
+	return streaming.NopCloser(bytes.NewReader(NewRandomBytes(size)))
+}
+
+// Validate the natural lifecycle of a request and response.
+func TestPolicyPacer_ReqRespSync(t *testing.T) {
+	const (
+		BodySize          = 1024 * 100
+		PacerBytesPerTick = 1024
+		// Work back to a rate that will give us the number of bytes we expect
+		PacerRate = PacerBytesPerTick * uint64(time.Second/PacerTickrate)
+	)
+
+	// Stupid simple cheat function to validate we're actually reading bytes in pace
+	validateRead := func(count uint64, body *policyPacerBody) {
+		read := false
+		var readBytes uint64
+		for tries := 0; tries < 100; tries++ {
+			readBytes = body.readHead.Load()
+			assert.LessOrEqual(t, readBytes, count)
+			if readBytes >= count {
+				read = true
+				break
+			}
+
+			// Give the reader a chance to finish, we're not sure where it really lives
+			time.Sleep(time.Millisecond)
+		}
+		assert.True(t, read, "Failed to read %d bytes over 100ms of retries, successfully read %d", count, readBytes)
+	}
+
+	// Create a manually ticked policy pacer
+	p, ticker := NewTestPolicyPacer(PacerRate, true)
+
+	// Get random bodies
+	reqBody := NewRandomBody(BodySize)
+	var respBody io.Reader = NewRandomBody(BodySize)
+
+	// Initialize our request body
+	var err error
+	reqBody, err = p.GetPacedRequestBody(streaming.NopCloser(reqBody))
+	rawReqBody := reqBody.(*policyPacerRequestBody)
+	assert.NoError(t, err, "Get Paced Request Body")
+
+	// fire up our background reader
+	go func() {
+		buf := make([]byte, BodySize)
+		n, err := reqBody.Read(buf)
+		assert.NoError(t, err, "Read body")
+		assert.Equal(t, n, BodySize, "Read expected amount from request")
+	}()
+
+	// Tick the pacer until completion, validating that each step is what we expect.
+	for i := uint64(PacerBytesPerTick); i <= BodySize; i += PacerBytesPerTick {
+		time.Sleep(time.Millisecond * 10) // Wait just a little for things to settle
+		ticker()
+		target := min(i, BodySize)
+		validateRead(target, rawReqBody.policyPacerBody)
+	}
+
+	// Close the body so we tell the pacer to drop this body
+	err = reqBody.Close()
+	assert.NoError(t, err, "Close request body")
+
+	// Give it a little bit for everything to settle
+	time.Sleep(time.Millisecond)
+	assert.Equal(t, int(BodySize), int(p.GetTotalTraffic()))
+
+	// Fire up the new body
+	respBody, err = p.GetPacedResponseBody(io.NopCloser(respBody), BodySize)
+	rawRespBody := respBody.(*policyPacerBody)
+	assert.NoError(t, err, "Get Paced Response Body")
+
+	// fire up our background reader
+	go func() {
+		buf := make([]byte, BodySize)
+		n, err := respBody.Read(buf)
+		assert.NoError(t, err, "Read body")
+		assert.Equal(t, n, BodySize, "Read expected amount from response")
+	}()
+
+	for i := uint64(PacerBytesPerTick); i <= BodySize; i += PacerBytesPerTick {
+		ticker()
+		target := min(i, BodySize)
+		validateRead(target, rawRespBody)
+	}
+
+	err = rawRespBody.Close()
+	assert.NoError(t, err, "Close resp body")
+
+	assert.Equal(t, BodySize*2, int(p.GetTotalTraffic()))
+}
+
+type NullWriter struct{}
+
+func (n2 NullWriter) Write(p []byte) (n int, err error) {
+	_ = p // discard the buffer
+	return len(p), nil
+}
+
+// Validate that multiple bodies receive bandwidth in parallel
+func TestPolicyPacer_Multibody(t *testing.T) {
+	const (
+		BodyCount = 100
+		BodySize  = common.MegaByte * 10
+		PacerMbps = common.MegaByte * 10
+
+		// We don't want this test to take 100 seconds,
+		// so we send ticks much faster than normal to effectively speed through this test.
+		// Normally, the tickrate is 10x per second, by dividing it by 100, we get 100x a second.
+		// This test should run in about 1s on a decent processor.
+		PacerTickrateDivisor = 100
+	)
+
+	// === Generate BodyCount separate BodySize bodies ===
+	bodies := make([]io.ReadSeekCloser, BodyCount)
+	wg := &sync.WaitGroup{}
+	wg.Add(100)
+
+	for bodyId := range bodies {
+		go func() {
+			bodies[bodyId] = NewRandomBody(BodySize)
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+
+	// === Initialize the pacer ===
+	p, tickerFunc := NewTestPolicyPacer(PacerMbps, true)
+	tickerRelease := make(chan bool)
+	go func() {
+		internalTickrate := PacerTickrate / PacerTickrateDivisor
+		ticker := time.NewTicker(internalTickrate)
+		for {
+			select {
+			case <-tickerRelease:
+				ticker.Stop()
+				close(tickerRelease)
+				return
+			case <-ticker.C:
+				tickerFunc()
+			}
+		}
+	}()
+
+	// === Initialize the bodies and their readers ===
+	wg.Add(100)
+	for bodyId := range bodies {
+		go func() {
+			defer wg.Done()
+
+			body, err := p.GetPacedRequestBody(bodies[bodyId])
+			assert.NoError(t, err, "Get paced body request for body %d", bodyId)
+
+			bytesRead, err := io.Copy(&NullWriter{}, body)
+			assert.NoError(t, err, "Read body %d, successfully managed %d bytes", bodyId, bytesRead)
+			assert.Equal(t, bytesRead, int64(BodySize), "Read whole body for body %d", bodyId)
+
+			err = body.Close()
+			assert.NoError(t, err)
+		}()
+	}
+
+	wg.Wait()
+
+	// === Wait a little bit, then check that we pushed as many bytes as we intended. ===
+	time.Sleep(time.Millisecond * 20)
+	assert.Equal(t, BodySize*BodyCount, int(p.GetTotalTraffic()))
+
+	// Release the ticker
+	tickerRelease <- true
+}
+
+// Validate that the pipeline policy works as expected
+func TestPolicyPacer_Policy(t *testing.T) {
+	const (
+		BodySize  = common.MegaByte * 100
+		PacerMbps = common.MegaByte * 10
+
+		// We don't want this test to take 10 seconds,
+		// so we send ticks much faster than normal to effectively speed through this test.
+		// Normally, the tickrate is 10x per second, by dividing it by 10, we get 100x a second.
+		// This test should run in about 1s on a decent processor.
+		PacerTickrateDivisor = 10
+	)
+
+	// === Set up the pacer ===
+	p, tickerFunc := NewTestPolicyPacer(PacerMbps, true)
+	cleanupTicker := make(chan bool, 1)
+	go func() {
+		t := time.NewTicker(PacerTickrate / PacerTickrateDivisor)
+		for {
+			select {
+			case <-cleanupTicker:
+				t.Stop()
+				close(cleanupTicker)
+				return
+			case <-t.C:
+				tickerFunc()
+			}
+		}
+	}()
+
+	// === Set up a dummy client ===
+	mockResp := &MockResponder{
+		resp: http.Response{
+			Status:        http.StatusText(http.StatusOK),
+			StatusCode:    200,
+			Header:        nil,
+			ContentLength: BodySize,
+			Close:         false,
+			Uncompressed:  true,
+		},
+		body: NewRandomBytes(BodySize),
+	}
+
+	blobClient, err := blockblob.NewClientWithNoCredential(
+		"https://asdf.blob.core.windows.net/notreal/blob",
+		&blockblob.ClientOptions{
+			ClientOptions: azcore.ClientOptions{
+				PerCallPolicies: []policy.Policy{
+					azruntime.NewRequestIDPolicy(),
+					NewVersionPolicy(),
+					newFileUploadRangeFromURLFixPolicy(),
+				},
+				PerRetryPolicies: []policy.Policy{
+					p.GetPolicy(),
+					mockResp,
+				},
+			},
+		},
+	)
+	assert.NoError(t, err, "Create blob Client")
+
+	dsr, err := blobClient.DownloadStream(context.TODO(), nil)
+	assert.NoError(t, err, "DownloadStream")
+
+	_, ok := dsr.Body.(*policyPacerBody)
+	assert.True(t, ok, "Body should be policyPacerBody")
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		n, err := io.Copy(&NullWriter{}, dsr.Body)
+		assert.NoError(t, err, "Read body")
+		assert.Equal(t, int(n), int(p.GetTotalTraffic()), "Expected n and total traffic to match")
+		assert.Equal(t, int(BodySize), int(p.GetTotalTraffic()), "Expected total traffic to match body size")
+
+		err = dsr.Body.Close()
+		assert.NoError(t, err, "Close body")
+		wg.Done()
+	}()
+
+	wg.Wait()
+	cleanupTicker <- true
+}
+
+type nilReader struct {
+	closed bool
+	n, len int64
+}
+
+func (r *nilReader) Seek(offset int64, whence int) (int64, error) {
+	if r.closed {
+		return 0, io.ErrClosedPipe
+	}
+
+	switch whence {
+	case io.SeekStart:
+		r.n = 0 + offset
+	case io.SeekCurrent:
+		r.n += offset
+	case io.SeekEnd:
+		r.n = r.len + offset
+	default:
+		return 0, errors.New("invalid relativity")
+	}
+
+	return r.n, nil
+}
+
+func (r *nilReader) Close() error {
+	r.closed = true
+	return nil
+}
+
+func (r *nilReader) Read(p []byte) (n int, err error) {
+	if r.closed {
+		return 0, io.ErrClosedPipe
+	}
+
+	count := int64(len(p))
+	if r.n+count > r.len {
+		count = r.len - r.n
+		err = io.EOF
+	}
+
+	r.n += count
+	return int(count), err
+}
+
+// During testing, it was possible to trigger a panic by ticking the pacer with nothing going on.
+// Attempt to reproduce that.
+func TestPolicyPacer_FullIdle(t *testing.T) {
+	if os.Getenv("PACER_FULLIDLE_TEST") == "" {
+		t.SkipNow() // We don't want to run this test in CI.
+	}
+
+	const (
+		PacerMbps    = common.MegaByte * 10
+		TestDuration = time.Second * 60
+	)
+
+	p, _ := NewTestPolicyPacer(PacerMbps, false)
+
+	body, _ := p.GetPacedRequestBody(&nilReader{len: common.MegaByte * 100})
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(&NullWriter{}, body)
+	}()
+
+	time.Sleep(TestDuration)
+	wg.Wait()
+}
+
+// Validate that idle bodies don't bog down resources on live bodies.
+// We want to make sure of this, because if somebody forgets to close a body, we don't want it hogging
+// resources until it naturally exits.
+func TestPolicyPacer_IdleBody(t *testing.T) {
+	const (
+		BodyCount     = 5
+		BodySize      = common.MegaByte * 5
+		FirstBodySize = BodySize * 5
+		PacerMbps     = common.MegaByte
+	)
+
+	p, ticker := NewTestPolicyPacer(PacerMbps, true)
+
+	// spin up 5 bodies
+	bodies := make([]*policyPacerRequestBody, BodyCount)
+	for k := range bodies {
+		rootBody := NewRandomBody(common.Iff[uint64](k == 0, FirstBodySize, BodySize))
+		b, err := p.GetPacedRequestBody(rootBody)
+		assert.NoError(t, err)
+
+		bodies[k] = b.(*policyPacerRequestBody)
+	}
+
+	// Start the first body reading
+	go func() {
+		b := bodies[0]
+		w, err := io.Copy(&NullWriter{}, b)
+		assert.NoError(t, err)
+		assert.Equal(t, w, FirstBodySize)
+	}()
+
+	ticker() // Tick once
+
+}

--- a/ste/pacer-RequestPolicyPacer-policy.go
+++ b/ste/pacer-RequestPolicyPacer-policy.go
@@ -1,0 +1,55 @@
+package ste
+
+import (
+	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"net/http"
+)
+
+func (r *requestPolicyPacer) GetPolicy() policy.Policy {
+	return &pacerPolicy{
+		parent: r,
+	}
+}
+
+type pacerPolicy struct {
+	parent *requestPolicyPacer
+}
+
+func (p pacerPolicy) Do(req *policy.Request) (*http.Response, error) {
+	err := req.RewindBody()
+	if err != nil {
+		return nil, fmt.Errorf("failed to rewind body: %w", err)
+	}
+
+	raw := req.Raw()
+
+	if reqBody := req.Body(); reqBody != nil {
+		pacedBody, err := p.parent.GetPacedRequestBody(reqBody)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get paced body: %w", err)
+		}
+
+		err = req.SetBody(pacedBody, raw.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, fmt.Errorf("failed to set new body: %w", err)
+		}
+	}
+
+	resp, err := req.Next()
+	if err != nil {
+		_ = req.Body().Close()
+		return nil, err
+	}
+
+	if resp.Body != nil {
+		pacedBody, err := p.parent.GetPacedResponseBody(resp.Body, uint64(resp.ContentLength))
+		if err != nil {
+			return nil, fmt.Errorf("failed to get paced body: %w", err)
+		}
+
+		resp.Body = pacedBody
+	}
+
+	return resp, err
+}

--- a/ste/pacer-RequestPolicyPacer-policy.go
+++ b/ste/pacer-RequestPolicyPacer-policy.go
@@ -25,10 +25,7 @@ func (p pacerPolicy) Do(req *policy.Request) (*http.Response, error) {
 	raw := req.Raw()
 
 	if reqBody := req.Body(); reqBody != nil {
-		pacedBody, err := p.parent.GetPacedRequestBody(reqBody)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get paced body: %w", err)
-		}
+		pacedBody := p.parent.GetPacedRequestBody(reqBody, uint64(max(req.Raw().ContentLength, 0)))
 
 		err = req.SetBody(pacedBody, raw.Header.Get("Content-Type"))
 		if err != nil {
@@ -43,11 +40,7 @@ func (p pacerPolicy) Do(req *policy.Request) (*http.Response, error) {
 	}
 
 	if resp.Body != nil {
-		pacedBody, err := p.parent.GetPacedResponseBody(resp.Body, uint64(resp.ContentLength))
-		if err != nil {
-			return nil, fmt.Errorf("failed to get paced body: %w", err)
-		}
-
+		pacedBody := p.parent.GetPacedResponseBody(resp.Body, uint64(max(resp.ContentLength, 0)))
 		resp.Body = pacedBody
 	}
 

--- a/ste/pacer-autoPacer.go
+++ b/ste/pacer-autoPacer.go
@@ -1,185 +1,135 @@
-// Copyright © 2017 Microsoft <wastore@microsoft.com>
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-
+// // // Copyright © 2017 Microsoft <wastore@microsoft.com>
+// // //
+// // // Permission is hereby granted, free of charge, to any person obtaining a copy
+// // // of this software and associated documentation files (the "Software"), to deal
+// // // in the Software without restriction, including without limitation the rights
+// // // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// // // copies of the Software, and to permit persons to whom the Software is
+// // // furnished to do so, subject to the following conditions:
+// // //
+// // // The above copyright notice and this permission notice shall be included in
+// // // all copies or substantial portions of the Software.
+// // //
+// // // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// // // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// // // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// // // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// // // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// // // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// // // THE SOFTWARE.
 package ste
 
-import (
-	"fmt"
-	"strings"
-	"sync"
-	"sync/atomic"
-	"time"
-
-	"github.com/Azure/azure-storage-azcopy/v10/common"
-)
-
-type autopacer interface {
-	pacer
-	retryNotificationReceiver
-}
-
-// autoTokenBucketPacer is a pacer which automatically seeks the right rate, based on retry (503)
-// statuses received from the target service.
-type autoTokenBucketPacer struct {
-	*tokenBucketPacer
-	lastPeakBytesPerSecond  float32
-	lastPeakTime            time.Time
-	done                    chan struct{}
-	atomicRetriesInInterval int32
-	logger                  common.ILogger
-	logPrefix               string // search for this in log, to easily all the logging output
-}
-
-const (
-	tuningIntervalDuration = time.Second
-
-	deadBandDuration = 20 * time.Second // TODO: review this rather generous value.  Might not be needed if we can pace the internal retry efforts inside the retryPolices, because we (presumably) won't get such big flurries of 503s if we do that
-
-	decreaseFactor = 0.65
-
-	// These increase factors were prototyped in a Excel sheet, then tweaked after live testing.
-	// In "steady state" we would expect one decrease every few minutes, with most of the time spent close to the optimal rate.
-	// (And yes, the shape of the resulting speed curve is at least superficially similar to that used by modern TCP variants,
-	// for the same reason, which is that we want slow change when near the last-known "best" level.)
-	fastRecoveryFactor = 0.1
-	probingFactor      = 0.015
-	stableZoneFactor   = probingFactor / 10
-	stableZoneStart    = 0.95
-	stableZoneEnd      = 1.05
-
-	pageBlobThroughputTunerString = "Page blob throughput tuner"
-
-	maxPacerGbps           = 100
-	maxPacerBytesPerSecond = maxPacerGbps * 1000 * 1000 * 1000 / 8
-)
-
-var (
-	shouldPacePageBlobs bool
-	shouldPaceOncer     sync.Once
-)
-
-func newPageBlobAutoPacer(bytesPerSecond int64, expectedBytesPerRequest int64, isFair bool, logger common.ILogger) autopacer {
-
-	shouldPaceOncer.Do(func() {
-		raw := common.GetEnvironmentVariable(common.EEnvironmentVariable.PacePageBlobs())
-		shouldPacePageBlobs = strings.ToLower(raw) != "false"
-	})
-
-	if shouldPacePageBlobs {
-		return newAutoPacer(bytesPerSecond, expectedBytesPerRequest, isFair, logger, pageBlobThroughputTunerString)
-	}
-	return NewNullAutoPacer()
-}
-
-func newAutoPacer(bytesPerSecond int64, expectedBytesPerRequest int64, isFair bool, logger common.ILogger, logPrefix string) autopacer {
-
-	// TODO support an additive increase approach, if/when we use this pacer for account throughput as a whole?
-	//     Why is fairness important there - because there may be other instances of AzCopy hitting the same account,
-	//     so we need cross-pacer fairness.  AIMD gives that, but we are not currently using AIMD because
-	//     it requires extra work on our part to figure out what the additive value should be.
-	//     So as at mid-March 2019, we are cheating and using multiplicative increase instead, which is fine
-	//     for cases where we don't have two pacers competing to control access to the same resource
-	if isFair {
-		panic("Fair pacing requires additive increase (AIMD), which is not yet supported by this pacer")
-	}
-
-	a := &autoTokenBucketPacer{
-		tokenBucketPacer:       NewTokenBucketPacer(bytesPerSecond, expectedBytesPerRequest),
-		lastPeakBytesPerSecond: float32(bytesPerSecond),
-		done:                   make(chan struct{}),
-		logger:                 logger,
-		logPrefix:              logPrefix,
-	}
-
-	go a.rateTunerBody()
-
-	return a
-}
-
-func (a *autoTokenBucketPacer) Close() error {
-	close(a.done)
-	return a.tokenBucketPacer.Close()
-}
-
-// RetryCallback records the fact that a retry has happened
-func (a *autoTokenBucketPacer) RetryCallback() {
-	a.logger.Log(common.LogInfo, fmt.Sprintf("%s: ServerBusy (503) recorded", a.logPrefix))
-	atomic.AddInt32(&a.atomicRetriesInInterval, 1)
-}
-
-func (a *autoTokenBucketPacer) rateTunerBody() {
-	for {
-		select {
-		case <-a.done:
-			return
-		case <-time.After(tuningIntervalDuration):
-			// continue looping
-		}
-
-		retriesInCompletedInterval := atomic.SwapInt32(&a.atomicRetriesInInterval, 0)
-		if retriesInCompletedInterval > 0 {
-			a.decreaseRate()
-			a.logRate()
-		} else {
-			a.increaseRate()
-			a.logRate()
-		}
-	}
-}
-
-func (a *autoTokenBucketPacer) decreaseRate() {
-	if time.Since(a.lastPeakTime) < deadBandDuration {
-		return // don't do another decrease so soon, since doing so would cause us to overreact
-	}
-	existingRate := float32(a.targetBytesPerSecond())
-	a.lastPeakBytesPerSecond = existingRate
-	a.lastPeakTime = time.Now()
-	newRate := existingRate * decreaseFactor
-	a.tokenBucketPacer.setTargetBytesPerSecond(int64(newRate))
-}
-
-func (a *autoTokenBucketPacer) increaseRate() {
-	existingRate := float32(a.targetBytesPerSecond())
-	var newRate float32
-	switch {
-	case existingRate < stableZoneStart*a.lastPeakBytesPerSecond:
-		// fast increase when below previous peak, to get us back there (if possible) quickly, with minimal loss of throughput
-		newRate = existingRate + fastRecoveryFactor*(a.lastPeakBytesPerSecond-existingRate)
-	case existingRate < stableZoneEnd*a.lastPeakBytesPerSecond:
-		// change slowly when near last peak, since maybe that peak really does represent the best we can do
-		newRate = existingRate * (1 + stableZoneFactor)
-	default:
-		// medium-pace increase if above last peak. Because if we've actually managed to get this far above it,
-		// with no need to decrease, that indicates that last peak was probably wrong
-		// (i.e. lower than where we should be now) so move reasonably quickly to find a new peak
-		newRate = existingRate * (1 + probingFactor)
-	}
-	// Next line enforces a max because otherwise, if we are constrained by something else (e.g. disk or network)
-	// we just keep increasing our rate for ever. And if that other constraint is temporary and goes away,
-	// then suddenly well be at a crazy high rate that takes too long to step back down to reality (and or get
-	// integer overflow issues).
-	if newRate < maxPacerBytesPerSecond {
-		a.tokenBucketPacer.setTargetBytesPerSecond(int64(newRate))
-	}
-}
-
-func (a *autoTokenBucketPacer) logRate() {
-	a.logger.Log(common.LogInfo, fmt.Sprintf("%s: Target Mbps %d", a.logPrefix, (a.targetBytesPerSecond()*8)/(1000*1000)))
-}
+//
+//var (
+//	shouldPacePageBlobs bool
+//	shouldPaceOncer     sync.Once
+//)
+//
+//func newPageBlobAutoPacer(bytesPerSecond int64, expectedBytesPerRequest int64, isFair bool, logger common.ILogger) autopacer {
+//
+//	shouldPaceOncer.Do(func() {
+//		raw := common.GetEnvironmentVariable(common.EEnvironmentVariable.PacePageBlobs())
+//		shouldPacePageBlobs = strings.ToLower(raw) != "false"
+//	})
+//
+//	if shouldPacePageBlobs {
+//		return newAutoPacer(bytesPerSecond, expectedBytesPerRequest, isFair, logger, pageBlobThroughputTunerString)
+//	}
+//	return NewNullAutoPacer()
+//}
+//
+//func newAutoPacer(bytesPerSecond int64, expectedBytesPerRequest int64, isFair bool, logger common.ILogger, logPrefix string) autopacer {
+//
+//	// TODO support an additive increase approach, if/when we use this pacer for account throughput as a whole?
+//	//     Why is fairness important there - because there may be other instances of AzCopy hitting the same account,
+//	//     so we need cross-pacer fairness.  AIMD gives that, but we are not currently using AIMD because
+//	//     it requires extra work on our part to figure out what the additive value should be.
+//	//     So as at mid-March 2019, we are cheating and using multiplicative increase instead, which is fine
+//	//     for cases where we don't have two pacers competing to control access to the same resource
+//	if isFair {
+//		panic("Fair pacing requires additive increase (AIMD), which is not yet supported by this pacer")
+//	}
+//
+//	a := &autoTokenBucketPacer{
+//		tokenBucketPacer:       NewTokenBucketPacer(bytesPerSecond, expectedBytesPerRequest),
+//		lastPeakBytesPerSecond: float32(bytesPerSecond),
+//		done:                   make(chan struct{}),
+//		logger:                 logger,
+//		logPrefix:              logPrefix,
+//	}
+//
+//	go a.rateTunerBody()
+//
+//	return a
+//}
+//
+//func (a *autoTokenBucketPacer) Close() error {
+//	close(a.done)
+//	return a.tokenBucketPacer.Close()
+//}
+//
+//// RetryCallback records the fact that a retry has happened
+//func (a *autoTokenBucketPacer) RetryCallback() {
+//	a.logger.Log(common.LogInfo, fmt.Sprintf("%s: ServerBusy (503) recorded", a.logPrefix))
+//	atomic.AddInt32(&a.atomicRetriesInInterval, 1)
+//}
+//
+//func (a *autoTokenBucketPacer) rateTunerBody() {
+//	for {
+//		select {
+//		case <-a.done:
+//			return
+//		case <-time.After(tuningIntervalDuration):
+//			// continue looping
+//		}
+//
+//		retriesInCompletedInterval := atomic.SwapInt32(&a.atomicRetriesInInterval, 0)
+//		if retriesInCompletedInterval > 0 {
+//			a.decreaseRate()
+//			a.logRate()
+//		} else {
+//			a.increaseRate()
+//			a.logRate()
+//		}
+//	}
+//}
+//
+//func (a *autoTokenBucketPacer) decreaseRate() {
+//	if time.Since(a.lastPeakTime) < deadBandDuration {
+//		return // don't do another decrease so soon, since doing so would cause us to overreact
+//	}
+//	existingRate := float32(a.targetBytesPerSecond())
+//	a.lastPeakBytesPerSecond = existingRate
+//	a.lastPeakTime = time.Now()
+//	newRate := existingRate * decreaseFactor
+//	a.tokenBucketPacer.setTargetBytesPerSecond(int64(newRate))
+//}
+//
+//func (a *autoTokenBucketPacer) increaseRate() {
+//	existingRate := float32(a.targetBytesPerSecond())
+//	var newRate float32
+//	switch {
+//	case existingRate < stableZoneStart*a.lastPeakBytesPerSecond:
+//		// fast increase when below previous peak, to get us back there (if possible) quickly, with minimal loss of throughput
+//		newRate = existingRate + fastRecoveryFactor*(a.lastPeakBytesPerSecond-existingRate)
+//	case existingRate < stableZoneEnd*a.lastPeakBytesPerSecond:
+//		// change slowly when near last peak, since maybe that peak really does represent the best we can do
+//		newRate = existingRate * (1 + stableZoneFactor)
+//	default:
+//		// medium-pace increase if above last peak. Because if we've actually managed to get this far above it,
+//		// with no need to decrease, that indicates that last peak was probably wrong
+//		// (i.e. lower than where we should be now) so move reasonably quickly to find a new peak
+//		newRate = existingRate * (1 + probingFactor)
+//	}
+//	// Next line enforces a max because otherwise, if we are constrained by something else (e.g. disk or network)
+//	// we just keep increasing our rate for ever. And if that other constraint is temporary and goes away,
+//	// then suddenly well be at a crazy high rate that takes too long to step back down to reality (and or get
+//	// integer overflow issues).
+//	if newRate < maxPacerBytesPerSecond {
+//		a.tokenBucketPacer.setTargetBytesPerSecond(int64(newRate))
+//	}
+//}
+//
+//func (a *autoTokenBucketPacer) logRate() {
+//	a.logger.Log(common.LogInfo, fmt.Sprintf("%s: Target Mbps %d", a.logPrefix, (a.targetBytesPerSecond()*8)/(1000*1000)))
+//}

--- a/ste/pacer-nullPolicyPacer.go
+++ b/ste/pacer-nullPolicyPacer.go
@@ -1,0 +1,68 @@
+package ste
+
+import (
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"io"
+	"net/http"
+	"sync/atomic"
+)
+
+type NullPolicyPacer struct {
+	processedBytes common.AtomicNumeric[uint64]
+}
+
+func NewNullPolicyPacer() RequestPolicyPacer {
+	return &NullPolicyPacer{
+		processedBytes: &atomic.Uint64{},
+	}
+}
+
+func (n *NullPolicyPacer) GetPacedRequestBody(body io.ReadSeekCloser, contentLength uint64) io.ReadSeekCloser {
+	return body
+}
+
+func (n *NullPolicyPacer) GetPacedResponseBody(body io.ReadCloser, contentLength uint64) io.ReadCloser {
+	return body
+}
+
+func (n *NullPolicyPacer) UpdateTargetBytesPerSecond(bytesPerSecond uint64) {}
+
+func (n *NullPolicyPacer) ProcessBytes(u uint64) {
+	n.processedBytes.Add(u)
+}
+
+func (n *NullPolicyPacer) UndoBytes(u uint64) {
+	common.AtomicSubtract(n.processedBytes, u)
+}
+
+func (n *NullPolicyPacer) ReturnBytes(u uint64) {}
+
+func (n *NullPolicyPacer) GetPolicy() policy.Policy {
+	return &nullPacerPolicy{}
+}
+
+func (n *NullPolicyPacer) GetTotalTraffic() uint64 {
+	return n.processedBytes.Load()
+}
+
+func (n *NullPolicyPacer) Cleanup() {}
+
+type nullPacerPolicy struct {
+	parent *NullPolicyPacer
+}
+
+func (n nullPacerPolicy) Do(req *policy.Request) (*http.Response, error) {
+	reqBytes := uint64(max(req.Raw().ContentLength, 0))
+	n.parent.ProcessBytes(reqBytes)
+
+	resp, err := req.Next()
+
+	if resp != nil {
+		n.parent.ProcessBytes(uint64(max(resp.ContentLength, 0)))
+	} else if err == nil {
+		n.parent.ReturnBytes(reqBytes)
+	}
+
+	return resp, err
+}

--- a/ste/pacer-policy-autoPacer.go
+++ b/ste/pacer-policy-autoPacer.go
@@ -1,0 +1,93 @@
+package ste
+
+import (
+	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"net/http"
+	"sync/atomic"
+	"time"
+)
+
+var PolicyAutoPacerKey = func() any {
+	type PolicyAutoPacerKey struct{}
+
+	return &PolicyAutoPacerKey{}
+}()
+
+const ( // values copied from old autoPacer code
+	tuningIntervalDuration = time.Second
+
+	deadBandDuration = 20 * time.Second // TODO: review this rather generous value.  Might not be needed if we can pace the internal retry efforts inside the retryPolices, because we (presumably) won't get such big flurries of 503s if we do that
+
+	decreaseFactor = 0.65
+
+	// These increase factors were prototyped in a Excel sheet, then tweaked after live testing.
+	// In "steady state" we would expect one decrease every few minutes, with most of the time spent close to the optimal rate.
+	// (And yes, the shape of the resulting speed curve is at least superficially similar to that used by modern TCP variants,
+	// for the same reason, which is that we want slow change when near the last-known "best" level.)
+	fastRecoveryFactor = 0.1
+	probingFactor      = 0.015
+	stableZoneFactor   = probingFactor / 10
+	stableZoneStart    = 0.95
+	stableZoneEnd      = 1.05
+
+	pageBlobThroughputTunerString = "Page blob throughput tuner"
+
+	maxPacerGbps           = 100
+	maxPacerBytesPerSecond = maxPacerGbps * 1000 * 1000 * 1000 / 8
+)
+
+// RequestPolicyAutoPacer adapts the functionality of the old autoPacer onto
+// the new RequestPolicyPacer architecture.
+type RequestPolicyAutoPacer struct {
+	RequestPolicyPacer
+
+	cancelFunc             context.CancelFunc
+	retriesInterval        common.AtomicNumeric[int32]
+	lastPeakBytesPerSecond float32
+	lastPeakTime           time.Time
+
+	logger    common.ILogger
+	logPrefix string
+}
+
+func NewRequestPolicyAutoPacer(targetBytesPerSecond uint64) RequestPolicyPacer {
+	pacer := NewRequestPolicyPacer(targetBytesPerSecond)
+
+	return &RequestPolicyAutoPacer{
+		RequestPolicyPacer: pacer,
+
+		cancelFunc:      func() {},
+		retriesInterval: &atomic.Int32{},
+	}
+}
+
+func (r *RequestPolicyAutoPacer) GetPolicy() policy.Policy {
+	corePolicy := r.RequestPolicyPacer.GetPolicy()
+
+	return &autoPacerPolicy{
+		p:      corePolicy,
+		parent: r,
+	}
+}
+
+func (r *RequestPolicyAutoPacer) Cleanup() {
+	r.cancelFunc()
+	r.RequestPolicyPacer.Cleanup()
+}
+
+type autoPacerPolicy struct {
+	p      policy.Policy
+	parent *RequestPolicyAutoPacer
+}
+
+func (p *autoPacerPolicy) Do(req *policy.Request) (*http.Response, error) {
+	resp, err := p.p.Do(req)
+
+	if resp != nil && resp.StatusCode == http.StatusServiceUnavailable {
+		p.parent.retriesInterval.Add(1)
+	}
+
+	return resp, err
+}

--- a/ste/pacer-requestPolicyPacer-body.go
+++ b/ste/pacer-requestPolicyPacer-body.go
@@ -1,0 +1,250 @@
+package ste
+
+import (
+	"errors"
+	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/google/uuid"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type BodyStatus int8
+
+const (
+	PacedBodyInactivityTimeout = time.Minute * 3
+
+	BodyStatusNew         BodyStatus = 0
+	BodyStatusAllocated   BodyStatus = 1
+	BodyStatusDeallocated BodyStatus = -1
+)
+
+func (r *requestPolicyPacer) GetPacedRequestBody(body io.ReadSeekCloser) (io.ReadSeekCloser, error) {
+	n, err := body.Seek(0, io.SeekEnd) // find the length of the body
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = body.Seek(0, io.SeekStart)
+	if err != nil {
+		return nil, err
+	}
+
+	pacedBody := newPolicyPacerBody(r, body, uint64(n))
+
+	pacedBody.bodySeekable = true
+
+	r.requestInitChannel <- pacedBody
+
+	if !r.manualTick {
+		pacedBody.AwaitFlight()
+	}
+
+	r.allocationRequestchannel <- struct {
+		pacerID uuid.UUID
+		size    uint64
+	}{pacerID: pacedBody.id, size: uint64(max(n, 0)) + 1}
+
+	return &policyPacerRequestBody{body, pacedBody}, nil
+}
+
+func (r *requestPolicyPacer) GetPacedResponseBody(body io.ReadCloser, contentLength uint64) (io.ReadCloser, error) {
+	pacedBody := newPolicyPacerBody(r, body, contentLength)
+
+	// This makes a strong assumption that nobody will misuse this API!
+	// Responses aren't paced like requests,
+	// because if they were, it'd unnecessarily extend request lifetime.
+	r.respInitChannel <- pacedBody
+
+	if !r.manualTick {
+		pacedBody.AwaitFlight()
+	}
+
+	r.allocationRequestchannel <- struct {
+		pacerID uuid.UUID
+		size    uint64
+	}{pacerID: pacedBody.id, size: contentLength}
+
+	return pacedBody, nil
+}
+
+type policyPacerBody struct {
+	parent *requestPolicyPacer
+	id     uuid.UUID
+
+	body               io.ReadCloser
+	bodySeekable       bool
+	bodyDeallocateOnce *sync.Once
+	respDeallocateOnce *sync.Once
+
+	timeout *time.Timer
+
+	bodySize       uint64
+	readHead       common.AtomicNumeric[uint64]
+	allocatedBytes common.AtomicNumeric[uint64]
+
+	bodyStatus common.Atomic[*BodyStatus]
+
+	allocationChannel chan uint64
+}
+
+func newPolicyPacerBody(parent *requestPolicyPacer, body io.ReadCloser, contentLength uint64) *policyPacerBody {
+	_, bodySeekable := body.(io.Seeker)
+
+	pBody := &policyPacerBody{
+		parent: parent,
+
+		id: uuid.New(),
+
+		body:               body,
+		bodySeekable:       bodySeekable,
+		bodyDeallocateOnce: &sync.Once{},
+		respDeallocateOnce: &sync.Once{},
+
+		bodyStatus: &atomic.Pointer[BodyStatus]{},
+
+		bodySize:       contentLength,
+		readHead:       &atomic.Uint64{},
+		allocatedBytes: &atomic.Uint64{},
+
+		allocationChannel: make(chan uint64, 100),
+	}
+
+	pBody.bodyStatus.Store(to.Ptr(BodyStatusNew))
+	pBody.setupTimeout(contentLength)
+
+	return pBody
+}
+
+// AwaitFlight should be called before calling Read for the first time.
+func (b *policyPacerBody) AwaitFlight() {
+	b.timeout.Stop()
+	defer b.timeout.Reset(PacedBodyInactivityTimeout)
+
+	for {
+		if *b.bodyStatus.Load() != BodyStatusNew {
+			return
+		}
+
+		time.Sleep(PacerTickrate)
+	}
+}
+
+func (b *policyPacerBody) Read(p []byte) (n int, err error) {
+	b.timeout.Stop()
+	defer b.timeout.Reset(PacedBodyInactivityTimeout)
+	for loop, writeHead := 0, 0; writeHead < len(p); loop++ {
+		allocu64 := b.captureAllocations(true)
+		// Pull only what we need for this read from our real allocation pool
+		allocation := int(min(allocu64, uint64(len(p)-writeHead)))
+
+		if allocation < 0 {
+			allocation = len(p)
+		} else if allocation == 0 {
+			continue
+		}
+
+		window := p[writeHead : writeHead+allocation]
+		n, err = b.body.Read(window)
+
+		writeHead += n
+		b.parent.ProcessBytes(uint64(n))
+		readHead := b.readHead.Add(uint64(n))
+		common.AtomicSubtract(b.allocatedBytes, uint64(n))
+
+		if readHead == b.bodySize {
+			return writeHead, io.EOF
+		}
+
+		if err != nil {
+			if n < allocation { // If we didn't use the entire allocation, return what's left.
+				b.parent.ReturnBytes(uint64(allocation - n))
+			}
+
+			if errors.Is(err, io.EOF) {
+				return writeHead, io.EOF
+			}
+
+			return writeHead, fmt.Errorf(
+				"failed to read %d bytes on loop %d (%d/%d bytes for this read): %w",
+				allocation, loop, writeHead, len(p), err)
+		}
+	}
+
+	return len(p), nil
+}
+
+func (b *policyPacerBody) Close() error {
+	b.Deallocate() // Timer is stopped by deallocate
+	return b.body.Close()
+}
+
+func (b *policyPacerBody) Deallocate() {
+	b.timeout.Stop()
+	b.bodyDeallocateOnce.Do(func() {
+		b.parent.pacerExitChannel <- b
+	})
+}
+
+func (b *policyPacerBody) setupTimeout(contentLength uint64) {
+	// If a body sits idle for an especially long time, with no attempted read,
+	// this is extremely abnormal. It probably should be disposed of because somebody forgot to close it.
+	b.timeout = time.AfterFunc(PacedBodyInactivityTimeout, func() {
+		_ = b.Close()
+	})
+}
+
+// captureAllocations does a non-blocking capture of allocations present on the channel
+// unless specified, in which case it blocks until it has any allocation available.
+func (b *policyPacerBody) captureAllocations(blocking ...bool) uint64 {
+	toBlock := false
+	if len(blocking) > 0 {
+		toBlock = blocking[0]
+	}
+
+	var out = b.allocatedBytes.Load()
+	if toBlock && out == 0 {
+		out = b.allocatedBytes.Add(uint64(<-b.allocationChannel))
+	}
+
+	for {
+		select {
+		case alloc := <-b.allocationChannel:
+			out = b.allocatedBytes.Add(uint64(alloc))
+		default:
+			return out
+		}
+	}
+}
+
+type policyPacerRequestBody struct {
+	seeker io.Seeker
+	*policyPacerBody
+}
+
+func (b *policyPacerRequestBody) Seek(offset int64, whence int) (int64, error) {
+	b.timeout.Reset(PacedBodyInactivityTimeout)
+
+	// For bodies
+	if !b.bodySeekable {
+		return 0, errors.New("can't seek a non-seekable body")
+	}
+
+	n, err := b.seeker.Seek(offset, whence)
+	b.readHead.Store(uint64(n))
+	return n, err
+}
+
+func (b *policyPacerRequestBody) DeallocateResponse() {
+	b.respDeallocateOnce.Do(func() {
+		common.AtomicSubtract(b.parent.allocatedBytesPerSecond, RequestMinimumBytesPerSecond)
+	})
+}
+
+type pacerBodyAllocationBucket struct {
+	Requested int64
+	Allocated int64
+}

--- a/ste/pacer-tokenBucketPacer.go
+++ b/ste/pacer-tokenBucketPacer.go
@@ -1,212 +1,212 @@
-// Copyright © 2017 Microsoft <wastore@microsoft.com>
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-
+// // Copyright © 2017 Microsoft <wastore@microsoft.com>
+// //
+// // Permission is hereby granted, free of charge, to any person obtaining a copy
+// // of this software and associated documentation files (the "Software"), to deal
+// // in the Software without restriction, including without limitation the rights
+// // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// // copies of the Software, and to permit persons to whom the Software is
+// // furnished to do so, subject to the following conditions:
+// //
+// // The above copyright notice and this permission notice shall be included in
+// // all copies or substantial portions of the Software.
+// //
+// // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// // THE SOFTWARE.
 package ste
 
-import (
-	"context"
-	"errors"
-	"sync/atomic"
-	"time"
-
-	"github.com/Azure/azure-storage-azcopy/v10/common"
-)
-
-// pacer is used by callers whose activity must be controlled to a certain pace
-type pacer interface {
-
-	// RequestTrafficAllocation blocks until the caller is allowed to process byteCount bytes.
-	RequestTrafficAllocation(ctx context.Context, byteCount int64) error
-
-	UpdateTargetBytesPerSecond(newTarget int64)
-
-	// UndoRequest reverses a previous request to process n bytes.  Is used when
-	// the caller did not need all of the allocation they previously requested
-	// e.g. when they asked for enough for a big buffer, but never filled it, they would
-	// call this method to return the unused portion.
-	UndoRequest(byteCount int64)
-
-	Close() error
-}
-
-type PacerAdmin interface {
-	pacer
-
-	// GetTotalTraffic returns the cumulative count of all traffic that has been processed
-	GetTotalTraffic() int64
-}
-
-const (
-	// How long to sleep in the loop that puts tokens into the bucket
-	bucketFillSleepDuration = time.Duration(float32(time.Second) * 0.1)
-
-	// How long to sleep when reading from the bucket and finding there's not enough tokens
-	bucketDrainSleepDuration = time.Duration(float32(time.Second) * 0.333)
-
-	// Controls the max amount by which the contents of the token bucket can build up, unused.
-	maxSecondsToOverpopulateBucket = 2.5 // had 5, when doing coarse-grained pacing. TODO: find best all-round value, or parameterize
-)
-
-// tokenBucketPacer allows us to control the pace of an activity, using a basic token bucket algorithm.
-// The target rate is fixed, but can be modified at any time through SetTargetBytesPerSecond
-type tokenBucketPacer struct {
-	atomicTokenBucket          int64
-	atomicTargetBytesPerSecond int64
-	atomicGrandTotal           int64
-	atomicWaitCount            int64
-	expectedBytesPerRequest    int64
-	newTargetBytesPerSecond    chan int64
-	done                       chan struct{}
-}
-
-func NewTokenBucketPacer(bytesPerSecond int64, expectedBytesPerCoarseRequest int64) *tokenBucketPacer {
-	p := &tokenBucketPacer{atomicTokenBucket: bytesPerSecond / 4, // seed it immediately with part-of-a-second's worth, to avoid a sluggish start
-		atomicTargetBytesPerSecond: bytesPerSecond,
-		expectedBytesPerRequest:    int64(expectedBytesPerCoarseRequest),
-		done:                       make(chan struct{}),
-		newTargetBytesPerSecond:    make(chan int64),
-	}
-
-	go p.pacerBody()
-
-	return p
-}
-
-// RequestTrafficAllocation function is called by goroutines to request right to send a certain amount of bytes.
-// It controls their rate by blocking until they are allowed to proceed
-func (p *tokenBucketPacer) RequestTrafficAllocation(ctx context.Context, byteCount int64) error {
-	targetBytes := p.targetBytesPerSecond()
-	//if targetBytesIsZero, we have a null pacer, we just track GrandTotal
-	if targetBytes == 0 {
-		atomic.AddInt64(&p.atomicGrandTotal, byteCount)
-		return nil
-	}
-
-	if targetBytes < byteCount {
-		return errors.New("request size greater than pacer target")
-	}
-
-	// block until tokens are available
-	for atomic.AddInt64(&p.atomicTokenBucket, -byteCount) < 0 {
-
-		// by taking our desired count we've moved below zero, which means our allocation is not available
-		// right now, so put back what we asked for, and then wait
-		atomic.AddInt64(&p.atomicTokenBucket, byteCount)
-
-		// vary the wait amount, to reduce risk of any kind of pulsing or synchronization effect, without the perf and
-		// and threadsafety issues of actual random numbers
-		totalWaitsSoFar := atomic.AddInt64(&p.atomicWaitCount, 1)
-		modifiedSleepDuration := time.Duration(float32(bucketDrainSleepDuration) * (float32(totalWaitsSoFar%10) + 5) / 10) // 50 to 150% of bucketDrainSleepDuration
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(modifiedSleepDuration):
-			// keep looping
-		}
-		
-		// If we've updated target to a NULL pacer, we'll return immediately
-		if p.targetBytesPerSecond() == 0 {
-			atomic.AddInt64(&p.atomicGrandTotal, byteCount)
-			return nil
-		}
-
-	}
-
-	// record what we issued
-	atomic.AddInt64(&p.atomicGrandTotal, byteCount)
-
-	return nil
-}
-
-// UndoRequest allows a caller to return unused tokens
-func (p *tokenBucketPacer) UndoRequest(byteCount int64) {
-	if byteCount > 0 {
-		atomic.AddInt64(&p.atomicTokenBucket, byteCount) // put them back in the bucket
-		atomic.AddInt64(&p.atomicGrandTotal, -byteCount) // deduct them from all-time issued count
-	}
-}
-
-func (p *tokenBucketPacer) Close() error {
-	close(p.done)
-	return nil
-}
-
-func (p *tokenBucketPacer) pacerBody() {
-	lastTime := time.Now()
-
-	lastTargetUpdateTime := time.Now()
-	newTarget := p.targetBytesPerSecond()
-	for {
-
-		select {
-		case <-p.done:
-			return
-		case newTarget = <- p.newTargetBytesPerSecond:
-		default:
-		}
-
-		/*check if we have to update target rate */
-		if newTarget != p.targetBytesPerSecond() && time.Since(lastTargetUpdateTime) >= deadBandDuration {
-			p.setTargetBytesPerSecond(newTarget)
-			lastTargetUpdateTime = time.Now()
-		}
-
-		currentTarget := atomic.LoadInt64(&p.atomicTargetBytesPerSecond)
-		time.Sleep(bucketFillSleepDuration)
-		elapsedSeconds := time.Since(lastTime).Seconds()
-		bytesToRelease := int64(float64(currentTarget) * elapsedSeconds)
-		newTokenCount := atomic.AddInt64(&p.atomicTokenBucket, bytesToRelease)
-
-		// If the backlog of unsent bytes is now too great, then trim it back down.
-		// Why don't we want a big backlog? Because it limits our ability to accurately control the speed.
-		maxAllowedUnsentBytes := int64(float32(currentTarget) * maxSecondsToOverpopulateBucket)
-		if maxAllowedUnsentBytes < p.expectedBytesPerRequest {
-			maxAllowedUnsentBytes = p.expectedBytesPerRequest // just in case we are very coarse grained at a very slow speed
-		}
-		if newTokenCount > maxAllowedUnsentBytes {
-			common.AtomicMorphInt64(&p.atomicTokenBucket, func(currentVal int64) (newVal int64, _ interface{}) {
-				newVal = currentVal
-				if currentVal > maxAllowedUnsentBytes {
-					newVal = maxAllowedUnsentBytes
-				}
-				return
-			})
-		}
-
-		lastTime = time.Now()
-	}
-}
-
-func (p *tokenBucketPacer) targetBytesPerSecond() int64 {
-	return atomic.LoadInt64(&p.atomicTargetBytesPerSecond)
-}
-
-func (p *tokenBucketPacer) setTargetBytesPerSecond(value int64) {
-	atomic.StoreInt64(&p.atomicTargetBytesPerSecond, value)
-}
-
-func (p *tokenBucketPacer) UpdateTargetBytesPerSecond(value int64) {
-	p.newTargetBytesPerSecond <- value
-}
-
-func (p *tokenBucketPacer) GetTotalTraffic() int64 {
-	return atomic.LoadInt64(&p.atomicGrandTotal)
-}
+//
+//import (
+//	"context"
+//	"errors"
+//	"sync/atomic"
+//	"time"
+//
+//	"github.com/Azure/azure-storage-azcopy/v10/common"
+//)
+//
+//// pacer is used by callers whose activity must be controlled to a certain pace
+//type pacer interface {
+//
+//	// RequestTrafficAllocation blocks until the caller is allowed to process byteCount bytes.
+//	RequestTrafficAllocation(ctx context.Context, byteCount int64) error
+//
+//	UpdateTargetBytesPerSecond(newTarget int64)
+//
+//	// UndoRequest reverses a previous request to process n bytes.  Is used when
+//	// the caller did not need all of the allocation they previously requested
+//	// e.g. when they asked for enough for a big buffer, but never filled it, they would
+//	// call this method to return the unused portion.
+//	UndoRequest(byteCount int64)
+//
+//	Close() error
+//}
+//
+//type PacerAdmin interface {
+//	pacer
+//
+//	// GetTotalTraffic returns the cumulative count of all traffic that has been processed
+//	GetTotalTraffic() int64
+//}
+//
+//const (
+//	// How long to sleep in the loop that puts tokens into the bucket
+//	bucketFillSleepDuration = time.Duration(float32(time.Second) * 0.1)
+//
+//	// How long to sleep when reading from the bucket and finding there's not enough tokens
+//	bucketDrainSleepDuration = time.Duration(float32(time.Second) * 0.333)
+//
+//	// Controls the max amount by which the contents of the token bucket can build up, unused.
+//	maxSecondsToOverpopulateBucket = 2.5 // had 5, when doing coarse-grained pacing. TODO: find best all-round value, or parameterize
+//)
+//
+//// tokenBucketPacer allows us to control the pace of an activity, using a basic token bucket algorithm.
+//// The target rate is fixed, but can be modified at any time through SetTargetBytesPerSecond
+//type tokenBucketPacer struct {
+//	atomicTokenBucket          int64
+//	atomicTargetBytesPerSecond int64
+//	atomicGrandTotal           int64
+//	atomicWaitCount            int64
+//	expectedBytesPerRequest    int64
+//	newTargetBytesPerSecond    chan int64
+//	done                       chan struct{}
+//}
+//
+//func NewTokenBucketPacer(bytesPerSecond int64, expectedBytesPerCoarseRequest int64) *tokenBucketPacer {
+//	p := &tokenBucketPacer{atomicTokenBucket: bytesPerSecond / 4, // seed it immediately with part-of-a-second's worth, to avoid a sluggish start
+//		atomicTargetBytesPerSecond: bytesPerSecond,
+//		expectedBytesPerRequest:    int64(expectedBytesPerCoarseRequest),
+//		done:                       make(chan struct{}),
+//		newTargetBytesPerSecond:    make(chan int64),
+//	}
+//
+//	go p.pacerBody()
+//
+//	return p
+//}
+//
+//// RequestTrafficAllocation function is called by goroutines to request right to send a certain amount of bytes.
+//// It controls their rate by blocking until they are allowed to proceed
+//func (p *tokenBucketPacer) RequestTrafficAllocation(ctx context.Context, byteCount int64) error {
+//	targetBytes := p.targetBytesPerSecond()
+//	//if targetBytesIsZero, we have a null pacer, we just track GrandTotal
+//	if targetBytes == 0 {
+//		atomic.AddInt64(&p.atomicGrandTotal, byteCount)
+//		return nil
+//	}
+//
+//	if targetBytes < byteCount {
+//		return errors.New("request size greater than pacer target")
+//	}
+//
+//	// block until tokens are available
+//	for atomic.AddInt64(&p.atomicTokenBucket, -byteCount) < 0 {
+//
+//		// by taking our desired count we've moved below zero, which means our allocation is not available
+//		// right now, so put back what we asked for, and then wait
+//		atomic.AddInt64(&p.atomicTokenBucket, byteCount)
+//
+//		// vary the wait amount, to reduce risk of any kind of pulsing or synchronization effect, without the perf and
+//		// and threadsafety issues of actual random numbers
+//		totalWaitsSoFar := atomic.AddInt64(&p.atomicWaitCount, 1)
+//		modifiedSleepDuration := time.Duration(float32(bucketDrainSleepDuration) * (float32(totalWaitsSoFar%10) + 5) / 10) // 50 to 150% of bucketDrainSleepDuration
+//
+//		select {
+//		case <-ctx.Done():
+//			return ctx.Err()
+//		case <-time.After(modifiedSleepDuration):
+//			// keep looping
+//		}
+//
+//		// If we've updated target to a NULL pacer, we'll return immediately
+//		if p.targetBytesPerSecond() == 0 {
+//			atomic.AddInt64(&p.atomicGrandTotal, byteCount)
+//			return nil
+//		}
+//
+//	}
+//
+//	// record what we issued
+//	atomic.AddInt64(&p.atomicGrandTotal, byteCount)
+//
+//	return nil
+//}
+//
+//// UndoRequest allows a caller to return unused tokens
+//func (p *tokenBucketPacer) UndoRequest(byteCount int64) {
+//	if byteCount > 0 {
+//		atomic.AddInt64(&p.atomicTokenBucket, byteCount) // put them back in the bucket
+//		atomic.AddInt64(&p.atomicGrandTotal, -byteCount) // deduct them from all-time issued count
+//	}
+//}
+//
+//func (p *tokenBucketPacer) Close() error {
+//	close(p.done)
+//	return nil
+//}
+//
+//func (p *tokenBucketPacer) pacerBody() {
+//	lastTime := time.Now()
+//
+//	lastTargetUpdateTime := time.Now()
+//	newTarget := p.targetBytesPerSecond()
+//	for {
+//
+//		select {
+//		case <-p.done:
+//			return
+//		case newTarget = <- p.newTargetBytesPerSecond:
+//		default:
+//		}
+//
+//		/*check if we have to update target rate */
+//		if newTarget != p.targetBytesPerSecond() && time.Since(lastTargetUpdateTime) >= deadBandDuration {
+//			p.setTargetBytesPerSecond(newTarget)
+//			lastTargetUpdateTime = time.Now()
+//		}
+//
+//		currentTarget := atomic.LoadInt64(&p.atomicTargetBytesPerSecond)
+//		time.Sleep(bucketFillSleepDuration)
+//		elapsedSeconds := time.Since(lastTime).Seconds()
+//		bytesToRelease := int64(float64(currentTarget) * elapsedSeconds)
+//		newTokenCount := atomic.AddInt64(&p.atomicTokenBucket, bytesToRelease)
+//
+//		// If the backlog of unsent bytes is now too great, then trim it back down.
+//		// Why don't we want a big backlog? Because it limits our ability to accurately control the speed.
+//		maxAllowedUnsentBytes := int64(float32(currentTarget) * maxSecondsToOverpopulateBucket)
+//		if maxAllowedUnsentBytes < p.expectedBytesPerRequest {
+//			maxAllowedUnsentBytes = p.expectedBytesPerRequest // just in case we are very coarse grained at a very slow speed
+//		}
+//		if newTokenCount > maxAllowedUnsentBytes {
+//			common.AtomicMorphInt64(&p.atomicTokenBucket, func(currentVal int64) (newVal int64, _ interface{}) {
+//				newVal = currentVal
+//				if currentVal > maxAllowedUnsentBytes {
+//					newVal = maxAllowedUnsentBytes
+//				}
+//				return
+//			})
+//		}
+//
+//		lastTime = time.Now()
+//	}
+//}
+//
+//func (p *tokenBucketPacer) targetBytesPerSecond() int64 {
+//	return atomic.LoadInt64(&p.atomicTargetBytesPerSecond)
+//}
+//
+//func (p *tokenBucketPacer) setTargetBytesPerSecond(value int64) {
+//	atomic.StoreInt64(&p.atomicTargetBytesPerSecond, value)
+//}
+//
+//func (p *tokenBucketPacer) UpdateTargetBytesPerSecond(value int64) {
+//	p.newTargetBytesPerSecond <- value
+//}
+//
+//func (p *tokenBucketPacer) GetTotalTraffic() int64 {
+//	return atomic.LoadInt64(&p.atomicGrandTotal)
+//}

--- a/ste/policy-conditionWrapper.go
+++ b/ste/policy-conditionWrapper.go
@@ -1,0 +1,31 @@
+package ste
+
+import (
+	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"net/http"
+)
+
+// PolicyInjector creates an open slot in a pipeline in which a
+// policy can be retroactively injected into an existing pipeline
+type PolicyInjector struct {
+	policyKey any
+}
+
+func NewPolicyInjector(key any) policy.Policy {
+	return &PolicyInjector{key}
+}
+
+func (p *PolicyInjector) Do(req *policy.Request) (*http.Response, error) {
+	ctx := req.Raw().Context()
+
+	newPolicy := ctx.Value(p.policyKey)
+
+	if pol, ok := newPolicy.(policy.Policy); ok {
+		return pol.Do(req)
+	} else if pol != nil {
+		return nil, fmt.Errorf("supplied policy for key %v was not a policy.Policy but a %v", p.policyKey, newPolicy)
+	}
+
+	return req.Next()
+}

--- a/ste/s2sCopier-URLToBlob.go
+++ b/ste/s2sCopier-URLToBlob.go
@@ -33,7 +33,7 @@ import (
 var LogBlobConversionOnce = &sync.Once{}
 
 // Creates the right kind of URL to blob copier, based on the blob type of the source
-func newURLToBlobCopier(jptm IJobPartTransferMgr, destination string, pacer pacer, sip ISourceInfoProvider) (sender, error) {
+func newURLToBlobCopier(jptm IJobPartTransferMgr, destination string, sip ISourceInfoProvider) (sender, error) {
 	srcInfoProvider := sip.(IRemoteSourceInfoProvider) // "downcast" to the type we know it really has
 
 	// If our destination is a dfs endpoint, make an attempt to cast it to the blob endpoint
@@ -110,11 +110,11 @@ func newURLToBlobCopier(jptm IJobPartTransferMgr, destination string, pacer pace
 
 	switch targetBlobType {
 	case blob.BlobTypeBlockBlob:
-		return newURLToBlockBlobCopier(jptm, pacer, srcInfoProvider)
+		return newURLToBlockBlobCopier(jptm, srcInfoProvider)
 	case blob.BlobTypeAppendBlob:
-		return newURLToAppendBlobCopier(jptm, destination, pacer, srcInfoProvider)
+		return newURLToAppendBlobCopier(jptm, destination, srcInfoProvider)
 	case blob.BlobTypePageBlob:
-		return newURLToPageBlobCopier(jptm, destination, pacer, srcInfoProvider)
+		return newURLToPageBlobCopier(jptm, destination, srcInfoProvider)
 	default:
 		if jptm.ShouldLog(common.LogDebug) { // To save fmt.Sprintf
 			jptm.LogTransferInfo(
@@ -123,6 +123,6 @@ func newURLToBlobCopier(jptm IJobPartTransferMgr, destination string, pacer pace
 				destination,
 				fmt.Sprintf("BlobType %q is used for destination blob by default.", blob.BlobTypeBlockBlob))
 		}
-		return newURLToBlockBlobCopier(jptm, pacer, srcInfoProvider)
+		return newURLToBlockBlobCopier(jptm, srcInfoProvider)
 	}
 }

--- a/ste/sender-appendBlob.go
+++ b/ste/sender-appendBlob.go
@@ -43,7 +43,7 @@ type appendBlobSenderBase struct {
 	destAppendBlobClient *appendblob.Client
 	chunkSize            int64
 	numChunks            uint32
-	pacer                pacer
+
 	// Headers and other info that we will apply to the destination
 	// object. For S2S, these come from the source service.
 	// When sending local data, they are computed based on
@@ -59,7 +59,7 @@ type appendBlobSenderBase struct {
 
 type appendBlockFunc = func()
 
-func newAppendBlobSenderBase(jptm IJobPartTransferMgr, destination string, pacer pacer, srcInfoProvider ISourceInfoProvider) (*appendBlobSenderBase, error) {
+func newAppendBlobSenderBase(jptm IJobPartTransferMgr, destination string, srcInfoProvider ISourceInfoProvider) (*appendBlobSenderBase, error) {
 	transferInfo := jptm.Info()
 
 	// compute chunk count
@@ -90,7 +90,6 @@ func newAppendBlobSenderBase(jptm IJobPartTransferMgr, destination string, pacer
 		destAppendBlobClient:   destAppendBlobClient,
 		chunkSize:              chunkSize,
 		numChunks:              numChunks,
-		pacer:                  pacer,
 		headersToApply:         props.SrcHTTPHeaders.ToBlobHTTPHeaders(),
 		metadataToApply:        props.SrcMetadata,
 		blobTagsToApply:        props.SrcBlobTags,

--- a/ste/sender-appendBlobFromURL.go
+++ b/ste/sender-appendBlobFromURL.go
@@ -32,8 +32,8 @@ type urlToAppendBlobCopier struct {
 	srcURL string
 }
 
-func newURLToAppendBlobCopier(jptm IJobPartTransferMgr, destination string, pacer pacer, srcInfoProvider IRemoteSourceInfoProvider) (s2sCopier, error) {
-	senderBase, err := newAppendBlobSenderBase(jptm, destination, pacer, srcInfoProvider)
+func newURLToAppendBlobCopier(jptm IJobPartTransferMgr, destination string, srcInfoProvider IRemoteSourceInfoProvider) (s2sCopier, error) {
+	senderBase, err := newAppendBlobSenderBase(jptm, destination, srcInfoProvider)
 	if err != nil {
 		return nil, err
 	}

--- a/ste/sender-azureFile.go
+++ b/ste/sender-azureFile.go
@@ -57,7 +57,6 @@ type azureFileSenderBase struct {
 	shareClient          *share.Client
 	chunkSize            int64
 	numChunks            uint32
-	pacer                pacer
 	ctx                  context.Context
 	sip                  ISourceInfoProvider
 	// Headers and other info that we will apply to the destination
@@ -70,7 +69,7 @@ type azureFileSenderBase struct {
 	metadataToApply      common.Metadata
 }
 
-func newAzureFileSenderBase(jptm IJobPartTransferMgr, destination string, pacer pacer, sip ISourceInfoProvider) (*azureFileSenderBase, error) {
+func newAzureFileSenderBase(jptm IJobPartTransferMgr, destination string, sip ISourceInfoProvider) (*azureFileSenderBase, error) {
 	info := jptm.Info()
 
 	// compute chunk size (irrelevant but harmless for folders)
@@ -138,7 +137,6 @@ func newAzureFileSenderBase(jptm IJobPartTransferMgr, destination string, pacer 
 		fileOrDirClient:      client,
 		chunkSize:            chunkSize,
 		numChunks:            numChunks,
-		pacer:                pacer,
 		ctx:                  jptm.Context(),
 		headersToApply:       props.SrcHTTPHeaders.ToFileHTTPHeaders(),
 		smbPropertiesToApply: file.SMBProperties{},
@@ -484,7 +482,7 @@ func (d AzureFileParentDirCreator) CreateDirToRoot(ctx context.Context, shareCli
 	if len(segments) == 0 {
 		// If we are trying to create root, perform GetProperties instead.
 		// Azure Files has delayed creation of root, and if we do not perform GetProperties,
-		// some operations like SetMetadata or SetProperties will fail. 
+		// some operations like SetMetadata or SetProperties will fail.
 		// TODO: Remove this block once the bug is fixed.
 		_, err := directoryClient.GetProperties(ctx, nil)
 		return err

--- a/ste/sender-azureFileFromURL.go
+++ b/ste/sender-azureFileFromURL.go
@@ -33,10 +33,10 @@ type urlToAzureFileCopier struct {
 	srcURL string
 }
 
-func newURLToAzureFileCopier(jptm IJobPartTransferMgr, destination string, pacer pacer, sip ISourceInfoProvider) (sender, error) {
+func newURLToAzureFileCopier(jptm IJobPartTransferMgr, destination string, sip ISourceInfoProvider) (sender, error) {
 	srcInfoProvider := sip.(IRemoteSourceInfoProvider) // "downcast" to the type we know it really has
 
-	senderBase, err := newAzureFileSenderBase(jptm, destination, pacer, sip)
+	senderBase, err := newAzureFileSenderBase(jptm, destination, sip)
 	if err != nil {
 		return nil, err
 	}

--- a/ste/sender-blobFS.go
+++ b/ste/sender-blobFS.go
@@ -53,13 +53,12 @@ type blobFSSenderBase struct {
 	parentDirClient     *directory.Client
 	chunkSize           int64
 	numChunks           uint32
-	pacer               pacer
 	creationTimeHeaders *file.HTTPHeaders
 	flushThreshold      int64
 	metadataToSet       common.Metadata
 }
 
-func newBlobFSSenderBase(jptm IJobPartTransferMgr, destination string, pacer pacer, sip ISourceInfoProvider) (*blobFSSenderBase, error) {
+func newBlobFSSenderBase(jptm IJobPartTransferMgr, destination string, sip ISourceInfoProvider) (*blobFSSenderBase, error) {
 	info := jptm.Info()
 
 	// compute chunk size and number of chunks
@@ -105,7 +104,6 @@ func newBlobFSSenderBase(jptm IJobPartTransferMgr, destination string, pacer pac
 		parentDirClient:     fsc.NewDirectoryClient(parentPath),
 		chunkSize:           chunkSize,
 		numChunks:           numChunks,
-		pacer:               pacer,
 		creationTimeHeaders: &headers,
 		flushThreshold:      chunkSize * int64(ADLSFlushThreshold),
 		metadataToSet:       props.SrcMetadata,

--- a/ste/sender-blobFSFromLocal.go
+++ b/ste/sender-blobFSFromLocal.go
@@ -32,8 +32,8 @@ type blobFSUploader struct {
 	md5Channel chan []byte
 }
 
-func newBlobFSUploader(jptm IJobPartTransferMgr, destination string, pacer pacer, sip ISourceInfoProvider) (sender, error) {
-	senderBase, err := newBlobFSSenderBase(jptm, destination, pacer, sip)
+func newBlobFSUploader(jptm IJobPartTransferMgr, destination string, sip ISourceInfoProvider) (sender, error) {
+	senderBase, err := newBlobFSSenderBase(jptm, destination, sip)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +58,7 @@ func (u *blobFSUploader) GenerateUploadFunc(id common.ChunkID, blockIndex int32,
 
 		// upload the byte range represented by this chunk
 		jptm.LogChunkStatus(id, common.EWaitReason.Body())
-		body := newPacedRequestBody(jptm.Context(), reader, u.pacer)
-		_, err := u.getFileClient().AppendData(jptm.Context(), id.OffsetInFile(), body, nil) // note: AppendData is really UpdatePath with "append" action
+		_, err := u.getFileClient().AppendData(jptm.Context(), id.OffsetInFile(), reader, nil) // note: AppendData is really UpdatePath with "append" action
 		if err != nil {
 			jptm.FailActiveUpload("Uploading range", err)
 			return

--- a/ste/sender-blockBlob.go
+++ b/ste/sender-blockBlob.go
@@ -48,7 +48,6 @@ type blockBlobSenderBase struct {
 	destBlockBlobClient *blockblob.Client
 	chunkSize           int64
 	numChunks           uint32
-	pacer               pacer
 	blockIDs            []string
 	destBlobTier        *blob.AccessTier
 
@@ -152,7 +151,7 @@ func getBlockNamePrefix(jobID common.JobID, partNum uint32, transferIndex uint32
 	return fmt.Sprintf("%s%s%05d%05d", placeHolderPrefix, jobIdStr, partNum, transferIndex)
 }
 
-func newBlockBlobSenderBase(jptm IJobPartTransferMgr, pacer pacer, srcInfoProvider ISourceInfoProvider, inferredAccessTierType *blob.AccessTier) (*blockBlobSenderBase, error) {
+func newBlockBlobSenderBase(jptm IJobPartTransferMgr, srcInfoProvider ISourceInfoProvider, inferredAccessTierType *blob.AccessTier) (*blockBlobSenderBase, error) {
 	// compute chunk count
 	chunkSize, numChunks, err := getVerifiedChunkParams(jptm.Info(), jptm.CacheLimiter().Limit(), jptm.CacheLimiter().StrictLimit())
 	if err != nil {
@@ -192,7 +191,6 @@ func newBlockBlobSenderBase(jptm IJobPartTransferMgr, pacer pacer, srcInfoProvid
 		destBlockBlobClient: destBlockBlobClient,
 		chunkSize:           chunkSize,
 		numChunks:           numChunks,
-		pacer:               pacer,
 		blockIDs:            make([]string, numChunks),
 		headersToApply:      props.SrcHTTPHeaders.ToBlobHTTPHeaders(),
 		metadataToApply:     props.SrcMetadata,

--- a/ste/sender-blockBlobFromLocal.go
+++ b/ste/sender-blockBlobFromLocal.go
@@ -36,8 +36,8 @@ type blockBlobUploader struct {
 	md5Channel chan []byte
 }
 
-func newBlockBlobUploader(jptm IJobPartTransferMgr, pacer pacer, sip ISourceInfoProvider) (sender, error) {
-	senderBase, err := newBlockBlobSenderBase(jptm, pacer, sip, nil)
+func newBlockBlobUploader(jptm IJobPartTransferMgr, sip ISourceInfoProvider) (sender, error) {
+	senderBase, err := newBlockBlobSenderBase(jptm, sip, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -100,8 +100,7 @@ func (u *blockBlobUploader) generatePutBlock(id common.ChunkID, blockIndex int32
 
 		// step 3: put block to remote
 		u.jptm.LogChunkStatus(id, common.EWaitReason.Body())
-		body := newPacedRequestBody(u.jptm.Context(), reader, u.pacer)
-		_, err := u.destBlockBlobClient.StageBlock(u.jptm.Context(), encodedBlockID, body,
+		_, err := u.destBlockBlobClient.StageBlock(u.jptm.Context(), encodedBlockID, reader,
 			&blockblob.StageBlockOptions{
 				CPKInfo:      u.jptm.CpkInfo(),
 				CPKScopeInfo: u.jptm.CpkScopeInfo(),
@@ -164,8 +163,7 @@ func (u *blockBlobUploader) generatePutWholeBlob(id common.ChunkID, reader commo
 			}
 
 			// Upload the file
-			body := newPacedRequestBody(jptm.Context(), reader, u.pacer)
-			_, err = u.destBlockBlobClient.Upload(jptm.Context(), body,
+			_, err = u.destBlockBlobClient.Upload(jptm.Context(), reader,
 				&blockblob.UploadOptions{
 					HTTPHeaders:  &u.headersToApply,
 					Metadata:     u.metadataToApply,

--- a/ste/sender-blockBlobFromURL.go
+++ b/ste/sender-blockBlobFromURL.go
@@ -35,7 +35,7 @@ type urlToBlockBlobCopier struct {
 	srcURL string
 }
 
-func newURLToBlockBlobCopier(jptm IJobPartTransferMgr, pacer pacer, srcInfoProvider IRemoteSourceInfoProvider) (s2sCopier, error) {
+func newURLToBlockBlobCopier(jptm IJobPartTransferMgr, srcInfoProvider IRemoteSourceInfoProvider) (s2sCopier, error) {
 	// Get blob tier, by default set none.
 	var destBlobTier *blob.AccessTier
 	// If the source is block blob, preserve source's blob tier.
@@ -45,7 +45,7 @@ func newURLToBlockBlobCopier(jptm IJobPartTransferMgr, pacer pacer, srcInfoProvi
 		}
 	}
 
-	senderBase, err := newBlockBlobSenderBase(jptm, pacer, srcInfoProvider, destBlobTier)
+	senderBase, err := newBlockBlobSenderBase(jptm, srcInfoProvider, destBlobTier)
 	if err != nil {
 		return nil, err
 	}

--- a/ste/sender-pageBlob.go
+++ b/ste/sender-pageBlob.go
@@ -42,7 +42,6 @@ type pageBlobSenderBase struct {
 	srcSize            int64
 	chunkSize          int64
 	numChunks          uint32
-	pacer              pacer
 
 	// Headers and other info that we will apply to the destination
 	// object. For S2S, these come from the source service.
@@ -79,7 +78,7 @@ var (
 	md5NotSupportedInManagedDiskError = errors.New("the Content-MD5 hash is not supported for managed disk uploads")
 )
 
-func newPageBlobSenderBase(jptm IJobPartTransferMgr, destination string, pacer pacer, srcInfoProvider ISourceInfoProvider, inferredAccessTierType *blob.AccessTier) (*pageBlobSenderBase, error) {
+func newPageBlobSenderBase(jptm IJobPartTransferMgr, destination string, srcInfoProvider ISourceInfoProvider, inferredAccessTierType *blob.AccessTier) (*pageBlobSenderBase, error) {
 	transferInfo := jptm.Info()
 
 	// compute chunk count
@@ -128,7 +127,6 @@ func newPageBlobSenderBase(jptm IJobPartTransferMgr, destination string, pacer p
 		srcSize:                srcSize,
 		chunkSize:              chunkSize,
 		numChunks:              numChunks,
-		pacer:                  pacer,
 		headersToApply:         props.SrcHTTPHeaders.ToBlobHTTPHeaders(),
 		metadataToApply:        props.SrcMetadata,
 		blobTagsToApply:        props.SrcBlobTags,

--- a/ste/sender-pageBlobFromLocal.go
+++ b/ste/sender-pageBlobFromLocal.go
@@ -36,8 +36,8 @@ type pageBlobUploader struct {
 	sip        ISourceInfoProvider
 }
 
-func newPageBlobUploader(jptm IJobPartTransferMgr, destination string, pacer pacer, sip ISourceInfoProvider) (sender, error) {
-	senderBase, err := newPageBlobSenderBase(jptm, destination, pacer, sip, nil)
+func newPageBlobUploader(jptm IJobPartTransferMgr, destination string, sip ISourceInfoProvider) (sender, error) {
+	senderBase, err := newPageBlobSenderBase(jptm, destination, sip, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -111,9 +111,8 @@ func (u *pageBlobUploader) GenerateUploadFunc(id common.ChunkID, blockIndex int3
 
 		// send it
 		jptm.LogChunkStatus(id, common.EWaitReason.Body())
-		body := newPacedRequestBody(jptm.Context(), reader, u.pacer)
 		enrichedContext := withRetryNotification(jptm.Context(), u.filePacer)
-		_, err := u.destPageBlobClient.UploadPages(enrichedContext, body, blob.HTTPRange{Offset: id.OffsetInFile(), Count: reader.Length()},
+		_, err := u.destPageBlobClient.UploadPages(enrichedContext, reader, blob.HTTPRange{Offset: id.OffsetInFile(), Count: reader.Length()},
 			&pageblob.UploadPagesOptions{
 				CPKInfo:      u.jptm.CpkInfo(),
 				CPKScopeInfo: u.jptm.CpkScopeInfo(),

--- a/ste/sender-pageBlobFromURL.go
+++ b/ste/sender-pageBlobFromURL.go
@@ -35,7 +35,7 @@ type urlToPageBlobCopier struct {
 	sourcePageRangeOptimizer *pageRangeOptimizer // nil if src is not a page blob
 }
 
-func newURLToPageBlobCopier(jptm IJobPartTransferMgr, destination string, pacer pacer, srcInfoProvider IRemoteSourceInfoProvider) (s2sCopier, error) {
+func newURLToPageBlobCopier(jptm IJobPartTransferMgr, destination string, srcInfoProvider IRemoteSourceInfoProvider) (s2sCopier, error) {
 	srcURL, err := srcInfoProvider.PreSignedSourceURL()
 	if err != nil {
 		return nil, err
@@ -76,7 +76,7 @@ func newURLToPageBlobCopier(jptm IJobPartTransferMgr, destination string, pacer 
 		}
 	}
 
-	senderBase, err := newPageBlobSenderBase(jptm, destination, pacer, srcInfoProvider, destBlobTier)
+	senderBase, err := newPageBlobSenderBase(jptm, destination, srcInfoProvider, destBlobTier)
 	if err != nil {
 		return nil, err
 	}

--- a/ste/sender.go
+++ b/ste/sender.go
@@ -28,9 +28,9 @@ import (
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
-/////////////////////////////////////////////////////////////////////////////////////////////////
+// ///////////////////////////////////////////////////////////////////////////////////////////////
 // sender is the abstraction that contains common sender behavior, for sending files/blobs.
-/////////////////////////////////////////////////////////////////////////////////////////////////
+// ///////////////////////////////////////////////////////////////////////////////////////////////
 type sender interface {
 	// ChunkSize returns the chunk size that should be used
 	ChunkSize() int64
@@ -75,9 +75,9 @@ type propertiesSender interface {
 	GenerateCopyMetadata(id common.ChunkID) chunkFunc
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////
+// ///////////////////////////////////////////////////////////////////////////////////////////////
 // folderSender is a sender that also knows how to send folder property information
-/////////////////////////////////////////////////////////////////////////////////////////////////
+// ///////////////////////////////////////////////////////////////////////////////////////////////
 type folderSender interface {
 	EnsureFolderExists() error
 	SetFolderProperties() error
@@ -98,22 +98,22 @@ func (f folderPropertiesNotOverwroteInCreation) Error() string {
 	panic("Not a real error")
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////
+// ///////////////////////////////////////////////////////////////////////////////////////////////
 // symlinkSender is a sender that also knows how to send symlink properties
-/////////////////////////////////////////////////////////////////////////////////////////////////
+// ///////////////////////////////////////////////////////////////////////////////////////////////
 type symlinkSender interface {
 	SendSymlink(linkData string) error
 }
 
-type senderFactory func(jptm IJobPartTransferMgr, destination string, pacer pacer, sip ISourceInfoProvider) (sender, error)
+type senderFactory func(jptm IJobPartTransferMgr, destination string, sip ISourceInfoProvider) (sender, error)
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 // For copying folder properties, many of the ISender of the methods needed to copy one file from URL to a remote location
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-/////////////////////////////////////////////////////////////////////////////////////////////////
+// ///////////////////////////////////////////////////////////////////////////////////////////////
 // Abstraction of the methods needed to copy one file from URL to a remote location
-/////////////////////////////////////////////////////////////////////////////////////////////////
+// ///////////////////////////////////////////////////////////////////////////////////////////////
 type s2sCopier interface {
 	sender
 
@@ -209,7 +209,7 @@ func createChunkFunc(setDoneStatusOnExit bool, jptm IJobPartTransferMgr, id comm
 }
 
 // newBlobUploader detects blob type and creates a uploader manually
-func newBlobUploader(jptm IJobPartTransferMgr, destination string, pacer pacer, sip ISourceInfoProvider) (sender, error) {
+func newBlobUploader(jptm IJobPartTransferMgr, destination string, sip ISourceInfoProvider) (sender, error) {
 	override := jptm.BlobTypeOverride()
 	intendedType := override.ToBlobType()
 
@@ -228,13 +228,13 @@ func newBlobUploader(jptm IJobPartTransferMgr, destination string, pacer pacer, 
 
 	switch intendedType {
 	case blob.BlobTypeBlockBlob:
-		return newBlockBlobUploader(jptm, pacer, sip)
+		return newBlockBlobUploader(jptm, sip)
 	case blob.BlobTypePageBlob:
-		return newPageBlobUploader(jptm, destination, pacer, sip)
+		return newPageBlobUploader(jptm, destination, sip)
 	case blob.BlobTypeAppendBlob:
-		return newAppendBlobUploader(jptm, destination, pacer, sip)
+		return newAppendBlobUploader(jptm, destination, sip)
 	default:
-		return newBlockBlobUploader(jptm, pacer, sip) // If no blob type was inferred, assume block blob.
+		return newBlockBlobUploader(jptm, sip) // If no blob type was inferred, assume block blob.
 	}
 }
 

--- a/ste/xfer-anyToRemote-file.go
+++ b/ste/xfer-anyToRemote-file.go
@@ -163,7 +163,7 @@ func ValidateTier(jptm IJobPartTransferMgr, blobTier *blob.AccessTier, client IB
 
 // xfer.go requires just a single xfer function for the whole job.
 // This routine serves that role for uploads and S2S copies, and redirects for each transfer to a file or folder implementation
-func anyToRemote(jptm IJobPartTransferMgr, pacer pacer, senderFactory senderFactory, sipf sourceInfoProviderFactory) {
+func anyToRemote(jptm IJobPartTransferMgr, senderFactory senderFactory, sipf sourceInfoProviderFactory) {
 	info := jptm.Info()
 	fromTo := jptm.FromTo()
 
@@ -194,22 +194,22 @@ func anyToRemote(jptm IJobPartTransferMgr, pacer pacer, senderFactory senderFact
 
 	switch info.EntityType {
 	case common.EEntityType.Folder():
-		anyToRemote_folder(jptm, info, pacer, senderFactory, sipf)
+		anyToRemote_folder(jptm, info, senderFactory, sipf)
 	case common.EEntityType.FileProperties():
-		anyToRemote_fileProperties(jptm, info, pacer, senderFactory, sipf)
+		anyToRemote_fileProperties(jptm, info, senderFactory, sipf)
 	case common.EEntityType.File():
 		if jptm.GetOverwriteOption() == common.EOverwriteOption.PosixProperties() {
-			anyToRemote_fileProperties(jptm, info, pacer, senderFactory, sipf)
+			anyToRemote_fileProperties(jptm, info, senderFactory, sipf)
 		} else {
-			anyToRemote_file(jptm, info, pacer, senderFactory, sipf)
+			anyToRemote_file(jptm, info, senderFactory, sipf)
 		}
 	case common.EEntityType.Symlink():
-		anyToRemote_symlink(jptm, info, pacer, senderFactory, sipf)
+		anyToRemote_symlink(jptm, info, senderFactory, sipf)
 	}
 }
 
 // anyToRemote_file handles all kinds of sender operations for files - both uploads from local files, and S2S copies
-func anyToRemote_file(jptm IJobPartTransferMgr, info *TransferInfo, pacer pacer, senderFactory senderFactory, sipf sourceInfoProviderFactory) {
+func anyToRemote_file(jptm IJobPartTransferMgr, info *TransferInfo, senderFactory senderFactory, sipf sourceInfoProviderFactory) {
 
 	pseudoId := common.NewPseudoChunkIDForWholeFile(info.Source)
 	jptm.LogChunkStatus(pseudoId, common.EWaitReason.XferStart())
@@ -237,7 +237,7 @@ func anyToRemote_file(jptm IJobPartTransferMgr, info *TransferInfo, pacer pacer,
 		panic("configuration error. Source Info Provider does not have File entity type")
 	}
 
-	s, err := senderFactory(jptm, info.Destination, pacer, srcInfoProvider)
+	s, err := senderFactory(jptm, info.Destination, srcInfoProvider)
 	if err != nil {
 		jptm.LogSendError(info.Source, info.Destination, err.Error(), 0)
 		jptm.SetStatus(common.ETransferStatus.Failed())
@@ -298,7 +298,9 @@ func anyToRemote_file(jptm IJobPartTransferMgr, info *TransferInfo, pacer pacer,
 	var sourceFileFactory func() (common.CloseableReaderAt, error)
 	srcFile := (common.CloseableReaderAt)(nil)
 	if srcInfoProvider.IsLocal() {
-		sourceFileFactory = srcInfoProvider.(ILocalSourceInfoProvider).OpenSourceFile // all local providers must implement this interface
+		sourceFileFactory = func() (common.CloseableReaderAt, error) {
+			return srcInfoProvider.(ILocalSourceInfoProvider).OpenSourceFile()
+		} // all local providers must implement this interface
 		srcFile, err = sourceFileFactory()
 		if err != nil {
 			suffix := ""

--- a/ste/xfer-anyToRemote-fileProperties.go
+++ b/ste/xfer-anyToRemote-fileProperties.go
@@ -25,7 +25,7 @@ import (
 )
 
 // anyToRemote_folder handles all kinds of sender operations for FOLDERS - both uploads from local files, and S2S copies
-func anyToRemote_fileProperties(jptm IJobPartTransferMgr, info *TransferInfo, pacer pacer, senderFactory senderFactory, sipf sourceInfoProviderFactory) {
+func anyToRemote_fileProperties(jptm IJobPartTransferMgr, info *TransferInfo, senderFactory senderFactory, sipf sourceInfoProviderFactory) {
 	// schedule the work as a chunk, so it will run on the main goroutine pool, instead of the
 	// smaller "transfer initiation pool", where this code runs.
 	id := common.NewChunkID(jptm.Info().Source, 0, 0)
@@ -48,12 +48,12 @@ func anyToRemote_fileProperties(jptm IJobPartTransferMgr, info *TransferInfo, pa
 		return
 	}
 
-	if (jptm.GetOverwriteOption() != common.EOverwriteOption.PosixProperties() ||
-						srcInfoProvider.EntityType() != common.EEntityType.File()) {
+	if jptm.GetOverwriteOption() != common.EOverwriteOption.PosixProperties() ||
+		srcInfoProvider.EntityType() != common.EEntityType.File() {
 		panic("configuration error. Source Info Provider does not have FileProperties entity type")
 	}
 
-	baseSender, err := senderFactory(jptm, info.Destination, pacer, srcInfoProvider)
+	baseSender, err := senderFactory(jptm, info.Destination, srcInfoProvider)
 	if err != nil {
 		jptm.LogSendError(info.Source, info.Destination, err.Error(), 0)
 		jptm.SetStatus(common.ETransferStatus.Failed())
@@ -79,5 +79,5 @@ func anyToRemote_fileProperties(jptm IJobPartTransferMgr, info *TransferInfo, pa
 
 	jptm.SetNumberOfChunks(1)
 	jptm.SetActionAfterLastChunk(func() { commonSenderCompletion(jptm, baseSender, info) }) // for consistency run standard Epilogue
-	jptm.ScheduleChunks(s.GenerateCopyMetadata(id)) // Just one chunk to schedule
+	jptm.ScheduleChunks(s.GenerateCopyMetadata(id))                                         // Just one chunk to schedule
 }

--- a/ste/xfer-anyToRemote-folder.go
+++ b/ste/xfer-anyToRemote-folder.go
@@ -25,7 +25,7 @@ import (
 )
 
 // anyToRemote_folder handles all kinds of sender operations for FOLDERS - both uploads from local files, and S2S copies
-func anyToRemote_folder(jptm IJobPartTransferMgr, info *TransferInfo, pacer pacer, senderFactory senderFactory, sipf sourceInfoProviderFactory) {
+func anyToRemote_folder(jptm IJobPartTransferMgr, info *TransferInfo, senderFactory senderFactory, sipf sourceInfoProviderFactory) {
 
 	// step 1. perform initial checks
 	if jptm.WasCanceled() {
@@ -47,7 +47,7 @@ func anyToRemote_folder(jptm IJobPartTransferMgr, info *TransferInfo, pacer pace
 		panic("configuration error. Source Info Provider does not have Folder entity type")
 	}
 
-	baseSender, err := senderFactory(jptm, info.Destination, pacer, srcInfoProvider)
+	baseSender, err := senderFactory(jptm, info.Destination, srcInfoProvider)
 	if err != nil {
 		jptm.LogSendError(info.Source, info.Destination, err.Error(), 0)
 		jptm.SetStatus(common.ETransferStatus.Failed())

--- a/ste/xfer-anyToRemote-symlink.go
+++ b/ste/xfer-anyToRemote-symlink.go
@@ -4,7 +4,7 @@ import (
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
-func anyToRemote_symlink(jptm IJobPartTransferMgr, info *TransferInfo, pacer pacer, senderFactory senderFactory, sipf sourceInfoProviderFactory) {
+func anyToRemote_symlink(jptm IJobPartTransferMgr, info *TransferInfo, senderFactory senderFactory, sipf sourceInfoProviderFactory) {
 	// Check if cancelled
 	if jptm.WasCanceled() {
 		/* This is earliest we detect that jptm has been cancelled before we reach destination */

--- a/ste/xfer-deleteBlob.go
+++ b/ste/xfer-deleteBlob.go
@@ -16,7 +16,7 @@ import (
 
 var explainedSkippedRemoveOnce sync.Once
 
-func DeleteBlob(jptm IJobPartTransferMgr, pacer pacer) {
+func DeleteBlob(jptm IJobPartTransferMgr) {
 
 	// If the transfer was cancelled, then reporting transfer as done and increasing the bytestransferred by the size of the source.
 	if jptm.WasCanceled() {

--- a/ste/xfer-deleteBlobFS.go
+++ b/ste/xfer-deleteBlobFS.go
@@ -18,7 +18,7 @@ var logBlobFSDeleteWarnOnce = &sync.Once{}
 
 const blobFSDeleteWarning = "Displayed file count will be either 1 or based upon list-of-files entries, and thus inaccurate, as deletes are performed recursively service-side."
 
-func DeleteHNSResource(jptm IJobPartTransferMgr, pacer pacer) {
+func DeleteHNSResource(jptm IJobPartTransferMgr) {
 	// If the transfer was cancelled, then report the transfer as done.
 	if jptm.WasCanceled() {
 		jptm.ReportTransferDone()

--- a/ste/xfer-deleteFile.go
+++ b/ste/xfer-deleteFile.go
@@ -15,7 +15,7 @@ import (
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
-func DeleteFile(jptm IJobPartTransferMgr, _ pacer) {
+func DeleteFile(jptm IJobPartTransferMgr) {
 
 	// If the transfer was cancelled, then reporting transfer as done and increasing the bytestransferred by the size of the source.
 	if jptm.WasCanceled() {

--- a/ste/xfer-remoteToLocal-file.go
+++ b/ste/xfer-remoteToLocal-file.go
@@ -37,19 +37,19 @@ const azcopyTempDownloadPrefix string = ".azDownload-%s-"
 
 // xfer.go requires just a single xfer function for the whole job.
 // This routine serves that role for downloads and redirects for each transfer to a file or folder implementation
-func remoteToLocal(jptm IJobPartTransferMgr, pacer pacer, df downloaderFactory) {
+func remoteToLocal(jptm IJobPartTransferMgr, df downloaderFactory) {
 	info := jptm.Info()
 	if info.IsFolderPropertiesTransfer() {
-		remoteToLocal_folder(jptm, pacer, df)
+		remoteToLocal_folder(jptm, df)
 	} else if info.EntityType == common.EEntityType.Symlink() {
-		remoteToLocal_symlink(jptm, pacer, df)
+		remoteToLocal_symlink(jptm, df)
 	} else {
-		remoteToLocal_file(jptm, pacer, df)
+		remoteToLocal_file(jptm, df)
 	}
 }
 
 // general-purpose "any remote persistence location" to local, for files
-func remoteToLocal_file(jptm IJobPartTransferMgr, pacer pacer, df downloaderFactory) {
+func remoteToLocal_file(jptm IJobPartTransferMgr, df downloaderFactory) {
 
 	info := jptm.Info()
 
@@ -323,7 +323,7 @@ func remoteToLocal_file(jptm IJobPartTransferMgr, pacer pacer, df downloaderFact
 		_ = dstWriter.WaitToScheduleChunk(jptm.Context(), id, adjustedChunkSize)
 
 		// create download func that is a appropriate to the remote data source
-		downloadFunc := dl.GenerateDownloadFunc(jptm, dstWriter, id, adjustedChunkSize, pacer)
+		downloadFunc := dl.GenerateDownloadFunc(jptm, dstWriter, id, adjustedChunkSize)
 
 		// schedule the download chunk job
 		jptm.ScheduleChunks(downloadFunc)

--- a/ste/xfer-remoteToLocal-folder.go
+++ b/ste/xfer-remoteToLocal-folder.go
@@ -25,7 +25,7 @@ import (
 )
 
 // general-purpose "any remote persistence location" to local, for folders
-func remoteToLocal_folder(jptm IJobPartTransferMgr, pacer pacer, df downloaderFactory) {
+func remoteToLocal_folder(jptm IJobPartTransferMgr, df downloaderFactory) {
 
 	info := jptm.Info()
 

--- a/ste/xfer-remoteToLocal-symlink.go
+++ b/ste/xfer-remoteToLocal-symlink.go
@@ -5,7 +5,7 @@ import (
 	"os"
 )
 
-func remoteToLocal_symlink(jptm IJobPartTransferMgr, pacer pacer, df downloaderFactory) {
+func remoteToLocal_symlink(jptm IJobPartTransferMgr, df downloaderFactory) {
 	info := jptm.Info()
 
 	// Perform initial checks

--- a/ste/xfer-setProperties.go
+++ b/ste/xfer-setProperties.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
-func SetProperties(jptm IJobPartTransferMgr, _ pacer) {
+func SetProperties(jptm IJobPartTransferMgr) {
 	// If the transfer was cancelled, then reporting transfer as done and increasing the bytes transferred by the size of the source.
 	if jptm.WasCanceled() {
 		jptm.ReportTransferDone()

--- a/ste/xfer.go
+++ b/ste/xfer.go
@@ -56,23 +56,23 @@ var cpkAccessFailureLogGLCM sync.Once
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // These types are define the STE Coordinator
-type newJobXfer func(jptm IJobPartTransferMgr, pacer pacer)
+type newJobXfer func(jptm IJobPartTransferMgr)
 
 // same as newJobXfer, but with an extra parameter
-type newJobXferWithDownloaderFactory = func(jptm IJobPartTransferMgr, pacer pacer, df downloaderFactory)
-type newJobXferWithSenderFactory = func(jptm IJobPartTransferMgr, pacer pacer, sf senderFactory, sipf sourceInfoProviderFactory)
+type newJobXferWithDownloaderFactory = func(jptm IJobPartTransferMgr, df downloaderFactory)
+type newJobXferWithSenderFactory = func(jptm IJobPartTransferMgr, sf senderFactory, sipf sourceInfoProviderFactory)
 
 // Takes a multi-purpose download function, and makes it ready to user with a specific type of downloader
 func parameterizeDownload(targetFunction newJobXferWithDownloaderFactory, df downloaderFactory) newJobXfer {
-	return func(jptm IJobPartTransferMgr, pacer pacer) {
-		targetFunction(jptm, pacer, df)
+	return func(jptm IJobPartTransferMgr) {
+		targetFunction(jptm, df)
 	}
 }
 
 // Takes a multi-purpose send function, and makes it ready to use with a specific type of sender
 func parameterizeSend(targetFunction newJobXferWithSenderFactory, sf senderFactory, sipf sourceInfoProviderFactory) newJobXfer {
-	return func(jptm IJobPartTransferMgr, pacer pacer) {
-		targetFunction(jptm, pacer, sf, sipf)
+	return func(jptm IJobPartTransferMgr) {
+		targetFunction(jptm, sf, sipf)
 	}
 }
 


### PR DESCRIPTION
This one is gonna be a bit lengthy, and I'm still sorta in the depths of it.

At this point, most of the meat and potatoes are here, but this still *isn't quite ready to go*. It won't build yet. I'm reworking the page blob auto pacer around the new model. At that point, things need to be plugged in.

It's important to note, before review, what's majorly different:

1) The pacer is implemented as a pipeline policy now.
2) The pacer now operates at a fine-grained level, allowing requests based upon  the ability to meet _minimum throughput_ requirements, with a "red line" before it starts sharing remaining bandwidth evenly. ***THIS WILL MOST LIKELY REQUIRE TUNING.***
3) This doesn't entirely apply for S2S, since we can't possibly pace that. Thus, it just allocates the blocks gradually similarly to the old way.