### PR TITLE
Honor process umask for default file permissions on Unix

### DIFF
--- a/common/default_file_perm_unix.go
+++ b/common/default_file_perm_unix.go
@@ -1,0 +1,36 @@
+//go:build !windows
+
+package common
+
+import (
+	"os"
+	"sync"
+	"syscall"
+)
+
+var (
+	umask     int
+	umaskOnce sync.Once
+)
+
+// GetUmask retrieves the current process's umask without permanently modifying it.
+// The value is cached after the first call.
+func GetUmask() int {
+	umaskOnce.Do(func() {
+		current := syscall.Umask(0)
+		syscall.Umask(current)
+		umask = current
+	})
+	return umask
+}
+
+// DEFAULT_FILE_PERM is 0666 masked by the process umask, matching standard
+// POSIX tool behavior (e.g. cp, rsync).  With a typical umask of 022 this
+// produces 0644; with 002 it produces 0664, etc.
+//
+// The value is computed once during package-level variable initialization
+// so that every file created by AzCopy receives permissions consistent with
+// the calling user's umask.
+var DEFAULT_FILE_PERM = func() os.FileMode {
+	return os.FileMode(0666 &^ GetUmask())
+}()

--- a/common/default_file_perm_windows.go
+++ b/common/default_file_perm_windows.go
@@ -1,0 +1,7 @@
+package common
+
+import "os"
+
+// DEFAULT_FILE_PERM on Windows retains the historical 0644 for backward
+// compatibility since Windows does not use a POSIX umask.
+var DEFAULT_FILE_PERM os.FileMode = 0644

--- a/common/fe-ste-models.go
+++ b/common/fe-ste-models.go
@@ -49,10 +49,6 @@ const (
 	EXTENDED_UNC_PATH_PREFIX     = `\\?\UNC`
 	Dev_Null                     = os.DevNull
 
-	//  this is the perm that AzCopy has used throughout its preview.  So, while we considered relaxing it to 0666
-	//  we decided that the best option was to leave it as is, and only relax it if user feedback so requires.
-	DEFAULT_FILE_PERM = 0644 // the os package will handle base-10 for us.
-
 	// Since we haven't updated the Go SDKs to handle CPK just yet, we need to detect CPK related errors
 	// and inform the user that we don't support CPK yet.
 	CPK_ERROR_SERVICE_CODE    = "BlobUsesCustomerSpecifiedEncryption"

--- a/ste/sourceInfoProvider-Local_linux.go
+++ b/ste/sourceInfoProvider-Local_linux.go
@@ -8,8 +8,6 @@ import (
 	"os/user"
 	"strconv"
 	"strings"
-	"sync"
-	"syscall"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -283,22 +281,8 @@ func (h HandleNFSPermissions) GetFileMode() *string {
 	return to.Ptr(fmt.Sprintf("%#o", fileMode))
 }
 
-var (
-	umask     int
-	umaskOnce sync.Once
-)
-
-// getUmask retrieves the current process's umask without permanently modifying it.
-func getUmask() int {
-	umaskOnce.Do(func() {
-		// Set umask to 0, capture the old value
-		current := syscall.Umask(0)
-		// Restore it immediately
-		syscall.Umask(current)
-		umask = current
-	})
-	return umask
-}
+// getUmask is a package-local alias for common.GetUmask.
+var getUmask = common.GetUmask
 
 // GetNFSDefaultPerms retrieves the default file permissions, owner UID, and group GID
 // for the current user, with permissions adjusted based on the user's umask.


### PR DESCRIPTION
## Summary

`DEFAULT_FILE_PERM` is currently hardcoded to `0644`. This prevents the process umask from influencing file permissions when AzCopy downloads files to a local filesystem.

Standard POSIX tools (`cp`, `rsync`, `tar`, etc.) create files with base mode `0666` and let the kernel apply the umask automatically. AzCopy should follow the same convention so that users get the permissions they expect from their environment.

For example, a user with `umask 002` expects group-writable files (`0664`), but AzCopy always produces `0644` regardless of umask. This is a common pain point in shared-storage environments (NFS, shared HPC clusters, multi-user training rigs).

The existing comment on the old constant acknowledged this:

> _"this is the perm that AzCopy has used throughout its preview. So, while we considered relaxing it to 0666, we decided that the best option was to leave it as is, and only relax it if user feedback so requires."_

This PR provides that user feedback and implements the change.

### What changed

- `DEFAULT_FILE_PERM` is now a `var` instead of a `const`, computed once at startup as `0666 &^ umask` on Unix.
- On Windows, `DEFAULT_FILE_PERM` remains `0644` for backward compatibility (Windows does not use POSIX umask).
- The existing private `getUmask()` in `ste/` is promoted to `common.GetUmask()` so both packages share one cached umask read.
- All existing call sites are unchanged -- they reference `common.DEFAULT_FILE_PERM` as before and receive the umask-aware value.

### Behavior change

| umask | Before (hardcoded) | After (umask-aware) |
|-------|-------------------|-------------------|
| 022   | 0644              | 0644 (no change)  |
| 002   | 0644              | 0664              |
| 077   | 0644              | 0600              |
| 000   | 0644              | 0666              |

### Breaking changes

- Users who relied on the implicit `0644` with a permissive umask (e.g., `umask 000`) will now see `0666` files. This matches what every other POSIX file-transfer tool produces.

## Test Plan

1. Build and run on Linux with different umask values:
   ```bash
   umask 022 && azcopy sync <src> <local-dest> && stat -c '%a' <local-dest>/*  # expect 644
   umask 002 && azcopy sync <src> <local-dest> && stat -c '%a' <local-dest>/*  # expect 664
   ```
2. Verify Windows builds produce the same `0644` as before (no behavioral change).
3. Verify `--preserve-posix-properties` still applies source permissions when available.

Made with [Cursor](https://cursor.com)