### PR TITLE
Fix invalidblocklist debug call

### DIFF
--- a/ste/sender-blockBlob.go
+++ b/ste/sender-blockBlob.go
@@ -277,8 +277,6 @@ func (s *blockBlobSenderBase) Epilogue() {
 				CPKScopeInfo: s.jptm.CpkScopeInfo(),
 			})
 		if err != nil {
-			jptm.FailActiveSend(common.Iff(blobTags != nil, "Committing block list (with tags)", "Committing block list"), err)
-
 			/*
 				If we get an invalid block list, it's likely one of our blocks was deleted, or GC'd mid-job or something.
 				Knowing which blocks are missing is useful, as up to 50k blocks can exist in a single object.
@@ -330,6 +328,9 @@ func (s *blockBlobSenderBase) Epilogue() {
 					jptm.Log(common.LogError, fmt.Sprintf("Unrecognized blocks: %s", formatBlocklist(extraBlocks)))
 				}
 			}
+
+			// Fail _afterwards_, since this is the action that cancels our context. Unfortunately, doing this would cause us to fail to send the request that'd get us details on the block list.
+			jptm.FailActiveSend(common.Iff(blobTags != nil, "Committing block list (with tags)", "Committing block list"), err)
 
 			return
 		}


### PR DESCRIPTION
## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**: Corrects an order-of-operations error when trying to output InvalidBlockList detail logs. We accidentally cancel the transfer before we try to grab the block list and compare. This means we instantly fail the call, every time. This is a quick fix to assist in the amex-ediscovery case.

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

Testing with eDiscovery PG to validate, since we have a reliable repro of the bug that causes this.