### PR TITLE
Add PutMd5 field to mover command argument structs

### DIFF
--- a/cmd/moverDependencies.go
+++ b/cmd/moverDependencies.go
@@ -333,6 +333,7 @@ type RawMoverSyncCmdArgs struct {
 	PreserveInfo            bool
 	ForceIfReadOnly         bool
 	Md5ValidationOption     string
+	PutMd5                  bool
 	CompareHash             string
 	LocalHashStorageMode    string
 	Hardlinks               string
@@ -352,6 +353,7 @@ type SyncCmdArgsInput struct {
 	PreserveSMBInfo         bool
 	ForceIfReadOnly         bool
 	Md5ValidationOption     string
+	PutMd5                  bool
 	CompareHash             string
 	LocalHashStorageMode    string
 	Hardlinks               string
@@ -372,6 +374,7 @@ func CookRawSyncCmdArgs(args RawMoverSyncCmdArgs) (cookedSyncCmdArgs, error) {
 		preserveInfo:            args.PreserveInfo,
 		forceIfReadOnly:         args.ForceIfReadOnly,
 		md5ValidationOption:     args.Md5ValidationOption,
+		putMd5:                  args.PutMd5,
 		compareHash:             args.CompareHash,
 		localHashStorageMode:    args.LocalHashStorageMode,
 		hardlinks:               args.Hardlinks,


### PR DESCRIPTION
Added a boolean PutMd5 field to RawMoverSyncCmdArgs and SyncCmdArgsInput structs in moverDependencies.go. Updated CookRawSyncCmdArgs to propagate PutMd5, enabling support for this option throughout the sync command argument pipeline.

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**: Add support to call PutMd5 from storage mover

- **Related Links**:
- [Issues](<link>)
- [Team thread](<link>)
- [Documents](<link>)
- [Email Subject]

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [ ] Bug fix
- [x ] New Support from Storage mover
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->
This has been tested from storage mover job.
