### PR TITLE
Pass POSIX Properties style to JobPartPlanFileName. Fix toCopyOptions…

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -240,6 +240,10 @@ func (raw *rawCopyCmdArgs) toCopyOptions(cmd *cobra.Command) (opts azcopy.CopyOp
 		return opts, err
 	}
 
+	if err = opts.PosixPropertiesStyle.Parse(raw.posixPropertiesStyle); err != nil {
+		return opts, err
+	}
+
 	err = opts.BlobType.Parse(raw.blobType)
 	if err != nil {
 		return opts, err

--- a/ste/JobPartPlanFileName.go
+++ b/ste/JobPartPlanFileName.go
@@ -217,6 +217,7 @@ func (jpfn JobPartPlanFileName) Create(order common.CopyJobPartOrderRequest) {
 		PreservePermissions:     order.PreservePermissions,
 		PreserveInfo:            order.PreserveInfo,
 		PreservePOSIXProperties: order.PreservePOSIXProperties,
+		PosixPropertiesStyle:    order.PosixPropertiesStyle,
 		// For S2S copy, per JobPartPlan info
 		S2SGetPropertiesInBackend:      order.S2SGetPropertiesInBackend,
 		S2SSourceChangeValidation:      order.S2SSourceChangeValidation,


### PR DESCRIPTION

## Description
This pull request introduces support for specifying and handling the POSIX properties style in copy operations. The main changes ensure that the `PosixPropertiesStyle` is properly parsed from user input and included in the job part plan for copy operations.

Enhancements to POSIX properties handling:

* Added parsing of the `posixPropertiesStyle` option in the `toCopyOptions` function to validate and set the POSIX properties style during copy command processing.
* Included the `PosixPropertiesStyle` field in the job part plan creation to ensure it is stored and used during job execution.… to consider POSIX Properties Style


- **Feature / Bug Fix**: #3398

- **Related Links**:
#3398


## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
Tested on real-use case scenario, validating that now Blob is copied with correct metadata


