### PR TITLE
Gapra/resume init

### DIFF
--- a/azcopy/client.go
+++ b/azcopy/client.go
@@ -29,6 +29,18 @@ import (
 	"github.com/Azure/azure-storage-azcopy/v10/ste"
 )
 
+const (
+	oauthLoginSessionCacheKeyName     = "AzCopyOAuthTokenCache"
+	oauthLoginSessionCacheServiceName = "AzCopyV10"
+	oauthLoginSessionCacheAccountName = "AzCopyOAuthTokenCache"
+)
+
+// It's not pretty that this one is read directly by credential util.
+// But doing otherwise required us passing it around in many places, even though really
+// it can be thought of as an "ambient" property. That's the (weak?) justification for implementing
+// it as a global
+var TrustedSuffixes string
+
 type Client struct {
 	CurrentJobID common.JobID // TODO (gapra): In future this should only be set when there is a current job running. On complete, this should be cleared. It can also behave as something we can check to see if a current job is running
 	logLevel     common.LogLevel
@@ -37,10 +49,12 @@ type Client struct {
 }
 
 type ClientOptions struct {
-	CapMbps float64
+	CapMbps         float64
+	TrustedSuffixes string
 }
 
 func NewClient(opts ClientOptions) (Client, error) {
+	TrustedSuffixes = opts.TrustedSuffixes
 	c := Client{
 		logLevel: common.ELogLevel.Info(), // Default: Info
 	}

--- a/azcopy/clientUtil.go
+++ b/azcopy/clientUtil.go
@@ -1,0 +1,33 @@
+package azcopy
+
+import (
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
+)
+
+// CreateClientOptions creates generic client options which are required to create any
+// client to interact with storage service. Default options are modified to suit azcopy.
+// srcCred is required in cases where source is authenticated via oAuth for S2S transfers
+func CreateClientOptions(logger common.ILoggerResetable, srcCred *common.ScopedToken, reauthCred *common.ScopedAuthenticator) azcore.ClientOptions {
+	logOptions := ste.LogOptions{}
+
+	if logger != nil {
+		logOptions.RequestLogOptions.SyslogDisabled = common.IsForceLoggingDisabled()
+		logOptions.Log = logger.Log
+		logOptions.ShouldLog = logger.ShouldLog
+	}
+	return ste.NewClientOptions(policy.RetryOptions{
+		MaxRetries:    ste.UploadMaxTries,
+		TryTimeout:    ste.UploadTryTimeout,
+		RetryDelay:    ste.UploadRetryDelay,
+		MaxRetryDelay: ste.UploadMaxRetryDelay,
+	}, policy.TelemetryOptions{
+		ApplicationID: common.AddUserAgentPrefix(common.UserAgent),
+	}, ste.NewAzcopyHTTPClient(frontEndMaxIdleConnectionsPerHost), logOptions, srcCred, reauthCred)
+}
+
+const frontEndMaxIdleConnectionsPerHost = http.DefaultMaxIdleConnsPerHost

--- a/azcopy/credentialUtil.go
+++ b/azcopy/credentialUtil.go
@@ -20,8 +20,390 @@
 
 package azcopy
 
-const (
-	oauthLoginSessionCacheKeyName     = "AzCopyOAuthTokenCache"
-	oauthLoginSessionCacheServiceName = "AzCopyV10"
-	oauthLoginSessionCacheAccountName = "AzCopyOAuthTokenCache"
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"sync"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
+	"github.com/minio/minio-go/pkg/s3utils"
 )
+
+const (
+	TrustedSuffixesNameAAD      = "trusted-microsoft-suffixes"
+	TrustedSuffixesAAD          = "*.core.windows.net;*.core.chinacloudapi.cn;*.core.cloudapi.de;*.core.usgovcloudapi.net;*.storage.azure.net"
+	sharedKeyDeprecationMessage = "*** WARNING *** shared key authentication for datalake is deprecated and will be removed in a future release. Please use shared access signature (SAS) or OAuth for authentication."
+)
+
+// TODO : reset per job
+var sharedKeyDeprecation sync.Once
+var autoOAuth sync.Once
+var announceOAuthTokenOnce sync.Once
+var authMessagesAlreadyLogged = &sync.Map{}
+var stashedEnvCredType = ""
+
+func warnIfSharedKeyAuthForDatalake() {
+	sharedKeyDeprecation.Do(func() {
+		common.GetLifecycleMgr().Warn(sharedKeyDeprecationMessage)
+		common.LogToJobLogWithPrefix(sharedKeyDeprecationMessage, common.LogWarning)
+	})
+}
+
+// GetCredTypeFromEnvVar tries to get credential type from environment variable defined by envVarCredentialType.
+func GetCredTypeFromEnvVar() common.CredentialType {
+	rawVal := stashedEnvCredType
+	if stashedEnvCredType == "" {
+		rawVal = common.GetEnvironmentVariable(common.EEnvironmentVariable.CredentialType())
+		if rawVal == "" {
+			return common.ECredentialType.Unknown()
+		}
+		stashedEnvCredType = rawVal
+	}
+
+	// Remove the env var after successfully fetching once,
+	// in case of env var is further spreading into child processes unexpectedly.
+	common.ClearEnvironmentVariable(common.EEnvironmentVariable.CredentialType())
+
+	// Try to get the value set.
+	var credType common.CredentialType
+	if err := credType.Parse(rawVal); err != nil {
+		return common.ECredentialType.Unknown()
+	}
+
+	return credType
+}
+
+// checkAuthSafeForTarget checks our "implicit" auth types (those that pick up creds from the environment
+// or a prior login) to make sure they are only being used in places where we know those auth types are safe.
+// This prevents, for example, us accidentally sending OAuth creds to some place they don't belong
+func checkAuthSafeForTarget(ct common.CredentialType, resource, extraSuffixesAAD string, resourceType common.Location) error {
+
+	getSuffixes := func(list string, extras string) []string {
+		extras = strings.Trim(extras, " ")
+		if extras != "" {
+			list += ";" + extras
+		}
+		return strings.Split(list, ";")
+	}
+
+	isResourceInSuffixList := func(suffixes []string) (string, bool) {
+		u, err := url.Parse(resource)
+		if err != nil {
+			return "<unparsable>", false
+		}
+		host := strings.ToLower(u.Host)
+
+		for _, s := range suffixes {
+			s = strings.Trim(s, " *") // trim *.foo to .foo
+			s = strings.ToLower(s)
+			if strings.HasSuffix(host, s) {
+				return host, true
+			}
+		}
+		return host, false
+	}
+
+	switch ct {
+	case common.ECredentialType.Unknown(),
+		common.ECredentialType.Anonymous():
+		// these auth types don't pick up anything from environment vars, so they are not the focus of this routine
+		return nil
+	case common.ECredentialType.OAuthToken(),
+		common.ECredentialType.MDOAuthToken(),
+		common.ECredentialType.SharedKey():
+		// Files doesn't currently support OAuth, but it's a valid azure endpoint anyway, so it'll pass the check.
+		if resourceType != common.ELocation.Blob() && resourceType != common.ELocation.BlobFS() && resourceType != common.ELocation.File() && resourceType != common.ELocation.FileNFS() {
+			// There may be a reason for files->blob to specify this.
+			if resourceType == common.ELocation.Local() {
+				return nil
+			}
+
+			return fmt.Errorf("azure OAuth authentication to %s is not enabled in AzCopy", resourceType.String())
+		}
+
+		// these are Azure auth types, so make sure the resource is known to be in Azure
+		domainSuffixes := getSuffixes(TrustedSuffixesAAD, extraSuffixesAAD)
+		if host, ok := isResourceInSuffixList(domainSuffixes); !ok {
+			return fmt.Errorf(
+				"the URL requires authentication. If this URL is in fact an Azure service, you can enable Azure authentication to %s. "+
+					"To enable, view the documentation for "+
+					"the parameter --%s, by running 'AzCopy copy --help'. BUT if this URL is not an Azure service, do NOT enable Azure authentication to it. "+
+					"Instead, see if the URL host supports authentication by way of a token that can be included in the URL's query string",
+				// E.g. CDN apparently supports a non-SAS type of token as noted here: https://docs.microsoft.com/en-us/azure/cdn/cdn-token-auth#setting-up-token-authentication
+				// Including such a token in the URL will cause AzCopy to see it as a "public" URL (since the URL on its own will pass
+				// our "isPublic" access tests, which run before this routine).
+				host, TrustedSuffixesNameAAD)
+		}
+
+	case common.ECredentialType.S3AccessKey():
+		if resourceType != common.ELocation.S3() {
+			//noinspection ALL
+			return fmt.Errorf("S3 access key authentication to %s is not enabled in AzCopy", resourceType.String())
+		}
+
+		// just check with minio. No need to have our own list of S3 domains, since minio effectively
+		// has that list already, we can't talk to anything outside that list because minio won't let us,
+		// and the parsing of s3 URL is non-trivial.  E.g. can't just look for the ending since
+		// something like https://someApi.execute-api.someRegion.amazonaws.com is AWS but is a customer-
+		// written code, not S3.
+		ok := false
+		host := "<unparsable url>"
+		u, err := url.Parse(resource)
+		if err == nil {
+			host = u.Host
+			parts, err := common.NewS3URLParts(*u) // strip any leading bucket name from URL, to get an endpoint we can pass to s3utils
+			if err == nil {
+				u, err := url.Parse("https://" + parts.Endpoint)
+				ok = err == nil && s3utils.IsAmazonEndpoint(*u)
+			}
+		}
+
+		if !ok {
+			return fmt.Errorf(
+				"s3 authentication to %s is not currently supported in AzCopy", host)
+		}
+	case common.ECredentialType.GoogleAppCredentials():
+		if resourceType != common.ELocation.GCP() {
+			return fmt.Errorf("google application credentials to %s is not valid", resourceType.String())
+		}
+
+		u, err := url.Parse(resource)
+		if err == nil {
+			host := u.Host
+			_, err := common.NewGCPURLParts(*u)
+			if err != nil {
+				return fmt.Errorf("GCP authentication to %s is not currently supported", host)
+			}
+		}
+	default:
+		panic("unknown credential type")
+	}
+
+	return nil
+}
+
+func logAuthType(ct common.CredentialType, location common.Location, isSource bool) {
+	if location == common.ELocation.Unknown() {
+		return // nothing to log
+	} else if location.IsLocal() {
+		return // don't log local ones, no point
+	} else if ct == common.ECredentialType.Anonymous() {
+		return // don't log these either (too cluttered and auth type is obvious from the URL)
+	}
+
+	resource := "destination"
+	if isSource {
+		resource = "source"
+	}
+	name := ct.String()
+	if ct == common.ECredentialType.OAuthToken() {
+		name = "Azure AD" // clarify the name to something users will recognize
+	} else if ct == common.ECredentialType.MDOAuthToken() {
+		name = "Azure AD (Managed Disk)"
+	}
+	message := fmt.Sprintf("Authenticating to %s using %s", resource, name)
+	if ct == common.ECredentialType.Unknown() && location.IsAzure() {
+		message += ", Please authenticate using Microsoft Entra ID (https://aka.ms/AzCopy/AuthZ), use AzCopy login, or append a SAS token to your Azure URL."
+	}
+	if _, exists := authMessagesAlreadyLogged.Load(message); !exists {
+		authMessagesAlreadyLogged.Store(message, struct{}{}) // dedup because source is auth'd by both enumerator and STE
+		common.LogToJobLogWithPrefix(message, common.LogInfo)
+		common.GetLifecycleMgr().Info(message)
+	}
+}
+
+// isPublic reports true if the Blob URL passed can be read without auth.
+func isPublic(ctx context.Context, blobResourceURL string, cpkOptions common.CpkOptions) (isPublicResource bool) {
+	bURLParts, err := blob.ParseURL(blobResourceURL)
+	if err != nil {
+		return false
+	}
+
+	if bURLParts.ContainerName == "" || strings.Contains(bURLParts.ContainerName, "*") {
+		// Service level searches can't possibly be public.
+		return false
+	}
+
+	// This request will not be logged. This can fail, and too many Cx do not like this.
+	clientOptions := ste.NewClientOptions(policy.RetryOptions{
+		MaxRetries:    ste.UploadMaxTries,
+		TryTimeout:    ste.UploadTryTimeout,
+		RetryDelay:    ste.UploadRetryDelay,
+		MaxRetryDelay: ste.UploadMaxRetryDelay,
+	}, policy.TelemetryOptions{
+		ApplicationID: common.AddUserAgentPrefix(common.UserAgent),
+	}, nil, ste.LogOptions{}, nil, nil)
+
+	blobClient, _ := blob.NewClientWithNoCredential(bURLParts.String(), &blob.ClientOptions{ClientOptions: clientOptions})
+	bURLParts.BlobName = ""
+	bURLParts.Snapshot = ""
+	bURLParts.VersionID = ""
+
+	// Scenario 1: When resourceURL points to a container or a virtual directory
+	// Check if the virtual directory is accessible by doing GetProperties on container.
+	// Virtual directory can be public only when its parent container is public.
+	containerClient, _ := container.NewClientWithNoCredential(bURLParts.String(), &container.ClientOptions{ClientOptions: clientOptions})
+	if _, err := containerClient.GetProperties(ctx, nil); err == nil {
+		return true
+	}
+
+	// Scenario 2: When resourceURL points to a blob
+	if _, err := blobClient.GetProperties(ctx, &blob.GetPropertiesOptions{CPKInfo: cpkOptions.GetCPKInfo()}); err == nil {
+		return true
+	}
+
+	return false
+}
+
+// mdAccountNeedsOAuth pings the passed in md account, and checks if we need additional token with Disk-socpe
+func mdAccountNeedsOAuth(ctx context.Context, blobResourceURL string, cpkOptions common.CpkOptions) bool {
+	// This request will not be logged. This can fail, and too many Cx do not like this.
+	clientOptions := ste.NewClientOptions(policy.RetryOptions{
+		MaxRetries:    ste.UploadMaxTries,
+		TryTimeout:    ste.UploadTryTimeout,
+		RetryDelay:    ste.UploadRetryDelay,
+		MaxRetryDelay: ste.UploadMaxRetryDelay,
+	}, policy.TelemetryOptions{
+		ApplicationID: common.AddUserAgentPrefix(common.UserAgent),
+	}, nil, ste.LogOptions{}, nil, nil)
+
+	blobClient, _ := blob.NewClientWithNoCredential(blobResourceURL, &blob.ClientOptions{ClientOptions: clientOptions})
+	_, err := blobClient.GetProperties(ctx, &blob.GetPropertiesOptions{CPKInfo: cpkOptions.GetCPKInfo()})
+	if err == nil {
+		return false
+	}
+
+	var respErr *azcore.ResponseError
+	if errors.As(err, &respErr) {
+		if respErr.StatusCode == 401 || respErr.StatusCode == 403 { // *sometimes* the service can return 403s.
+			challenge := respErr.RawResponse.Header.Get("WWW-Authenticate")
+			if strings.Contains(challenge, common.MDResource) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func GetCredentialTypeForLocation(ctx context.Context, location common.Location, resource common.ResourceString, isSource bool, uotm *common.UserOAuthTokenManager, cpkOptions common.CpkOptions) (credType common.CredentialType, isPublic bool, err error) {
+	return doGetCredentialTypeForLocation(ctx, location, resource, isSource, GetCredTypeFromEnvVar, uotm, cpkOptions)
+}
+
+func doGetCredentialTypeForLocation(ctx context.Context, location common.Location, resource common.ResourceString, isSource bool, getForcedCredType func() common.CredentialType, uotm *common.UserOAuthTokenManager, cpkOptions common.CpkOptions) (credType common.CredentialType, public bool, err error) {
+	public = false
+	err = nil
+
+	switch location {
+	case common.ELocation.Local(), common.ELocation.Benchmark(), common.ELocation.None(), common.ELocation.Pipe():
+		return common.ECredentialType.Anonymous(), false, nil
+	}
+
+	defer func() {
+		logAuthType(credType, location, isSource)
+	}()
+
+	// caution: If auth-type is unsafe, below defer statement will change the return value credType
+	defer func() {
+		if err != nil {
+			return
+		}
+
+		if err = checkAuthSafeForTarget(credType, resource.Value, TrustedSuffixes, location); err != nil {
+			credType = common.ECredentialType.Unknown()
+			public = false
+		}
+	}()
+
+	if getForcedCredType() != common.ECredentialType.Unknown() &&
+		location != common.ELocation.S3() && location != common.ELocation.GCP() {
+		credType = getForcedCredType()
+		return
+	}
+
+	if location == common.ELocation.S3() {
+		accessKeyID := common.GetEnvironmentVariable(common.EEnvironmentVariable.AWSAccessKeyID())
+		secretAccessKey := common.GetEnvironmentVariable(common.EEnvironmentVariable.AWSSecretAccessKey())
+		if accessKeyID == "" || secretAccessKey == "" {
+			credType = common.ECredentialType.S3PublicBucket()
+			public = true
+			return
+		}
+
+		credType = common.ECredentialType.S3AccessKey()
+		return
+	}
+
+	if location == common.ELocation.GCP() {
+		googleAppCredentials := common.GetEnvironmentVariable(common.EEnvironmentVariable.GoogleAppCredentials())
+		if googleAppCredentials == "" {
+			return common.ECredentialType.Unknown(), false, errors.New("GOOGLE_APPLICATION_CREDENTIALS environment variable must be set before using GCP transfer feature")
+		}
+		credType = common.ECredentialType.GoogleAppCredentials()
+		return
+	}
+
+	// Special blob destinations - public and MD account needing oAuth
+	if location == common.ELocation.Blob() {
+		uri, _ := resource.FullURL()
+		if isSource && resource.SAS == "" && isPublic(ctx, uri.String(), cpkOptions) {
+			credType = common.ECredentialType.Anonymous()
+			public = true
+			return
+		}
+
+		if strings.HasPrefix(uri.Host, "md-") && mdAccountNeedsOAuth(ctx, uri.String(), cpkOptions) {
+			var oAuthTokenExists bool
+			oAuthTokenExists, err = uotm.OAuthTokenExists(&announceOAuthTokenOnce, &autoOAuth)
+			if err != nil {
+				return common.ECredentialType.Unknown(), false, err
+			}
+			if !oAuthTokenExists {
+				return common.ECredentialType.Unknown(), false,
+					common.NewAzError(common.EAzError.LoginCredMissing(), "No SAS token or OAuth token is present and the resource is not public")
+			}
+
+			credType = common.ECredentialType.MDOAuthToken()
+			return
+		}
+	}
+
+	if resource.SAS != "" {
+		credType = common.ECredentialType.Anonymous()
+		return
+	}
+
+	var oAuthTokenExists bool
+	oAuthTokenExists, err = uotm.OAuthTokenExists(&announceOAuthTokenOnce, &autoOAuth)
+	if err != nil {
+		return common.ECredentialType.Unknown(), false, err
+	}
+	if oAuthTokenExists {
+		credType = common.ECredentialType.OAuthToken()
+		return
+	}
+
+	// BlobFS currently supports Shared key. Remove this piece of code, once
+	// we deprecate that.
+	if location == common.ELocation.BlobFS() {
+		name := common.GetEnvironmentVariable(common.EEnvironmentVariable.AccountName())
+		key := common.GetEnvironmentVariable(common.EEnvironmentVariable.AccountKey())
+		if name != "" && key != "" { // TODO: To remove, use for internal testing, SharedKey should not be supported from commandline
+			credType = common.ECredentialType.SharedKey()
+			warnIfSharedKeyAuthForDatalake()
+		}
+	}
+
+	// We may not always use the OAuth token on Managed Disks. As such, we should change to the type indicating the potential for use.
+	// if mdAccount && credType == common.ECredentialType.OAuthToken() {
+	// 	credType = common.ECredentialType.MDOAuthToken()
+	// }
+	return
+}

--- a/azcopy/jobsResume.go
+++ b/azcopy/jobsResume.go
@@ -21,9 +21,14 @@
 package azcopy
 
 import (
+	"context"
 	"errors"
+	"fmt"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/jobsAdmin"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
 )
 
 type ResumeJobOptions struct {
@@ -33,10 +38,178 @@ type ResumeJobOptions struct {
 
 // ResumeJob resumes a job with the specified JobID.
 func (c *Client) ResumeJob(jobID common.JobID, opts ResumeJobOptions) (err error) {
-
 	if jobID.IsEmpty() {
 		return errors.New("resume job requires the JobID")
 	}
-	// TODO (gapra): Implement the logic to resume a job.
+
+	// TODO : resume init, set glcm
+
+	// if no logging, set this empty so that we don't display the log location
+	if c.GetLogLevel() == common.LogNone {
+		common.LogPathFolder = ""
+	}
+
+	// Get fromTo info, so we can decide what's the proper credential type to use.
+	jobDetails := jobsAdmin.GetJobDetails(common.GetJobDetailsRequest{JobID: jobID})
+	if jobDetails.ErrorMsg != "" {
+		return errors.New(jobDetails.ErrorMsg)
+	}
+	if jobDetails.FromTo.From() == common.ELocation.Benchmark() ||
+		jobDetails.FromTo.To() == common.ELocation.Benchmark() {
+		// Doesn't make sense to resume a benchmark job.
+		// It's not tested, and wouldn't report progress correctly and wouldn't clean up after itself properly
+		return errors.New("resuming benchmark jobs is not supported")
+	}
+
+	sourceSAS := normalizeSAS(opts.SourceSAS)
+	destinationSAS := normalizeSAS(opts.DestinationSAS)
+
+	srcResourceString, err := SplitResourceString(jobDetails.Source, jobDetails.FromTo.From())
+	if err != nil {
+		return fmt.Errorf("error parsing source resource string: %w", err)
+	}
+	srcResourceString.SAS = sourceSAS
+	dstResourceString, err := SplitResourceString(jobDetails.Destination, jobDetails.FromTo.To())
+	if err != nil {
+		return fmt.Errorf("error parsing destination resource string: %w", err)
+	}
+	dstResourceString.SAS = destinationSAS
+
+	// TODO: Replace context with root context
+	ctx := context.WithValue(context.TODO(), ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
+	srcServiceClient, dstServiceClient, err := getSourceAndDestinationServiceClients(
+		ctx,
+		srcResourceString,
+		dstResourceString,
+		jobDetails,
+		c.GetUserOAuthTokenManagerInstance(),
+	)
+	if err != nil {
+		return fmt.Errorf("cannot resume job with JobId %s, could not create service clients %v", jobID, err.Error())
+	}
+
+	// Send resume job request.
+	resumeJobResponse := jobsAdmin.ResumeJobOrder(common.ResumeJobRequest{
+		JobID:            jobID,
+		SourceSAS:        sourceSAS,
+		DestinationSAS:   destinationSAS,
+		SrcServiceClient: srcServiceClient,
+		DstServiceClient: dstServiceClient,
+	})
+
+	if !resumeJobResponse.CancelledPauseResumed {
+		return errors.New(resumeJobResponse.ErrorMsg)
+	}
+
 	return nil
+}
+
+// normalizeSAS ensures the SAS token starts with "?" if non-empty.
+func normalizeSAS(sas string) string {
+	if sas != "" && sas[0] != '?' {
+		return "?" + sas
+	}
+	return sas
+}
+
+func getSourceAndDestinationServiceClients(
+	ctx context.Context,
+	source common.ResourceString,
+	destination common.ResourceString,
+	jobDetails common.GetJobDetailsResponse,
+	uotm *common.UserOAuthTokenManager,
+) (*common.ServiceClient, *common.ServiceClient, error) {
+	fromTo := jobDetails.FromTo
+	srcCredType, isSrcPublic, err := GetCredentialTypeForLocation(ctx,
+		fromTo.From(),
+		source,
+		true,
+		uotm,
+		common.CpkOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var errorMsg = ""
+
+	// For an Azure source, if there is no SAS, the cred type is Anonymous and the resource is not Azure public blob, tell the user they need to pass a new SAS.
+	if fromTo.From().IsAzure() && srcCredType == common.ECredentialType.Anonymous() && source.SAS == "" {
+		if !(fromTo.From() == common.ELocation.Blob() && isSrcPublic) {
+			errorMsg += "source-sas"
+		}
+	}
+
+	dstCredType, isDstPublic, err := GetCredentialTypeForLocation(ctx,
+		fromTo.To(),
+		destination,
+		false,
+		uotm,
+		common.CpkOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if fromTo.To().IsAzure() && dstCredType == common.ECredentialType.Anonymous() && destination.SAS == "" {
+		if !(fromTo.To() == common.ELocation.Blob() && isDstPublic) {
+			if errorMsg == "" {
+				errorMsg = "destination-sas"
+			} else {
+				errorMsg += " and destination-sas"
+			}
+		}
+	}
+	if errorMsg != "" {
+		return nil, nil, fmt.Errorf("the %s switch must be provided to resume the job", errorMsg)
+	}
+
+	var tc azcore.TokenCredential
+	if srcCredType.IsAzureOAuth() || dstCredType.IsAzureOAuth() {
+		// Get token from env var or cache.
+		tokenInfo, err := uotm.GetTokenInfo(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		tc, err = tokenInfo.GetTokenCredential()
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	var reauthTok *common.ScopedAuthenticator
+	if at, ok := tc.(common.AuthenticateToken); ok { // We don't need two different tokens here since it gets passed in just the same either way.
+		// This will cause a reauth with StorageScope, which is fine, that's the original Authenticate call as it stands.
+		reauthTok = (*common.ScopedAuthenticator)(common.NewScopedCredential(at, common.ECredentialType.OAuthToken()))
+	}
+	// But we don't want to supply a reauth token if we're not using OAuth. That could cause problems if say, a SAS is invalid.
+	options := CreateClientOptions(common.AzcopyCurrentJobLogger, nil, common.Iff(srcCredType.IsAzureOAuth(), reauthTok, nil))
+
+	var fileSrcClientOptions any
+	if fromTo.From() == common.ELocation.File() || fromTo.From() == common.ELocation.FileNFS() {
+		fileSrcClientOptions = &common.FileClientOptions{
+			AllowTrailingDot: jobDetails.TrailingDot.IsEnabled(), //Access the trailingDot option of the job
+		}
+	}
+	srcServiceClient, err := common.GetServiceClientForLocation(fromTo.From(), source, srcCredType, tc, &options, fileSrcClientOptions)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var srcCred *common.ScopedToken
+	if fromTo.IsS2S() && srcCredType.IsAzureOAuth() {
+		srcCred = common.NewScopedCredential(tc, srcCredType)
+	}
+	options = CreateClientOptions(common.AzcopyCurrentJobLogger, srcCred, common.Iff(dstCredType.IsAzureOAuth(), reauthTok, nil))
+	var fileClientOptions any
+	if fromTo.To() == common.ELocation.File() || fromTo.To() == common.ELocation.FileNFS() {
+		fileClientOptions = &common.FileClientOptions{
+			AllowSourceTrailingDot: jobDetails.TrailingDot.IsEnabled() && fromTo.From() == common.ELocation.File(),
+			AllowTrailingDot:       jobDetails.TrailingDot.IsEnabled(),
+		}
+	}
+	dstServiceClient, err := common.GetServiceClientForLocation(fromTo.To(), destination, dstCredType, tc, &options, fileClientOptions)
+	if err != nil {
+		return nil, nil, err
+	}
+	return srcServiceClient, dstServiceClient, nil
 }

--- a/azcopy/pathUtils.go
+++ b/azcopy/pathUtils.go
@@ -1,0 +1,149 @@
+package azcopy
+
+import (
+	"fmt"
+	"net/url"
+	"path"
+	"strings"
+
+	blobsas "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas"
+	datalakesas "github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/sas"
+	filesas "github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/sas"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+)
+
+func SplitResourceString(raw string, loc common.Location) (common.ResourceString, error) {
+	sasless, sas, err := splitAuthTokenFromResource(raw, loc)
+	if err != nil {
+		return common.ResourceString{}, err
+	}
+	main, query := splitQueryFromSaslessResource(sasless, loc)
+	return common.ResourceString{
+		Value:      main,
+		SAS:        sas,
+		ExtraQuery: query,
+	}, nil
+}
+
+// resourceBase will always be returned regardless of the location.
+// resourceToken will be separated and returned depending on the location.
+func splitAuthTokenFromResource(resource string, location common.Location) (resourceBase, resourceToken string, err error) {
+	switch location {
+	case common.ELocation.Local():
+		if resource == common.Dev_Null {
+			return resource, "", nil // don't mess with the special dev-null path, at all
+		}
+		return CleanLocalPath(common.ToExtendedPath(resource)), "", nil
+	case common.ELocation.Pipe():
+		return resource, "", nil
+	case common.ELocation.S3():
+		// Encoding +s as %20 (space) is important in S3 URLs as this is unsupported in Azure (but %20 can still be used as a space in S3 URLs)
+		var baseURL *url.URL
+		baseURL, err = url.Parse(resource)
+
+		if err != nil {
+			return resource, "", err
+		}
+
+		*baseURL = common.URLExtension{URL: *baseURL}.URLWithPlusDecodedInPath()
+		return baseURL.String(), "", nil
+	case common.ELocation.GCP():
+		return resource, "", nil
+	case common.ELocation.Benchmark(), // cover for benchmark as we generate data for that
+		common.ELocation.Unknown(), // cover for unknown as we treat that as garbage
+		common.ELocation.None():
+		// Local and S3 don't feature URL-embedded tokens
+		return resource, "", nil
+
+	// Use resource-specific APIs that all mostly do the same thing, just on the off-chance they end up doing something slightly different in the future.
+	// TODO: make GetAccountRoot and GetContainerName use their own specific APIs as well. It's _unlikely_ at best that the URL format will change drastically.
+	//       but just on the off-chance that it does, I'd prefer if AzCopy could adapt adequately as soon as the SDK catches the change
+	//       We've already seen a similar thing happen with Blob SAS tokens and the introduction of User Delegation Keys.
+	//       It's not a breaking change to the way SAS tokens work, but a pretty major addition.
+	// TODO: Find a clever way to reduce code duplication in here. Especially the URL parsing.
+	case common.ELocation.Blob():
+		var bURLParts blobsas.URLParts
+		bURLParts, err = blobsas.ParseURL(resource)
+		if err != nil {
+			return resource, "", err
+		}
+
+		resourceToken = bURLParts.SAS.Encode()
+		bURLParts.SAS = blobsas.QueryParameters{} // clear the SAS token and drop the raw, base URL
+		resourceBase = bURLParts.String()
+		return
+	case common.ELocation.File(), common.ELocation.FileNFS():
+		var fURLParts filesas.URLParts
+		fURLParts, err = filesas.ParseURL(resource)
+		if err != nil {
+			return resource, "", err
+		}
+
+		resourceToken = fURLParts.SAS.Encode()
+		fURLParts.SAS = filesas.QueryParameters{} // clear the SAS token and drop the raw, base URL
+		resourceBase = fURLParts.String()
+		return
+	case common.ELocation.BlobFS():
+		var dURLParts datalakesas.URLParts
+		dURLParts, err = datalakesas.ParseURL(resource)
+		if err != nil {
+			return resource, "", err
+		}
+
+		resourceToken = dURLParts.SAS.Encode()
+		dURLParts.SAS = datalakesas.QueryParameters{} // clear the SAS token and drop the raw, base URL
+		resourceBase = dURLParts.String()
+		return
+	default:
+		panic(fmt.Sprintf("One or more location(s) may be missing from SplitAuthTokenFromResource. Location: %s", location))
+	}
+}
+
+// While there should be on SAS's in resource, it may have other query string elements,
+// such as a snapshot identifier, or other unparsed params. This splits those out,
+// so we can preserve them without having them get in the way of our use of
+// the resource root string. (e.g. don't want them right on the end of it, when we append stuff)
+func splitQueryFromSaslessResource(resource string, loc common.Location) (mainUrl string, queryAndFragment string) {
+	if !loc.IsRemote() {
+		return resource, "" // only remote resources have query strings
+	}
+
+	if u, err := url.Parse(resource); err == nil && u.Query().Get("sig") != "" {
+		panic("this routine can only be called after the SAS has been removed")
+		// because, for security reasons, we don't want SASs returned in queryAndFragment, since
+		// we will persist that (but we don't want to persist SAS's)
+	}
+
+	// Work directly with a string-based format, so that we get both snapshot identifiers AND any other unparsed params
+	// (types like BlobUrlParts handle those two things in separate properties, but return them together in the query string)
+	i := strings.Index(resource, "?") // only the first ? is syntactically significant in a URL
+	if i < 0 {
+		return resource, ""
+	} else if i == len(resource)-1 {
+		return resource[:i], ""
+	} else {
+		return resource[:i], resource[i+1:]
+	}
+}
+
+func CleanLocalPath(localPath string) string {
+	localPathSeparator := common.DeterminePathSeparator(localPath)
+	// path.Clean only likes /, and will only handle /. So, we consolidate it to /.
+	// it will do absolutely nothing with \.
+	normalizedPath := path.Clean(strings.ReplaceAll(localPath, localPathSeparator, common.AZCOPY_PATH_SEPARATOR_STRING))
+	// return normalizedPath path separator.
+	normalizedPath = strings.ReplaceAll(normalizedPath, common.AZCOPY_PATH_SEPARATOR_STRING, localPathSeparator)
+
+	// path.Clean steals the first / from the // or \\ prefix.
+	if strings.HasPrefix(localPath, `\\`) || strings.HasPrefix(localPath, `//`) {
+		// return the \ we stole from the UNC/extended path.
+		normalizedPath = localPathSeparator + normalizedPath
+	}
+
+	// path.Clean steals the last / from C:\, C:/, and does not add one for C:
+	if common.RootDriveRegex.MatchString(strings.ReplaceAll(common.ToShortPath(normalizedPath), common.OS_PATH_SEPARATOR, common.AZCOPY_PATH_SEPARATOR_STRING)) {
+		normalizedPath += common.OS_PATH_SEPARATOR
+	}
+
+	return normalizedPath
+}

--- a/azcopy/timeUtils.go
+++ b/azcopy/timeUtils.go
@@ -1,0 +1,65 @@
+package azcopy
+
+import (
+	"fmt"
+	"time"
+)
+
+const ISO8601 = "2006-01-02T15:04:05.0000000Z" // must have 0's for fractional seconds, because Files Service requires fixed width
+
+// ParseISO8601 parses ISO 8601 dates. This routine is needed because GoLang's time.Parse* routines require all expected
+// elements to be present.  I.e. you can't specify just a date, and have the time default to 00:00. But ISO 8601 requires
+// that and, for usability, that's what we want.  (So that users can omit the whole time, or at least the seconds portion of it, if they wish)
+func ParseISO8601(s string, chooseEarliest bool) (time.Time, error) {
+
+	// list of ISO-8601 Go-lang formats in descending order of completeness
+	formats := []string{
+		ISO8601,                     // Support AzFile's more accurate format
+		"2006-01-02T15:04:05Z07:00", // equal to time.RFC3339, which in Go parsing is basically "ISO 8601 with nothing optional"
+		"2006-01-02T15:04:05",       // no timezone
+		"2006-01-02T15:04",          // no seconds
+		"2006-01-02T15",             // no minutes
+		"2006-01-02",                // no time
+		// we don't want to support the no day, or no month options. They are too vague for our purposes
+	}
+
+	loc, err := time.LoadLocation("Local")
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	// Try from most precise to least
+	// (If user has some OTHER format, with extra chars we don't expect an any format, all will fail)
+	for _, f := range formats {
+		t, err := time.ParseInLocation(f, s, loc)
+		if err == nil {
+			if t.Location() == loc {
+				// if we are working in local time, then detect the case where the time falls in the repeated hour
+				// at then end of daylight saving, and resolve it according to chooseEarliest
+				const localNoTimezone = "2006-01-02T15:04:05"
+				var possibleLocalDuplicate time.Time
+				if chooseEarliest {
+					possibleLocalDuplicate = t.Add(-time.Hour) // test an hour earlier, and favour it, if it's the same local time
+				} else {
+					possibleLocalDuplicate = t.Add(time.Hour) // test an hour later, and favour it, if it's the same local time
+				}
+				isSameLocalTime := possibleLocalDuplicate.Format(localNoTimezone) == t.Format(localNoTimezone)
+				if isSameLocalTime {
+					return possibleLocalDuplicate, nil
+				}
+			}
+			return t, nil
+		}
+	}
+
+	// Nothing worked. Get fresh error from first format, and supplement it with additional hints.
+	_, err = time.ParseInLocation(formats[0], s, loc)
+	err = fmt.Errorf("could not parse date/time '%s'. Expecting ISO8601 format, with 4 digit year and 2-digits for all other elements. Error hint: %w",
+		s, err)
+	return time.Time{}, err
+}
+
+// FormatAsUTC is inverse of parseISO8601 (and always uses the most detailed format)
+func FormatAsUTC(t time.Time) string {
+	return t.UTC().Format(time.RFC3339)
+}

--- a/azcopy/zt_credentialUtil_test.go
+++ b/azcopy/zt_credentialUtil_test.go
@@ -32,11 +32,47 @@ import (
 	chk "gopkg.in/check.v1"
 )
 
+// Needed so UT don't panic when they try to use the lifecycle manager
+type mockedLifecycleManager struct {
+}
+
+func (m mockedLifecycleManager) OnStart(ctx common.JobContext) {
+}
+
+func (m mockedLifecycleManager) OnScanProgress(progress common.ScanProgress) {
+}
+
+func (m mockedLifecycleManager) OnTransferProgress(progress common.TransferProgress) {
+}
+
+func (m mockedLifecycleManager) OnComplete(summary common.JobSummary) {
+}
+
+func (m mockedLifecycleManager) Error(s string) {
+}
+
+func (m mockedLifecycleManager) RegisterCloseFunc(f func()) {
+}
+
+func (m mockedLifecycleManager) Prompt(message string, details common.PromptDetails) common.ResponseOption {
+	return common.EResponseOption.Default()
+}
+
+func (m mockedLifecycleManager) Info(s string) {
+}
+
+func (m mockedLifecycleManager) Warn(s string) {
+}
+
+func (m mockedLifecycleManager) E2EAwaitAllowOpenFiles() {
+}
+
 type credentialUtilSuite struct{}
 
 var _ = chk.Suite(&credentialUtilSuite{})
 
 func TestCheckAuthSafeForTarget(t *testing.T) {
+	common.SetJobLifecycleHandler(mockedLifecycleManager{})
 	a := assert.New(t)
 	tests := []struct {
 		ct               common.CredentialType
@@ -94,6 +130,7 @@ func TestCheckAuthSafeForTarget(t *testing.T) {
 }
 
 func TestCheckAuthSafeForTargetIsCalledWhenGettingAuthType(t *testing.T) {
+	common.SetJobLifecycleHandler(mockedLifecycleManager{})
 	common.AzcopyJobPlanFolder = os.TempDir()
 	a := assert.New(t)
 	mockGetCredTypeFromEnvVar := func() common.CredentialType {
@@ -112,6 +149,7 @@ func TestCheckAuthSafeForTargetIsCalledWhenGettingAuthType(t *testing.T) {
 }
 
 func TestCheckAuthSafeForTargetIsCalledWhenGettingAuthTypeMDOAuth(t *testing.T) {
+	common.SetJobLifecycleHandler(mockedLifecycleManager{})
 	a := assert.New(t)
 	mockGetCredTypeFromEnvVar := func() common.CredentialType {
 		return common.ECredentialType.MDOAuthToken() // force it to OAuth, which is the case we want to test
@@ -133,6 +171,7 @@ func TestCheckAuthSafeForTargetIsCalledWhenGettingAuthTypeMDOAuth(t *testing.T) 
  * Two cases are considered, a blob is public or a container is public.
  */
 func TestIsPublic(t *testing.T) {
+	common.SetJobLifecycleHandler(mockedLifecycleManager{})
 	// TODO: Migrate this test to mocked UT.
 	t.Skip("Public access is sometimes turned off due to organization policy. This test should ideally be migrated to a mocked UT.")
 

--- a/azcopy/zt_credentialUtil_test.go
+++ b/azcopy/zt_credentialUtil_test.go
@@ -32,47 +32,12 @@ import (
 	chk "gopkg.in/check.v1"
 )
 
-// Needed so UT don't panic when they try to use the lifecycle manager
-type mockedLifecycleManager struct {
-}
-
-func (m mockedLifecycleManager) OnStart(ctx common.JobContext) {
-}
-
-func (m mockedLifecycleManager) OnScanProgress(progress common.ScanProgress) {
-}
-
-func (m mockedLifecycleManager) OnTransferProgress(progress common.TransferProgress) {
-}
-
-func (m mockedLifecycleManager) OnComplete(summary common.JobSummary) {
-}
-
-func (m mockedLifecycleManager) Error(s string) {
-}
-
-func (m mockedLifecycleManager) RegisterCloseFunc(f func()) {
-}
-
-func (m mockedLifecycleManager) Prompt(message string, details common.PromptDetails) common.ResponseOption {
-	return common.EResponseOption.Default()
-}
-
-func (m mockedLifecycleManager) Info(s string) {
-}
-
-func (m mockedLifecycleManager) Warn(s string) {
-}
-
-func (m mockedLifecycleManager) E2EAwaitAllowOpenFiles() {
-}
-
 type credentialUtilSuite struct{}
 
 var _ = chk.Suite(&credentialUtilSuite{})
 
 func TestCheckAuthSafeForTarget(t *testing.T) {
-	common.SetJobLifecycleHandler(mockedLifecycleManager{})
+	common.SetJobLifecycleHandler(common.MockedJobLifecycleHandler{})
 	a := assert.New(t)
 	tests := []struct {
 		ct               common.CredentialType
@@ -130,7 +95,7 @@ func TestCheckAuthSafeForTarget(t *testing.T) {
 }
 
 func TestCheckAuthSafeForTargetIsCalledWhenGettingAuthType(t *testing.T) {
-	common.SetJobLifecycleHandler(mockedLifecycleManager{})
+	common.SetJobLifecycleHandler(common.MockedJobLifecycleHandler{})
 	common.AzcopyJobPlanFolder = os.TempDir()
 	a := assert.New(t)
 	mockGetCredTypeFromEnvVar := func() common.CredentialType {
@@ -149,7 +114,7 @@ func TestCheckAuthSafeForTargetIsCalledWhenGettingAuthType(t *testing.T) {
 }
 
 func TestCheckAuthSafeForTargetIsCalledWhenGettingAuthTypeMDOAuth(t *testing.T) {
-	common.SetJobLifecycleHandler(mockedLifecycleManager{})
+	common.SetJobLifecycleHandler(common.MockedJobLifecycleHandler{})
 	a := assert.New(t)
 	mockGetCredTypeFromEnvVar := func() common.CredentialType {
 		return common.ECredentialType.MDOAuthToken() // force it to OAuth, which is the case we want to test
@@ -171,7 +136,7 @@ func TestCheckAuthSafeForTargetIsCalledWhenGettingAuthTypeMDOAuth(t *testing.T) 
  * Two cases are considered, a blob is public or a container is public.
  */
 func TestIsPublic(t *testing.T) {
-	common.SetJobLifecycleHandler(mockedLifecycleManager{})
+	common.SetJobLifecycleHandler(common.MockedJobLifecycleHandler{})
 	// TODO: Migrate this test to mocked UT.
 	t.Skip("Public access is sometimes turned off due to organization policy. This test should ideally be migrated to a mocked UT.")
 

--- a/azcopy/zt_credentialUtil_test.go
+++ b/azcopy/zt_credentialUtil_test.go
@@ -18,19 +18,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package cmd
+package azcopy
 
 import (
 	"context"
 	"os"
 	"strings"
 	"testing"
-	"time"
 
-	"github.com/Azure/azure-storage-azcopy/v10/azcopy"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	chk "gopkg.in/check.v1"
 )
@@ -103,7 +100,7 @@ func TestCheckAuthSafeForTargetIsCalledWhenGettingAuthType(t *testing.T) {
 		return common.ECredentialType.OAuthToken() // force it to OAuth, which is the case we want to test
 	}
 
-	res, err := azcopy.SplitResourceString("http://notblob.example.com", common.ELocation.Blob())
+	res, err := SplitResourceString("http://notblob.example.com", common.ELocation.Blob())
 	a.NoError(err)
 
 	// Call our core cred type getter function, in a way that will fail the safety check, and assert
@@ -120,7 +117,7 @@ func TestCheckAuthSafeForTargetIsCalledWhenGettingAuthTypeMDOAuth(t *testing.T) 
 		return common.ECredentialType.MDOAuthToken() // force it to OAuth, which is the case we want to test
 	}
 
-	res, err := azcopy.SplitResourceString("http://notblob.example.com", common.ELocation.Blob())
+	res, err := SplitResourceString("http://notblob.example.com", common.ELocation.Blob())
 	a.NoError(err)
 
 	// Call our core cred type getter function, in a way that will fail the safety check, and assert
@@ -139,30 +136,29 @@ func TestIsPublic(t *testing.T) {
 	// TODO: Migrate this test to mocked UT.
 	t.Skip("Public access is sometimes turned off due to organization policy. This test should ideally be migrated to a mocked UT.")
 
-	a := assert.New(t)
-	ctx, _ := context.WithTimeout(context.TODO(), 5*time.Minute)
-	bsc := getBlobServiceClient()
-	ctr, _ := getContainerClient(a, bsc)
-	defer ctr.Delete(ctx, nil)
-
-	publicAccess := container.PublicAccessTypeContainer
-
-	// Create a public container
-	_, err := ctr.Create(ctx, &container.CreateOptions{Access: &publicAccess})
-	a.Nil(err)
-
-	// verify that container is public
-	a.True(isPublic(ctx, ctr.URL(), common.CpkOptions{}))
-
-	publicAccess = container.PublicAccessTypeBlob
-	_, err = ctr.SetAccessPolicy(ctx, &container.SetAccessPolicyOptions{Access: &publicAccess})
-	a.Nil(err)
-
-	// Verify that blob is public.
-	bb, _ := getBlockBlobClient(a, ctr, "")
-	_, err = bb.UploadBuffer(ctx, []byte("I'm a block blob."), nil)
-	a.Nil(err)
-
-	a.True(isPublic(ctx, bb.URL(), common.CpkOptions{}))
-
+	//a := assert.New(t)
+	//ctx, _ := context.WithTimeout(context.TODO(), 5*time.Minute)
+	//bsc := getBlobServiceClient()
+	//ctr, _ := getContainerClient(a, bsc)
+	//defer ctr.Delete(ctx, nil)
+	//
+	//publicAccess := container.PublicAccessTypeContainer
+	//
+	//// Create a public container
+	//_, err := ctr.Create(ctx, &container.CreateOptions{Access: &publicAccess})
+	//a.Nil(err)
+	//
+	//// verify that container is public
+	//a.True(isPublic(ctx, ctr.URL(), common.CpkOptions{}))
+	//
+	//publicAccess = container.PublicAccessTypeBlob
+	//_, err = ctr.SetAccessPolicy(ctx, &container.SetAccessPolicyOptions{Access: &publicAccess})
+	//a.Nil(err)
+	//
+	//// Verify that blob is public.
+	//bb, _ := getBlockBlobClient(a, ctr, "")
+	//_, err = bb.UploadBuffer(ctx, []byte("I'm a block blob."), nil)
+	//a.Nil(err)
+	//
+	//a.True(isPublic(ctx, bb.URL(), common.CpkOptions{}))
 }

--- a/azcopy/zt_pathUtils_test.go
+++ b/azcopy/zt_pathUtils_test.go
@@ -18,12 +18,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package cmd
+package azcopy
 
 import (
 	"testing"
 
-	"github.com/Azure/azure-storage-azcopy/v10/azcopy"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/stretchr/testify/assert"
 	chk "gopkg.in/check.v1"
@@ -57,16 +56,8 @@ func TestStripQueryFromSaslessUrl(t *testing.T) {
 		if t.isRemote {
 			loc = common.ELocation.File()
 		}
-		m, q := azcopy.splitQueryFromSaslessResource(t.full, loc)
+		m, q := splitQueryFromSaslessResource(t.full, loc)
 		a.Equal(t.expectedMain, m)
 		a.Equal(t.expectedQuery, q)
 	}
-}
-
-func TestToReversedString(t *testing.T) {
-	a := assert.New(t)
-	traverser := &benchmarkTraverser{}
-	a.Equal("1", traverser.toReversedString(1))
-	a.Equal("01", traverser.toReversedString(10))
-	a.Equal("54321", traverser.toReversedString(12345))
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -170,6 +170,11 @@ jobs:
         name: 'Acquire_the_distributed_mutex'
       - template: azurePipelineTemplates/run-ut.yml
         parameters:
+          directory: 'azcopy'
+          coverage_name: 'azcopy'
+      - template: azurePipelineTemplates/run-ut.yml
+      - template: azurePipelineTemplates/run-ut.yml
+        parameters:
           directory: 'cmd'
           coverage_name: 'cmd'
       - template: azurePipelineTemplates/run-ut.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -173,7 +173,6 @@ jobs:
           directory: 'azcopy'
           coverage_name: 'azcopy'
       - template: azurePipelineTemplates/run-ut.yml
-      - template: azurePipelineTemplates/run-ut.yml
         parameters:
           directory: 'cmd'
           coverage_name: 'cmd'

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -56,14 +56,5 @@ const (
 	base10Mega = 1000 * 1000
 )
 
-// credentials related consts
-const (
-	oauthLoginSessionCacheKeyName     = "AzCopyOAuthTokenCache"
-	oauthLoginSessionCacheServiceName = "AzCopyV10"
-	oauthLoginSessionCacheAccountName = "AzCopyOAuthTokenCache"
-	trustedSuffixesNameAAD            = "trusted-microsoft-suffixes"
-	trustedSuffixesAAD                = "*.core.windows.net;*.core.chinacloudapi.cn;*.core.cloudapi.de;*.core.usgovcloudapi.net;*.storage.azure.net"
-)
-
 const MAX_SYMLINKS_TO_FOLLOW = 40
 const NumOfFilesPerDispatchJobPart = 10000

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -325,7 +325,7 @@ func (raw *rawCopyCmdArgs) toOptions() (cooked CookedCopyCmdArgs, err error) {
 	if raw.includeBefore != "" {
 		// must set chooseEarliest = false, so that if there's an ambiguous local date, the latest will be returned
 		// (since that's safest for includeBefore.  Better to choose the later time and do more work, than the earlier one and fail to pick up a changed file
-		parsedIncludeBefore, err := IncludeBeforeDateFilter{}.ParseISO8601(raw.includeBefore, false)
+		parsedIncludeBefore, err := azcopy.ParseISO8601(raw.includeBefore, false)
 		if err != nil {
 			return cooked, err
 		}
@@ -335,7 +335,7 @@ func (raw *rawCopyCmdArgs) toOptions() (cooked CookedCopyCmdArgs, err error) {
 	if raw.includeAfter != "" {
 		// must set chooseEarliest = true, so that if there's an ambiguous local date, the earliest will be returned
 		// (since that's safest for includeAfter.  Better to choose the earlier time and do more work, than the later one and fail to pick up a changed file
-		parsedIncludeAfter, err := IncludeAfterDateFilter{}.ParseISO8601(raw.includeAfter, true)
+		parsedIncludeAfter, err := azcopy.ParseISO8601(raw.includeAfter, true)
 		if err != nil {
 			return cooked, err
 		}

--- a/cmd/copyEnumeratorHelper_test.go
+++ b/cmd/copyEnumeratorHelper_test.go
@@ -21,9 +21,11 @@
 package cmd
 
 import (
+	"testing"
+
+	"github.com/Azure/azure-storage-azcopy/v10/azcopy"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func newLocalRes(path string) common.ResourceString {
@@ -31,7 +33,7 @@ func newLocalRes(path string) common.ResourceString {
 }
 
 func newRemoteRes(url string) common.ResourceString {
-	r, err := SplitResourceString(url, common.ELocation.Blob())
+	r, err := azcopy.SplitResourceString(url, common.ELocation.Blob())
 	if err != nil {
 		panic("can't parse resource string")
 	}

--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/datalakeerror"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/fileerror"
+	"github.com/Azure/azure-storage-azcopy/v10/azcopy"
 
 	"github.com/Azure/azure-storage-azcopy/v10/jobsAdmin"
 
@@ -67,7 +68,7 @@ func (cca *CookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 		(cca.FromTo.From().IsFile() &&
 			cca.FromTo.To().IsRemote() && (cca.s2sSourceChangeValidation || cca.IncludeAfter != nil || cca.IncludeBefore != nil)) || // If S2S from File to *, and sourceChangeValidation is enabled, we get properties so that we have LMTs. Likewise, if we are using includeAfter or includeBefore, which require LMTs.
 		(cca.FromTo.From().IsRemote() && cca.FromTo.To().IsRemote() && cca.s2sPreserveProperties.Value() && !cca.s2sGetPropertiesInBackend) // If S2S and preserve properties AND get properties in backend is on, turn this off, as properties will be obtained in the backend.
-	jobPartOrder.S2SGetPropertiesInBackend = cca.s2sPreserveProperties.Value() && !getRemoteProperties && cca.s2sGetPropertiesInBackend     // Infer GetProperties if GetPropertiesInBackend is enabled.
+	jobPartOrder.S2SGetPropertiesInBackend = cca.s2sPreserveProperties.Value() && !getRemoteProperties && cca.s2sGetPropertiesInBackend // Infer GetProperties if GetPropertiesInBackend is enabled.
 	jobPartOrder.S2SSourceChangeValidation = cca.s2sSourceChangeValidation
 	jobPartOrder.DestLengthValidation = cca.CheckLength
 	jobPartOrder.S2SInvalidMetadataHandleOption = cca.s2sInvalidMetadataHandleOption
@@ -501,7 +502,7 @@ func (cca *CookedCopyCmdArgs) createDstContainer(containerName string, dstWithSA
 		reauthTok = (*common.ScopedAuthenticator)(common.NewScopedCredential(at, common.ECredentialType.OAuthToken()))
 	}
 
-	options := createClientOptions(
+	options := azcopy.CreateClientOptions(
 		common.LogLevelOverrideLogger{ // override our log level here
 			ILoggerResetable:  common.AzcopyCurrentJobLogger,
 			MinimumLevelToLog: common.Iff(Client.GetLogLevel() == common.ELogLevel.Debug(), common.ELogLevel.Debug(), common.ELogLevel.None()),

--- a/cmd/credentialUtil.go
+++ b/cmd/credentialUtil.go
@@ -24,400 +24,21 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"net/http"
-	"net/url"
-	"strings"
-	"sync"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
+	"github.com/Azure/azure-storage-azcopy/v10/azcopy"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
-	"github.com/Azure/azure-storage-azcopy/v10/ste"
-	"github.com/minio/minio-go/pkg/s3utils"
 )
-
-var autoOAuth sync.Once
-
-var sharedKeyDeprecation sync.Once
-var sharedKeyDeprecationMessage = "*** WARNING *** shared key authentication for datalake is deprecated and will be removed in a future release. Please use shared access signature (SAS) or OAuth for authentication."
-
-func warnIfSharedKeyAuthForDatalake() {
-	sharedKeyDeprecation.Do(func() {
-		glcm.Warn(sharedKeyDeprecationMessage)
-		common.LogToJobLogWithPrefix(sharedKeyDeprecationMessage, common.LogWarning)
-	})
-}
-
-var announceOAuthTokenOnce sync.Once
-
-var stashedEnvCredType = ""
-
-// GetCredTypeFromEnvVar tries to get credential type from environment variable defined by envVarCredentialType.
-func GetCredTypeFromEnvVar() common.CredentialType {
-	rawVal := stashedEnvCredType
-	if stashedEnvCredType == "" {
-		rawVal = common.GetEnvironmentVariable(common.EEnvironmentVariable.CredentialType())
-		if rawVal == "" {
-			return common.ECredentialType.Unknown()
-		}
-		stashedEnvCredType = rawVal
-	}
-
-	// Remove the env var after successfully fetching once,
-	// in case of env var is further spreading into child processes unexpectedly.
-	common.ClearEnvironmentVariable(common.EEnvironmentVariable.CredentialType())
-
-	// Try to get the value set.
-	var credType common.CredentialType
-	if err := credType.Parse(rawVal); err != nil {
-		return common.ECredentialType.Unknown()
-	}
-
-	return credType
-}
 
 type rawFromToInfo struct {
 	fromTo              common.FromTo
 	source, destination common.ResourceString
 }
 
-// checkAuthSafeForTarget checks our "implicit" auth types (those that pick up creds from the environment
-// or a prior login) to make sure they are only being used in places where we know those auth types are safe.
-// This prevents, for example, us accidentally sending OAuth creds to some place they don't belong
-func checkAuthSafeForTarget(ct common.CredentialType, resource, extraSuffixesAAD string, resourceType common.Location) error {
-
-	getSuffixes := func(list string, extras string) []string {
-		extras = strings.Trim(extras, " ")
-		if extras != "" {
-			list += ";" + extras
-		}
-		return strings.Split(list, ";")
-	}
-
-	isResourceInSuffixList := func(suffixes []string) (string, bool) {
-		u, err := url.Parse(resource)
-		if err != nil {
-			return "<unparsable>", false
-		}
-		host := strings.ToLower(u.Host)
-
-		for _, s := range suffixes {
-			s = strings.Trim(s, " *") // trim *.foo to .foo
-			s = strings.ToLower(s)
-			if strings.HasSuffix(host, s) {
-				return host, true
-			}
-		}
-		return host, false
-	}
-
-	switch ct {
-	case common.ECredentialType.Unknown(),
-		common.ECredentialType.Anonymous():
-		// these auth types don't pick up anything from environment vars, so they are not the focus of this routine
-		return nil
-	case common.ECredentialType.OAuthToken(),
-		common.ECredentialType.MDOAuthToken(),
-		common.ECredentialType.SharedKey():
-		// Files doesn't currently support OAuth, but it's a valid azure endpoint anyway, so it'll pass the check.
-		if resourceType != common.ELocation.Blob() && resourceType != common.ELocation.BlobFS() && resourceType != common.ELocation.File() && resourceType != common.ELocation.FileNFS() {
-			// There may be a reason for files->blob to specify this.
-			if resourceType == common.ELocation.Local() {
-				return nil
-			}
-
-			return fmt.Errorf("azure OAuth authentication to %s is not enabled in AzCopy", resourceType.String())
-		}
-
-		// these are Azure auth types, so make sure the resource is known to be in Azure
-		domainSuffixes := getSuffixes(trustedSuffixesAAD, extraSuffixesAAD)
-		if host, ok := isResourceInSuffixList(domainSuffixes); !ok {
-			return fmt.Errorf(
-				"the URL requires authentication. If this URL is in fact an Azure service, you can enable Azure authentication to %s. "+
-					"To enable, view the documentation for "+
-					"the parameter --%s, by running 'AzCopy copy --help'. BUT if this URL is not an Azure service, do NOT enable Azure authentication to it. "+
-					"Instead, see if the URL host supports authentication by way of a token that can be included in the URL's query string",
-				// E.g. CDN apparently supports a non-SAS type of token as noted here: https://docs.microsoft.com/en-us/azure/cdn/cdn-token-auth#setting-up-token-authentication
-				// Including such a token in the URL will cause AzCopy to see it as a "public" URL (since the URL on its own will pass
-				// our "isPublic" access tests, which run before this routine).
-				host, trustedSuffixesNameAAD)
-		}
-
-	case common.ECredentialType.S3AccessKey():
-		if resourceType != common.ELocation.S3() {
-			//noinspection ALL
-			return fmt.Errorf("S3 access key authentication to %s is not enabled in AzCopy", resourceType.String())
-		}
-
-		// just check with minio. No need to have our own list of S3 domains, since minio effectively
-		// has that list already, we can't talk to anything outside that list because minio won't let us,
-		// and the parsing of s3 URL is non-trivial.  E.g. can't just look for the ending since
-		// something like https://someApi.execute-api.someRegion.amazonaws.com is AWS but is a customer-
-		// written code, not S3.
-		ok := false
-		host := "<unparsable url>"
-		u, err := url.Parse(resource)
-		if err == nil {
-			host = u.Host
-			parts, err := common.NewS3URLParts(*u) // strip any leading bucket name from URL, to get an endpoint we can pass to s3utils
-			if err == nil {
-				u, err := url.Parse("https://" + parts.Endpoint)
-				ok = err == nil && s3utils.IsAmazonEndpoint(*u)
-			}
-		}
-
-		if !ok {
-			return fmt.Errorf(
-				"s3 authentication to %s is not currently supported in AzCopy", host)
-		}
-	case common.ECredentialType.GoogleAppCredentials():
-		if resourceType != common.ELocation.GCP() {
-			return fmt.Errorf("google application credentials to %s is not valid", resourceType.String())
-		}
-
-		u, err := url.Parse(resource)
-		if err == nil {
-			host := u.Host
-			_, err := common.NewGCPURLParts(*u)
-			if err != nil {
-				return fmt.Errorf("GCP authentication to %s is not currently supported", host)
-			}
-		}
-	default:
-		panic("unknown credential type")
-	}
-
-	return nil
-}
-
-func logAuthType(ct common.CredentialType, location common.Location, isSource bool) {
-	if location == common.ELocation.Unknown() {
-		return // nothing to log
-	} else if location.IsLocal() {
-		return // don't log local ones, no point
-	} else if ct == common.ECredentialType.Anonymous() {
-		return // don't log these either (too cluttered and auth type is obvious from the URL)
-	}
-
-	resource := "destination"
-	if isSource {
-		resource = "source"
-	}
-	name := ct.String()
-	if ct == common.ECredentialType.OAuthToken() {
-		name = "Azure AD" // clarify the name to something users will recognize
-	} else if ct == common.ECredentialType.MDOAuthToken() {
-		name = "Azure AD (Managed Disk)"
-	}
-	message := fmt.Sprintf("Authenticating to %s using %s", resource, name)
-	if ct == common.ECredentialType.Unknown() && location.IsAzure() {
-		message += ", Please authenticate using Microsoft Entra ID (https://aka.ms/AzCopy/AuthZ), use AzCopy login, or append a SAS token to your Azure URL."
-	}
-	if _, exists := authMessagesAlreadyLogged.Load(message); !exists {
-		authMessagesAlreadyLogged.Store(message, struct{}{}) // dedup because source is auth'd by both enumerator and STE
-		common.LogToJobLogWithPrefix(message, common.LogInfo)
-		glcm.Info(message)
-	}
-}
-
-var authMessagesAlreadyLogged = &sync.Map{}
-
-// isPublic reports true if the Blob URL passed can be read without auth.
-func isPublic(ctx context.Context, blobResourceURL string, cpkOptions common.CpkOptions) (isPublicResource bool) {
-	bURLParts, err := blob.ParseURL(blobResourceURL)
-	if err != nil {
-		return false
-	}
-
-	if bURLParts.ContainerName == "" || strings.Contains(bURLParts.ContainerName, "*") {
-		// Service level searches can't possibly be public.
-		return false
-	}
-
-	// This request will not be logged. This can fail, and too many Cx do not like this.
-	clientOptions := ste.NewClientOptions(policy.RetryOptions{
-		MaxRetries:    ste.UploadMaxTries,
-		TryTimeout:    ste.UploadTryTimeout,
-		RetryDelay:    ste.UploadRetryDelay,
-		MaxRetryDelay: ste.UploadMaxRetryDelay,
-	}, policy.TelemetryOptions{
-		ApplicationID: common.AddUserAgentPrefix(common.UserAgent),
-	}, nil, ste.LogOptions{}, nil, nil)
-
-	blobClient, _ := blob.NewClientWithNoCredential(bURLParts.String(), &blob.ClientOptions{ClientOptions: clientOptions})
-	bURLParts.BlobName = ""
-	bURLParts.Snapshot = ""
-	bURLParts.VersionID = ""
-
-	// Scenario 1: When resourceURL points to a container or a virtual directory
-	// Check if the virtual directory is accessible by doing GetProperties on container.
-	// Virtual directory can be public only when its parent container is public.
-	containerClient, _ := container.NewClientWithNoCredential(bURLParts.String(), &container.ClientOptions{ClientOptions: clientOptions})
-	if _, err := containerClient.GetProperties(ctx, nil); err == nil {
-		return true
-	}
-
-	// Scenario 2: When resourceURL points to a blob
-	if _, err := blobClient.GetProperties(ctx, &blob.GetPropertiesOptions{CPKInfo: cpkOptions.GetCPKInfo()}); err == nil {
-		return true
-	}
-
-	return false
-}
-
-// mdAccountNeedsOAuth pings the passed in md account, and checks if we need additional token with Disk-socpe
-func mdAccountNeedsOAuth(ctx context.Context, blobResourceURL string, cpkOptions common.CpkOptions) bool {
-	// This request will not be logged. This can fail, and too many Cx do not like this.
-	clientOptions := ste.NewClientOptions(policy.RetryOptions{
-		MaxRetries:    ste.UploadMaxTries,
-		TryTimeout:    ste.UploadTryTimeout,
-		RetryDelay:    ste.UploadRetryDelay,
-		MaxRetryDelay: ste.UploadMaxRetryDelay,
-	}, policy.TelemetryOptions{
-		ApplicationID: common.AddUserAgentPrefix(common.UserAgent),
-	}, nil, ste.LogOptions{}, nil, nil)
-
-	blobClient, _ := blob.NewClientWithNoCredential(blobResourceURL, &blob.ClientOptions{ClientOptions: clientOptions})
-	_, err := blobClient.GetProperties(ctx, &blob.GetPropertiesOptions{CPKInfo: cpkOptions.GetCPKInfo()})
-	if err == nil {
-		return false
-	}
-
-	var respErr *azcore.ResponseError
-	if errors.As(err, &respErr) {
-		if respErr.StatusCode == 401 || respErr.StatusCode == 403 { // *sometimes* the service can return 403s.
-			challenge := respErr.RawResponse.Header.Get("WWW-Authenticate")
-			if strings.Contains(challenge, common.MDResource) {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func getCredentialTypeForLocation(ctx context.Context, location common.Location, resource common.ResourceString, isSource bool, uotm *common.UserOAuthTokenManager, cpkOptions common.CpkOptions) (credType common.CredentialType, isPublic bool, err error) {
-	return doGetCredentialTypeForLocation(ctx, location, resource, isSource, GetCredTypeFromEnvVar, uotm, cpkOptions)
-}
-
-func doGetCredentialTypeForLocation(ctx context.Context, location common.Location, resource common.ResourceString, isSource bool, getForcedCredType func() common.CredentialType, uotm *common.UserOAuthTokenManager, cpkOptions common.CpkOptions) (credType common.CredentialType, public bool, err error) {
-	public = false
-	err = nil
-
-	switch location {
-	case common.ELocation.Local(), common.ELocation.Benchmark(), common.ELocation.None(), common.ELocation.Pipe():
-		return common.ECredentialType.Anonymous(), false, nil
-	}
-
-	defer func() {
-		logAuthType(credType, location, isSource)
-	}()
-
-	// caution: If auth-type is unsafe, below defer statement will change the return value credType
-	defer func() {
-		if err != nil {
-			return
-		}
-
-		if err = checkAuthSafeForTarget(credType, resource.Value, TrustedSuffixes, location); err != nil {
-			credType = common.ECredentialType.Unknown()
-			public = false
-		}
-	}()
-
-	if getForcedCredType() != common.ECredentialType.Unknown() &&
-		location != common.ELocation.S3() && location != common.ELocation.GCP() {
-		credType = getForcedCredType()
-		return
-	}
-
-	if location == common.ELocation.S3() {
-		accessKeyID := common.GetEnvironmentVariable(common.EEnvironmentVariable.AWSAccessKeyID())
-		secretAccessKey := common.GetEnvironmentVariable(common.EEnvironmentVariable.AWSSecretAccessKey())
-		if accessKeyID == "" || secretAccessKey == "" {
-			credType = common.ECredentialType.S3PublicBucket()
-			public = true
-			return
-		}
-
-		credType = common.ECredentialType.S3AccessKey()
-		return
-	}
-
-	if location == common.ELocation.GCP() {
-		googleAppCredentials := common.GetEnvironmentVariable(common.EEnvironmentVariable.GoogleAppCredentials())
-		if googleAppCredentials == "" {
-			return common.ECredentialType.Unknown(), false, errors.New("GOOGLE_APPLICATION_CREDENTIALS environment variable must be set before using GCP transfer feature")
-		}
-		credType = common.ECredentialType.GoogleAppCredentials()
-		return
-	}
-
-	// Special blob destinations - public and MD account needing oAuth
-	if location == common.ELocation.Blob() {
-		uri, _ := resource.FullURL()
-		if isSource && resource.SAS == "" && isPublic(ctx, uri.String(), cpkOptions) {
-			credType = common.ECredentialType.Anonymous()
-			public = true
-			return
-		}
-
-		if strings.HasPrefix(uri.Host, "md-") && mdAccountNeedsOAuth(ctx, uri.String(), cpkOptions) {
-			var oAuthTokenExists bool
-			oAuthTokenExists, err = uotm.OAuthTokenExists(&announceOAuthTokenOnce, &autoOAuth)
-			if err != nil {
-				return common.ECredentialType.Unknown(), false, err
-			}
-			if !oAuthTokenExists {
-				return common.ECredentialType.Unknown(), false,
-					common.NewAzError(common.EAzError.LoginCredMissing(), "No SAS token or OAuth token is present and the resource is not public")
-			}
-
-			credType = common.ECredentialType.MDOAuthToken()
-			return
-		}
-	}
-
-	if resource.SAS != "" {
-		credType = common.ECredentialType.Anonymous()
-		return
-	}
-
-	var oAuthTokenExists bool
-	oAuthTokenExists, err = uotm.OAuthTokenExists(&announceOAuthTokenOnce, &autoOAuth)
-	if err != nil {
-		return common.ECredentialType.Unknown(), false, err
-	}
-	if oAuthTokenExists {
-		credType = common.ECredentialType.OAuthToken()
-		return
-	}
-
-	// BlobFS currently supports Shared key. Remove this piece of code, once
-	// we deprecate that.
-	if location == common.ELocation.BlobFS() {
-		name := common.GetEnvironmentVariable(common.EEnvironmentVariable.AccountName())
-		key := common.GetEnvironmentVariable(common.EEnvironmentVariable.AccountKey())
-		if name != "" && key != "" { // TODO: To remove, use for internal testing, SharedKey should not be supported from commandline
-			credType = common.ECredentialType.SharedKey()
-			warnIfSharedKeyAuthForDatalake()
-		}
-	}
-
-	// We may not always use the OAuth token on Managed Disks. As such, we should change to the type indicating the potential for use.
-	// if mdAccount && credType == common.ECredentialType.OAuthToken() {
-	// 	credType = common.ECredentialType.MDOAuthToken()
-	// }
-	return
-}
-
 func GetCredentialInfoForLocation(ctx context.Context, location common.Location, resource common.ResourceString, isSource bool, uotm *common.UserOAuthTokenManager, cpkOptions common.CpkOptions) (credInfo common.CredentialInfo, isPublic bool, err error) {
 
 	// get the type
-	credInfo.CredentialType, isPublic, err = getCredentialTypeForLocation(ctx, location, resource, isSource, uotm, cpkOptions)
+	credInfo.CredentialType, isPublic, err = azcopy.GetCredentialTypeForLocation(ctx, location, resource, isSource, uotm, cpkOptions)
 
 	if err != nil {
 		glcm.Error(err.Error())
@@ -445,7 +66,7 @@ func getCredentialType(ctx context.Context, raw rawFromToInfo, uotm *common.User
 	switch {
 	case raw.fromTo.To().IsRemote():
 		// we authenticate to the destination. Source is assumed to be SAS, or public, or a local resource
-		credType, _, err = getCredentialTypeForLocation(ctx, raw.fromTo.To(), raw.destination, false, uotm, common.CpkOptions{})
+		credType, _, err = azcopy.GetCredentialTypeForLocation(ctx, raw.fromTo.To(), raw.destination, false, uotm, common.CpkOptions{})
 		if err != nil {
 			glcm.Error(err.Error())
 			return
@@ -454,16 +75,16 @@ func getCredentialType(ctx context.Context, raw rawFromToInfo, uotm *common.User
 		raw.fromTo == common.EFromTo.BlobFSTrash() ||
 		raw.fromTo == common.EFromTo.FileTrash():
 		// For to Trash direction, use source as resource URL
-		// Also, by setting isSource=false we inform getCredentialTypeForLocation() that resource
+		// Also, by setting isSource=false we inform GetCredentialTypeForLocation() that resource
 		// being deleted cannot be public.
-		credType, _, err = getCredentialTypeForLocation(ctx, raw.fromTo.From(), raw.source, false, uotm, cpkOptions)
+		credType, _, err = azcopy.GetCredentialTypeForLocation(ctx, raw.fromTo.From(), raw.source, false, uotm, cpkOptions)
 		if err != nil {
 			glcm.Error(err.Error())
 			return
 		}
 	case raw.fromTo.From().IsRemote() && raw.fromTo.To().IsLocal():
 		// we authenticate to the source.
-		credType, _, err = getCredentialTypeForLocation(ctx, raw.fromTo.From(), raw.source, true, uotm, cpkOptions)
+		credType, _, err = azcopy.GetCredentialTypeForLocation(ctx, raw.fromTo.From(), raw.source, true, uotm, cpkOptions)
 		if err != nil {
 			glcm.Error(err.Error())
 			return
@@ -476,29 +97,3 @@ func getCredentialType(ctx context.Context, raw rawFromToInfo, uotm *common.User
 
 	return
 }
-
-// ==============================================================================================
-// pipeline factory methods
-// ==============================================================================================
-// createClientOptions creates generic client options which are required to create any
-// client to interact with storage service. Default options are modified to suit azcopy.
-// srcCred is required in cases where source is authenticated via oAuth for S2S transfers
-func createClientOptions(logger common.ILoggerResetable, srcCred *common.ScopedToken, reauthCred *common.ScopedAuthenticator) azcore.ClientOptions {
-	logOptions := ste.LogOptions{}
-
-	if logger != nil {
-		logOptions.RequestLogOptions.SyslogDisabled = common.IsForceLoggingDisabled()
-		logOptions.Log = logger.Log
-		logOptions.ShouldLog = logger.ShouldLog
-	}
-	return ste.NewClientOptions(policy.RetryOptions{
-		MaxRetries:    ste.UploadMaxTries,
-		TryTimeout:    ste.UploadTryTimeout,
-		RetryDelay:    ste.UploadRetryDelay,
-		MaxRetryDelay: ste.UploadMaxRetryDelay,
-	}, policy.TelemetryOptions{
-		ApplicationID: common.AddUserAgentPrefix(common.UserAgent),
-	}, ste.NewAzcopyHTTPClient(frontEndMaxIdleConnectionsPerHost), logOptions, srcCred, reauthCred)
-}
-
-const frontEndMaxIdleConnectionsPerHost = http.DefaultMaxIdleConnsPerHost

--- a/cmd/jobsResume.go
+++ b/cmd/jobsResume.go
@@ -21,17 +21,15 @@
 package cmd
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-storage-azcopy/v10/azcopy"
 	"github.com/Azure/azure-storage-azcopy/v10/jobsAdmin"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
-	"github.com/Azure/azure-storage-azcopy/v10/ste"
 	"github.com/spf13/cobra"
 )
 
@@ -207,106 +205,6 @@ type resumeCmdArgs struct {
 	DestinationSAS string
 }
 
-// normalizeSAS ensures the SAS token starts with "?" if non-empty.
-func normalizeSAS(sas string) string {
-	if sas != "" && sas[0] != '?' {
-		return "?" + sas
-	}
-	return sas
-}
-
-func getSourceAndDestinationServiceClients(
-	ctx context.Context,
-	source common.ResourceString,
-	destination common.ResourceString,
-	jobDetails common.GetJobDetailsResponse,
-) (*common.ServiceClient, *common.ServiceClient, error) {
-	fromTo := jobDetails.FromTo
-	srcCredType, isSrcPublic, err := getCredentialTypeForLocation(ctx, fromTo.From(), source, true, Client.GetUserOAuthTokenManagerInstance(), common.CpkOptions{})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var errorMsg = ""
-
-	// For an Azure source, if there is no SAS, the cred type is Anonymous and the resource is not Azure public blob, tell the user they need to pass a new SAS.
-	if fromTo.From().IsAzure() && srcCredType == common.ECredentialType.Anonymous() && source.SAS == "" {
-		if !(fromTo.From() == common.ELocation.Blob() && isSrcPublic) {
-			errorMsg += "source-sas"
-		}
-	}
-
-	dstCredType, isDstPublic, err := getCredentialTypeForLocation(ctx, fromTo.To(), destination, false, Client.GetUserOAuthTokenManagerInstance(), common.CpkOptions{})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if fromTo.To().IsAzure() && dstCredType == common.ECredentialType.Anonymous() && destination.SAS == "" {
-		if !(fromTo.To() == common.ELocation.Blob() && isDstPublic) {
-			if errorMsg == "" {
-				errorMsg = "destination-sas"
-			} else {
-				errorMsg += " and destination-sas"
-			}
-		}
-	}
-	if errorMsg != "" {
-		return nil, nil, fmt.Errorf("the %s switch must be provided to resume the job", errorMsg)
-	}
-
-	var tc azcore.TokenCredential
-	if srcCredType.IsAzureOAuth() || dstCredType.IsAzureOAuth() {
-		uotm := Client.GetUserOAuthTokenManagerInstance()
-		// Get token from env var or cache.
-		tokenInfo, err := uotm.GetTokenInfo(ctx)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		tc, err = tokenInfo.GetTokenCredential()
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-
-	var reauthTok *common.ScopedAuthenticator
-	if at, ok := tc.(common.AuthenticateToken); ok { // We don't need two different tokens here since it gets passed in just the same either way.
-		// This will cause a reauth with StorageScope, which is fine, that's the original Authenticate call as it stands.
-		reauthTok = (*common.ScopedAuthenticator)(common.NewScopedCredential(at, common.ECredentialType.OAuthToken()))
-	}
-	// But we don't want to supply a reauth token if we're not using OAuth. That could cause problems if say, a SAS is invalid.
-	options := createClientOptions(common.AzcopyCurrentJobLogger, nil, common.Iff(srcCredType.IsAzureOAuth(), reauthTok, nil))
-
-	var fileSrcClientOptions any
-	if fromTo.From() == common.ELocation.File() || fromTo.From() == common.ELocation.FileNFS() {
-		fileSrcClientOptions = &common.FileClientOptions{
-			AllowTrailingDot: jobDetails.TrailingDot.IsEnabled(), //Access the trailingDot option of the job
-		}
-	}
-	srcServiceClient, err := common.GetServiceClientForLocation(fromTo.From(), source, srcCredType, tc, &options, fileSrcClientOptions)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var srcCred *common.ScopedToken
-	if fromTo.IsS2S() && srcCredType.IsAzureOAuth() {
-		srcCred = common.NewScopedCredential(tc, srcCredType)
-	}
-	options = createClientOptions(common.AzcopyCurrentJobLogger, srcCred, common.Iff(dstCredType.IsAzureOAuth(), reauthTok, nil))
-	var fileClientOptions any
-	if fromTo.To() == common.ELocation.File() || fromTo.To() == common.ELocation.FileNFS() {
-		fileClientOptions = &common.FileClientOptions{
-			AllowSourceTrailingDot: jobDetails.TrailingDot.IsEnabled() && fromTo.From() == common.ELocation.File(),
-			AllowTrailingDot:       jobDetails.TrailingDot.IsEnabled(),
-		}
-	}
-	dstServiceClient, err := common.GetServiceClientForLocation(fromTo.To(), destination, dstCredType, tc, &options, fileClientOptions)
-	if err != nil {
-		return nil, nil, err
-	}
-	return srcServiceClient, dstServiceClient, nil
-}
-
 // processes the resume command,
 // dispatches the resume Job order to the storage engine.
 func (rca resumeCmdArgs) process() error {
@@ -317,59 +215,13 @@ func (rca resumeCmdArgs) process() error {
 		return fmt.Errorf("error parsing the jobId %s. Failed with error %w", rca.jobID, err)
 	}
 
-	// if no logging, set this empty so that we don't display the log location
-	if Client.GetLogLevel() == common.LogNone {
-		common.LogPathFolder = ""
+	opts := azcopy.ResumeJobOptions{
+		SourceSAS:      rca.SourceSAS,
+		DestinationSAS: rca.DestinationSAS,
 	}
-
-	// Get fromTo info, so we can decide what's the proper credential type to use.
-	jobDetails := jobsAdmin.GetJobDetails(common.GetJobDetailsRequest{JobID: jobID})
-	if jobDetails.ErrorMsg != "" {
-		glcm.Error(jobDetails.ErrorMsg)
-	}
-
-	if jobDetails.FromTo.From() == common.ELocation.Benchmark() ||
-		jobDetails.FromTo.To() == common.ELocation.Benchmark() {
-		// Doesn't make sense to resume a benchmark job.
-		// It's not tested, and wouldn't report progress correctly and wouldn't clean up after itself properly
-		return errors.New("resuming benchmark jobs is not supported")
-	}
-	rca.SourceSAS = normalizeSAS(rca.SourceSAS)
-	rca.DestinationSAS = normalizeSAS(rca.DestinationSAS)
-
-	ctx := context.WithValue(context.TODO(), ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
-	// TODO: Replace context with root context
-	srcResourceString, err := SplitResourceString(jobDetails.Source, jobDetails.FromTo.From())
+	err = Client.ResumeJob(jobID, opts)
 	if err != nil {
-		return fmt.Errorf("error parsing source resource string: %w", err)
-	}
-	srcResourceString.SAS = rca.SourceSAS
-	dstResourceString, err := SplitResourceString(jobDetails.Destination, jobDetails.FromTo.To())
-	if err != nil {
-		return fmt.Errorf("error parsing destination resource string: %w", err)
-	}
-	dstResourceString.SAS = rca.DestinationSAS
-
-	srcServiceClient, dstServiceClient, err := getSourceAndDestinationServiceClients(
-		ctx,
-		srcResourceString,
-		dstResourceString,
-		jobDetails,
-	)
-	if err != nil {
-		return fmt.Errorf("cannot resume job with JobId %s, could not create service clients %v", jobID, err.Error())
-	}
-	// Send resume job request.
-	resumeJobResponse := jobsAdmin.ResumeJobOrder(common.ResumeJobRequest{
-		JobID:            jobID,
-		SourceSAS:        rca.SourceSAS,
-		DestinationSAS:   rca.DestinationSAS,
-		SrcServiceClient: srcServiceClient,
-		DstServiceClient: dstServiceClient,
-	})
-
-	if !resumeJobResponse.CancelledPauseResumed {
-		glcm.Error(resumeJobResponse.ErrorMsg)
+		return err
 	}
 
 	controller := resumeJobController{jobID: jobID}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -33,6 +33,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/lease"
+	"github.com/Azure/azure-storage-azcopy/v10/azcopy"
 
 	"github.com/spf13/cobra"
 
@@ -224,7 +225,7 @@ func (cooked cookedListCmdArgs) handleListContainerCommand() (err error) {
 
 	var credentialInfo common.CredentialInfo
 
-	source, err := SplitResourceString(cooked.sourcePath, cooked.location)
+	source, err := azcopy.SplitResourceString(cooked.sourcePath, cooked.location)
 	if err != nil {
 		return err
 	}

--- a/cmd/make.go
+++ b/cmd/make.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake"
+	"github.com/Azure/azure-storage-azcopy/v10/azcopy"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
@@ -77,7 +78,7 @@ type cookedMakeCmdArgs struct {
 func (cookedArgs cookedMakeCmdArgs) process() (err error) {
 	ctx := context.WithValue(context.TODO(), ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
 
-	resourceStringParts, err := SplitResourceString(cookedArgs.resourceURL.String(), cookedArgs.resourceLocation)
+	resourceStringParts, err := azcopy.SplitResourceString(cookedArgs.resourceURL.String(), cookedArgs.resourceLocation)
 	if err != nil {
 		return err
 	}
@@ -98,7 +99,7 @@ func (cookedArgs cookedMakeCmdArgs) process() (err error) {
 	}
 
 	// Note : trailing dot is only applicable to file operations anyway, so setting this to false
-	options := createClientOptions(common.AzcopyCurrentJobLogger, nil, reauthTok)
+	options := azcopy.CreateClientOptions(common.AzcopyCurrentJobLogger, nil, reauthTok)
 	resourceURL := cookedArgs.resourceURL.String()
 	cred := credentialInfo.OAuthTokenInfo.TokenCredential
 

--- a/cmd/pathUtils.go
+++ b/cmd/pathUtils.go
@@ -8,6 +8,7 @@ import (
 	blobsas "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas"
 	datalakesas "github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/sas"
 	filesas "github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/sas"
+	"github.com/Azure/azure-storage-azcopy/v10/azcopy"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/pkg/errors"
@@ -105,7 +106,7 @@ func GetResourceRoot(resource string, location common.Location) (resourceBase st
 		common.ELocation.Benchmark(): // do nothing
 		return resource, nil
 	case common.ELocation.Local():
-		return cleanLocalPath(getPathBeforeFirstWildcard(resource)), nil
+		return azcopy.CleanLocalPath(getPathBeforeFirstWildcard(resource)), nil
 
 	//noinspection GoNilness
 	case common.ELocation.Blob():
@@ -191,120 +192,6 @@ func GetResourceRoot(resource string, location common.Location) (resourceBase st
 	}
 }
 
-func SplitResourceString(raw string, loc common.Location) (common.ResourceString, error) {
-	sasless, sas, err := splitAuthTokenFromResource(raw, loc)
-	if err != nil {
-		return common.ResourceString{}, err
-	}
-	main, query := splitQueryFromSaslessResource(sasless, loc)
-	return common.ResourceString{
-		Value:      main,
-		SAS:        sas,
-		ExtraQuery: query,
-	}, nil
-}
-
-// resourceBase will always be returned regardless of the location.
-// resourceToken will be separated and returned depending on the location.
-func splitAuthTokenFromResource(resource string, location common.Location) (resourceBase, resourceToken string, err error) {
-	switch location {
-	case common.ELocation.Local():
-		if resource == common.Dev_Null {
-			return resource, "", nil // don't mess with the special dev-null path, at all
-		}
-		return cleanLocalPath(common.ToExtendedPath(resource)), "", nil
-	case common.ELocation.Pipe():
-		return resource, "", nil
-	case common.ELocation.S3():
-		// Encoding +s as %20 (space) is important in S3 URLs as this is unsupported in Azure (but %20 can still be used as a space in S3 URLs)
-		var baseURL *url.URL
-		baseURL, err = url.Parse(resource)
-
-		if err != nil {
-			return resource, "", err
-		}
-
-		*baseURL = common.URLExtension{URL: *baseURL}.URLWithPlusDecodedInPath()
-		return baseURL.String(), "", nil
-	case common.ELocation.GCP():
-		return resource, "", nil
-	case common.ELocation.Benchmark(), // cover for benchmark as we generate data for that
-		common.ELocation.Unknown(), // cover for unknown as we treat that as garbage
-		common.ELocation.None():
-		// Local and S3 don't feature URL-embedded tokens
-		return resource, "", nil
-
-	// Use resource-specific APIs that all mostly do the same thing, just on the off-chance they end up doing something slightly different in the future.
-	// TODO: make GetAccountRoot and GetContainerName use their own specific APIs as well. It's _unlikely_ at best that the URL format will change drastically.
-	//       but just on the off-chance that it does, I'd prefer if AzCopy could adapt adequately as soon as the SDK catches the change
-	//       We've already seen a similar thing happen with Blob SAS tokens and the introduction of User Delegation Keys.
-	//       It's not a breaking change to the way SAS tokens work, but a pretty major addition.
-	// TODO: Find a clever way to reduce code duplication in here. Especially the URL parsing.
-	case common.ELocation.Blob():
-		var bURLParts blobsas.URLParts
-		bURLParts, err = blobsas.ParseURL(resource)
-		if err != nil {
-			return resource, "", err
-		}
-
-		resourceToken = bURLParts.SAS.Encode()
-		bURLParts.SAS = blobsas.QueryParameters{} // clear the SAS token and drop the raw, base URL
-		resourceBase = bURLParts.String()
-		return
-	case common.ELocation.File(), common.ELocation.FileNFS():
-		var fURLParts filesas.URLParts
-		fURLParts, err = filesas.ParseURL(resource)
-		if err != nil {
-			return resource, "", err
-		}
-
-		resourceToken = fURLParts.SAS.Encode()
-		fURLParts.SAS = filesas.QueryParameters{} // clear the SAS token and drop the raw, base URL
-		resourceBase = fURLParts.String()
-		return
-	case common.ELocation.BlobFS():
-		var dURLParts datalakesas.URLParts
-		dURLParts, err = datalakesas.ParseURL(resource)
-		if err != nil {
-			return resource, "", err
-		}
-
-		resourceToken = dURLParts.SAS.Encode()
-		dURLParts.SAS = datalakesas.QueryParameters{} // clear the SAS token and drop the raw, base URL
-		resourceBase = dURLParts.String()
-		return
-	default:
-		panic(fmt.Sprintf("One or more location(s) may be missing from SplitAuthTokenFromResource. Location: %s", location))
-	}
-}
-
-// While there should be on SAS's in resource, it may have other query string elements,
-// such as a snapshot identifier, or other unparsed params. This splits those out,
-// so we can preserve them without having them get in the way of our use of
-// the resource root string. (e.g. don't want them right on the end of it, when we append stuff)
-func splitQueryFromSaslessResource(resource string, loc common.Location) (mainUrl string, queryAndFragment string) {
-	if !loc.IsRemote() {
-		return resource, "" // only remote resources have query strings
-	}
-
-	if u, err := url.Parse(resource); err == nil && u.Query().Get("sig") != "" {
-		panic("this routine can only be called after the SAS has been removed")
-		// because, for security reasons, we don't want SASs returned in queryAndFragment, since
-		// we will persist that (but we don't want to persist SAS's)
-	}
-
-	// Work directly with a string-based format, so that we get both snapshot identifiers AND any other unparsed params
-	// (types like BlobUrlParts handle those two things in separate properties, but return them together in the query string)
-	i := strings.Index(resource, "?") // only the first ? is syntactically significant in a URL
-	if i < 0 {
-		return resource, ""
-	} else if i == len(resource)-1 {
-		return resource[:i], ""
-	} else {
-		return resource[:i], resource[i+1:]
-	}
-}
-
 // All of the below functions only really do one thing at the moment.
 // They've been separated from copyEnumeratorInit.go in order to make the code more maintainable, should we want more destinations in the future.
 func getPathBeforeFirstWildcard(path string) string {
@@ -318,36 +205,6 @@ func getPathBeforeFirstWildcard(path string) string {
 	result = result[:lastSepIndex+1]
 
 	return result
-}
-
-func GetAccountRoot(resource common.ResourceString, location common.Location) (string, error) {
-	switch location {
-	case common.ELocation.Local():
-		panic("attempted to get account root on local location")
-	case common.ELocation.Blob(),
-		common.ELocation.File(),
-		common.ELocation.FileNFS(),
-		common.ELocation.BlobFS():
-		baseURL, err := resource.String()
-		if err != nil {
-			return "", err
-		}
-
-		// Clear the path
-		bURLParts, err := blobsas.ParseURL(baseURL)
-		if err != nil {
-			return "", err
-		}
-
-		bURLParts.ContainerName = ""
-		bURLParts.BlobName = ""
-		bURLParts.Snapshot = ""
-		bURLParts.VersionID = ""
-
-		return bURLParts.String(), nil
-	default:
-		return "", fmt.Errorf("cannot get account root on location type %s", location.String())
-	}
 }
 
 func GetContainerName(path string, location common.Location) (string, error) {

--- a/cmd/removeEnumerator.go
+++ b/cmd/removeEnumerator.go
@@ -32,6 +32,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/filesystem"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/service"
+	"github.com/Azure/azure-storage-azcopy/v10/azcopy"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-azcopy/v10/ste"
@@ -113,7 +114,7 @@ func newRemoveEnumerator(cca *CookedCopyCmdArgs) (enumerator *CopyEnumerator, er
 		reauthTok = (*common.ScopedAuthenticator)(common.NewScopedCredential(at, common.ECredentialType.OAuthToken()))
 	}
 
-	options := createClientOptions(common.AzcopyCurrentJobLogger, nil, reauthTok)
+	options := azcopy.CreateClientOptions(common.AzcopyCurrentJobLogger, nil, reauthTok)
 	var fileClientOptions any
 	if cca.FromTo.From().IsFile() {
 		fileClientOptions = &common.FileClientOptions{AllowTrailingDot: cca.trailingDot.IsEnabled()}
@@ -171,7 +172,7 @@ func removeBfsResources(cca *CookedCopyCmdArgs) (err error) {
 		reauthTok = (*common.ScopedAuthenticator)(common.NewScopedCredential(at, common.ECredentialType.OAuthToken()))
 	}
 
-	options := createClientOptions(common.AzcopyCurrentJobLogger, nil, reauthTok)
+	options := azcopy.CreateClientOptions(common.AzcopyCurrentJobLogger, nil, reauthTok)
 
 	targetServiceClient, err := common.GetServiceClientForLocation(cca.FromTo.From(), cca.Source, cca.credentialInfo.CredentialType, cca.credentialInfo.OAuthTokenInfo.TokenCredential, &options, nil)
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,11 +52,6 @@ var OutputLevel common.OutputVerbosity
 var CapMbps float64
 var SkipVersionCheck bool
 
-// It's not pretty that this one is read directly by credential util.
-// But doing otherwise required us passing it around in many places, even though really
-// it can be thought of as an "ambient" property. That's the (weak?) justification for implementing
-// it as a global
-var TrustedSuffixes string
 var azcopyAwaitContinue bool
 var azcopyAwaitAllowOpenFiles bool
 var azcopyScanningLogger common.ILoggerResetable
@@ -183,6 +178,9 @@ var rootCmd = &cobra.Command{
 }
 
 func Initialize(resumeJobID common.JobID, isBench bool) (err error) {
+	glcm.SetOutputFormat(OutputFormat)
+	glcm.SetOutputVerbosity(OutputLevel)
+
 	currPid := os.Getpid()
 	AsyncWarnMultipleProcesses(cmd.GetAzCopyAppPath(), currPid)
 	jobsAdmin.BenchmarkResults = isBench
@@ -207,8 +205,6 @@ func Initialize(resumeJobID common.JobID, isBench bool) (err error) {
 	Client.SetLogLevel(&logLevel)
 
 	timeAtPrestart := time.Now()
-	glcm.SetOutputFormat(OutputFormat)
-	glcm.SetOutputVerbosity(OutputLevel)
 
 	common.AzcopyCurrentJobLogger = common.NewJobLogger(Client.CurrentJobID, Client.GetLogLevel(), common.LogPathFolder, "")
 	common.AzcopyCurrentJobLogger.OpenLog()
@@ -333,9 +329,9 @@ func init() {
 			"\n available levels: DEBUG(detailed trace), INFO(all requests/responses), WARNING(slow responses),"+
 			"\n ERROR(only failed requests), and NONE(no output logs). (default 'INFO').")
 
-	rootCmd.PersistentFlags().StringVar(&TrustedSuffixes, trustedSuffixesNameAAD, "",
+	rootCmd.PersistentFlags().StringVar(&azcopy.TrustedSuffixes, azcopy.TrustedSuffixesNameAAD, "",
 		"\nSpecifies additional domain suffixes where Azure Active Directory login tokens may be sent.  \nThe default is '"+
-			trustedSuffixesAAD+"'. \n Any listed here are added to the default. For security, you should only put Microsoft Azure domains here. "+
+			azcopy.TrustedSuffixesAAD+"'. \n Any listed here are added to the default. For security, you should only put Microsoft Azure domains here. "+
 			"\n Separate multiple entries with semi-colons.")
 
 	rootCmd.PersistentFlags().BoolVar(&SkipVersionCheck, "skip-version-check", false,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,7 +22,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -117,20 +116,6 @@ var rootCmd = &cobra.Command{
 			return err
 		}
 
-		// If the command is for resuming a job with a specific JobID,
-		// use the provided JobID to resume the job; otherwise, create a new JobID.
-		var resumeJobID common.JobID
-		if cmd.Use == "resume [jobID]" {
-			// If no argument is passed then it is not valid
-			if len(args) != 1 {
-				return errors.New("this command requires jobId to be passed as argument")
-			}
-			resumeJobID, err = common.ParseJobID(args[0])
-			if err != nil {
-				return err
-			}
-		}
-
 		// Check if we are downloading to Pipe so we can bypass version check and not write it to stdout, customer is
 		// only expecting blob data in stdout
 		var fromToFlagValue string
@@ -173,11 +158,13 @@ var rootCmd = &cobra.Command{
 
 		isBench := cmd.Use == "bench [destination]"
 
-		return Initialize(resumeJobID, isBench)
+		isMigratedToLibrary := cmd.Use == "resume [jobID]"
+
+		return Initialize(isMigratedToLibrary, isBench)
 	},
 }
 
-func Initialize(resumeJobID common.JobID, isBench bool) (err error) {
+func Initialize(isMigratedToLibrary, isBench bool) (err error) {
 	glcm.SetOutputFormat(OutputFormat)
 	glcm.SetOutputVerbosity(OutputLevel)
 
@@ -188,9 +175,26 @@ func Initialize(resumeJobID common.JobID, isBench bool) (err error) {
 	if err != nil {
 		return err
 	}
-	Client.CurrentJobID = resumeJobID
-	if Client.CurrentJobID.IsEmpty() {
+	if !isMigratedToLibrary {
 		Client.CurrentJobID = common.NewJobID()
+		timeAtPrestart := time.Now()
+
+		common.AzcopyCurrentJobLogger = common.NewJobLogger(Client.CurrentJobID, Client.GetLogLevel(), common.LogPathFolder, "")
+		common.AzcopyCurrentJobLogger.OpenLog()
+		glcm.RegisterCloseFunc(func() {
+			if common.AzcopyCurrentJobLogger != nil {
+				common.AzcopyCurrentJobLogger.CloseLog()
+			}
+		})
+		// Log a clear ISO 8601-formatted start time, so it can be read and use in the --include-after parameter
+		// Subtract a few seconds, to ensure that this date DEFINITELY falls before the LMT of any file changed while this
+		// job is running. I.e. using this later with --include-after is _guaranteed_ to pick up all files that changed during
+		// or after this job
+		adjustedTime := timeAtPrestart.Add(-5 * time.Second)
+		startTimeMessage := fmt.Sprintf("ISO 8601 START TIME: to copy files that changed before or after this job started, use the parameter --%s=%s or --%s=%s",
+			common.IncludeBeforeFlagName, azcopy.FormatAsUTC(adjustedTime),
+			common.IncludeAfterFlagName, azcopy.FormatAsUTC(adjustedTime))
+		common.LogToJobLogWithPrefix(startTimeMessage, common.LogInfo)
 	}
 
 	// Run MessagHandler to process messages from Input Watcher
@@ -203,16 +207,6 @@ func Initialize(resumeJobID common.JobID, isBench bool) (err error) {
 		return err
 	}
 	Client.SetLogLevel(&logLevel)
-
-	timeAtPrestart := time.Now()
-
-	common.AzcopyCurrentJobLogger = common.NewJobLogger(Client.CurrentJobID, Client.GetLogLevel(), common.LogPathFolder, "")
-	common.AzcopyCurrentJobLogger.OpenLog()
-	glcm.RegisterCloseFunc(func() {
-		if common.AzcopyCurrentJobLogger != nil {
-			common.AzcopyCurrentJobLogger.CloseLog()
-		}
-	})
 
 	// For benchmarking, try to autotune if possible, otherwise use the default values
 	if jobsAdmin.JobsAdmin != nil && isBench {
@@ -228,16 +222,6 @@ func Initialize(resumeJobID common.JobID, isBench bool) (err error) {
 
 	}
 	EnumerationParallelism, EnumerationParallelStatFiles = jobsAdmin.JobsAdmin.GetConcurrencySettings()
-
-	// Log a clear ISO 8601-formatted start time, so it can be read and use in the --include-after parameter
-	// Subtract a few seconds, to ensure that this date DEFINITELY falls before the LMT of any file changed while this
-	// job is running. I.e. using this later with --include-after is _guaranteed_ to pick up all files that changed during
-	// or after this job
-	adjustedTime := timeAtPrestart.Add(-5 * time.Second)
-	startTimeMessage := fmt.Sprintf("ISO 8601 START TIME: to copy files that changed before or after this job started, use the parameter --%s=%s or --%s=%s",
-		common.IncludeBeforeFlagName, IncludeBeforeDateFilter{}.FormatAsUTC(adjustedTime),
-		common.IncludeAfterFlagName, IncludeAfterDateFilter{}.FormatAsUTC(adjustedTime))
-	common.LogToJobLogWithPrefix(startTimeMessage, common.LogInfo)
 
 	if !SkipVersionCheck && !isPipeDownload {
 		// spawn a routine to fetch and compare the local application's version against the latest version available

--- a/cmd/setPropertiesEnumerator.go
+++ b/cmd/setPropertiesEnumerator.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/Azure/azure-storage-azcopy/v10/azcopy"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-azcopy/v10/ste"
 )
@@ -94,7 +95,7 @@ func setPropertiesEnumerator(cca *CookedCopyCmdArgs) (enumerator *CopyEnumerator
 		reauthTok = (*common.ScopedAuthenticator)(common.NewScopedCredential(at, common.ECredentialType.OAuthToken()))
 	}
 
-	options := createClientOptions(common.AzcopyCurrentJobLogger, nil, reauthTok)
+	options := azcopy.CreateClientOptions(common.AzcopyCurrentJobLogger, nil, reauthTok)
 	var fileClientOptions any
 	if cca.FromTo.From().IsFile() {
 		fileClientOptions = &common.FileClientOptions{AllowTrailingDot: cca.trailingDot.IsEnabled()}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -30,6 +30,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/Azure/azure-storage-azcopy/v10/azcopy"
 	"github.com/Azure/azure-storage-azcopy/v10/jobsAdmin"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
@@ -150,15 +151,15 @@ func (raw rawSyncCmdArgs) toOptions() (cooked cookedSyncCmdArgs, err error) {
 	case common.EFromTo.Unknown():
 		return cooked, fmt.Errorf("unable to infer the source '%s' / destination '%s'. ", raw.src, raw.dst)
 	case common.EFromTo.LocalBlob(), common.EFromTo.LocalFile(), common.EFromTo.LocalBlobFS(), common.EFromTo.LocalFileNFS():
-		cooked.destination, err = SplitResourceString(raw.dst, cooked.fromTo.To())
+		cooked.destination, err = azcopy.SplitResourceString(raw.dst, cooked.fromTo.To())
 		common.PanicIfErr(err)
 	case common.EFromTo.BlobLocal(), common.EFromTo.FileLocal(), common.EFromTo.BlobFSLocal(), common.EFromTo.FileNFSLocal():
-		cooked.source, err = SplitResourceString(raw.src, cooked.fromTo.From())
+		cooked.source, err = azcopy.SplitResourceString(raw.src, cooked.fromTo.From())
 		common.PanicIfErr(err)
 	case common.EFromTo.BlobBlob(), common.EFromTo.FileFile(), common.EFromTo.FileNFSFileNFS(), common.EFromTo.BlobFile(), common.EFromTo.FileBlob(), common.EFromTo.BlobFSBlobFS(), common.EFromTo.BlobFSBlob(), common.EFromTo.BlobFSFile(), common.EFromTo.BlobBlobFS(), common.EFromTo.FileBlobFS():
-		cooked.destination, err = SplitResourceString(raw.dst, cooked.fromTo.To())
+		cooked.destination, err = azcopy.SplitResourceString(raw.dst, cooked.fromTo.To())
 		common.PanicIfErr(err)
-		cooked.source, err = SplitResourceString(raw.src, cooked.fromTo.From())
+		cooked.source, err = azcopy.SplitResourceString(raw.src, cooked.fromTo.From())
 		common.PanicIfErr(err)
 	default:
 		return cooked, fmt.Errorf("source '%s' / destination '%s' combination '%s' not supported for sync command ", raw.src, raw.dst, cooked.fromTo)
@@ -166,9 +167,9 @@ func (raw rawSyncCmdArgs) toOptions() (cooked cookedSyncCmdArgs, err error) {
 
 	// Do this check separately so we don't end up with a bunch of code duplication when new src/dstn are added
 	if cooked.fromTo.From() == common.ELocation.Local() {
-		cooked.source = common.ResourceString{Value: common.ToExtendedPath(cleanLocalPath(raw.src))}
+		cooked.source = common.ResourceString{Value: common.ToExtendedPath(azcopy.CleanLocalPath(raw.src))}
 	} else if cooked.fromTo.To() == common.ELocation.Local() {
-		cooked.destination = common.ResourceString{Value: common.ToExtendedPath(cleanLocalPath(raw.dst))}
+		cooked.destination = common.ResourceString{Value: common.ToExtendedPath(azcopy.CleanLocalPath(raw.dst))}
 	}
 
 	if err = cooked.symlinkHandling.Determine(raw.followSymlinks, raw.preserveSymlinks); err != nil {

--- a/cmd/syncEnumerator.go
+++ b/cmd/syncEnumerator.go
@@ -31,6 +31,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/fileerror"
+	"github.com/Azure/azure-storage-azcopy/v10/azcopy"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
@@ -256,7 +257,7 @@ func (cca *cookedSyncCmdArgs) initEnumerator(ctx context.Context) (enumerator *s
 		srcReauthTok = (*common.ScopedAuthenticator)(common.NewScopedCredential(at, common.ECredentialType.OAuthToken()))
 	}
 
-	options := createClientOptions(common.AzcopyCurrentJobLogger, nil, srcReauthTok)
+	options := azcopy.CreateClientOptions(common.AzcopyCurrentJobLogger, nil, srcReauthTok)
 
 	// Create Source Client.
 	var azureFileSpecificOptions any
@@ -297,7 +298,7 @@ func (cca *cookedSyncCmdArgs) initEnumerator(ctx context.Context) (enumerator *s
 		srcTokenCred = common.NewScopedCredential(srcCredInfo.OAuthTokenInfo.TokenCredential, srcCredInfo.CredentialType)
 	}
 
-	options = createClientOptions(common.AzcopyCurrentJobLogger, srcTokenCred, dstReauthTok)
+	options = azcopy.CreateClientOptions(common.AzcopyCurrentJobLogger, srcTokenCred, dstReauthTok)
 	copyJobTemplate.DstServiceClient, err = common.GetServiceClientForLocation(
 		cca.fromTo.To(),
 		cca.destination,

--- a/cmd/zc_enumerator.go
+++ b/cmd/zc_enumerator.go
@@ -36,6 +36,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/datalakeerror"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/fileerror"
+	"github.com/Azure/azure-storage-azcopy/v10/azcopy"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/lease"
@@ -404,7 +405,7 @@ func InitResourceTraverser(resource common.ResourceString, resourceLocation comm
 
 	// Clean up the resource if it's a local path
 	if resourceLocation == common.ELocation.Local() {
-		resource = common.ResourceString{Value: cleanLocalPath(resource.ValueLocal())}
+		resource = common.ResourceString{Value: azcopy.CleanLocalPath(resource.ValueLocal())}
 	}
 
 	// Feed list of files channel into new list traverser
@@ -431,7 +432,7 @@ func InitResourceTraverser(resource common.ResourceString, resourceLocation comm
 		}
 	}
 
-	options := createClientOptions(azcopyScanningLogger, nil, reauthTok)
+	options := azcopy.CreateClientOptions(azcopyScanningLogger, nil, reauthTok)
 
 	switch resourceLocation {
 	case common.ELocation.Local():
@@ -457,7 +458,7 @@ func InitResourceTraverser(resource common.ResourceString, resourceLocation comm
 
 			opts.ListOfFiles = globChan
 
-			baseResource := resource.CloneWithValue(cleanLocalPath(basePath))
+			baseResource := resource.CloneWithValue(azcopy.CleanLocalPath(basePath))
 			output = newListTraverser(baseResource, resourceLocation, ctx, opts)
 		} else {
 			output, _ = newLocalTraverser(resource.ValueLocal(), ctx, opts)
@@ -491,7 +492,7 @@ func InitResourceTraverser(resource common.ResourceString, resourceLocation comm
 		blobURLParts.Snapshot = ""
 		blobURLParts.VersionID = ""
 
-		res, err := SplitResourceString(blobURLParts.String(), common.ELocation.Blob())
+		res, err := azcopy.SplitResourceString(blobURLParts.String(), common.ELocation.Blob())
 		if err != nil {
 			return nil, err
 		}
@@ -544,7 +545,7 @@ func InitResourceTraverser(resource common.ResourceString, resourceLocation comm
 		} else {
 			resLoc = common.ELocation.FileNFS()
 		}
-		res, err := SplitResourceString(fileURLParts.String(), resLoc)
+		res, err := azcopy.SplitResourceString(fileURLParts.String(), resLoc)
 		if err != nil {
 			return nil, err
 		}
@@ -587,7 +588,7 @@ func InitResourceTraverser(resource common.ResourceString, resourceLocation comm
 		blobURLParts.Snapshot = ""
 		blobURLParts.VersionID = ""
 
-		res, err := SplitResourceString(blobURLParts.String(), common.ELocation.Blob())
+		res, err := azcopy.SplitResourceString(blobURLParts.String(), common.ELocation.Blob())
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/zc_filter.go
+++ b/cmd/zc_filter.go
@@ -21,7 +21,6 @@
 package cmd
 
 import (
-	"fmt"
 	"path"
 	"regexp"
 	"strings"
@@ -32,7 +31,6 @@ import (
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
-const ISO8601 = "2006-01-02T15:04:05.0000000Z" // must have 0's for fractional seconds, because Files Service requires fixed width
 // Design explanation:
 /*
 Blob type exclusion is required as a part of the copy enumerators refactor. This would be used in Download and S2S scenarios.
@@ -348,14 +346,6 @@ func (f *IncludeAfterDateFilter) DoesPass(storedObject StoredObject) bool {
 		storedObject.lastModifiedTime.Equal(f.Threshold) // >= is easier for users to understand than >
 }
 
-func (IncludeAfterDateFilter) ParseISO8601(s string, chooseEarliest bool) (time.Time, error) {
-	return parseISO8601(s, chooseEarliest)
-}
-
-func (IncludeAfterDateFilter) FormatAsUTC(t time.Time) string {
-	return formatAsUTC(t)
-}
-
 // IncludeBeforeDateFilter includes files with Last Modified Times <= the specified Threshold
 // Used for copy, but doesn't make conceptual sense for sync
 type IncludeBeforeDateFilter struct {
@@ -380,14 +370,6 @@ func (f *IncludeBeforeDateFilter) DoesPass(storedObject StoredObject) bool {
 
 	return storedObject.lastModifiedTime.Before(f.Threshold) ||
 		storedObject.lastModifiedTime.Equal(f.Threshold) // <= is easier for users to understand than <
-}
-
-func (_ IncludeBeforeDateFilter) ParseISO8601(s string, chooseEarliest bool) (time.Time, error) {
-	return parseISO8601(s, chooseEarliest)
-}
-
-func (_ IncludeBeforeDateFilter) FormatAsUTC(t time.Time) string {
-	return formatAsUTC(t)
 }
 
 type permDeleteFilter struct {
@@ -425,61 +407,4 @@ func buildIncludeSoftDeleted(permanentDeleteOption common.PermanentDeleteOption)
 		filters = append(filters, &permDeleteFilter{deleteSnapshots: true, deleteVersions: true})
 	}
 	return filters
-}
-
-// parseISO8601 parses ISO 8601 dates. This routine is needed because GoLang's time.Parse* routines require all expected
-// elements to be present.  I.e. you can't specify just a date, and have the time default to 00:00. But ISO 8601 requires
-// that and, for usability, that's what we want.  (So that users can omit the whole time, or at least the seconds portion of it, if they wish)
-func parseISO8601(s string, chooseEarliest bool) (time.Time, error) {
-
-	// list of ISO-8601 Go-lang formats in descending order of completeness
-	formats := []string{
-		ISO8601,                     // Support AzFile's more accurate format
-		"2006-01-02T15:04:05Z07:00", // equal to time.RFC3339, which in Go parsing is basically "ISO 8601 with nothing optional"
-		"2006-01-02T15:04:05",       // no timezone
-		"2006-01-02T15:04",          // no seconds
-		"2006-01-02T15",             // no minutes
-		"2006-01-02",                // no time
-		// we don't want to support the no day, or no month options. They are too vague for our purposes
-	}
-
-	loc, err := time.LoadLocation("Local")
-	if err != nil {
-		return time.Time{}, err
-	}
-
-	// Try from most precise to least
-	// (If user has some OTHER format, with extra chars we don't expect an any format, all will fail)
-	for _, f := range formats {
-		t, err := time.ParseInLocation(f, s, loc)
-		if err == nil {
-			if t.Location() == loc {
-				// if we are working in local time, then detect the case where the time falls in the repeated hour
-				// at then end of daylight saving, and resolve it according to chooseEarliest
-				const localNoTimezone = "2006-01-02T15:04:05"
-				var possibleLocalDuplicate time.Time
-				if chooseEarliest {
-					possibleLocalDuplicate = t.Add(-time.Hour) // test an hour earlier, and favour it, if it's the same local time
-				} else {
-					possibleLocalDuplicate = t.Add(time.Hour) // test an hour later, and favour it, if it's the same local time
-				}
-				isSameLocalTime := possibleLocalDuplicate.Format(localNoTimezone) == t.Format(localNoTimezone)
-				if isSameLocalTime {
-					return possibleLocalDuplicate, nil
-				}
-			}
-			return t, nil
-		}
-	}
-
-	// Nothing worked. Get fresh error from first format, and supplement it with additional hints.
-	_, err = time.ParseInLocation(formats[0], s, loc)
-	err = fmt.Errorf("could not parse date/time '%s'. Expecting ISO8601 format, with 4 digit year and 2-digits for all other elements. Error hint: %w",
-		s, err)
-	return time.Time{}, err
-}
-
-// formatAsUTC is inverse of parseISO8601 (and always uses the most detailed format)
-func formatAsUTC(t time.Time) string {
-	return t.UTC().Format(time.RFC3339)
 }

--- a/cmd/zc_traverser_local.go
+++ b/cmd/zc_traverser_local.go
@@ -37,6 +37,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/Azure/azure-storage-azcopy/v10/azcopy"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-azcopy/v10/common/parallel"
 )
@@ -245,8 +246,8 @@ func WalkWithSymlinks(appCtx context.Context,
 				writeToErrorChannel(errorChannel, ErrorFileInfo{FilePath: filePath, FileInfo: fileInfo, ErrorMsg: fileError})
 				return nil
 			}
-			computedRelativePath := strings.TrimPrefix(cleanLocalPath(filePath), cleanLocalPath(queueItem.fullPath))
-			computedRelativePath = cleanLocalPath(common.GenerateFullPath(queueItem.relativeBase, computedRelativePath))
+			computedRelativePath := strings.TrimPrefix(azcopy.CleanLocalPath(filePath), azcopy.CleanLocalPath(queueItem.fullPath))
+			computedRelativePath = azcopy.CleanLocalPath(common.GenerateFullPath(queueItem.relativeBase, computedRelativePath))
 			computedRelativePath = strings.TrimPrefix(computedRelativePath, common.AZCOPY_PATH_SEPARATOR_STRING)
 
 			if computedRelativePath == "." {
@@ -754,7 +755,7 @@ func (t *localTraverser) Traverse(preprocessor objectMorpher, processor objectPr
 					}
 				}
 
-				relPath := strings.TrimPrefix(strings.TrimPrefix(cleanLocalPath(filePath), cleanLocalPath(t.fullPath)), common.DeterminePathSeparator(t.fullPath))
+				relPath := strings.TrimPrefix(strings.TrimPrefix(azcopy.CleanLocalPath(filePath), azcopy.CleanLocalPath(t.fullPath)), common.DeterminePathSeparator(t.fullPath))
 				if t.symlinkHandling.None() && fileInfo.Mode()&os.ModeSymlink != 0 {
 					WarnStdoutAndScanningLog(fmt.Sprintf("Skipping over symlink at %s because symlinks are not handled (--follow-symlinks or --preserve-symlinks)", common.GenerateFullPath(t.fullPath, relPath)))
 					return nil
@@ -861,7 +862,7 @@ func (t *localTraverser) Traverse(preprocessor objectMorpher, processor objectPr
 						preprocessor,
 						entry.Name(),
 						strings.ReplaceAll(relativePath, common.DeterminePathSeparator(t.fullPath), common.AZCOPY_PATH_SEPARATOR_STRING), // Consolidate relative paths to the azcopy path separator for sync
-						entityType, // TODO: add code path for folders
+						entityType,                                                                                                       // TODO: add code path for folders
 						fileInfo.ModTime(),
 						fileInfo.Size(),
 						noContentProps, // Local MD5s are computed in the STE, and other props don't apply to local files
@@ -893,7 +894,7 @@ func newLocalTraverser(fullPath string, ctx context.Context, opts InitResourceTr
 	}
 
 	traverser := localTraverser{
-		fullPath:                    cleanLocalPath(fullPath),
+		fullPath:                    azcopy.CleanLocalPath(fullPath),
 		recursive:                   opts.Recursive,
 		symlinkHandling:             opts.SymlinkHandling,
 		appCtx:                      ctx,
@@ -905,28 +906,6 @@ func newLocalTraverser(fullPath string, ctx context.Context, opts InitResourceTr
 		hardlinkHandling:            opts.HardlinkHandling,
 	}
 	return &traverser, nil
-}
-
-func cleanLocalPath(localPath string) string {
-	localPathSeparator := common.DeterminePathSeparator(localPath)
-	// path.Clean only likes /, and will only handle /. So, we consolidate it to /.
-	// it will do absolutely nothing with \.
-	normalizedPath := path.Clean(strings.ReplaceAll(localPath, localPathSeparator, common.AZCOPY_PATH_SEPARATOR_STRING))
-	// return normalizedPath path separator.
-	normalizedPath = strings.ReplaceAll(normalizedPath, common.AZCOPY_PATH_SEPARATOR_STRING, localPathSeparator)
-
-	// path.Clean steals the first / from the // or \\ prefix.
-	if strings.HasPrefix(localPath, `\\`) || strings.HasPrefix(localPath, `//`) {
-		// return the \ we stole from the UNC/extended path.
-		normalizedPath = localPathSeparator + normalizedPath
-	}
-
-	// path.Clean steals the last / from C:\, C:/, and does not add one for C:
-	if common.RootDriveRegex.MatchString(strings.ReplaceAll(common.ToShortPath(normalizedPath), common.OS_PATH_SEPARATOR, common.AZCOPY_PATH_SEPARATOR_STRING)) {
-		normalizedPath += common.OS_PATH_SEPARATOR
-	}
-
-	return normalizedPath
 }
 
 func logSpecialFileWarning(fileName string) {

--- a/cmd/zc_traverser_local_test.go
+++ b/cmd/zc_traverser_local_test.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	"github.com/Azure/azure-storage-azcopy/v10/azcopy"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCleanLocalPath(t *testing.T) {
@@ -18,7 +20,7 @@ func TestCleanLocalPath(t *testing.T) {
 	}
 
 	for orig, expected := range testCases {
-		a.Equal(expected, cleanLocalPath(orig))
+		a.Equal(expected, azcopy.CleanLocalPath(orig))
 	}
 }
 
@@ -45,6 +47,6 @@ func TestCleanLocalPathForWindows(t *testing.T) {
 	}
 
 	for orig, expected := range testCases {
-		a.Equal(expected, cleanLocalPath(orig))
+		a.Equal(expected, azcopy.CleanLocalPath(orig))
 	}
 }

--- a/cmd/zt_benchmark_traverser_test.go
+++ b/cmd/zt_benchmark_traverser_test.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToReversedString(t *testing.T) {
+	a := assert.New(t)
+	traverser := &benchmarkTraverser{}
+	a.Equal("1", traverser.toReversedString(1))
+	a.Equal("01", traverser.toReversedString(10))
+	a.Equal("54321", traverser.toReversedString(12345))
+}

--- a/cmd/zt_credentialUtil_test.go
+++ b/cmd/zt_credentialUtil_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-storage-azcopy/v10/azcopy"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
@@ -102,7 +103,7 @@ func TestCheckAuthSafeForTargetIsCalledWhenGettingAuthType(t *testing.T) {
 		return common.ECredentialType.OAuthToken() // force it to OAuth, which is the case we want to test
 	}
 
-	res, err := SplitResourceString("http://notblob.example.com", common.ELocation.Blob())
+	res, err := azcopy.SplitResourceString("http://notblob.example.com", common.ELocation.Blob())
 	a.NoError(err)
 
 	// Call our core cred type getter function, in a way that will fail the safety check, and assert
@@ -119,7 +120,7 @@ func TestCheckAuthSafeForTargetIsCalledWhenGettingAuthTypeMDOAuth(t *testing.T) 
 		return common.ECredentialType.MDOAuthToken() // force it to OAuth, which is the case we want to test
 	}
 
-	res, err := SplitResourceString("http://notblob.example.com", common.ELocation.Blob())
+	res, err := azcopy.SplitResourceString("http://notblob.example.com", common.ELocation.Blob())
 	a.NoError(err)
 
 	// Call our core cred type getter function, in a way that will fail the safety check, and assert

--- a/cmd/zt_generic_filter_test.go
+++ b/cmd/zt_generic_filter_test.go
@@ -23,10 +23,12 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Azure/azure-storage-azcopy/v10/azcopy"
+	"github.com/stretchr/testify/assert"
 
 	chk "gopkg.in/check.v1"
 )
@@ -111,7 +113,7 @@ func TestDateParsingForIncludeAfter(t *testing.T) {
 	loc, _ := time.LoadLocation("Local")
 
 	for _, x := range examples {
-		t, err := IncludeAfterDateFilter{}.ParseISO8601(x.input, true)
+		t, err := azcopy.ParseISO8601(x.input, true)
 		if x.expectedErrorContents == "" {
 			a.Nil(err, x.input)
 			//fmt.Printf("%v -> %v\n", x.input, t)
@@ -152,14 +154,14 @@ func TestDateParsingForIncludeAfter_IsSafeAtDaylightSavingsTransition(t *testing
 	fmt.Println("Testing end of daylight saving at " + dateString + " local time")
 
 	// ask for the earliest of the two ambiguous times
-	parsed, err := IncludeAfterDateFilter{}.ParseISO8601(dateString, true) // we use chooseEarliest=true for includeAfter
+	parsed, err := azcopy.ParseISO8601(dateString, true) // we use chooseEarliest=true for includeAfter
 	a.Nil(err)
 	fmt.Printf("For chooseEarliest = true, the times are parsed %v, utcEarly %v, utcLate %v \n", parsed, utcEarlyVersion, utcLateVersion)
 	a.True(parsed.Equal(utcEarlyVersion))
 	a.False(parsed.Equal(utcLateVersion))
 
 	// ask for the latest of the two ambiguous times
-	parsed, err = IncludeAfterDateFilter{}.ParseISO8601(dateString, false) // we test the false case in this test too, just for completeness
+	parsed, err = azcopy.ParseISO8601(dateString, false) // we test the false case in this test too, just for completeness
 	a.Nil(err)
 	fmt.Printf("For chooseEarliest = false, the times are parsed %v, utcEarly %v, utcLate %v \n", parsed, utcEarlyVersion, utcLateVersion)
 	a.False(parsed.UTC().Equal(utcEarlyVersion))

--- a/cmd/zt_generic_traverser_test.go
+++ b/cmd/zt_generic_traverser_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/file"
+	"github.com/Azure/azure-storage-azcopy/v10/azcopy"
 	"github.com/stretchr/testify/assert"
 
 	gcpUtils "cloud.google.com/go/storage"
@@ -79,7 +80,7 @@ func TestLocalWildcardOverlap(t *testing.T) {
 		"foobarbaz/test.txt",
 	})
 
-	resource, err := SplitResourceString(filepath.Join(tmpDir, "tes*t.txt"), common.ELocation.Local())
+	resource, err := azcopy.SplitResourceString(filepath.Join(tmpDir, "tes*t.txt"), common.ELocation.Local())
 	a.Nil(err)
 
 	traverser, err := InitResourceTraverser(resource, common.ELocation.Local(), ctx, InitResourceTraverserOptions{

--- a/cmd/zt_pathUtils_test.go
+++ b/cmd/zt_pathUtils_test.go
@@ -21,10 +21,12 @@
 package cmd
 
 import (
+	"testing"
+
+	"github.com/Azure/azure-storage-azcopy/v10/azcopy"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/stretchr/testify/assert"
 	chk "gopkg.in/check.v1"
-	"testing"
 )
 
 type pathUtilsSuite struct{}
@@ -55,7 +57,7 @@ func TestStripQueryFromSaslessUrl(t *testing.T) {
 		if t.isRemote {
 			loc = common.ELocation.File()
 		}
-		m, q := splitQueryFromSaslessResource(t.full, loc)
+		m, q := azcopy.splitQueryFromSaslessResource(t.full, loc)
 		a.Equal(t.expectedMain, m)
 		a.Equal(t.expectedQuery, q)
 	}

--- a/common/lifecyleMgr.go
+++ b/common/lifecyleMgr.go
@@ -1,5 +1,8 @@
 package common
 
+// lcm is the lifecycle manager for the AzCopy client. This needs to be reset per copy/sync/resume job for AzCopy as a library users.
+// It is a bit of an anti pattern to have a global variable like this, but it is necessary to minimize code changes
+// while implementing AzCopy as a library.
 var lcm JobLifecycleHandler
 
 // SetJobLifecycleHandler allows AzCopy CLI and AzCopy as a library to set a custom JobLifecycleHandler

--- a/common/zt_ProxyLookupCache_test.go
+++ b/common/zt_ProxyLookupCache_test.go
@@ -30,43 +30,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Needed so UT don't panic when they try to use the lifecycle manager
-type mockedLifecycleManager struct {
-}
-
-func (m mockedLifecycleManager) OnStart(ctx JobContext) {
-}
-
-func (m mockedLifecycleManager) OnScanProgress(progress ScanProgress) {
-}
-
-func (m mockedLifecycleManager) OnTransferProgress(progress TransferProgress) {
-}
-
-func (m mockedLifecycleManager) OnComplete(summary JobSummary) {
-}
-
-func (m mockedLifecycleManager) Error(s string) {
-}
-
-func (m mockedLifecycleManager) RegisterCloseFunc(f func()) {
-}
-
-func (m mockedLifecycleManager) Prompt(message string, details PromptDetails) ResponseOption {
-	return EResponseOption.Default()
-}
-
-func (m mockedLifecycleManager) Info(s string) {
-}
-
-func (m mockedLifecycleManager) Warn(s string) {
-}
-
-func (m mockedLifecycleManager) E2EAwaitAllowOpenFiles() {
-}
-
 func TestCacheIsUsed(t *testing.T) {
-	lcm = mockedLifecycleManager{} // avoid panic in tests that use the lifecycle manager
+	lcm = MockedJobLifecycleHandler{} // avoid panic in tests that use the lifecycle manager
 	a := assert.New(t)
 	fakeMu := &sync.Mutex{} // avoids race condition in test code
 	var fakeResult *url.URL
@@ -130,7 +95,7 @@ func TestCacheIsUsed(t *testing.T) {
 }
 
 func TestCacheEntriesGetRefreshed(t *testing.T) {
-	lcm = mockedLifecycleManager{} // avoid panic in tests that use the lifecycle manager
+	lcm = MockedJobLifecycleHandler{} // avoid panic in tests that use the lifecycle manager
 	a := assert.New(t)
 	fakeMu := &sync.Mutex{} // avoids race condition in test code
 	var fakeResult *url.URL
@@ -172,7 +137,7 @@ func TestCacheEntriesGetRefreshed(t *testing.T) {
 }
 
 func TestUseOfLookupMethodHasTimout(t *testing.T) {
-	lcm = mockedLifecycleManager{} // avoid panic in tests that use the lifecycle manager
+	lcm = MockedJobLifecycleHandler{} // avoid panic in tests that use the lifecycle manager
 	a := assert.New(t)
 	pc := &proxyLookupCache{
 		m:             &sync.Map{},

--- a/common/zt_mockedlcm.go
+++ b/common/zt_mockedlcm.go
@@ -1,0 +1,36 @@
+package common
+
+// Needed so UT don't panic when they try to use the lcm in common
+type MockedJobLifecycleHandler struct {
+}
+
+func (m MockedJobLifecycleHandler) OnStart(ctx JobContext) {
+}
+
+func (m MockedJobLifecycleHandler) OnScanProgress(progress ScanProgress) {
+}
+
+func (m MockedJobLifecycleHandler) OnTransferProgress(progress TransferProgress) {
+}
+
+func (m MockedJobLifecycleHandler) OnComplete(summary JobSummary) {
+}
+
+func (m MockedJobLifecycleHandler) Error(s string) {
+}
+
+func (m MockedJobLifecycleHandler) RegisterCloseFunc(f func()) {
+}
+
+func (m MockedJobLifecycleHandler) Prompt(message string, details PromptDetails) ResponseOption {
+	return EResponseOption.Default()
+}
+
+func (m MockedJobLifecycleHandler) Info(s string) {
+}
+
+func (m MockedJobLifecycleHandler) Warn(s string) {
+}
+
+func (m MockedJobLifecycleHandler) E2EAwaitAllowOpenFiles() {
+}

--- a/e2etest/declarativeResourceManagers.go
+++ b/e2etest/declarativeResourceManagers.go
@@ -22,14 +22,6 @@ package e2etest
 
 import (
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
-	blobsas "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/datalakeerror"
-	datalakedirectory "github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/directory"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/file"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/share"
-	"github.com/Azure/azure-storage-azcopy/v10/cmd"
 	"net/url"
 	"os"
 	"path"
@@ -37,6 +29,15 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
+	blobsas "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/datalakeerror"
+	datalakedirectory "github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/directory"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/file"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/share"
+	"github.com/Azure/azure-storage-azcopy/v10/azcopy"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
@@ -329,7 +330,7 @@ func (r *resourceBlobContainer) getVersions(a asserter, objectName string) []str
 
 	versions := &timestampSortable{
 		timestamps: make([]string, 0),
-		format:     cmd.ISO8601,
+		format:     azcopy.ISO8601,
 		a:          a,
 	}
 
@@ -339,7 +340,7 @@ func (r *resourceBlobContainer) getVersions(a asserter, objectName string) []str
 
 		for _, v := range page.Segment.BlobItems {
 			if v.Name != nil && *v.Name == objectName && v.VersionID != nil {
-				_, err := time.Parse(cmd.ISO8601, *v.VersionID) // Make sure we can parse it
+				_, err := time.Parse(azcopy.ISO8601, *v.VersionID) // Make sure we can parse it
 				a.AssertNoErr(err, "parsing timestamp "+*v.VersionID)
 
 				versions.timestamps = append(versions.timestamps, *v.VersionID)

--- a/e2etest/zt_preserve_smb_properties_test.go
+++ b/e2etest/zt_preserve_smb_properties_test.go
@@ -6,8 +6,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	"github.com/Azure/azure-storage-azcopy/v10/cmd"
-
+	"github.com/Azure/azure-storage-azcopy/v10/azcopy"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
@@ -16,7 +15,7 @@ import (
 //	See https://github.com/Azure/azure-storage-azcopy/issues/113 (which incidentally, I'm not observing in the tests above, for reasons unknown)
 func TestProperties_SMBDates(t *testing.T) {
 	RunScenarios(t, eOperation.CopyAndSync(), eTestFromTo.Other(common.EFromTo.LocalFile(), common.EFromTo.FileLocal()), eValidate.Auto(), anonymousAuthOnly, anonymousAuthOnly, params{
-		recursive:       true,
+		recursive: true,
 
 		// default, but present for clarity
 		//preserveSMBInfo:        to.Ptr(true),
@@ -48,7 +47,7 @@ func TestProperties_SMBDates(t *testing.T) {
 
 func TestProperties_SMBFlags(t *testing.T) {
 	RunScenarios(t, eOperation.CopyAndSync(), eTestFromTo.Other(common.EFromTo.LocalFile(), common.EFromTo.FileFile(), common.EFromTo.FileLocal()), eValidate.Auto(), anonymousAuthOnly, anonymousAuthOnly, params{
-		recursive:       true,
+		recursive: true,
 
 		// default, but present for clarity
 		//preserveSMBInfo:        to.Ptr(true),
@@ -75,7 +74,7 @@ func TestProperties_SMBPermsAndFlagsWithIncludeAfter(t *testing.T) {
 	}
 
 	RunScenarios(t, eOperation.Copy(), eTestFromTo.Other(common.EFromTo.FileLocal()), eValidate.Auto(), anonymousAuthOnly, anonymousAuthOnly, params{
-		recursive:       true,
+		recursive: true,
 
 		// default, but present for clarity
 		//preserveSMBInfo:        to.Ptr(true),
@@ -84,7 +83,7 @@ func TestProperties_SMBPermsAndFlagsWithIncludeAfter(t *testing.T) {
 		beforeRunJob: func(h hookHelper) {
 			// Pause for a includeAfter time
 			time.Sleep(5 * time.Second)
-			h.GetModifiableParameters().includeAfter = time.Now().Format(cmd.ISO8601)
+			h.GetModifiableParameters().includeAfter = time.Now().Format(azcopy.ISO8601)
 			// Pause then re-write all the files, so that their LastWriteTime is different from their creation time
 			// So that when validating, our validation can be sure that the right datetime has ended up in the right
 			// field
@@ -124,7 +123,7 @@ func TestProperties_SMBPermsAndFlagsWithSync(t *testing.T) {
 	}
 
 	RunScenarios(t, eOperation.Sync(), eTestFromTo.Other(common.EFromTo.LocalFile(), common.EFromTo.FileLocal()), eValidate.Auto(), anonymousAuthOnly, anonymousAuthOnly, params{
-		recursive:       true,
+		recursive: true,
 
 		// default, but present for clarity
 		//preserveSMBInfo:        to.Ptr(true),
@@ -163,7 +162,7 @@ func TestProperties_SMBTimes(t *testing.T) {
 		anonymousAuthOnly,
 		anonymousAuthOnly,
 		params{
-			recursive:       true,
+			recursive: true,
 
 			// default, but present for clarity
 			//preserveSMBInfo:        to.Ptr(true),
@@ -198,8 +197,8 @@ func TestProperties_EnsureContainerBehavior(t *testing.T) {
 		anonymousAuthOnly,
 		anonymousAuthOnly,
 		params{
-			recursive: true,
-			preserveSMBInfo: to.Ptr(true),
+			recursive:              true,
+			preserveSMBInfo:        to.Ptr(true),
 			preserveSMBPermissions: true,
 		},
 		nil,
@@ -229,9 +228,9 @@ func TestProperties_ForceReadOnly(t *testing.T) {
 		anonymousAuthOnly,
 		anonymousAuthOnly,
 		params{
-			recursive:       true,
+			recursive:         true,
 			deleteDestination: common.EDeleteDestination.True(),
-			forceIfReadOnly: true,
+			forceIfReadOnly:   true,
 		},
 		&hooks{
 			beforeRunJob: func(h hookHelper) {

--- a/e2etest/zt_remove_test.go
+++ b/e2etest/zt_remove_test.go
@@ -21,12 +21,13 @@
 package e2etest
 
 import (
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
-	"github.com/Azure/azure-storage-azcopy/v10/cmd"
-	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"testing"
 	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-storage-azcopy/v10/azcopy"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 func TestRemove_IncludeAfter(t *testing.T) {
@@ -46,7 +47,7 @@ func TestRemove_IncludeAfter(t *testing.T) {
 		beforeRunJob: func(h hookHelper) {
 			// Pause for a includeAfter time
 			time.Sleep(5 * time.Second)
-			h.GetModifiableParameters().includeAfter = time.Now().Format(cmd.ISO8601)
+			h.GetModifiableParameters().includeAfter = time.Now().Format(azcopy.ISO8601)
 			// Pause then re-write all the files, so that their LastWriteTime is different from their creation time
 			// So that when validating, our validation can be sure that the right datetime has ended up in the right
 			// field

--- a/ste/sender_blockBlob_test.go
+++ b/ste/sender_blockBlob_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func TestGetVerifiedChunkParams(t *testing.T) {
+	common.SetJobLifecycleHandler(common.MockedJobLifecycleHandler{})
 	a := assert.New(t)
 	// Mock required params
 	transferInfo := &TransferInfo{


### PR DESCRIPTION
In this PR, I've moved the glcm instantiation to the cmd folder, since that is where all azcopy CLI related code should live. There is no need for the CLI lcm to be instantiated during usage of azcopy as a library. 

As a result, I've also needed to set up some mocked LCMs in some UTs since they call into methods that assume that the lcm was magically instantiated