### PR TITLE
Add creation of parent directory if not existing

### DIFF
--- a/ste/xfer-remoteToLocal-symlink.go
+++ b/ste/xfer-remoteToLocal-symlink.go
@@ -75,6 +75,14 @@ func remoteToLocal_symlink(jptm IJobPartTransferMgr, pacer pacer, df downloaderF
 		return
 	}
 
+	err = common.CreateParentDirectoryIfNotExist(jptm.Info().Destination, jptm.GetFolderCreationTracker())
+
+	if err != nil {
+		jptm.FailActiveSend("creating destination folder for symlink", err)
+		jptm.ReportTransferDone()
+		return
+	}
+	
 	err = dl.CreateSymlink(jptm)
 	if err != nil {
 		jptm.FailActiveSend("creating destination symlink", err)


### PR DESCRIPTION
## Description
This Pull Request adds the creation/existence check flow when creating a symlink in a Blob to local scenario. This 

**Related Links**:
- [AzCopy copy Blob to local with --preserve-symlinks fails because of not created directories when using wildcard in URL](https://github.com/Azure/azure-storage-azcopy/issues/3148)

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?

This has been tested reproducing the same flow described in the issue and confirming job didn't present failed entries
