### PR TITLE
feat: Configurable block size, access tier, and S3 Glacier archive skip in STE

### DIFF
--- a/cmd/moverDependencies.go
+++ b/cmd/moverDependencies.go
@@ -349,6 +349,7 @@ type RawMoverSyncCmdArgs struct {
 	S2sPreserveAccessTier   bool
 	S2sPreserveBlobTags     bool
 	BlobType                common.BlobType
+	BlockSizeMB             float64
 }
 
 type SyncCmdArgsInput struct {
@@ -395,6 +396,7 @@ func CookRawSyncCmdArgs(args RawMoverSyncCmdArgs) (cookedSyncCmdArgs, error) {
 		s2sPreserveAccessTier:   args.S2sPreserveAccessTier,
 		s2sPreserveBlobTags:     args.S2sPreserveBlobTags,
 		blobType:                args.BlobType.String(),
+		blockSizeMB:             args.BlockSizeMB,
 	}
 	return raw.cook()
 }

--- a/cmd/moverDependencies.go
+++ b/cmd/moverDependencies.go
@@ -350,6 +350,7 @@ type RawMoverSyncCmdArgs struct {
 	S2sPreserveBlobTags     bool
 	BlobType                common.BlobType
 	BlockSizeMB             float64
+	BlockBlobTier           string
 }
 
 type SyncCmdArgsInput struct {
@@ -397,6 +398,7 @@ func CookRawSyncCmdArgs(args RawMoverSyncCmdArgs) (cookedSyncCmdArgs, error) {
 		s2sPreserveBlobTags:     args.S2sPreserveBlobTags,
 		blobType:                args.BlobType.String(),
 		blockSizeMB:             args.BlockSizeMB,
+		blockBlobTier:           args.BlockBlobTier,
 	}
 	return raw.cook()
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -109,6 +109,8 @@ type rawSyncCmdArgs struct {
 	hardlinks    string
 	// blobType specifies the type of blob to use at the destination (BlockBlob, PageBlob, AppendBlob).
 	blobType string
+	// blockBlobTier specifies the access tier for block blobs at the destination.
+	blockBlobTier string
 }
 
 // it is assume that the given url has the SAS stripped, and safe to print
@@ -252,6 +254,12 @@ func (raw rawSyncCmdArgs) toOptions() (cooked cookedSyncCmdArgs, err error) {
 
 	if err = cooked.blobType.Parse(raw.blobType); err != nil {
 		return cooked, err
+	}
+
+	if raw.blockBlobTier != "" {
+		if err = cooked.blockBlobTier.Parse(raw.blockBlobTier); err != nil {
+			return cooked, err
+		}
 	}
 
 	if cooked.fromTo.IsS2S() {
@@ -537,6 +545,9 @@ type cookedSyncCmdArgs struct {
 
 	// blobType specifies the type of blob to use at the destination (BlockBlob, PageBlob, AppendBlob).
 	blobType common.BlobType
+
+	// blockBlobTier specifies the access tier for block blobs at the destination.
+	blockBlobTier common.BlockBlobTier
 
 	// cancellation for sync orchestrator
 	orchestratorCancel context.CancelFunc

--- a/cmd/syncEnumerator.go
+++ b/cmd/syncEnumerator.go
@@ -305,6 +305,7 @@ func (cca *cookedSyncCmdArgs) InitEnumerator(ctx context.Context, enumeratorOpti
 		// flags
 		BlobAttributes: common.BlobTransferAttributes{
 			BlobType:                         cca.blobType,
+			BlockBlobTier:                    cca.blockBlobTier,
 			PreserveLastModifiedTime:         cca.preserveInfo, // true by default for sync so that future syncs have this information available
 			PutMd5:                           cca.putMd5,
 			MD5ValidationOption:              cca.md5ValidationOption,

--- a/cmd/zc_traverser_s3.go
+++ b/cmd/zc_traverser_s3.go
@@ -239,24 +239,6 @@ func (t *s3Traverser) Traverse(preprocessor objectMorpher, processor objectProce
 			return fmt.Errorf("cannot list objects, %v", objectInfo.Err)
 		}
 
-		// Skip objects in archive storage classes unless they have been restored.
-		// Objects in GLACIER or DEEP_ARCHIVE require restoration before transfer;
-		// attempting to transfer un-restored objects results in 403 errors.
-		// We issue a HEAD request to check the x-amz-restore header for restore status.
-		if isArchiveStorageClass(objectInfo.StorageClass) {
-			statInfo, err := t.s3Client.StatObject(t.ctx, t.s3URLParts.BucketName, objectInfo.Key, minio.StatObjectOptions{})
-			if err != nil || !isRestoredFromArchive(statInfo.Restore) {
-				skipMessage := fmt.Sprintf("Skipping S3 object %s as it is in %s storage class and has not been restored. "+
-					"Objects in archive storage classes must be restored before they can be transferred.",
-					objectInfo.Key, objectInfo.StorageClass)
-				WarnStdoutAndScanningLog(skipMessage)
-
-				// Increment the enumeration counter to track this as a skipped object
-				t.incrementEnumerationCounter(common.EEntityType.Other())
-				continue
-			}
-		}
-
 		if objectInfo.StorageClass == "" && !t.includeDirectoryOrPrefix {
 			// Directories are the only objects without storage classes.
 			// Skip directories if not using sync orchestrator
@@ -454,31 +436,4 @@ func CreateSharedS3Client(ctx context.Context, s3URLParts common.S3URLParts, cre
 	}, azcopyScanningLogger)
 }
 
-// isArchiveStorageClass checks if the given storage class is an archive tier
-// that requires restoration before objects can be accessed. Objects in these storage classes
-// cannot be directly downloaded and will result in 403 errors if attempted.
-// This function supports archive storage classes from multiple S3-compatible providers:
-//
-// AWS S3 Glacier storage classes that require restoration:
-// - GLACIER: Glacier Flexible Retrieval (formerly just "Glacier") - requires restoration
-// - DEEP_ARCHIVE: Glacier Deep Archive - requires restoration
-//
-// Note: The following storage classes are NOT included as they provide immediate access:
-// - GLACIER_IR (AWS): Provides millisecond access without restoration
-// - NEARLINE, COLDLINE, ARCHIVE (GCS): All provide immediate access without restoration
-//
-// To add support for additional archive storage classes from other S3-compatible providers
-// that require restoration, add the storage class string to the comparison below.
-func isArchiveStorageClass(storageClass string) bool {
-	// AWS Glacier storage classes that require restoration
-	return storageClass == "GLACIER" || storageClass == "DEEP_ARCHIVE"
-}
 
-// isRestoredFromArchive checks whether an archived object has been successfully
-// restored and is currently accessible. A restore is considered ready when:
-//   - RestoreInfo is not nil (x-amz-restore header was present)
-//   - OngoingRestore is false (restore operation has completed)
-//   - ExpiryTime is set (the temporary copy has an expiry, confirming availability)
-func isRestoredFromArchive(restore *minio.RestoreInfo) bool {
-	return restore != nil && !restore.OngoingRestore && !restore.ExpiryTime.IsZero()
-}

--- a/cmd/zc_traverser_s3.go
+++ b/cmd/zc_traverser_s3.go
@@ -239,18 +239,22 @@ func (t *s3Traverser) Traverse(preprocessor objectMorpher, processor objectProce
 			return fmt.Errorf("cannot list objects, %v", objectInfo.Err)
 		}
 
-		// Skip objects in archive storage classes as they cannot be accessed directly
-		// and require restoration before transfer. Attempting to transfer these objects
-		// will result in 403 errors and job failures.
+		// Skip objects in archive storage classes unless they have been restored.
+		// Objects in GLACIER or DEEP_ARCHIVE require restoration before transfer;
+		// attempting to transfer un-restored objects results in 403 errors.
+		// We issue a HEAD request to check the x-amz-restore header for restore status.
 		if isArchiveStorageClass(objectInfo.StorageClass) {
-			skipMessage := fmt.Sprintf("Skipping S3 object %s as it is in %s storage class. "+
-				"Objects in archive storage classes must be restored before they can be transferred.",
-				objectInfo.Key, objectInfo.StorageClass)
-			WarnStdoutAndScanningLog(skipMessage)
+			statInfo, err := t.s3Client.StatObject(t.ctx, t.s3URLParts.BucketName, objectInfo.Key, minio.StatObjectOptions{})
+			if err != nil || !isRestoredFromArchive(statInfo.Restore) {
+				skipMessage := fmt.Sprintf("Skipping S3 object %s as it is in %s storage class and has not been restored. "+
+					"Objects in archive storage classes must be restored before they can be transferred.",
+					objectInfo.Key, objectInfo.StorageClass)
+				WarnStdoutAndScanningLog(skipMessage)
 
-			// Increment the enumeration counter to track this as a skipped object
-			t.incrementEnumerationCounter(common.EEntityType.Other())
-			continue
+				// Increment the enumeration counter to track this as a skipped object
+				t.incrementEnumerationCounter(common.EEntityType.Other())
+				continue
+			}
 		}
 
 		if objectInfo.StorageClass == "" && !t.includeDirectoryOrPrefix {
@@ -468,4 +472,13 @@ func CreateSharedS3Client(ctx context.Context, s3URLParts common.S3URLParts, cre
 func isArchiveStorageClass(storageClass string) bool {
 	// AWS Glacier storage classes that require restoration
 	return storageClass == "GLACIER" || storageClass == "DEEP_ARCHIVE"
+}
+
+// isRestoredFromArchive checks whether an archived object has been successfully
+// restored and is currently accessible. A restore is considered ready when:
+//   - RestoreInfo is not nil (x-amz-restore header was present)
+//   - OngoingRestore is false (restore operation has completed)
+//   - ExpiryTime is set (the temporary copy has an expiry, confirming availability)
+func isRestoredFromArchive(restore *minio.RestoreInfo) bool {
+	return restore != nil && !restore.OngoingRestore && !restore.ExpiryTime.IsZero()
 }

--- a/common/fe-ste-models.go
+++ b/common/fe-ste-models.go
@@ -902,7 +902,15 @@ func (TransferStatus) TierAvailabilityCheckFailure() TransferStatus { return Tra
 
 func (TransferStatus) Cancelled() TransferStatus { return TransferStatus(-6) }
 
+// Transfer was skipped because S3 source object is in an archive storage class (GLACIER/DEEP_ARCHIVE)
+// and has not been restored.
+func (TransferStatus) SkippedArchiveNotRestored() TransferStatus { return TransferStatus(-7) }
+
 // Transfer is any of the three possible state (InProgress, Completer or Failed)
+// ErrS3ArchiveObjectNotRestored is returned when an S3 object is in an archive storage class
+// (GLACIER/DEEP_ARCHIVE) and has not been restored. The STE uses this to skip the transfer.
+var ErrS3ArchiveObjectNotRestored = errors.New("S3 object is in archive storage class and has not been restored")
+
 func (TransferStatus) All() TransferStatus { return TransferStatus(math.MaxInt8) }
 func (ts TransferStatus) String() string {
 	return enum.StringInt(ts, reflect.TypeOf(ts))

--- a/jobsAdmin/init.go
+++ b/jobsAdmin/init.go
@@ -598,6 +598,17 @@ func resurrectJobSummary(jm ste.IJobMgr) common.ListJobSummaryResponse {
 						IsFolderProperties: isFolder,
 						TransferStatus:     jppt.TransferStatus(),
 					})
+			case common.ETransferStatus.SkippedArchiveNotRestored():
+				js.SkippedArchiveFileCount++
+				// getting the source and destination for skipped transfer at position - index
+				src, dst, isFolder := jpp.TransferSrcDstStrings(t)
+				js.SkippedTransfers = append(js.SkippedTransfers,
+					common.TransferDetail{
+						Src:                src,
+						Dst:                dst,
+						IsFolderProperties: isFolder,
+						TransferStatus:     jppt.TransferStatus(),
+					})
 			}
 		}
 	})

--- a/jobsAdmin/init.go
+++ b/jobsAdmin/init.go
@@ -600,15 +600,6 @@ func resurrectJobSummary(jm ste.IJobMgr) common.ListJobSummaryResponse {
 					})
 			case common.ETransferStatus.SkippedArchiveNotRestored():
 				js.SkippedArchiveFileCount++
-				// getting the source and destination for skipped transfer at position - index
-				src, dst, isFolder := jpp.TransferSrcDstStrings(t)
-				js.SkippedTransfers = append(js.SkippedTransfers,
-					common.TransferDetail{
-						Src:                src,
-						Dst:                dst,
-						IsFolderProperties: isFolder,
-						TransferStatus:     jppt.TransferStatus(),
-					})
 			}
 		}
 	})

--- a/ste/jobStatusManager.go
+++ b/ste/jobStatusManager.go
@@ -173,7 +173,6 @@ func (jm *jobMgr) handleStatusUpdateMessage() {
 				js.SkippedTransfers = append(js.SkippedTransfers, msg)
 			case common.ETransferStatus.SkippedArchiveNotRestored():
 				js.SkippedArchiveFileCount++
-				js.SkippedTransfers = append(js.SkippedTransfers, msg)
 			}
 
 		case <-jstm.listReq:

--- a/ste/jobStatusManager.go
+++ b/ste/jobStatusManager.go
@@ -171,6 +171,9 @@ func (jm *jobMgr) handleStatusUpdateMessage() {
 				}
 				js.TransfersSkipped++
 				js.SkippedTransfers = append(js.SkippedTransfers, msg)
+			case common.ETransferStatus.SkippedArchiveNotRestored():
+				js.SkippedArchiveFileCount++
+				js.SkippedTransfers = append(js.SkippedTransfers, msg)
 			}
 
 		case <-jstm.listReq:

--- a/ste/sourceInfoProvider-S3.go
+++ b/ste/sourceInfoProvider-S3.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common/buildmode"
 	minio "github.com/minio/minio-go/v7"
 )
 
@@ -118,6 +119,15 @@ func (p *s3SourceInfoProvider) Properties() (*SrcProperties, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		// For mover builds, skip objects in archive storage classes (GLACIER, DEEP_ARCHIVE) unless restored.
+		// This check piggybacks on the existing StatObject call (no extra API call) and runs with
+		// 64-way parallelism in the STE, avoiding the single-threaded enumeration bottleneck.
+		if buildmode.IsMover && isArchiveStorageClass(objectInfo.StorageClass) && !isRestoredFromArchive(objectInfo.Restore) {
+			return nil, fmt.Errorf("%w: object %q is in %s storage class",
+				common.ErrS3ArchiveObjectNotRestored, p.s3URLPart.ObjectKey, objectInfo.StorageClass)
+		}
+
 		oie := common.ObjectInfoExtension{ObjectInfo: objectInfo}
 
 		srcProperties = SrcProperties{
@@ -235,4 +245,25 @@ func (p *s3SourceInfoProvider) GetMD5(offset, count int64) ([]byte, error) {
 		return nil, err
 	}
 	return h.Sum(nil), nil
+}
+
+// isArchiveStorageClass checks if the given S3 storage class is an archive tier
+// that requires restoration before objects can be accessed.
+//
+// AWS S3 Glacier storage classes that require restoration:
+//   - GLACIER: Glacier Flexible Retrieval (formerly just "Glacier")
+//   - DEEP_ARCHIVE: Glacier Deep Archive
+//
+// Note: GLACIER_IR (AWS) provides millisecond access without restoration, so it is NOT included.
+func isArchiveStorageClass(storageClass string) bool {
+	return storageClass == "GLACIER" || storageClass == "DEEP_ARCHIVE"
+}
+
+// isRestoredFromArchive checks whether an archived S3 object has been successfully
+// restored and is currently accessible. A restore is considered ready when:
+//   - RestoreInfo is not nil (x-amz-restore header was present)
+//   - OngoingRestore is false (restore operation has completed)
+//   - ExpiryTime is set (the temporary copy has an expiry, confirming availability)
+func isRestoredFromArchive(restore *minio.RestoreInfo) bool {
+	return restore != nil && !restore.OngoingRestore && !restore.ExpiryTime.IsZero()
 }

--- a/ste/sourceInfoProvider-S3.go
+++ b/ste/sourceInfoProvider-S3.go
@@ -123,9 +123,12 @@ func (p *s3SourceInfoProvider) Properties() (*SrcProperties, error) {
 		// For mover builds, skip objects in archive storage classes (GLACIER, DEEP_ARCHIVE) unless restored.
 		// This check piggybacks on the existing StatObject call (no extra API call) and runs with
 		// 64-way parallelism in the STE, avoiding the single-threaded enumeration bottleneck.
-		if buildmode.IsMover && isArchiveStorageClass(objectInfo.StorageClass) && !isRestoredFromArchive(objectInfo.Restore) {
+		// Note: minio-go's StatObject (HEAD) does NOT populate ObjectInfo.StorageClass directly;
+		// the storage class is only available via the X-Amz-Storage-Class header in Metadata.
+		storageClass := objectInfo.Metadata.Get("X-Amz-Storage-Class")
+		if buildmode.IsMover && isArchiveStorageClass(storageClass) && !isRestoredFromArchive(objectInfo.Restore) {
 			return nil, fmt.Errorf("%w: object %q is in %s storage class",
-				common.ErrS3ArchiveObjectNotRestored, p.s3URLPart.ObjectKey, objectInfo.StorageClass)
+				common.ErrS3ArchiveObjectNotRestored, p.s3URLPart.ObjectKey, storageClass)
 		}
 
 		oie := common.ObjectInfoExtension{ObjectInfo: objectInfo}

--- a/ste/xfer-anyToRemote-file.go
+++ b/ste/xfer-anyToRemote-file.go
@@ -250,6 +250,12 @@ func anyToRemote_file(jptm IJobPartTransferMgr, info *TransferInfo, pacer pacer,
 
 	s, err := senderFactory(jptm, info.Destination, pacer, srcInfoProvider)
 	if err != nil {
+		if errors.Is(err, common.ErrS3ArchiveObjectNotRestored) {
+			jptm.LogAtLevelForCurrentTransfer(common.LogWarning, err.Error())
+			jptm.SetStatus(common.ETransferStatus.SkippedArchiveNotRestored())
+			jptm.ReportTransferDone()
+			return
+		}
 		jptm.LogSendError(info.Source, info.Destination, err.Error(), 0)
 		jptm.SetStatus(common.ETransferStatus.Failed())
 		jptm.ReportTransferDone()


### PR DESCRIPTION
## Summary

Adds configurable block size, access tier support, and moves S3 Glacier/DEEP_ARCHIVE archive object skip logic from the traverser (single-threaded) to the STE Properties() call (64-way parallel).

## Changes

### Configurable Block Size
- Add BlockSizeMB field to mover dependencies for configurable block size

### Access Tier
- Add BlockBlobTier to sync path and mover dependencies for configurable access tier

### S3 Glacier Archive Skip (STE-based)
- Move archive/Glacier skip from traverser to STE for parallel execution
- Allow restored Glacier/Deep Archive objects through S3 listing
- Read StorageClass from objectInfo.Metadata header instead of objectInfo.StorageClass (minio-go StatObject HEAD does not populate the field directly)
- New TransferStatus(-7) = SkippedArchiveNotRestored with dedicated SkippedArchiveFileCount counter
- ErrS3ArchiveObjectNotRestored sentinel error caught in sender factory error path
- Mover-only guard via buildmode.IsMover

## Testing
- E2E test TestS3ToAzureCopyAndSync/s3-restored-archive-objects passes on c2cbiceptest2
- Both mover and non-mover builds verified clean
