### PR TITLE
Centralize HTTP client into a shared global instance

### DIFF
--- a/azcopy/client.go
+++ b/azcopy/client.go
@@ -78,6 +78,10 @@ func NewClient(opts ClientOptions) (Client, error) {
 	}
 	// startup of the STE happens here, so that the startup can access the values of command line parameters that are defined for "root" command
 	concurrencySettings := ste.NewConcurrencySettings(azcopyMaxFileAndSocketHandles)
+	// Initialize the process-wide HTTP client using the concurrency-derived idle-conn limit so
+	// the transport honors AZCOPY_CONCURRENCY_VALUE / auto-tuning, and so subsequent callers
+	// (JobMgr, traverser.CreateClientOptions, etc.) reuse the same configured client.
+	common.InitGlobalHTTPClient(concurrencySettings.MaxIdleConnections)
 	err = jobsAdmin.MainSTE(concurrencySettings, opts.CapMbps)
 	if err != nil {
 		return c, err

--- a/common/azHttpClient.go
+++ b/common/azHttpClient.go
@@ -1,0 +1,256 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package common
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptrace"
+	"runtime"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+// GlobalHTTPClient is the process-wide HTTP client used by AzCopy when initialized via InitGlobalHTTPClient.
+var (
+	GlobalHTTPClient     *http.Client
+	globalHTTPClientOnce sync.Once
+)
+
+const (
+	maxIdleConnsPerHost_MaxValue = 3000
+	httpTraceTickerInterval      = time.Minute * 1
+)
+
+// GetGlobalHTTPClient initializes and returns the process-global HTTP client exactly once.
+// Subsequent calls return the same client. The logger function, if provided on the first call,
+// will be invoked with status messages.
+func GetGlobalHTTPClient(logger ILoggerResetable) *http.Client {
+	globalHTTPClientOnce.Do(func() {
+		const concurrentDialsPerCpu = 10
+		client := &http.Client{
+			Transport: &http.Transport{
+				Proxy:                  GlobalProxyLookup,
+				MaxConnsPerHost:        concurrentDialsPerCpu * runtime.NumCPU(),
+				MaxIdleConns:           0,
+				MaxIdleConnsPerHost:    GetMaxIdleConnsPerHost(),
+				IdleConnTimeout:        180 * time.Second,
+				TLSHandshakeTimeout:    10 * time.Second,
+				ExpectContinueTimeout:  1 * time.Second,
+				DisableKeepAlives:      false,
+				DisableCompression:     true,
+				MaxResponseHeaderBytes: 0,
+			},
+		}
+		GlobalHTTPClient = client
+		if logger != nil {
+			if tr, ok := client.Transport.(*http.Transport); ok {
+				logger.Log(LogError, // XDM: This is error level on purpose as we want to make sure it is seen in the logs
+					fmt.Sprintf(
+						"GetGlobalHTTPClient: initialized %p MaxIdleConnsPerHost=%d MaxConnsPerHost=%d MaxIdleConns=%d",
+						client, tr.MaxIdleConnsPerHost, tr.MaxConnsPerHost, tr.MaxIdleConns))
+			} else {
+				logger.Log(LogError, fmt.Sprintf("GetGlobalHTTPClient: initialized %p", client))
+			}
+		}
+	})
+	return GlobalHTTPClient
+}
+
+// This is a code duplication of GetMainPoolSize in ste/concurrency.go
+// Ideally we should just move concurrency.go to common package. That is a todo for future.
+func GetMaxIdleConnsPerHost() int {
+
+	autoTune := true
+	envVar := EEnvironmentVariable.ConcurrencyValue()
+	envValue := GetEnvironmentVariable(envVar)
+	concurrencyValue := maxIdleConnsPerHost_MaxValue
+
+	if envValue != "AUTO" && envValue != "" {
+		concurrencyVal, err := strconv.ParseInt(envValue, 10, 0)
+		if err == nil {
+			concurrencyValue = min(int(concurrencyVal), concurrencyValue)
+			autoTune = false
+		}
+	}
+
+	if autoTune {
+		var computedDefaultVal int
+		numOfCPUs := runtime.NumCPU()
+
+		if autoTune {
+			computedDefaultVal = 4 // deliberately start with a small initial value if we are auto-tuning.  If it's not small enough, then the auto tuning becomes
+			// sluggish since, every time it needs to tune downwards, it needs to let a lot of data (num connections * block size) get transmitted,
+			// and that is slow over very small links, e.g. 10 Mbps, and produces noticeable time lag when downsizing the connection count.
+			// So we start small. (The alternatives, of using small chunk sizes or small file sizes just for the first 200 MB or so, were too hard to orchestrate within the existing app architecture)
+		} else if numOfCPUs <= 4 {
+			// fix the concurrency value for smaller machines
+			computedDefaultVal = 32
+		} else if 16*numOfCPUs > 300 {
+			// for machines that are extremely powerful, fix to 300 (previously this was to avoid running out of file descriptors, but we have another solution to that now)
+			computedDefaultVal = 300
+		} else {
+			// for moderately powerful machines, compute a reasonable number
+			computedDefaultVal = 16 * numOfCPUs
+		}
+
+		concurrencyValue = min(computedDefaultVal, concurrencyValue) // we don't expect to ever need more than this, even in small-files cases
+	}
+
+	// Set the max idle connections that we allow. If there are any more idle connections
+	// than this, they will be closed, and then will result in creation of new connections
+	// later if needed. In AzCopy, they almost always will be needed soon after, so better to
+	// keep them open.
+	// So set this number high so that that will not happen.
+	// (Previously, when using Dial instead of DialContext, there was an added benefit of keeping
+	// this value high, which was that, without it being high, all the extra dials,
+	// to compensate for the closures, were causing a pathological situation
+	// where lots and lots of OS threads get created during the creation of new connections
+	// (presumably due to some blocking OS call in dial) and the app hits Go's default
+	// limit of 10,000 OS threads, and panics and shuts down.  This has been observed
+	// on Windows when this value was set to 500 but there were 1000 to 2000 goroutines in the
+	// main pool size.  Using DialContext appears to mitigate that issue, so the value
+	// we compute here is really just to reduce unneeded make and break of connections)
+
+	// Add a buffer to the concurrencyValue to compute the max idle conns value.
+	// This buffer is to allow for some extra idle connections that might be needed
+	// in certain scenarios
+
+	maxIdleConnsPerHost := int(float64(concurrencyValue) * 1.2)
+
+	return maxIdleConnsPerHost
+}
+
+// connStats aggregates connection reuse metrics per label.
+type connStats struct {
+	total       uint64
+	reused      uint64
+	idle        uint64
+	idleTotalNs uint64 // cumulative idle time in nanoseconds
+	putIdle     uint64
+	putIdleErr  uint64
+}
+
+var connStatsMap sync.Map // map[string]*connStats
+var connStatsLoggerOnce sync.Once
+
+var connDumpLogger ILoggerResetable
+
+func incrementConnStats(label string, reused, wasIdle bool, idleNs uint64) {
+	v, _ := connStatsMap.LoadOrStore(label, &connStats{})
+	s := v.(*connStats)
+	atomic.AddUint64(&s.total, 1)
+	if reused {
+		atomic.AddUint64(&s.reused, 1)
+	}
+	if wasIdle {
+		atomic.AddUint64(&s.idle, 1)
+		if idleNs > 0 {
+			atomic.AddUint64(&s.idleTotalNs, idleNs)
+		}
+	}
+}
+
+func incrementPutIdleStats(label string, err error) {
+	v, _ := connStatsMap.LoadOrStore(label, &connStats{})
+	s := v.(*connStats)
+	if err != nil {
+		atomic.AddUint64(&s.putIdleErr, 1)
+	} else {
+		atomic.AddUint64(&s.putIdle, 1)
+	}
+}
+
+func dumpConnStats() {
+	connStatsMap.Range(func(k, v interface{}) bool {
+		label := k.(string)
+		s := v.(*connStats)
+		total := atomic.LoadUint64(&s.total)
+		reused := atomic.LoadUint64(&s.reused)
+		idle := atomic.LoadUint64(&s.idle)
+		idleTotalNs := atomic.LoadUint64(&s.idleTotalNs)
+		putIdle := atomic.LoadUint64(&s.putIdle)
+		putIdleErr := atomic.LoadUint64(&s.putIdleErr)
+		avgIdleMs := 0.0
+		if idle > 0 {
+			avgIdleMs = float64(idleTotalNs) / float64(idle) / 1e6
+		}
+		msg := fmt.Sprintf("connStats[%s]: total=%d reused=%d idle=%d avgIdleMs=%.2f putIdle=%d putIdleErr=%d", label, total, reused, idle, avgIdleMs, putIdle, putIdleErr)
+		if connDumpLogger != nil {
+			connDumpLogger.Log(LogError, msg)
+		} else {
+			fmt.Println(msg)
+		}
+		return true
+	})
+}
+
+// NewTracingTransport wraps an existing policy.Transporter and injects an httptrace.ClientTrace to
+// collect aggregated connection reuse metrics (per label). A periodic dumper is started once.
+//
+// Usage: replace the Transport field of an *http.Client with the result of this function.
+// Use common.NewTracingTransport(client, "createClientOptions", logger) for http.Trace
+// This will log connection stats every minute using the provided logger.
+func NewTracingTransport(inner policy.Transporter, label string, logger ILoggerResetable) policy.Transporter {
+	connStatsLoggerOnce.Do(func() {
+		if logger != nil {
+			connDumpLogger = logger
+		}
+		go func() {
+			ticker := time.NewTicker(httpTraceTickerInterval)
+			defer ticker.Stop()
+			for range ticker.C {
+				dumpConnStats()
+			}
+		}()
+	})
+	return &traceTransport{inner: inner, label: label, logger: logger}
+}
+
+// traceTransport implements policy.Transporter using the wrapped transport's Do method.
+type traceTransport struct {
+	inner  policy.Transporter
+	label  string
+	logger ILoggerResetable
+}
+
+func (t *traceTransport) Do(req *http.Request) (*http.Response, error) {
+	trace := &httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) {
+			// Record whether the connection was reused and whether it was idle; also capture IdleTime when available.
+			var idleNs uint64 = 0
+			if info.WasIdle {
+				idleNs = uint64(info.IdleTime.Nanoseconds())
+			}
+			incrementConnStats(t.label, info.Reused, info.WasIdle, idleNs)
+		},
+		PutIdleConn: func(err error) {
+			// Record when a connection is returned to the idle pool (or why it wasn't)
+			incrementPutIdleStats(t.label, err)
+		},
+	}
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
+	return t.inner.Do(req)
+}

--- a/common/azHttpClient.go
+++ b/common/azHttpClient.go
@@ -25,7 +25,6 @@ import (
 	"net/http"
 	"net/http/httptrace"
 	"runtime"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -33,114 +32,64 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
-// GlobalHTTPClient is the process-wide HTTP client used by AzCopy when initialized via InitGlobalHTTPClient.
+// GlobalHTTPClient is the process-wide HTTP client used by AzCopy. It is configured by
+// InitGlobalHTTPClient (which should be called once at startup, after concurrency
+// settings have been computed) and retrieved by GetGlobalHTTPClient.
 var (
 	GlobalHTTPClient     *http.Client
 	globalHTTPClientOnce sync.Once
 )
 
 const (
-	maxIdleConnsPerHost_MaxValue = 3000
-	httpTraceTickerInterval      = time.Minute * 1
+	httpTraceTickerInterval = time.Minute * 1
+
+	// fallbackMaxIdleConnsPerHost is used only when GetGlobalHTTPClient is called
+	// before InitGlobalHTTPClient (e.g. from a unit test). It mirrors the Go default
+	// rather than picking a workload-specific value.
+	fallbackMaxIdleConnsPerHost = http.DefaultMaxIdleConnsPerHost
 )
 
-// GetGlobalHTTPClient initializes and returns the process-global HTTP client exactly once.
-// Subsequent calls return the same client. The logger function, if provided on the first call,
-// will be invoked with status messages.
-func GetGlobalHTTPClient(logger ILoggerResetable) *http.Client {
+// InitGlobalHTTPClient initializes the process-global HTTP client exactly once with
+// the supplied limits. Callers should pass the value derived from the STE
+// ConcurrencySettings (e.g. ConcurrencySettings.MaxIdleConnections) so that the HTTP
+// transport honors the same concurrency configuration as the rest of AzCopy.
+// Subsequent calls are no-ops and the originally supplied values continue to apply.
+// The configured client's transport limits are logged later by JobMgr when a job
+// first picks it up, where a job-scoped logger is available.
+func InitGlobalHTTPClient(maxIdleConnsPerHost int) *http.Client {
 	globalHTTPClientOnce.Do(func() {
-		const concurrentDialsPerCpu = 10
-		client := &http.Client{
-			Transport: &http.Transport{
-				Proxy:                  GlobalProxyLookup,
-				MaxConnsPerHost:        concurrentDialsPerCpu * runtime.NumCPU(),
-				MaxIdleConns:           0,
-				MaxIdleConnsPerHost:    GetMaxIdleConnsPerHost(),
-				IdleConnTimeout:        180 * time.Second,
-				TLSHandshakeTimeout:    10 * time.Second,
-				ExpectContinueTimeout:  1 * time.Second,
-				DisableKeepAlives:      false,
-				DisableCompression:     true,
-				MaxResponseHeaderBytes: 0,
-			},
-		}
-		GlobalHTTPClient = client
-		if logger != nil {
-			if tr, ok := client.Transport.(*http.Transport); ok {
-				logger.Log(LogError, // XDM: This is error level on purpose as we want to make sure it is seen in the logs
-					fmt.Sprintf(
-						"GetGlobalHTTPClient: initialized %p MaxIdleConnsPerHost=%d MaxConnsPerHost=%d MaxIdleConns=%d",
-						client, tr.MaxIdleConnsPerHost, tr.MaxConnsPerHost, tr.MaxIdleConns))
-			} else {
-				logger.Log(LogError, fmt.Sprintf("GetGlobalHTTPClient: initialized %p", client))
-			}
-		}
+		GlobalHTTPClient = buildGlobalHTTPClient(maxIdleConnsPerHost)
 	})
 	return GlobalHTTPClient
 }
 
-// This is a code duplication of GetMainPoolSize in ste/concurrency.go
-// Ideally we should just move concurrency.go to common package. That is a todo for future.
-func GetMaxIdleConnsPerHost() int {
+// GetGlobalHTTPClient returns the process-global HTTP client previously configured
+// via InitGlobalHTTPClient. If InitGlobalHTTPClient has not yet been called, the
+// client is lazily created with a conservative fallback so that test/import paths
+// which bypass azcopy.NewClient still get a working client.
+func GetGlobalHTTPClient() *http.Client {
+	globalHTTPClientOnce.Do(func() {
+		GlobalHTTPClient = buildGlobalHTTPClient(fallbackMaxIdleConnsPerHost)
+	})
+	return GlobalHTTPClient
+}
 
-	autoTune := true
-	envVar := EEnvironmentVariable.ConcurrencyValue()
-	envValue := GetEnvironmentVariable(envVar)
-	concurrencyValue := maxIdleConnsPerHost_MaxValue
-
-	if envValue != "AUTO" && envValue != "" {
-		concurrencyVal, err := strconv.ParseInt(envValue, 10, 0)
-		if err == nil {
-			concurrencyValue = min(int(concurrencyVal), concurrencyValue)
-			autoTune = false
-		}
+func buildGlobalHTTPClient(maxIdleConnsPerHost int) *http.Client {
+	const concurrentDialsPerCpu = 10
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy:                  GlobalProxyLookup,
+			MaxConnsPerHost:        concurrentDialsPerCpu * runtime.NumCPU(),
+			MaxIdleConns:           0,
+			MaxIdleConnsPerHost:    maxIdleConnsPerHost,
+			IdleConnTimeout:        180 * time.Second,
+			TLSHandshakeTimeout:    10 * time.Second,
+			ExpectContinueTimeout:  1 * time.Second,
+			DisableKeepAlives:      false,
+			DisableCompression:     true,
+			MaxResponseHeaderBytes: 0,
+		},
 	}
-
-	if autoTune {
-		var computedDefaultVal int
-		numOfCPUs := runtime.NumCPU()
-
-		if autoTune {
-			computedDefaultVal = 4 // deliberately start with a small initial value if we are auto-tuning.  If it's not small enough, then the auto tuning becomes
-			// sluggish since, every time it needs to tune downwards, it needs to let a lot of data (num connections * block size) get transmitted,
-			// and that is slow over very small links, e.g. 10 Mbps, and produces noticeable time lag when downsizing the connection count.
-			// So we start small. (The alternatives, of using small chunk sizes or small file sizes just for the first 200 MB or so, were too hard to orchestrate within the existing app architecture)
-		} else if numOfCPUs <= 4 {
-			// fix the concurrency value for smaller machines
-			computedDefaultVal = 32
-		} else if 16*numOfCPUs > 300 {
-			// for machines that are extremely powerful, fix to 300 (previously this was to avoid running out of file descriptors, but we have another solution to that now)
-			computedDefaultVal = 300
-		} else {
-			// for moderately powerful machines, compute a reasonable number
-			computedDefaultVal = 16 * numOfCPUs
-		}
-
-		concurrencyValue = min(computedDefaultVal, concurrencyValue) // we don't expect to ever need more than this, even in small-files cases
-	}
-
-	// Set the max idle connections that we allow. If there are any more idle connections
-	// than this, they will be closed, and then will result in creation of new connections
-	// later if needed. In AzCopy, they almost always will be needed soon after, so better to
-	// keep them open.
-	// So set this number high so that that will not happen.
-	// (Previously, when using Dial instead of DialContext, there was an added benefit of keeping
-	// this value high, which was that, without it being high, all the extra dials,
-	// to compensate for the closures, were causing a pathological situation
-	// where lots and lots of OS threads get created during the creation of new connections
-	// (presumably due to some blocking OS call in dial) and the app hits Go's default
-	// limit of 10,000 OS threads, and panics and shuts down.  This has been observed
-	// on Windows when this value was set to 500 but there were 1000 to 2000 goroutines in the
-	// main pool size.  Using DialContext appears to mitigate that issue, so the value
-	// we compute here is really just to reduce unneeded make and break of connections)
-
-	// Add a buffer to the concurrencyValue to compute the max idle conns value.
-	// This buffer is to allow for some extra idle connections that might be needed
-	// in certain scenarios
-
-	maxIdleConnsPerHost := int(float64(concurrencyValue) * 1.2)
-
-	return maxIdleConnsPerHost
 }
 
 // connStats aggregates connection reuse metrics per label.

--- a/common/azHttpClient.go
+++ b/common/azHttpClient.go
@@ -32,22 +32,15 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
-// globalHTTPClient is the process-wide HTTP client used by AzCopy. It is configured by
-// InitGlobalHTTPClient (which should be called once at startup, after concurrency
-// settings have been computed) and retrieved by GetGlobalHTTPClient.
+// globalHTTPClient is the process-wide HTTP client used by AzCopy. It is configured
+// exactly once by InitGlobalHTTPClient at startup (after ConcurrencySettings have
+// been computed) and retrieved thereafter by GetGlobalHTTPClient.
 var (
 	globalHTTPClient     *http.Client
 	globalHTTPClientOnce sync.Once
 )
 
-const (
-	httpTraceTickerInterval = time.Minute * 1
-
-	// fallbackMaxIdleConnsPerHost is used only when GetGlobalHTTPClient is called
-	// before InitGlobalHTTPClient (e.g. from a unit test). It mirrors the Go default
-	// rather than picking a workload-specific value.
-	fallbackMaxIdleConnsPerHost = http.DefaultMaxIdleConnsPerHost
-)
+const httpTraceTickerInterval = time.Minute * 1
 
 // InitGlobalHTTPClient initializes the process-global HTTP client exactly once with
 // the supplied limits. Callers should pass the value derived from the STE
@@ -56,6 +49,8 @@ const (
 // Subsequent calls are no-ops and the originally supplied values continue to apply.
 // The configured client's transport limits are logged later by JobMgr when a job
 // first picks it up, where a job-scoped logger is available.
+//
+// Must be called before GetGlobalHTTPClient. azcopy.NewClient is the canonical caller.
 func InitGlobalHTTPClient(maxIdleConnsPerHost int) *http.Client {
 	globalHTTPClientOnce.Do(func() {
 		globalHTTPClient = buildGlobalHTTPClient(maxIdleConnsPerHost)
@@ -64,13 +59,14 @@ func InitGlobalHTTPClient(maxIdleConnsPerHost int) *http.Client {
 }
 
 // GetGlobalHTTPClient returns the process-global HTTP client previously configured
-// via InitGlobalHTTPClient. If InitGlobalHTTPClient has not yet been called, the
-// client is lazily created with a conservative fallback so that test/import paths
-// which bypass azcopy.NewClient still get a working client.
+// via InitGlobalHTTPClient. Panics if Init has not run yet; this is intentional so
+// that an init-order bug fails loudly instead of silently producing a misconfigured
+// client (e.g. with the Go default of 2 idle conns per host).
 func GetGlobalHTTPClient() *http.Client {
-	globalHTTPClientOnce.Do(func() {
-		globalHTTPClient = buildGlobalHTTPClient(fallbackMaxIdleConnsPerHost)
-	})
+	if globalHTTPClient == nil {
+		panic("common.GetGlobalHTTPClient called before InitGlobalHTTPClient; " +
+			"InitGlobalHTTPClient must run during process startup (see azcopy.NewClient)")
+	}
 	return globalHTTPClient
 }
 

--- a/common/azHttpClient.go
+++ b/common/azHttpClient.go
@@ -32,11 +32,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
-// GlobalHTTPClient is the process-wide HTTP client used by AzCopy. It is configured by
+// globalHTTPClient is the process-wide HTTP client used by AzCopy. It is configured by
 // InitGlobalHTTPClient (which should be called once at startup, after concurrency
 // settings have been computed) and retrieved by GetGlobalHTTPClient.
 var (
-	GlobalHTTPClient     *http.Client
+	globalHTTPClient     *http.Client
 	globalHTTPClientOnce sync.Once
 )
 
@@ -58,9 +58,9 @@ const (
 // first picks it up, where a job-scoped logger is available.
 func InitGlobalHTTPClient(maxIdleConnsPerHost int) *http.Client {
 	globalHTTPClientOnce.Do(func() {
-		GlobalHTTPClient = buildGlobalHTTPClient(maxIdleConnsPerHost)
+		globalHTTPClient = buildGlobalHTTPClient(maxIdleConnsPerHost)
 	})
-	return GlobalHTTPClient
+	return globalHTTPClient
 }
 
 // GetGlobalHTTPClient returns the process-global HTTP client previously configured
@@ -69,9 +69,9 @@ func InitGlobalHTTPClient(maxIdleConnsPerHost int) *http.Client {
 // which bypass azcopy.NewClient still get a working client.
 func GetGlobalHTTPClient() *http.Client {
 	globalHTTPClientOnce.Do(func() {
-		GlobalHTTPClient = buildGlobalHTTPClient(fallbackMaxIdleConnsPerHost)
+		globalHTTPClient = buildGlobalHTTPClient(fallbackMaxIdleConnsPerHost)
 	})
-	return GlobalHTTPClient
+	return globalHTTPClient
 }
 
 func buildGlobalHTTPClient(maxIdleConnsPerHost int) *http.Client {
@@ -157,11 +157,14 @@ func dumpConnStats() {
 }
 
 // NewTracingTransport wraps an existing policy.Transporter and injects an httptrace.ClientTrace to
-// collect aggregated connection reuse metrics (per label). A periodic dumper is started once.
+// collect aggregated connection reuse metrics (per label). A periodic dumper is started once,
+// using the logger supplied on the FIRST call; loggers passed to later calls are ignored.
 //
-// Usage: replace the Transport field of an *http.Client with the result of this function.
-// Use common.NewTracingTransport(client, "createClientOptions", logger) for http.Trace
-// This will log connection stats every minute using the provided logger.
+// Note: *http.Client satisfies policy.Transporter, so it can be passed directly. Typical usage:
+//
+//	common.NewTracingTransport(common.GetGlobalHTTPClient(), "createClientOptions", logger)
+//
+// Connection stats are logged every httpTraceTickerInterval using the captured logger.
 func NewTracingTransport(inner policy.Transporter, label string, logger ILoggerResetable) policy.Transporter {
 	connStatsLoggerOnce.Do(func() {
 		if logger != nil {
@@ -175,14 +178,13 @@ func NewTracingTransport(inner policy.Transporter, label string, logger ILoggerR
 			}
 		}()
 	})
-	return &traceTransport{inner: inner, label: label, logger: logger}
+	return &traceTransport{inner: inner, label: label}
 }
 
 // traceTransport implements policy.Transporter using the wrapped transport's Do method.
 type traceTransport struct {
-	inner  policy.Transporter
-	label  string
-	logger ILoggerResetable
+	inner policy.Transporter
+	label string
 }
 
 func (t *traceTransport) Do(req *http.Request) (*http.Response, error) {

--- a/common/azHttpClient_test.go
+++ b/common/azHttpClient_test.go
@@ -1,0 +1,37 @@
+package common
+
+import (
+	"net/http"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGlobalHTTPClientRequiresInit(t *testing.T) {
+	assert.PanicsWithValue(t,
+		"common.GetGlobalHTTPClient called before InitGlobalHTTPClient; InitGlobalHTTPClient must run during process startup (see azcopy.NewClient)",
+		func() {
+			_ = GetGlobalHTTPClient()
+		})
+}
+
+func TestGlobalHTTPClientInitUsesConfiguredIdleConnLimit(t *testing.T) {
+	client := InitGlobalHTTPClient(196)
+	require.NotNil(t, client)
+
+	retrieved := GetGlobalHTTPClient()
+	require.Same(t, client, retrieved)
+
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok, "global client transport should be an *http.Transport")
+	assert.Equal(t, 196, transport.MaxIdleConnsPerHost)
+	assert.Equal(t, 0, transport.MaxIdleConns)
+	assert.Equal(t, 10*runtime.NumCPU(), transport.MaxConnsPerHost)
+
+	// A second init call should be a no-op and keep the first configuration.
+	clientAgain := InitGlobalHTTPClient(42)
+	require.Same(t, client, clientAgain)
+	assert.Equal(t, 196, transport.MaxIdleConnsPerHost)
+}

--- a/common/oauthTokenManager.go
+++ b/common/oauthTokenManager.go
@@ -87,6 +87,19 @@ func NewUserOAuthTokenManagerInstance(credCacheOptions CredCacheOptions) *UserOA
 	}
 }
 
+// newAzcopyHTTPClient builds a dedicated HTTP client for AAD / IMDS / token endpoints.
+//
+// This is intentionally NOT the data-plane client (common.GetGlobalHTTPClient()). The
+// two clients differ in ways that matter for token acquisition:
+//   - this client uses net.Dialer.Dial (not DialContext), which has historically been
+//     reported as faster for the short-lived AAD calls;
+//   - this client has no MaxConnsPerHost cap, whereas the data-plane client caps at
+//     10*NumCPU per host;
+//   - this client talks to a different set of hosts (login.microsoftonline.com, IMDS at
+//     169.254.169.254, etc.), so its idle-pool sizing is independent of data-plane needs.
+//
+// Token RPS is tiny compared to data-plane RPS, so the shared-client benefits don't
+// apply here; consolidating would be a behavior change worth its own review.
 func newAzcopyHTTPClient() *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{

--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -135,7 +135,7 @@ func NewJobMgr(concurrency ConcurrencySettings, jobID common.JobID, appCtx conte
 	}
 
 	jm := jobMgr{jobID: jobID, jobPartMgrs: newJobPartToJobPartMgr(),
-		httpClient:           NewAzcopyHTTPClient(concurrency.MaxIdleConnections),
+		httpClient:           common.GetGlobalHTTPClient(jobLogger),
 		logger:               jobLogger,
 		chunkStatusLogger:    common.NewChunkStatusLogger(jobID, cpuMon, common.LogPathFolder, enableChunkLogOutput),
 		concurrency:          concurrency,

--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -135,7 +135,7 @@ func NewJobMgr(concurrency ConcurrencySettings, jobID common.JobID, appCtx conte
 	}
 
 	jm := jobMgr{jobID: jobID, jobPartMgrs: newJobPartToJobPartMgr(),
-		httpClient:           common.GetGlobalHTTPClient(jobLogger),
+		httpClient:           common.GetGlobalHTTPClient(),
 		logger:               jobLogger,
 		chunkStatusLogger:    common.NewChunkStatusLogger(jobID, cpuMon, common.LogPathFolder, enableChunkLogOutput),
 		concurrency:          concurrency,
@@ -248,6 +248,12 @@ func (jm *jobMgr) logConcurrencyParameters() {
 
 	jm.logger.Log(level, fmt.Sprintf("Max open files when downloading: %d (auto-computed)",
 		jm.concurrency.MaxOpenDownloadFiles))
+
+	if tr, ok := jm.httpClient.Transport.(*http.Transport); ok {
+		jm.logger.Log(level, fmt.Sprintf(
+			"Global HTTP client %p: MaxIdleConnsPerHost=%d MaxConnsPerHost=%d MaxIdleConns=%d IdleConnTimeout=%s",
+			jm.httpClient, tr.MaxIdleConnsPerHost, tr.MaxConnsPerHost, tr.MaxIdleConns, tr.IdleConnTimeout))
+	}
 }
 
 // jobMgrInitState holds one-time init structures (such as SIPM), that initialize when the first part is added.

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -75,6 +75,17 @@ type IJobPartMgr interface {
 }
 
 // NewAzcopyHTTPClient creates a new HTTP client.
+//
+// Production data-plane code does NOT use this constructor; it uses the process-wide
+// client common.GetGlobalHTTPClient(), initialized once at startup from
+// ConcurrencySettings.MaxIdleConnections. See common/azHttpClient.go.
+//
+// This constructor is retained for tests (ste/sender-*_test.go,
+// ste/testJobPartTransferManager_test.go) and for the standalone testSuite/cmd
+// binary, all of which run outside the azcopy command and therefore cannot rely on
+// the global client being initialized. Tests want their own isolated transport so
+// they don't depend on package-level startup wiring from another package.
+//
 // We must minimize use of this, and instead maximize reuse of the returned client object.
 // Why? Because that makes our connection pooling more efficient, and prevents us exhausting the
 // number of available network sockets on resource-constrained Linux systems. (E.g. when

--- a/traverser/credentialUtil.go
+++ b/traverser/credentialUtil.go
@@ -21,8 +21,9 @@ func CreateClientOptions(logger common.ILoggerResetable, srcCred *common.ScopedT
 		logOptions.Log = logger.Log
 		logOptions.ShouldLog = logger.ShouldLog
 	}
-	// Job-level/global client if available so we reuse connections and transports.
-	client := common.GetGlobalHTTPClient(logger)
+	// Process-wide HTTP client (initialized at startup from ConcurrencySettings) so we
+	// reuse connections and transports across the front-end and STE.
+	client := common.GetGlobalHTTPClient()
 
 	return ste.NewClientOptions(
 		policy.RetryOptions{

--- a/traverser/credentialUtil.go
+++ b/traverser/credentialUtil.go
@@ -1,8 +1,6 @@
 package traverser
 
 import (
-	"net/http"
-
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
@@ -23,14 +21,21 @@ func CreateClientOptions(logger common.ILoggerResetable, srcCred *common.ScopedT
 		logOptions.Log = logger.Log
 		logOptions.ShouldLog = logger.ShouldLog
 	}
-	return ste.NewClientOptions(policy.RetryOptions{
-		MaxRetries:    ste.UploadMaxTries,
-		TryTimeout:    ste.UploadTryTimeout,
-		RetryDelay:    ste.UploadRetryDelay,
-		MaxRetryDelay: ste.UploadMaxRetryDelay,
-	}, policy.TelemetryOptions{
-		ApplicationID: common.AddUserAgentPrefix(common.UserAgent),
-	}, ste.NewAzcopyHTTPClient(frontEndMaxIdleConnectionsPerHost), logOptions, srcCred, reauthCred)
-}
+	// Job-level/global client if available so we reuse connections and transports.
+	client := common.GetGlobalHTTPClient(logger)
 
-const frontEndMaxIdleConnectionsPerHost = http.DefaultMaxIdleConnsPerHost
+	return ste.NewClientOptions(
+		policy.RetryOptions{
+			MaxRetries:    ste.UploadMaxTries,
+			TryTimeout:    ste.UploadTryTimeout,
+			RetryDelay:    ste.UploadRetryDelay,
+			MaxRetryDelay: ste.UploadMaxRetryDelay,
+		},
+		policy.TelemetryOptions{
+			ApplicationID: common.AddUserAgentPrefix(common.UserAgent),
+		},
+		client, /*Use common.NewTracingTransport(client, "createClientOptions", logger) for http.Trace*/
+		logOptions,
+		srcCred,
+		reauthCred)
+}


### PR DESCRIPTION
Introduce common.GetGlobalHTTPClient() to create a single process-wide HTTP client, replacing per-job client creation in jobMgr and the separate front-end client in traverser/credentialUtil.go.

- Add common/azHttpClient.go with GetGlobalHTTPClient, MaxIdleConnsPerHost tuning logic, and optional connection-reuse tracing via httptrace
- Replace NewAzcopyHTTPClient in ste/mgr-JobMgr.go with the global client
- Update traverser/credentialUtil.go to use the global client, removing the local frontEndMaxIdleConnectionsPerHost constant
- Add NewTracingTransport wrapper for per-label connection stats logging (GotConn reuse/idle metrics, PutIdleConn errors, periodic dump)

Current http client configuration sets the connection reuse to 2 instead of a value based on concurrency. High concurrency leads to a high number of new TCP connections which causes socket errors and high syscall latency impacting performance. This change addresses this issue. 

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**: (Brief description of the feature or issue being addressed)

- **Related Links**:
- [Issues](<link>)
- [Team thread](<link>)
- [Documents](<link>)
- [Email Subject]

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
Pipeline run - **https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=30434&view=results**

Thank you for your contribution to AzCopy!
