### PR TITLE
Enabled SPN credentials to be set via publically exposed function

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -46,6 +46,25 @@ type LoginOptions struct {
 	identityObjectID string
 }
 
+// loginWithSPNArgs is a type that holds the arguments for login with SPN so we don't need to use environment variables. It also uses certData rather than certPath
+type SPNArgs struct {
+	certData      string
+	applicationId string
+	certPass      string
+	tenantId      string
+	aadEndpoint   string
+}
+
+var loginWithSPNArgs SPNArgs = SPNArgs{}
+
+func SetSPNArgs(certData string, certPass string, applicationId string, tenantId string, aadEndpoint string) {
+	loginWithSPNArgs.certData = certData
+	loginWithSPNArgs.applicationId = applicationId
+	loginWithSPNArgs.certPass = certPass
+	loginWithSPNArgs.tenantId = tenantId
+	loginWithSPNArgs.aadEndpoint = aadEndpoint
+}
+
 var loginCmdArg = rawLoginArgs{tenantID: common.DefaultTenantID}
 
 var lgCmd = &cobra.Command{
@@ -187,6 +206,11 @@ func (options LoginOptions) process() error {
 	case common.EAutoLoginType.SPN():
 		if options.CertificatePath != "" {
 			if err := uotm.CertLogin(options.TenantID, options.AADEndpoint, options.CertificatePath, options.certificatePassword, options.ApplicationID, options.persistToken); err != nil {
+				return err
+			}
+			glcm.Info("SPN Auth via cert succeeded.")
+		} else if options.CertificatePath == "" && loginWithSPNArgs.certData != "" {
+			if err := uotm.SpnArgsLogin(loginWithSPNArgs.tenantId, loginWithSPNArgs.aadEndpoint, loginWithSPNArgs.certData, loginWithSPNArgs.certPass, loginWithSPNArgs.applicationId, options.persistToken); err != nil {
 				return err
 			}
 			glcm.Info("SPN Auth via cert succeeded.")

--- a/common/oauthTokenManager.go
+++ b/common/oauthTokenManager.go
@@ -36,6 +36,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache"
+	"github.com/Azure/azure-storage-azcopy/v10/common/buildmode"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
@@ -635,6 +636,14 @@ func (credInfo *OAuthTokenInfo) GetManagedIdentityCredential() (azcore.TokenCred
 
 func (credInfo *OAuthTokenInfo) GetClientCertificateCredential() (azcore.TokenCredential, error) {
 	authorityHost, err := getAuthorityURL(credInfo.ActiveDirectoryEndpoint)
+
+	var host string
+	if buildmode.IsMover {
+		host = credInfo.ActiveDirectoryEndpoint
+	} else {
+		host = authorityHost.String()
+	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -656,7 +665,7 @@ func (credInfo *OAuthTokenInfo) GetClientCertificateCredential() (azcore.TokenCr
 	}
 	tc, err := azidentity.NewClientCertificateCredential(credInfo.Tenant, credInfo.ApplicationID, certs, key, &azidentity.ClientCertificateCredentialOptions{
 		ClientOptions: azcore.ClientOptions{
-			Cloud:     cloud.Configuration{ActiveDirectoryAuthorityHost: authorityHost.String()},
+			Cloud:     cloud.Configuration{ActiveDirectoryAuthorityHost: host},
 			Transport: newAzcopyHTTPClient(),
 		},
 		SendCertificateChain: true,


### PR DESCRIPTION
This PR allows SPN login via function call if used as a library. This removes the need for using environment variables for SPN login.

-cmd/login.go: Defines SPN args and public function to set them. 
-common/oauthTokenManager.go: Defines function for login using SPN args, as well as a flow for parsing certificate if utilized.