### PR TITLE
Add shnayak-msft to CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @gapra-msft @adreed-msft @dphulkar-msft @vibhansa-msft @seanmcc-msft @souravgupta-msft @tanyasethi-msft @wonwuakpa-msft
+*       @gapra-msft @adreed-msft @dphulkar-msft @vibhansa-msft @seanmcc-msft @souravgupta-msft @tanyasethi-msft @wonwuakpa-msft @shnayak-msft


### PR DESCRIPTION
Add shnayak-msft to CODEOWNERS file, adding them to the default reviewers list.