### PR TITLE
Disable x509 serial number validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,9 @@
 module github.com/Azure/azure-storage-azcopy/v10
 
+godebug (
+	x509negativeserial=1
+)
+
 require (
 	cloud.google.com/go/storage v1.45.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.2


### PR DESCRIPTION
Final Result: MITM proxy is using negative serials, which isn’t [RFC-compliant](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.2), so I'd prefer to avoid allowing something that isn't RFC compliant by default. Let’s just document how to set GODEBUG=x509negativeserial=1 instead for folks who need it.


## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

**Feature / Bug Fix**: 

In Go 1.23, a new feature was introduced in the [crypto/x509](https://pkg.go.dev/crypto/x509#ParseCertificate) package that disabled certificates with a negative serial number, sometimes breaking mitm proxies, which prove useful in debugging.

There is no way to disable this at runtime outside of setting the GODEBUG environment variable-- This is often above user's heads, but it's arguable that, anybody going out of their way to use a MITM proxy _probably_ is technically inclined enough to figure out that this changed.

Hence, this isn't the cleanest solution, and I'm not the happiest with it. This PR is here to serve as a discussion point, not necessarily something _to review_.

**Related Links**:
- PBI #32923845

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [x] Bug fix (sorta)
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

Manually tested behind fiddler
