### PR TITLE
Skip Archive/Glacier objects during enumeration for S3 (#3368)

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -774,6 +774,7 @@ type CookedCopyCmdArgs struct {
 	hardlinks                     common.HardlinkHandlingType
 	atomicSkippedSymlinkCount     uint32
 	atomicSkippedSpecialFileCount uint32
+	atomicSkippedArchiveFileCount uint64
 	BlockSizeMB                   float64
 	PutBlobSizeMB                 float64
 	IncludePathPatterns           []string
@@ -1434,6 +1435,7 @@ func (cca *CookedCopyCmdArgs) ReportProgressOrExit(lcm common.LifecycleMgr) (tot
 	if jobDone {
 		summary.SkippedSymlinkCount = atomic.LoadUint32(&cca.atomicSkippedSymlinkCount)
 		summary.SkippedSpecialFileCount = atomic.LoadUint32(&cca.atomicSkippedSpecialFileCount)
+		summary.SkippedArchiveFileCount = atomic.LoadUint64(&cca.atomicSkippedArchiveFileCount)
 
 		exitCode := cca.getSuccessExitCode()
 		if summary.TransfersFailed > 0 || summary.JobStatus == common.EJobStatus.Cancelled() || summary.JobStatus == common.EJobStatus.Cancelling() {
@@ -1466,6 +1468,7 @@ Number of Folder Transfers Skipped: %v
 Number of Symbolic Links Skipped: %v
 Number of Hardlinks Converted: %v
 Number of Special Files Skipped: %v
+Number of Archive/Glacier Objects Skipped: %v
 Total Number of Bytes Transferred: %v
 Final Job Status: %v%s%s
 `,
@@ -1484,6 +1487,7 @@ Final Job Status: %v%s%s
 					summary.SkippedSymlinkCount,
 					summary.HardlinksConvertedCount,
 					summary.SkippedSpecialFileCount,
+					summary.SkippedArchiveFileCount,
 					summary.TotalBytesTransferred,
 					summary.JobStatus,
 					screenStats,

--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -104,6 +104,11 @@ func (cca *CookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 				} else if entityType == common.EEntityType.Symlink() {
 					atomic.AddUint32(&cca.atomicSkippedSymlinkCount, 1)
 				}
+			} else if cca.FromTo.From() == common.ELocation.S3() {
+				// Track skipped S3 objects (e.g., Archive/Glacier storage class objects)
+				if entityType == common.EEntityType.Other() {
+					atomic.AddUint64(&cca.atomicSkippedArchiveFileCount, 1)
+				}
 			}
 		},
 	})

--- a/cmd/moverDependencies.go
+++ b/cmd/moverDependencies.go
@@ -864,6 +864,10 @@ func (cooked *CookedCopyCmdArgs) ToStringMap() map[string]string {
 	if skippedSpecialFiles > 0 {
 		result["skippedSpecialFileCount"] = fmt.Sprintf("%d", skippedSpecialFiles)
 	}
+	skippedArchiveFiles := atomic.LoadUint64(&cooked.atomicSkippedArchiveFileCount)
+	if skippedArchiveFiles > 0 {
+		result["skippedArchiveFileCount"] = fmt.Sprintf("%d", skippedArchiveFiles)
+	}
 
 	// Always mask credential info
 	if cooked.credentialInfo.CredentialType != common.ECredentialType.Unknown() {
@@ -918,6 +922,18 @@ func (cooked *CookedCopyCmdArgs) ToString() string {
 
 func SetJobId(jobId common.JobID) {
 	azcopyCurrentJobID = jobId
+}
+
+func OpenScanningLogger() {
+	// set up the front end scanning logger
+	azcopyScanningLogger = common.NewJobLogger(azcopyCurrentJobID, LogLevel, azcopyLogPathFolder, "-scanning")
+	azcopyScanningLogger.OpenLog()
+}
+
+func CloseScanningLogger() {
+	if azcopyScanningLogger != nil {
+		azcopyScanningLogger.CloseLog()
+	}
 }
 
 // ============================================================================

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -526,6 +526,7 @@ type cookedSyncCmdArgs struct {
 	hardlinks                        common.HardlinkHandlingType
 	atomicSkippedSymlinkCount        uint32
 	atomicSkippedSpecialFileCount    uint32
+	atomicSkippedArchiveFileCount    uint64
 
 	blockSizeMB   float64
 	putBlobSizeMB float64
@@ -597,6 +598,11 @@ func (cca *cookedSyncCmdArgs) GetDestinationFilesScanned() uint64 {
 // GetDestinationFoldersScanned returns folders scanned at destination.
 func (cca *cookedSyncCmdArgs) GetDestinationFoldersScanned() uint64 {
 	return atomic.LoadUint64(&cca.atomicDestinationFoldersScanned)
+}
+
+// GetSkippedArchiveFileCount returns the number of archive/glacier storage class objects skipped during scanning.
+func (cca *cookedSyncCmdArgs) GetSkippedArchiveFileCount() uint64 {
+	return atomic.LoadUint64(&cca.atomicSkippedArchiveFileCount)
 }
 
 func (cca *cookedSyncCmdArgs) IncrementSourceFolderEnumerationFailed() {
@@ -785,6 +791,7 @@ func (cca *cookedSyncCmdArgs) ReportProgressOrExit(lcm common.LifecycleMgr) (tot
 
 		summary.SkippedSymlinkCount = atomic.LoadUint32(&cca.atomicSkippedSymlinkCount)
 		summary.SkippedSpecialFileCount = atomic.LoadUint32(&cca.atomicSkippedSpecialFileCount)
+		summary.SkippedArchiveFileCount = atomic.LoadUint64(&cca.atomicSkippedArchiveFileCount)
 
 		lcm.Exit(func(format common.OutputFormat) string {
 			if format == common.EOutputFormat.Json() {
@@ -920,6 +927,7 @@ Number of Copy Transfers Failed: %v
 Number of Deletions at Destination: %v
 Number of Symbolic Links Skipped: %v
 Number of Special Files Skipped: %v
+Number of Archive/Glacier Objects Skipped: %v
 Number of Hardlinks Converted: %v
 Total Number of Bytes Transferred: %v
 Total Number of Bytes Enumerated: %v
@@ -937,6 +945,7 @@ Final Job Status: %v%s%s
 		cca.atomicDeletionCount,
 		summary.SkippedSymlinkCount,
 		summary.SkippedSpecialFileCount,
+		summary.SkippedArchiveFileCount,
 		summary.HardlinksConvertedCount,
 		summary.TotalBytesTransferred,
 		summary.TotalBytesEnumerated,
@@ -966,6 +975,7 @@ Number of Copy Transfers Failed: ............... %12v
 Number of Deletions at Destination: ............ %12v
 Number of Symbolic Links Skipped: .............. %12v
 Number of Special Files Skipped: ............... %12v
+Number of Archive/Glacier Objects Skipped: ..... %12v
 Number of Hardlinks Converted: ................. %12v
 ------------------------------------------------------------
 Number of Files Not Requiring Transfer: ........ %12v
@@ -998,6 +1008,7 @@ Final Job Status: .............................. %12v
 		cca.atomicDeletionCount,
 		summary.SkippedSymlinkCount,
 		summary.SkippedSpecialFileCount,
+		summary.SkippedArchiveFileCount,
 		summary.HardlinksConvertedCount,
 
 		atomic.LoadUint64(&cca.atomicSourceFilesTransferNotRequired),

--- a/cmd/syncEnumerator.go
+++ b/cmd/syncEnumerator.go
@@ -121,6 +121,13 @@ func (cca *cookedSyncCmdArgs) InitEnumerator(ctx context.Context, enumeratorOpti
 					atomic.AddUint32(&cca.atomicSkippedSymlinkCount, 1)
 				}
 			}
+			if cca.fromTo.From() == common.ELocation.S3() {
+				// Track skipped S3 objects (e.g., Archive/Glacier storage class objects)
+				if entityType == common.EEntityType.Other() {
+					atomic.AddUint64(&cca.atomicSkippedArchiveFileCount, 1)
+					atomic.AddUint64(&cca.atomicSourceFilesScanned, 1) // Count skipped archive files as scanned files
+				}
+			}
 		},
 
 		CpkOptions: cca.cpkOptions,

--- a/cmd/zc_traverser_s3.go
+++ b/cmd/zc_traverser_s3.go
@@ -239,6 +239,20 @@ func (t *s3Traverser) Traverse(preprocessor objectMorpher, processor objectProce
 			return fmt.Errorf("cannot list objects, %v", objectInfo.Err)
 		}
 
+		// Skip objects in archive storage classes as they cannot be accessed directly
+		// and require restoration before transfer. Attempting to transfer these objects
+		// will result in 403 errors and job failures.
+		if isArchiveStorageClass(objectInfo.StorageClass) {
+			skipMessage := fmt.Sprintf("Skipping S3 object %s as it is in %s storage class. "+
+				"Objects in archive storage classes must be restored before they can be transferred.",
+				objectInfo.Key, objectInfo.StorageClass)
+			WarnStdoutAndScanningLog(skipMessage)
+
+			// Increment the enumeration counter to track this as a skipped object
+			t.incrementEnumerationCounter(common.EEntityType.Other())
+			continue
+		}
+
 		if objectInfo.StorageClass == "" && !t.includeDirectoryOrPrefix {
 			// Directories are the only objects without storage classes.
 			// Skip directories if not using sync orchestrator
@@ -434,4 +448,24 @@ func CreateSharedS3Client(ctx context.Context, s3URLParts common.S3URLParts, cre
 	}, common.CredentialOpOptions{
 		LogError: glcm.Error,
 	}, azcopyScanningLogger)
+}
+
+// isArchiveStorageClass checks if the given storage class is an archive tier
+// that requires restoration before objects can be accessed. Objects in these storage classes
+// cannot be directly downloaded and will result in 403 errors if attempted.
+// This function supports archive storage classes from multiple S3-compatible providers:
+//
+// AWS S3 Glacier storage classes that require restoration:
+// - GLACIER: Glacier Flexible Retrieval (formerly just "Glacier") - requires restoration
+// - DEEP_ARCHIVE: Glacier Deep Archive - requires restoration
+//
+// Note: The following storage classes are NOT included as they provide immediate access:
+// - GLACIER_IR (AWS): Provides millisecond access without restoration
+// - NEARLINE, COLDLINE, ARCHIVE (GCS): All provide immediate access without restoration
+//
+// To add support for additional archive storage classes from other S3-compatible providers
+// that require restoration, add the storage class string to the comparison below.
+func isArchiveStorageClass(storageClass string) bool {
+	// AWS Glacier storage classes that require restoration
+	return storageClass == "GLACIER" || storageClass == "DEEP_ARCHIVE"
 }

--- a/common/rpc-models.go
+++ b/common/rpc-models.go
@@ -335,6 +335,7 @@ type ListJobSummaryResponse struct {
 	SkippedSymlinkCount     uint32 `json:",string"`
 	HardlinksConvertedCount uint32 `json:",string"`
 	SkippedSpecialFileCount uint32 `json:",string"`
+	SkippedArchiveFileCount uint64 `json:",string"`
 }
 
 // wraps the standard ListJobSummaryResponse with sync-specific stats


### PR DESCRIPTION
* Skip Archive/Glacier objects during enumeration for S3

* using new counter variable for archive objects skipped

* removing GetSkippedSpecialFileCount()

* changing counter to uint64

* Review point fixed for incrmeentEnumCounter func

* MoverDependencies: Add init and close utils for scanning logger

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**: (Brief description of the feature or issue being addressed)

- **Related Links**:
- [Issues](<link>)
- [Team thread](<link>)
- [Documents](<link>)
- [Email Subject]

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

Thank you for your contribution to AzCopy!
