### PR TITLE
[do not merge] temporarily disable network isolation

### DIFF
--- a/build-1es-pipeline.yaml
+++ b/build-1es-pipeline.yaml
@@ -61,6 +61,8 @@ extends:
   # For productions pipelines, use "Official".
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
+    featureFlags:
+      disableNetworkIsolation: true
     sdl:
       sourceAnalysisPool:
         name: azcopy-pool  # Name of your hosted pool


### PR DESCRIPTION
## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->
Temporarily disabled network isolation injection because it was wrongly blocking github.com. This caused git fetch to fail and preventing our 10.32.2 release. You can see the failing step [here](https://dev.azure.com/azstorage/AzCopy-NextGen/AzCopy-NextGen%20Team/_build/results?buildId=30265&view=logs&j=252b3077-b64a-596e-8ec6-cbbad2120f40&t=7c032268-7464-53bc-3acd-28fe7153180a&l=45)



- **Feature / Bug Fix**: (Brief description of the feature or issue being addressed)
Fix was to temporarily disable network isolation till the team can identify why github.com is being blocked.

- **Related Links**:
- [Email Subject: ]

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

Thank you for your contribution to AzCopy!
