### PR TITLE
C2C Specific Changes for Blob to Blob V1 Support

### DIFF
--- a/cmd/moverDependencies.go
+++ b/cmd/moverDependencies.go
@@ -472,10 +472,10 @@ func (cooked *cookedSyncCmdArgs) ToStringMap() map[string]string {
 	if cooked.preservePOSIXProperties {
 		result["preservePOSIXProperties"] = "true"
 	}
-	if cooked.s2sPreserveBlobTags {
+	if cooked.S2sPreserveBlobTags {
 		result["s2sPreserveBlobTags"] = "true"
 	}
-	if cooked.preserveAccessTier {
+	if cooked.PreserveAccessTier {
 		result["preserveAccessTier"] = "true"
 	}
 	if cooked.includeDirectoryStubs {
@@ -486,10 +486,10 @@ func (cooked *cookedSyncCmdArgs) ToStringMap() map[string]string {
 	}
 
 	// Add enums/options if not default/empty
-	if cooked.preservePermissions != common.EPreservePermissionsOption.None() {
+	if cooked.PreservePermissions != common.EPreservePermissionsOption.None() {
 		// PreservePermissionsOption doesn't have String() method, so we handle it manually
 		permStr := "None"
-		switch cooked.preservePermissions {
+		switch cooked.PreservePermissions {
 		case common.EPreservePermissionsOption.ACLsOnly():
 			permStr = "ACLsOnly"
 		case common.EPreservePermissionsOption.OwnershipAndACLs():

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -133,7 +133,7 @@ func (raw rawSyncCmdArgs) toOptions() (cooked cookedSyncCmdArgs, err error) {
 		backupMode:                       raw.backupMode,
 		isNFSCopy:                        raw.isNFSCopy,
 		putMd5:                           raw.putMd5,
-		s2sPreserveBlobTags:              raw.s2sPreserveBlobTags,
+		S2sPreserveBlobTags:              raw.s2sPreserveBlobTags,
 		cpkByName:                        raw.cpkScopeInfo,
 		cpkByValue:                       raw.cpkInfo,
 		mirrorMode:                       raw.mirrorMode,
@@ -214,7 +214,7 @@ func (raw rawSyncCmdArgs) toOptions() (cooked cookedSyncCmdArgs, err error) {
 		//TBD: We will be preserving ACLs and ownership info in case of NFS. (UserID,GroupID and FileMode)
 		// Using the same EPreservePermissionsOption that we have today for NFS as well
 		// Please provide the feedback if we should introduce new EPreservePermissionsOption instead.
-		cooked.preservePermissions = common.NewPreservePermissionsOption(raw.preservePermissions,
+		cooked.PreservePermissions = common.NewPreservePermissionsOption(raw.preservePermissions,
 			true,
 			cooked.fromTo)
 		if err = cooked.hardlinks.Parse(raw.hardlinks); err != nil {
@@ -223,7 +223,7 @@ func (raw rawSyncCmdArgs) toOptions() (cooked cookedSyncCmdArgs, err error) {
 	} else {
 		cooked.preserveInfo = raw.preserveInfo && areBothLocationsSMBAware(cooked.fromTo)
 		cooked.preservePOSIXProperties = raw.preservePOSIXProperties
-		cooked.preservePermissions = common.NewPreservePermissionsOption(raw.preservePermissions,
+		cooked.PreservePermissions = common.NewPreservePermissionsOption(raw.preservePermissions,
 			raw.preserveOwner,
 			cooked.fromTo)
 	}
@@ -249,7 +249,7 @@ func (raw rawSyncCmdArgs) toOptions() (cooked cookedSyncCmdArgs, err error) {
 	}
 
 	if cooked.fromTo.IsS2S() {
-		cooked.preserveAccessTier = raw.s2sPreserveAccessTier
+		cooked.PreserveAccessTier = raw.s2sPreserveAccessTier
 	}
 
 	cooked.includeRegex = parsePatterns(raw.includeRegex)
@@ -299,13 +299,13 @@ func (cooked *cookedSyncCmdArgs) validate() (err error) {
 	// NFS/SMB validation
 	if cooked.isNFSCopy {
 		if err := performNFSSpecificValidation(
-			cooked.fromTo, cooked.preservePermissions, cooked.preserveInfo,
+			cooked.fromTo, cooked.PreservePermissions, cooked.preserveInfo,
 			cooked.symlinkHandling, cooked.hardlinks); err != nil {
 			return err
 		}
 	} else {
 		if err := performSMBSpecificValidation(
-			cooked.fromTo, cooked.preservePermissions, cooked.preserveInfo,
+			cooked.fromTo, cooked.PreservePermissions, cooked.preserveInfo,
 			cooked.preservePOSIXProperties); err != nil {
 			return err
 		}
@@ -321,7 +321,7 @@ func (cooked *cookedSyncCmdArgs) validate() (err error) {
 
 	// Check if user has provided `s2s-preserve-blob-tags` flag.
 	// If yes, we have to ensure that both source and destination must be blob storage.
-	if cooked.s2sPreserveBlobTags && (cooked.fromTo.From() != common.ELocation.Blob() || cooked.fromTo.To() != common.ELocation.Blob()) {
+	if cooked.S2sPreserveBlobTags && (cooked.fromTo.From() != common.ELocation.Blob() || cooked.fromTo.To() != common.ELocation.Blob()) {
 		return fmt.Errorf("either source or destination is not a blob storage. " +
 			"blob index tags is a property of blobs only therefore both source and destination must be blob storage")
 	}
@@ -466,7 +466,7 @@ type cookedSyncCmdArgs struct {
 
 	// options
 	compareHash             common.SyncHashType
-	preservePermissions     common.PreservePermissionsOption
+	PreservePermissions     common.PreservePermissionsOption
 	preserveInfo            bool
 	preservePOSIXProperties bool
 	putMd5                  bool
@@ -504,9 +504,9 @@ type cookedSyncCmdArgs struct {
 	// otherwise the user is prompted to make a decision
 	deleteDestination common.DeleteDestination
 
-	preserveAccessTier bool
+	PreserveAccessTier bool
 	// To specify whether user wants to preserve the blob index tags during service to service transfer.
-	s2sPreserveBlobTags bool
+	S2sPreserveBlobTags bool
 
 	cpkOptions common.CpkOptions
 

--- a/cmd/syncEnumerator.go
+++ b/cmd/syncEnumerator.go
@@ -97,7 +97,7 @@ func (cca *cookedSyncCmdArgs) InitEnumerator(ctx context.Context, enumeratorOpti
 		}
 	}
 
-	includeDirStubs := (cca.fromTo.From().SupportsHnsACLs() && cca.fromTo.To().SupportsHnsACLs() && cca.preservePermissions.IsTruthy()) || cca.includeDirectoryStubs
+	includeDirStubs := (cca.fromTo.From().SupportsHnsACLs() && cca.fromTo.To().SupportsHnsACLs() && cca.PreservePermissions.IsTruthy()) || cca.includeDirectoryStubs
 
 	// TODO: enable symlink support in a future release after evaluating the implications
 	// TODO: Consider passing an errorChannel so that enumeration errors during sync can be conveyed to the caller.
@@ -126,13 +126,13 @@ func (cca *cookedSyncCmdArgs) InitEnumerator(ctx context.Context, enumeratorOpti
 		CpkOptions: cca.cpkOptions,
 
 		SyncHashType:        cca.compareHash,
-		PreservePermissions: cca.preservePermissions,
+		PreservePermissions: cca.PreservePermissions,
 		TrailingDotOption:   cca.trailingDot,
 
 		Recursive:               cca.recursive,
 		GetPropertiesInFrontend: true,
 		IncludeDirectoryStubs:   includeDirStubs,
-		PreserveBlobTags:        cca.s2sPreserveBlobTags,
+		PreserveBlobTags:        cca.S2sPreserveBlobTags,
 		HardlinkHandling:        cca.hardlinks,
 		IncrementNotTransferred: func(entityType common.EntityType) {
 			if entityType == common.EEntityType.File() {
@@ -175,13 +175,13 @@ func (cca *cookedSyncCmdArgs) InitEnumerator(ctx context.Context, enumeratorOpti
 		CpkOptions: cca.cpkOptions,
 
 		SyncHashType:        cca.compareHash,
-		PreservePermissions: cca.preservePermissions,
+		PreservePermissions: cca.PreservePermissions,
 		TrailingDotOption:   cca.trailingDot,
 
 		Recursive:               cca.recursive,
 		GetPropertiesInFrontend: true,
 		IncludeDirectoryStubs:   includeDirStubs,
-		PreserveBlobTags:        cca.s2sPreserveBlobTags,
+		PreserveBlobTags:        cca.S2sPreserveBlobTags,
 		HardlinkHandling:        common.EHardlinkHandlingType.Follow(),
 	}
 	dstTraverserTemplate := ResourceTraverserTemplate{
@@ -272,7 +272,7 @@ func (cca *cookedSyncCmdArgs) InitEnumerator(ctx context.Context, enumeratorOpti
 
 	// decide our folder transfer strategy
 	// sync always acts like stripTopDir=true, but if we intend to persist the root, we must tell NewFolderPropertyOption stripTopDir=false.
-	fpo, folderMessage := NewFolderPropertyOption(cca.fromTo, cca.recursive, !cca.includeRoot, filters, cca.preserveInfo, cca.preservePermissions.IsTruthy(), false, strings.EqualFold(cca.destination.Value, common.Dev_Null), cca.includeDirectoryStubs)
+	fpo, folderMessage := NewFolderPropertyOption(cca.fromTo, cca.recursive, !cca.includeRoot, filters, cca.preserveInfo, cca.PreservePermissions.IsTruthy(), false, strings.EqualFold(cca.destination.Value, common.Dev_Null), cca.includeDirectoryStubs)
 	if !cca.dryrunMode {
 		glcm.Info(folderMessage)
 	}
@@ -306,7 +306,7 @@ func (cca *cookedSyncCmdArgs) InitEnumerator(ctx context.Context, enumeratorOpti
 		ForceWrite:                     common.EOverwriteOption.True(), // once we decide to transfer for a sync operation, we overwrite the destination regardless
 		ForceIfReadOnly:                cca.forceIfReadOnly,
 		LogLevel:                       LogLevel,
-		PreservePermissions:            cca.preservePermissions,
+		PreservePermissions:            cca.PreservePermissions,
 		PreserveInfo:                   cca.preserveInfo,
 		PreservePOSIXProperties:        cca.preservePOSIXProperties,
 		S2SSourceChangeValidation:      true,
@@ -314,7 +314,7 @@ func (cca *cookedSyncCmdArgs) InitEnumerator(ctx context.Context, enumeratorOpti
 		S2SGetPropertiesInBackend:      true,
 		S2SInvalidMetadataHandleOption: common.EInvalidMetadataHandleOption.RenameIfInvalid(),
 		CpkOptions:                     cca.cpkOptions,
-		S2SPreserveBlobTags:            cca.s2sPreserveBlobTags,
+		S2SPreserveBlobTags:            cca.S2sPreserveBlobTags,
 
 		S2SSourceCredentialType: cca.s2sSourceCredentialType,
 		FileAttributes: common.FileTransferAttributes{

--- a/cmd/syncOrchestrator.go
+++ b/cmd/syncOrchestrator.go
@@ -37,6 +37,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-azcopy/v10/common/parallel"
 )
@@ -66,6 +67,7 @@ var (
 	notFoundErrors []string = []string{
 		"ParentNotFound",
 		"BlobNotFound",
+		"PathNotFound",
 		"ResourceNotFound",
 	}
 
@@ -210,6 +212,25 @@ func validateS3Root(sourcePath string) error {
 	return nil
 }
 
+func validateBlobRoot(sourcePath string) error {
+	_, err := blob.ParseURL(sourcePath)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateBlobFSRoot validates a BlobFS root URL by converting the DFS endpoint to Blob
+// and then parsing it using the Blob URL parser. This mirrors how BlobFS traversers are initialized.
+func validateBlobFSRoot(sourcePath string) error {
+	r := strings.Replace(sourcePath, ".dfs", ".blob", 1)
+	_, err := blob.ParseURL(r)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // validateAndGetRootObject returns the root object for the sync orchestrator
 // based on the source path and fromTo configuration. This determines the starting
 // point for sync enumeration operations.
@@ -232,6 +253,10 @@ func validateAndGetRootObject(path string, fromTo common.FromTo) (minimalStoredO
 		err = validateLocalRoot(path)
 	case common.ELocation.S3():
 		err = validateS3Root(path)
+	case common.ELocation.Blob():
+		err = validateBlobRoot(path)
+	case common.ELocation.BlobFS():
+		err = validateBlobFSRoot(path)
 	default:
 		err = fmt.Errorf("sync orchestrator is not supported for %s source", fromTo.From().String())
 	}
@@ -508,7 +533,7 @@ func newSyncTraverser(enumerator *syncEnumerator, dir string, comparator objectP
 
 func validate(cca *cookedSyncCmdArgs, orchestratorOptions *SyncOrchestratorOptions) error {
 	switch cca.fromTo {
-	case common.EFromTo.LocalBlob(), common.EFromTo.LocalBlobFS(), common.EFromTo.LocalFile(), common.EFromTo.S3Blob():
+	case common.EFromTo.LocalBlob(), common.EFromTo.LocalBlobFS(), common.EFromTo.LocalFile(), common.EFromTo.S3Blob(), common.EFromTo.BlobBlob(), common.EFromTo.BlobBlobFS(), common.EFromTo.BlobFSBlob(), common.EFromTo.BlobFSBlobFS():
 		// sync orchestrator is supported for these types
 	default:
 		return fmt.Errorf(
@@ -516,7 +541,11 @@ func validate(cca *cookedSyncCmdArgs, orchestratorOptions *SyncOrchestratorOptio
 				"\t- Local->Blob\n" +
 				"\t- Local->BlobFS\n" +
 				"\t- Local->File\n" +
-				"\t- S3->Blob",
+				"\t- S3->Blob\n" +
+				"\t- Blob->Blob\n" +
+				"\t- Blob->BlobFS\n" +
+				"\t- BlobFS->Blob\n" +
+				"\t- BlobFS->BlobFS",
 		)
 	}
 

--- a/cmd/syncOrchestratorModels.go
+++ b/cmd/syncOrchestratorModels.go
@@ -77,7 +77,7 @@ func (s *SyncOrchestratorOptions) validate(from common.Location) error {
 		return errors.New("sync orchestrator options should only be used when UseSyncOrchestrator is true")
 	}
 
-	if from != common.ELocation.Local() && from != common.ELocation.S3() {
+	if from != common.ELocation.Local() && from != common.ELocation.S3() && from != common.ELocation.Blob() && from != common.ELocation.BlobFS() {
 		return errors.New("sync optimizations using timestamps should only be used for local to remote syncs")
 	}
 

--- a/cmd/syncProcessor.go
+++ b/cmd/syncProcessor.go
@@ -51,7 +51,7 @@ func newSyncTransferProcessor(cca *cookedSyncCmdArgs,
 	// note that the source and destination, along with the template are given to the generic processor's constructor
 	// this means that given an object with a relative path, this processor already knows how to schedule the right kind of transfers
 	return newCopyTransferProcessor(copyJobTemplate, numOfTransfersPerPart, cca.source, cca.destination,
-		reportFirstPart, reportFinalPart, cca.preserveAccessTier, cca.dryrunMode)
+		reportFirstPart, reportFinalPart, cca.PreserveAccessTier, cca.dryrunMode)
 }
 
 // base for delete processors targeting different resources


### PR DESCRIPTION
## Description

1) Adding support for Blob/BlobFS sources/targets in syncOrchestrator
2) Making blob acces tier, preserve access tier, preserve permissions public for sync cooked copy args such that they can be set in mover repo

- **Feature / Bug Fix**: (Brief description of the feature or issue being addressed)
Mover C2C Blob to Blob V1 Feature Support

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):


Thank you for your contribution to AzCopy!
