### PR TITLE
Enable external custom credential provider in the S3toBlob case

### DIFF
--- a/cmd/credentialUtil.go
+++ b/cmd/credentialUtil.go
@@ -456,14 +456,16 @@ func doGetCredentialTypeForLocation(ctx context.Context, location common.Locatio
 	}
 
 	if location == common.ELocation.S3() {
-		accessKeyID := common.GetEnvironmentVariable(common.EEnvironmentVariable.AWSAccessKeyID())
-		secretAccessKey := common.GetEnvironmentVariable(common.EEnvironmentVariable.AWSSecretAccessKey())
-		if accessKeyID == "" || secretAccessKey == "" {
-			credType = common.ECredentialType.S3PublicBucket()
-			public = true
-			return
-		}
-
+		//Commenting this block out because checkAuthSafeForTarget has no case to handle public. Copy defaults S3 to access key, so similar functionality should be present for sync
+		/*
+			accessKeyID := common.GetEnvironmentVariable(common.EEnvironmentVariable.AWSAccessKeyID())
+			secretAccessKey := common.GetEnvironmentVariable(common.EEnvironmentVariable.AWSSecretAccessKey())
+			if accessKeyID == "" || secretAccessKey == "" {
+				credType = common.ECredentialType.S3PublicBucket()
+				public = true
+				return
+			}
+		*/
 		credType = common.ECredentialType.S3AccessKey()
 		return
 	}

--- a/cmd/syncEnumerator.go
+++ b/cmd/syncEnumerator.go
@@ -33,9 +33,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/file"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/fileerror"
 
-	"github.com/Azure/azure-storage-azcopy/v10/jobsAdmin"
-
 	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/jobsAdmin"
+	"github.com/minio/minio-go/pkg/credentials"
 )
 
 type SyncEnumeratorOptions struct {
@@ -312,6 +312,13 @@ func (cca *cookedSyncCmdArgs) InitEnumerator(ctx context.Context, enumeratorOpti
 			TrailingDot: cca.trailingDot,
 		},
 		IsNFSCopy: cca.isNFSCopy,
+	}
+	//Optional check for custom credential provider
+	var credProvider credentials.Provider = nil
+	creds := ctx.Value(customCreds)
+	if creds != nil {
+		credProvider = creds.(credentials.Provider) //if passed through context, use custom provider
+		copyJobTemplate.Provider = credProvider
 	}
 
 	var srcReauthTok *common.ScopedAuthenticator

--- a/common/rpc-models.go
+++ b/common/rpc-models.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	datalake "github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/service"
-
 	"github.com/JeffreyRichter/enum/enum"
+	"github.com/minio/minio-go/pkg/credentials"
 )
 
 var ERpcCmd = RpcCmd("")
@@ -181,6 +181,7 @@ type CopyJobPartOrderRequest struct {
 	// This may not always be the case (for instance, if we opt to use multiple OAuth tokens). At that point, this will likely be it's own CredentialInfo.
 	S2SSourceCredentialType CredentialType // Only Anonymous and OAuth will really be used in response to this, but S3 and GCP will come along too...
 	FileAttributes          FileTransferAttributes
+	Provider                credentials.Provider //credential provider implementation for custom credential management
 	IsNFSCopy               bool
 }
 
@@ -206,6 +207,7 @@ type GCPCredentialInfo struct {
 type S3CredentialInfo struct {
 	Endpoint string
 	Region   string
+	Provider credentials.Provider //credential provider implementation for custom credential management
 }
 
 type CopyJobPartOrderErrorType string
@@ -356,6 +358,7 @@ type ResumeJobRequest struct {
 	IncludeTransfer  map[string]int
 	ExcludeTransfer  map[string]int
 	CredentialInfo   CredentialInfo
+	Provider         credentials.Provider
 }
 
 // represents the Details and details of a single transfer

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,8 @@ require (
 	cloud.google.com/go/iam v1.2.1 // indirect
 	cloud.google.com/go/monitoring v1.21.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/keyvault/azsecrets v0.12.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,10 @@ github.com/Azure/azure-sdk-for-go/sdk/data/aztables v1.3.0 h1:NnE8y/opvxowwNcSNH
 github.com/Azure/azure-sdk-for-go/sdk/data/aztables v1.3.0/go.mod h1:GhHzPHiiHxZloo6WvKu9X7krmSAKTyGoIwoKMbrKTTA=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 h1:ywEEhmNahHBihViHepv3xPBn1663uRv2t2q/ESv9seY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkYRNWPENUnqx6bJ2xnSDFI2tjwZNuY=
+github.com/Azure/azure-sdk-for-go/sdk/keyvault/azsecrets v0.12.0 h1:xnO4sFyG8UH2fElBkcqLTOZsAajvKfnSlgBBW8dXYjw=
+github.com/Azure/azure-sdk-for-go/sdk/keyvault/azsecrets v0.12.0/go.mod h1:XD3DIOOVgBCO03OleB1fHjgktVRFxlT++KwKgIOewdM=
+github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1 h1:FbH3BbSb4bvGluTesZZ+ttN/MDsnMmQP36OSnDuSXqw=
+github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1/go.mod h1:9V2j0jn9jDEkCkv8w/bKTNppX/d0FVA1ud77xCIP4KA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.6.0 h1:PiSrjRPpkQNjrM8H0WwKMnZUdu1RGMtd/LdGKUrOo+c=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.6.0/go.mod h1:oDrbWx4ewMylP7xHivfgixbfGBT6APAwsSoHRKotnIc=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.0 h1:UXT0o77lXQrikd1kgwIPQOUect7EoR/+sbP4wQKdzxM=

--- a/jobsAdmin/init.go
+++ b/jobsAdmin/init.go
@@ -178,6 +178,7 @@ func ExecuteNewCopyJobPartOrder(order common.CopyJobPartOrderRequest) common.Cop
 		ste.InMemoryTransitJobState{
 			CredentialInfo:          order.CredentialInfo,
 			S2SSourceCredentialType: order.S2SSourceCredentialType,
+			Provider:                order.Provider,
 		})
 	// Supply no plan MMF because we don't have one, and AddJobPart will create one on its own.
 	// Add this part to the Job and schedule its transfers
@@ -363,6 +364,7 @@ func ResumeJobOrder(req common.ResumeJobRequest) common.CancelPauseResumeRespons
 		jm.SetInMemoryTransitJobState(
 			ste.InMemoryTransitJobState{
 				CredentialInfo: req.CredentialInfo,
+				Provider:       req.Provider,
 			})
 
 		// Prevents previous number of failed transfers seeping into a new run

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -16,8 +16,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
-
 	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/minio/minio-go/pkg/credentials"
 )
 
 var _ IJobPartMgr = &jobPartMgr{}
@@ -354,6 +354,13 @@ func (jpm *jobPartMgr) ScheduleTransfers(jobCtx context.Context) {
 
 		//build transferInfo after we've set transferIndex
 		jptm.transferInfo = jptm.Info()
+		//populate transfer info with the provider for custom s3 credential provider
+		var credProvider credentials.Provider = nil
+		creds := jobCtx.Value("customS3Creds")
+		if creds != nil {
+			credProvider = creds.(credentials.Provider) //if passed through context, use custom provider
+		}
+		jptm.transferInfo.Provider = credProvider
 		jpm.Log(common.LogDebug, fmt.Sprintf("scheduling JobID=%v, Part#=%d, Transfer#=%d, priority=%v", plan.JobID, plan.PartNum, t, plan.Priority))
 
 		// ===== TEST KNOB

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -17,6 +17,7 @@ import (
 	"net/url"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/minio/minio-go/pkg/credentials"
 )
 
 type IJobPartTransferMgr interface {
@@ -143,6 +144,7 @@ type TransferInfo struct {
 
 	VersionID  string
 	SnapshotID string
+	Provider   credentials.Provider //custom Provider
 	IsNFSCopy  bool
 }
 

--- a/ste/sourceInfoProvider-S3.go
+++ b/ste/sourceInfoProvider-S3.go
@@ -64,7 +64,9 @@ func newS3SourceInfoProvider(jptm IJobPartTransferMgr) (ISourceInfoProvider, err
 		return nil, err
 	}
 
-	if os.Getenv("AWS_ACCESS_KEY_ID") == "" && os.Getenv("AWS_SECRET_ACCESS_KEY") == "" {
+	if p.transferInfo.Provider != nil { //add check for if we want to use provider case
+		p.credType = common.ECredentialType.S3AccessKey()
+	} else if os.Getenv("AWS_ACCESS_KEY_ID") == "" && os.Getenv("AWS_SECRET_ACCESS_KEY") == "" {
 		p.credType = common.ECredentialType.S3PublicBucket()
 	} else {
 		p.credType = common.ECredentialType.S3AccessKey()
@@ -76,6 +78,7 @@ func newS3SourceInfoProvider(jptm IJobPartTransferMgr) (ISourceInfoProvider, err
 		S3CredentialInfo: common.S3CredentialInfo{
 			Endpoint: p.s3URLPart.Endpoint,
 			Region:   p.s3URLPart.Region,
+			Provider: p.transferInfo.Provider,
 		},
 	}, common.CredentialOpOptions{
 		LogInfo:  func(str string) { p.jptm.Log(common.LogInfo, str) },


### PR DESCRIPTION
The following changes enable a custom credential provider to be utilized in the case that setting static credentials through env variable is not sufficient, specifically for s3 to blob scenario. It can only be done if using azcopy as a library, in all other cases the provider will be a NULL field wherever it has been added.

-cmd/credentialUtil.go: The change comments out the logic that sets credType to S3PublicBucket when AWS access keys are missing, defaulting instead to S3AccessKey.

-cmd/syncEnumerator.go: Adds support for injecting a custom S3 credential provider into the job context, specifically for sync case

- cmd/zc_traverser_s3.go: Adds support for injecting custom S3 credential providers via context in the S3 traverser to enable flexible authentication in the copy case

-common/credentialFactory.go: Enables the use of the provider in the s3 client creation workflow

-common/rpc-models.go: Adds support for custom credential providers in S3CredentialInfo and CopyJobPartOrderRequest  structures so cmd can pass it along its ste workflow

-JobsAdmin/init.go: Adds provider in the InMemoryTransitJobState struct so that it can be passed through ste workflow

-ste/mgr-JobMgr.go: Adds provider to appropriate jobmgr structs to pass down through ste workflow

-ste/mgr-JobPartMgr.go: Adds provider to appropriate jobpartmgr structs to pass down through ste workflow

-ste/mgr-JobPartTransferMgr.go: Adds provider to appropriate jobparttransfermgr structs to pass down through ste workflow

-ste/sourceInfoProvider-S3.go: Adds provider to s3 credential info for ste client