### PR TITLE
Bugfix for crashes on cancel operation for sync job

### DIFF
--- a/common/privateNetwork.go
+++ b/common/privateNetwork.go
@@ -252,6 +252,12 @@ func (rr *RoundRobinTransport) RoundTrip(req *http.Request) (*http.Response, err
 				// No response - parse error from the error object itself
 				errCode = 0
 				errMsg = err.Error()
+
+				// Incase of cancel operation return response without checking for errors.
+				if errMsg == "context canceled" {
+					log.Printf("Returning for cancel operation for Private Endpoint IP %s", peIP)
+					return resp, fmt.Errorf(errMsg)
+				}
 				log.Printf("[Counter=%d Retry=%d] Network error with no response, Error Message:%s retryable:%v", idx, ipAttempt, errMsg, isRetryableErr)
 			}
 


### PR DESCRIPTION
## Description
Bugfix for crashes seen during cancel operation of sync job with private networking

- **Feature / Bug Fix**: (Brief description of the feature or issue being addressed)
Root cause: When RoundRobin returns ErrorMessage: "context canceled", roundrobin gets into loop asynchronously to check the PE health on cancel in the meantime syncOrchestrator exit and error channel is closed. After PE retries, we see the crash while logging into SyncOrchestrator error channel which was closed.  
 
Fix for the issue:
In roundrobin function, return response without getting into retry loop when ErrorMessage is  "context canceled" this should fix the issue. 
Avoid crashes in synOrchestrator's error channel in such scenarios with recover function


## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
Tested the fix by cancelling the sync job and verifying no crashes are seen and job reaches terminal stage. Also retriggering the job to ensure job resumes successfully.

Thank you for your contribution to AzCopy!
