### PR TITLE
Fix deadlock in ResumeTransfers, mmap safety in ScheduleTransfers

### DIFF
--- a/jobsAdmin/JobsAdmin.go
+++ b/jobsAdmin/JobsAdmin.go
@@ -377,7 +377,6 @@ func (ja *jobsAdmin) ResurrectJob(jobId common.JobID,
 	// Search the existing plan files for the PartPlans for the given jobId
 	// only the files which are not empty and have JobId has prefix and DataSchemaVersion as Suffix
 	// are include in the result
-
 	files := func(prefix, ext string) []os.FileInfo {
 		var files []os.FileInfo
 		_ = filepath.Walk(ja.planDir, func(path string, fileInfo os.FileInfo, _ error) error {
@@ -392,14 +391,12 @@ func (ja *jobsAdmin) ResurrectJob(jobId common.JobID,
 	if len(files) == 0 {
 		return false
 	}
-
 	// sort the JobPartPlan files with respect to Part Number
 	sort.Sort(sortPlanFiles{Files: files})
 	for f := 0; f < len(files); f++ {
 		planFile := ste.JobPartPlanFileName(files[f].Name())
 		jobID, partNum, err := planFile.Parse()
 		if err != nil {
-
 			continue
 		}
 		mmf := planFile.Map()

--- a/jobsAdmin/init.go
+++ b/jobsAdmin/init.go
@@ -239,9 +239,6 @@ func CancelPauseJobOrder(jobID common.JobID, desiredJobStatus common.JobStatus) 
 }
 
 func ResumeJobOrder(req common.ResumeJobRequest) common.CancelPauseResumeResponse {
-	resumeOrderStart := time.Now()
-
-
 	// Strip '?' if present as first character of the source sas / destination sas
 	if len(req.SourceSAS) > 0 && req.SourceSAS[0] == '?' {
 		req.SourceSAS = req.SourceSAS[1:]
@@ -258,7 +255,6 @@ func ResumeJobOrder(req common.ResumeJobRequest) common.CancelPauseResumeRespons
 			ErrorMsg:              fmt.Sprintf("no job with JobId %v exists", req.JobID),
 		}
 	}
-
 
 	// If the job manager was not found, then Job was resurrected
 	// Get the Job manager again for given JobId
@@ -279,13 +275,11 @@ func ResumeJobOrder(req common.ResumeJobRequest) common.CancelPauseResumeRespons
 	}
 	// If the job has not been ordered completely, then job cannot be resumed
 	if !completeJobOrdered(jm) {
-
 		return common.CancelPauseResumeResponse{
 			CancelledPauseResumed: false,
 			ErrorMsg:              fmt.Sprintf("cannot resume job with JobId %s . It hasn't been ordered completely", req.JobID),
 		}
 	}
-
 
 	var jr common.CancelPauseResumeResponse
 	jpm, found := jm.JobPartMgr(0)
@@ -350,7 +344,6 @@ func ResumeJobOrder(req common.ResumeJobRequest) common.CancelPauseResumeRespons
 	// After creating the Job mgr, set the include / exclude list of transfer.
 	jm.SetIncludeExclude(req.IncludeTransfer, req.ExcludeTransfer)
 	jpp0 := jpm.Plan()
-
 	switch jpp0.JobStatus() {
 	// Cannot resume a Job which is in Cancelling state
 	// Cancelling is an intermediary state. The reason we accept and process it here, rather than returning an error,
@@ -395,8 +388,12 @@ func ResumeJobOrder(req common.ResumeJobRequest) common.CancelPauseResumeRespons
 		// Iterate through all transfer of the Job Parts and reset the transfer status
 		jm.IterateJobParts(true, func(partNum common.PartNumber, jpm ste.IJobPartMgr) {
 			jpp := jpm.Plan()
+			// Iterate through this job part's transfers
 			for t := uint32(0); t < jpp.NumTransfers; t++ {
+				// transferHeader represents the memory map transfer header of transfer at index position for given job and part number
 				jppt := jpp.Transfer(t)
+				// If the transfer status is less than -1, it means the transfer failed because of some reason.
+				// Transfer Status needs to reset.
 				if jppt.TransferStatus() <= common.ETransferStatus.Failed() {
 					jppt.SetTransferStatus(common.ETransferStatus.Restarted(), true)
 					jppt.SetErrorCode(0, true)
@@ -405,16 +402,12 @@ func ResumeJobOrder(req common.ResumeJobRequest) common.CancelPauseResumeRespons
 			}
 		})
 
-		resumeTransfersStart := time.Now()
 		jm.ResumeTransfers(steCtx) // Reschedule all job part's transfers
-		common.GetLifecycleMgr().Info(fmt.Sprintf("[RESUME] JobId=%s: ResumeTransfers took %dms", req.JobID, time.Since(resumeTransfersStart).Milliseconds()))
-		// }()
 		jr = common.CancelPauseResumeResponse{
 			CancelledPauseResumed: true,
 			ErrorMsg:              "",
 		}
 	}
-	common.GetLifecycleMgr().Info(fmt.Sprintf("[RESUME] JobId=%s: ResumeJobOrder total elapsed=%dms", req.JobID, time.Since(resumeOrderStart).Milliseconds()))
 	return jr
 }
 

--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -724,8 +724,9 @@ func (jm *jobMgr) ResumeTransfers(appCtx context.Context) {
 	//   - scheduleJobParts blocks on unbuffered jobPartProgress, waiting for reportJobPartDoneHandler
 	// Read lock avoids this because RWMutex allows concurrent readers.
 	// No writers exist at this point — all AddJobPart/AddJobOrder calls completed in ResurrectJob (step 1).
+	useReadLock := buildmode.IsMover
 	partCount := 0
-	jm.jobPartMgrs.Iterate(buildmode.IsMover, func(p common.PartNumber, jpm IJobPartMgr) {
+	jm.jobPartMgrs.Iterate(useReadLock, func(p common.PartNumber, jpm IJobPartMgr) {
 		jm.QueueJobParts(jpm)
 		partCount++
 	})
@@ -788,6 +789,7 @@ func (jm *jobMgr) ReportJobPartDone(progressInfo jobPartProgressInfo) {
 }
 
 func (jm *jobMgr) reportJobPartDoneHandler() {
+	var haveFinalPart bool
 	var jobProgressInfo jobPartProgressInfo
 	shouldLog := jm.ShouldLog(common.LogInfo)
 
@@ -841,7 +843,7 @@ func (jm *jobMgr) reportJobPartDoneHandler() {
 
 			// If the last part is still awaited or other parts all still not complete,
 			// JobPart 0 status is not changed (unless we are cancelling)
-			haveFinalPart := atomic.LoadInt32(&jm.atomicFinalPartOrderedIndicator) == 1
+			haveFinalPart = atomic.LoadInt32(&jm.atomicFinalPartOrderedIndicator) == 1
 			allKnownPartsDone := partsDone == jm.jobPartMgrs.Count()
 			isCancelling := jobStatus == common.EJobStatus.Cancelling()
 			shouldComplete := (haveFinalPart && allKnownPartsDone) || // If we have all of the parts, they should all exit cleanly, so the job can be resumed properly.


### PR DESCRIPTION
Bug fixes for resume path in azcopy engine:

- **Deadlock fix**: Changed ResumeTransfers to use READ lock (via buildmode.IsMover) instead of write lock when iterating jobPartMgrs to queue parts. Write lock caused deadlock when partsChannel fills up: ResumeTransfers holds write lock -> reportJobPartDoneHandler needs read lock -> scheduleJobParts blocks on unbuffered jobPartProgress.
- **Mmap safety**: Cached isFinalPart and cachedNumTransfers before the transfer loop in ScheduleTransfers to avoid accessing memory-mapped plan data that may be unmapped during iteration.