### PR TITLE
Fix for issue seen with read-only source files on Azure Files targets…

### DIFF
--- a/ste/sender-azureFile.go
+++ b/ste/sender-azureFile.go
@@ -251,6 +251,9 @@ func (u *azureFileSenderBase) Prologue(state common.PrologueState) (destinationM
 		creationProperties.LastWriteTime = &minimalLwt
 	}
 
+	// Set this before file creation
+	createOptions.SMBProperties = &creationProperties
+
 	err := common.DoWithOverrideReadOnlyOnAzureFiles(u.ctx,
 		func() (interface{}, error) {
 			return u.getFileClient().Create(u.ctx, info.SourceSize, createOptions)
@@ -276,9 +279,6 @@ func (u *azureFileSenderBase) Prologue(state common.PrologueState) (destinationM
 			u.jptm.FailActiveUpload("Creating parent directory", err)
 		}
 
-		if creationProperties.Attributes != nil {
-			createOptions.SMBProperties = &creationProperties
-		}
 		// retrying file creation
 		err = common.DoWithOverrideReadOnlyOnAzureFiles(u.ctx,
 			func() (interface{}, error) {


### PR DESCRIPTION
## Description
This is a fix for the issue we saw where some SMB source files set to read-only would fail transfer due to 409 error from the target stating that the file on the target is read-only and cannot be modified. Since the AzFiles REST API has two separate calls for creating a file on the target and transferring data to the created target file, if we create the file with read-only set to true, we can't put any data in it. 
Before, if the target returned a 404 error due to a missing parent folder, we would set the target's read-only bit to false for the Prologue, and set it back to true for the Epilogue, so we saw the issue with all files that don't have targets 

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
Used a source share with some read-only files. Before the change, azcopy copy would fail to transfer any of those files if it tried to transfer them after the folder was created on the target side. After the change, they would all succeed. 

Thank you for your contribution to AzCopy!
