### PR TITLE
Dont set defaults(uid/gid=0) when preserve-permissions=false when downloading

### DIFF
--- a/cmd/flagsValidation.go
+++ b/cmd/flagsValidation.go
@@ -160,20 +160,6 @@ func performNFSSpecificValidation(fromTo common.FromTo,
 		return err
 	}
 
-	// If we are not preserving original file permissions (raw.preservePermissions == false),
-	// and the operation is a file copy from azure file NFS to local linux (FromTo == FileLocal),
-	// and the current OS is Linux, then we require root privileges to proceed.
-	//
-	// This is because modifying file ownership or permissions on Linux
-	// typically requires elevated privileges. To safely handle permission
-	// changes during the local file operation, we enforce that the process
-	// must be running as root.
-	if !preservePermissions.IsTruthy() && fromTo == common.EFromTo.FileNFSLocal() {
-		if err := common.EnsureRunningAsRoot(); err != nil {
-			return fmt.Errorf("failed to copy source to destination without preserving permissions: operation not permitted. Please retry with root privileges or use the default option (--preserve-permissions=true)")
-		}
-	}
-
 	if err = validatePreserveNFSPropertyOption(preserveInfo,
 		fromTo,
 		PreserveInfoFlag); err != nil {
@@ -227,7 +213,7 @@ func performSMBSpecificValidation(fromTo common.FromTo,
 		PreservePermissionsFlag); err != nil {
 		return err
 	}
-	
+
 	// TODO: Add this check in Phase-3 which targets to support hardlinks for NFS copy.
 	// if err = validateAndAdjustHardlinksFlag(hardlinkHandling, fromTo); err != nil {
 	// 	return err

--- a/common/osOpen_fallback.go
+++ b/common/osOpen_fallback.go
@@ -6,9 +6,7 @@
 package common
 
 import (
-	"fmt"
 	"os"
-	"syscall"
 )
 
 // NOTE: OSOpenFile not safe to use on directories on Windows. See comment on the Windows version of this routine
@@ -18,11 +16,4 @@ func OSOpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
 
 func OSStat(name string) (os.FileInfo, error) {
 	return os.Stat(name)
-}
-
-func EnsureRunningAsRoot() error {
-	if syscall.Geteuid() != 0 {
-		return fmt.Errorf("must be run as root")
-	}
-	return nil
 }

--- a/ste/downloader-azureFiles.go
+++ b/ste/downloader-azureFiles.go
@@ -83,23 +83,6 @@ func (bd *azureFilesDownloader) preserveAttributes() (stage string, err error) {
 		if err != nil {
 			return
 		}
-	} else {
-		// If PreservePermissions is false and the source is an NFS share,
-		// apply default NFS permissions (mode, owner, group) to the destination file.
-		// This ensures the destination has valid permissions when none are preserved.
-		if bd.jptm.FromTo().IsNFS() {
-			if spdl, ok := interface{}(bd).(nfsPermissionsAwareDownloader); ok {
-				// Azure Files sources always implement INFSPropertyBearingSourceInfoProvider,
-				// so the type assertion below is guaranteed to succeed.
-				err := spdl.PutNFSDefaultPermissions(
-					bd.sip.(INFSPropertyBearingSourceInfoProvider),
-					bd.txInfo,
-				)
-				if err != nil {
-					return "Setting destination file NFS permissions", err
-				}
-			}
-		}
 	}
 
 	if info.PreserveInfo {

--- a/ste/downloader-azureFiles_linux.go
+++ b/ste/downloader-azureFiles_linux.go
@@ -317,38 +317,6 @@ func (a *azureFilesDownloader) PutNFSPermissions(sip INFSPropertyBearingSourceIn
 	return nil
 }
 
-// PutNFSDefaultPermissions sets default ownership and permissions for NFS shares
-// when no explicit NFS permissions are provided by the source.
-// Default: 0755 for directories, 0644 for files. Owner/group set to root (UID 0, GID 0).
-func (a *azureFilesDownloader) PutNFSDefaultPermissions(sip INFSPropertyBearingSourceInfoProvider, txInfo *TransferInfo) error {
-	const (
-		defaultFileMode = 0644
-		defaultDirMode  = 0755
-		defaultUID      = 0 // root
-		defaultGID      = 0 // root
-	)
-
-	// Determine file mode based on entity type
-	var mode os.FileMode
-	if txInfo.EntityType == common.EEntityType.Folder() {
-		mode = defaultDirMode
-	} else {
-		mode = defaultFileMode
-	}
-
-	// Set ownership
-	if err := os.Chown(txInfo.Destination, defaultUID, defaultGID); err != nil {
-		return fmt.Errorf("failed to set owner/group for %s: %w", txInfo.Destination, err)
-	}
-
-	// Set permissions
-	if err := os.Chmod(txInfo.Destination, mode); err != nil {
-		return fmt.Errorf("failed to set permissions for %s: %w", txInfo.Destination, err)
-	}
-
-	return nil
-}
-
 func (a *azureFilesDownloader) CreateSymlink(jptm IJobPartTransferMgr) error {
 	sip, err := newFileSourceInfoProvider(jptm)
 	if err != nil {

--- a/ste/downloader.go
+++ b/ste/downloader.go
@@ -86,7 +86,6 @@ type nfsPropertyAwareDownloader interface {
 // nfsPermissionsAwareDownloader
 type nfsPermissionsAwareDownloader interface {
 	PutNFSPermissions(sip INFSPropertyBearingSourceInfoProvider, txInfo *TransferInfo) error
-	PutNFSDefaultPermissions(sip INFSPropertyBearingSourceInfoProvider, txInfo *TransferInfo) error
 }
 
 type downloaderFactory func(jptm IJobPartTransferMgr) (downloader, error)


### PR DESCRIPTION
## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->
Don't set defaults(uid/gid=0) when preserve-permissions=false when downloading to avoid azcopy command run with sudo. System will set its default. Azcopy will not be setting any defaults.

- **Feature / Bug Fix**: (Brief description of the feature or issue being addressed)

- **Related Links**:
- [Issues](<link>)
- [Team thread](<link>)
- [Documents](<link>)
- [Email Subject] Permissions Complications from NFS File Transfers

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

Thank you for your contribution to AzCopy!
