### PR TITLE
NFS overwrite bug fix (04, 05)

### DIFF
--- a/azcopy/zc_processor.go
+++ b/azcopy/zc_processor.go
@@ -215,7 +215,7 @@ func (s *CopyTransferProcessor) appendTransfer(copyTransfer common.CopyTransfer)
 		case common.EEntityType.Symlink():
 			s.dispatcher.PendingTransfers.SymlinkTransferCount++
 		case common.EEntityType.Hardlink():
-			// This is the first occurance of a hardlink file which will be copied as a regular file
+			// This is the first occurrence of a hardlink file which will be copied as a regular file
 			if s.hardlinkHandlingType == common.EHardlinkHandlingType.Preserve() {
 				s.dispatcher.PendingTransfers.HardlinksTransferCount++
 			} else if s.hardlinkHandlingType == common.EHardlinkHandlingType.Follow() {

--- a/e2etest/zt_newe2e_nfs_scenarios_test.go
+++ b/e2etest/zt_newe2e_nfs_scenarios_test.go
@@ -1718,7 +1718,7 @@ func (s *FilesNFSTestSuite) Scenario_NFSToNFS_OverwriteSymlinkToFile(svm *Scenar
 		ObjectName:       pointerTo(rootDir),
 		ObjectProperties: ObjectProperties{EntityType: common.EEntityType.Folder()},
 	}
-	CreateResource[ObjectResourceManager](svm, srcContainer, srcObjs[rootDir])
+	CreateResource[ObjectResourceManager](svm, srcContainer, obj)
 	srcObjs[rootDir] = obj
 
 	// target file
@@ -1728,7 +1728,7 @@ func (s *FilesNFSTestSuite) Scenario_NFSToNFS_OverwriteSymlinkToFile(svm *Scenar
 		Body:             NewRandomObjectContentContainer(SizeFromString("1K")),
 		ObjectProperties: ObjectProperties{EntityType: common.EEntityType.File()},
 	}
-	CreateResource[ObjectResourceManager](svm, srcContainer, srcObjs[targetName])
+	CreateResource[ObjectResourceManager](svm, srcContainer, obj)
 	srcObjs[targetName] = obj
 
 	// symlink

--- a/e2etest/zt_newe2e_nfs_scenarios_test.go
+++ b/e2etest/zt_newe2e_nfs_scenarios_test.go
@@ -1677,3 +1677,118 @@ func (s *FilesNFSTestSuite) Scenario_DstShareDoesNotExists(svm *ScenarioVariatio
 			},
 		})
 }
+
+func (s *FilesNFSTestSuite) Scenario_NFSToNFS_OverwriteSymlinkToFile(svm *ScenarioVariationManager) {
+	// Test Scenario:
+	// 1. Create source and destination NFS enabled file shares
+	// 2. Source NFS share contains:
+	//      target.txt (regular file)
+	//      mylink (symlink -> target.txt)
+	// 3.  Destination NFS share contains:
+	//      mylink (regular file, same path as the source symlink)
+	// 4. Run azcopy copy with --preserve-symlinks and --overwrite set
+	// 5. Expected: dest regular file mylink is replaced with a symlink pointing to target.txt.
+
+	dstContainer := GetRootResource(svm, common.ELocation.FileNFS(), GetResourceOptions{
+		PreferredAccount: pointerTo(PremiumFileShareAcct),
+	}).(ServiceResourceManager).GetContainer("dstnfs")
+	if !dstContainer.Exists() {
+		dstContainer.Create(svm, ContainerProperties{
+			FileContainerProperties: FileContainerProperties{
+				EnabledProtocols: pointerTo("NFS")},
+		})
+	}
+	srcContainer := GetRootResource(svm, common.ELocation.FileNFS(), GetResourceOptions{
+		PreferredAccount: pointerTo(PremiumFileShareAcct),
+	}).(ServiceResourceManager).GetContainer("srcnfs")
+	if !srcContainer.Exists() {
+		srcContainer.Create(svm, ContainerProperties{
+			FileContainerProperties: FileContainerProperties{
+				EnabledProtocols: pointerTo("NFS")},
+		})
+	}
+	rootDir := "dir_overwrite_sym_to_file_" + uuid.NewString()
+	defer CleanupNFSDirectory(svm, srcContainer, rootDir)
+	defer CleanupNFSDirectory(svm, dstContainer, rootDir)
+
+	//  Source: symlink (mylink) pointing to target file (target.txt)
+	// root directory
+	srcObjs := make(ObjectResourceMappingFlat)
+	obj := ResourceDefinitionObject{
+		ObjectName:       pointerTo(rootDir),
+		ObjectProperties: ObjectProperties{EntityType: common.EEntityType.Folder()},
+	}
+	CreateResource[ObjectResourceManager](svm, srcContainer, srcObjs[rootDir])
+	srcObjs[rootDir] = obj
+
+	// target file
+	targetName := rootDir + "/target.txt"
+	obj = ResourceDefinitionObject{
+		ObjectName:       pointerTo(targetName),
+		Body:             NewRandomObjectContentContainer(SizeFromString("1K")),
+		ObjectProperties: ObjectProperties{EntityType: common.EEntityType.File()},
+	}
+	CreateResource[ObjectResourceManager](svm, srcContainer, srcObjs[targetName])
+	srcObjs[targetName] = obj
+
+	// symlink
+	linkName := rootDir + "/mylink"
+	obj = ResourceDefinitionObject{
+		ObjectName: pointerTo(linkName),
+		Body:       NewRandomObjectContentContainer(SizeFromString("1K")),
+		ObjectProperties: ObjectProperties{
+			EntityType:        common.EEntityType.Symlink(),
+			SymlinkedFileName: targetName,
+		},
+	}
+	CreateResource[ObjectResourceManager](svm, srcContainer, obj)
+	srcObjs[linkName] = obj
+
+	// Destination: pre-existing REGULAR FILE (mylink) with the same path as symlink
+	dstContainer.GetObject(svm, linkName, common.EEntityType.File()).
+		Create(svm, NewRandomObjectContentContainer(SizeFromString("1K")),
+			ObjectProperties{
+				EntityType: common.EEntityType.File(),
+			})
+
+	src := srcContainer.GetObject(svm, rootDir, common.EEntityType.Folder())
+	dst := dstContainer.GetObject(svm, rootDir, common.EEntityType.Folder())
+
+	RunAzCopy(
+		svm,
+		AzCopyCommand{
+			Verb: AzCopyVerbCopy,
+			Targets: []ResourceManager{
+				src.(RemoteResourceManager).WithSpecificAuthType(
+					ResolveVariation(svm, []ExplicitCredentialTypes{
+						EExplicitCredentialType.SASToken(),
+						EExplicitCredentialType.OAuth(),
+					}), svm, CreateAzCopyTargetOptions{}),
+				dst.(RemoteResourceManager).WithSpecificAuthType(
+					ResolveVariation(svm, []ExplicitCredentialTypes{
+						EExplicitCredentialType.SASToken(),
+						EExplicitCredentialType.OAuth(),
+					}), svm, CreateAzCopyTargetOptions{}),
+			},
+			Flags: CopyFlags{
+				CopySyncCommonFlags: CopySyncCommonFlags{
+					Recursive:        pointerTo(true),
+					FromTo:           pointerTo(common.EFromTo.FileNFSFileNFS()),
+					PreserveSymlinks: pointerTo(true),
+				},
+				Overwrite: pointerTo(true),
+			},
+		})
+
+	// Verify dest object is a symlink not regular file.
+	dstLink := dstContainer.GetObject(svm, linkName, common.EEntityType.Symlink())
+	svm.Assert("destination should be a symlink after overwrite",
+		Equal{}, dstLink.EntityType(), common.EEntityType.Symlink())
+
+	ValidateResource[ContainerResourceManager](svm, dstContainer, ResourceDefinitionContainer{
+		Objects: srcObjs,
+	}, ValidateResourceOptions{
+		validateObjectContent: true,
+		fromTo:                common.EFromTo.FileNFSFileNFS(),
+	})
+}

--- a/e2etest/zt_newe2e_nfs_scenarios_test.go
+++ b/e2etest/zt_newe2e_nfs_scenarios_test.go
@@ -83,7 +83,7 @@ func (b *bestEffortAsserter) Failed() bool                { return false }
 func (b *bestEffortAsserter) HelperMarker() HelperMarker  { return b.inner.HelperMarker() }
 func (b *bestEffortAsserter) GetTestName() string         { return b.inner.GetTestName() }
 
-// These tests are using the same source and desination shares for testing to avoid
+// These tests are using the same source and destination shares for testing to avoid
 // creating too many share accounts which may lead to throttling by Azure.
 // So in order to avoid conflicts between tests, we cleanup the test directories created during the test run.
 func CleanupNFSDirectory(

--- a/e2etest/zt_newe2e_nfs_scenarios_test.go
+++ b/e2etest/zt_newe2e_nfs_scenarios_test.go
@@ -1752,7 +1752,7 @@ func (s *FilesNFSTestSuite) Scenario_NFSToNFS_OverwriteSymlinkToFile(svm *Scenar
 			})
 
 	src := srcContainer.GetObject(svm, rootDir, common.EEntityType.Folder())
-	dst := dstContainer.GetObject(svm, rootDir, common.EEntityType.Folder())
+	//dst := dstContainer.GetObject(svm, rootDir, common.EEntityType.Folder())
 
 	RunAzCopy(
 		svm,
@@ -1764,7 +1764,7 @@ func (s *FilesNFSTestSuite) Scenario_NFSToNFS_OverwriteSymlinkToFile(svm *Scenar
 						EExplicitCredentialType.SASToken(),
 						EExplicitCredentialType.OAuth(),
 					}), svm, CreateAzCopyTargetOptions{}),
-				dst.(RemoteResourceManager).WithSpecificAuthType(
+				dstContainer.(RemoteResourceManager).WithSpecificAuthType(
 					ResolveVariation(svm, []ExplicitCredentialTypes{
 						EExplicitCredentialType.SASToken(),
 						EExplicitCredentialType.OAuth(),

--- a/ste/downloader-azureFiles_linux_test.go
+++ b/ste/downloader-azureFiles_linux_test.go
@@ -118,7 +118,7 @@ func TestComputeDownloadHardlinkTarget(t *testing.T) {
 
 		// ───────────── invalid source root URL → ERROR ─────────────
 		{
-			name:                   "error — unparseable source root URL",
+			name:                   "error — unparsable source root URL",
 			sourceRoot:             "://not-a-valid-url",
 			srcFilePath:            "dir/link.txt",
 			destination:            "/local/dir/link.txt",

--- a/ste/sender-azureFile.go
+++ b/ste/sender-azureFile.go
@@ -571,3 +571,30 @@ func (u *azureFileSenderBase) CreateHardlink(targetHardlinkFilePath string) erro
 	u.jptm.Log(common.LogDebug, fmt.Sprintf("Created hardlink with data: %s", targetHardlinkFilePath))
 	return nil
 }
+
+// DeleteIfNotSymlink deletes the destination resource in over write scenarios
+// where the source is a symlink and destination is not.
+func (u *azureFileSenderBase) DeleteIfNotSymlink() error {
+	if !u.jptm.FromTo().IsNFS() {
+		return nil
+	}
+
+	destClient := u.getFileClient()
+	props, err := destClient.GetProperties(u.ctx, nil)
+	if err != nil {
+		// First, check if there is anything to delete
+		var respErr *azcore.ResponseError
+		if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
+			return nil
+		}
+		return err
+	}
+	if props.NFSFileType != nil && *props.NFSFileType == file.NFSFileTypeSymlink {
+		return nil
+	}
+	// Delete non-symlink
+	if _, delErr := destClient.Delete(u.ctx, nil); delErr != nil {
+		return fmt.Errorf("failed to delete file for ovewrite: %w", delErr)
+	}
+	return nil
+}

--- a/ste/sender-azureFile.go
+++ b/ste/sender-azureFile.go
@@ -572,29 +572,22 @@ func (u *azureFileSenderBase) CreateHardlink(targetHardlinkFilePath string) erro
 	return nil
 }
 
-// DeleteIfNotSymlink deletes the destination resource in over write scenarios
-// where the source is a symlink and destination is not.
-func (u *azureFileSenderBase) DeleteIfNotSymlink() error {
+// DeleteDestInOverwrite deletes the destination resource in FileNFS transfer with symlink where overwrite=True.
+// This was added because the overwrite retry logic was gated on status codes from the service that were not
+// always hit
+func (u *azureFileSenderBase) DeleteDestInOverwrite() error {
 	if !u.jptm.FromTo().IsNFS() {
 		return nil
 	}
 
 	destClient := u.getFileClient()
-	props, err := destClient.GetProperties(u.ctx, nil)
-	if err != nil {
+	if _, delErr := destClient.Delete(u.ctx, nil); delErr != nil {
 		// First, check if there is anything to delete
 		var respErr *azcore.ResponseError
-		if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
+		if errors.As(delErr, &respErr) && respErr.StatusCode == http.StatusNotFound {
 			return nil
 		}
-		return err
-	}
-	if props.NFSFileType != nil && *props.NFSFileType == file.NFSFileTypeSymlink {
-		return nil
-	}
-	// Delete non-symlink
-	if _, delErr := destClient.Delete(u.ctx, nil); delErr != nil {
-		return fmt.Errorf("failed to delete file for ovewrite: %w", delErr)
+		return fmt.Errorf("failed to delete file for overwrite: %w", delErr)
 	}
 	return nil
 }

--- a/ste/xfer-anyToRemote-hardlink_test.go
+++ b/ste/xfer-anyToRemote-hardlink_test.go
@@ -152,7 +152,7 @@ func TestComputeUploadHardlinkTarget(t *testing.T) {
 
 		// ───────────── invalid destination URL → FailActiveSend ─────────────
 		{
-			name:                   "error — unparseable destination URL",
+			name:                   "error — unparsable destination URL",
 			sourceRoot:             "/local",
 			source:                 "/local/link.txt",
 			destination:            "://not-a-valid-url",

--- a/ste/xfer-anyToRemote-symlink.go
+++ b/ste/xfer-anyToRemote-symlink.go
@@ -20,6 +20,7 @@
 package ste
 
 import (
+	"fmt"
 	"net/url"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
@@ -111,6 +112,22 @@ func anyToRemote_symlink(jptm IJobPartTransferMgr, info *TransferInfo, pacer pac
 				jptm.SetStatus(common.ETransferStatus.SkippedEntityAlreadyExists())
 				jptm.ReportTransferDone()
 				return
+			}
+		}
+	}
+
+	// Handles overwrite=True S2S FileNFS copies where source and destination are different entity types.
+	// E.g the source is a symlink and destination is a regular file.
+	// In this situation, the destination file is proactively deleted and replaced with the source symlink.
+	// This was added so the following CreateSymbolicLink call does not need to depend on the service
+	// returning a specific error code to be retried on.
+	if shouldOverwrite := jptm.GetOverwriteOption() == common.EOverwriteOption.True(); jptm.FromTo().IsNFS() && shouldOverwrite {
+		if azFileSender, ok := baseSender.(*urlToAzureFileCopier); ok {
+			if delErr := azFileSender.DeleteIfNotSymlink(); delErr != nil {
+				jptm.LogAtLevelForCurrentTransfer(common.LogWarning,
+					fmt.Sprintf("Could not delete the destination %s before symlink overwrites it: %s",
+						jptm.Info().Destination, delErr.Error()))
+				// Don't fail the transfer, let retry logic in DoWithCreateSymlinkOnAzureFilesNFS() take a shot
 			}
 		}
 	}

--- a/ste/xfer-anyToRemote-symlink.go
+++ b/ste/xfer-anyToRemote-symlink.go
@@ -123,7 +123,7 @@ func anyToRemote_symlink(jptm IJobPartTransferMgr, info *TransferInfo, pacer pac
 	// returning a specific error code to be retried on.
 	if shouldOverwrite := jptm.GetOverwriteOption() == common.EOverwriteOption.True(); jptm.FromTo().IsNFS() && shouldOverwrite {
 		if azFileSender, ok := baseSender.(*urlToAzureFileCopier); ok {
-			if delErr := azFileSender.DeleteIfNotSymlink(); delErr != nil {
+			if delErr := azFileSender.DeleteDestInOverwrite(); delErr != nil {
 				jptm.LogAtLevelForCurrentTransfer(common.LogWarning,
 					fmt.Sprintf("Could not delete the destination %s before symlink overwrites it: %s",
 						jptm.Info().Destination, delErr.Error()))

--- a/ste/xfer-anyToRemote-symlink.go
+++ b/ste/xfer-anyToRemote-symlink.go
@@ -116,11 +116,10 @@ func anyToRemote_symlink(jptm IJobPartTransferMgr, info *TransferInfo, pacer pac
 		}
 	}
 
-	// Handles overwrite=True S2S FileNFS copies where source and destination are different entity types.
-	// E.g the source is a symlink and destination is a regular file.
-	// In this situation, the destination file is proactively deleted and replaced with the source symlink.
+	// Handles overwrite=True FileNFS symlink transfers.
+	// The destination file is proactively deleted and replaced with the source symlink.
 	// This was added so the following CreateSymbolicLink call does not need to depend on the service
-	// returning a specific error code to be retried on.
+	// returning specific error codes to perform the destination deletion
 	if shouldOverwrite := jptm.GetOverwriteOption() == common.EOverwriteOption.True(); jptm.FromTo().IsNFS() && shouldOverwrite {
 		if azFileSender, ok := baseSender.(*urlToAzureFileCopier); ok {
 			if delErr := azFileSender.DeleteDestInOverwrite(); delErr != nil {

--- a/ste/xfer-anyToRemote-symlink.go
+++ b/ste/xfer-anyToRemote-symlink.go
@@ -121,7 +121,7 @@ func anyToRemote_symlink(jptm IJobPartTransferMgr, info *TransferInfo, pacer pac
 	// This was added so the following CreateSymbolicLink call does not need to depend on the service
 	// returning specific error codes to perform the destination deletion
 	if shouldOverwrite := jptm.GetOverwriteOption() == common.EOverwriteOption.True(); jptm.FromTo().IsNFS() && shouldOverwrite {
-		if azFileSender, ok := baseSender.(*urlToAzureFileCopier); ok {
+		if azFileSender, ok := baseSender.(interface{ DeleteDestInOverwrite() error }); ok {
 			if delErr := azFileSender.DeleteDestInOverwrite(); delErr != nil {
 				jptm.LogAtLevelForCurrentTransfer(common.LogWarning,
 					fmt.Sprintf("Could not delete the destination %s before symlink overwrites it: %s",


### PR DESCRIPTION
## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

Fixes a bug where the target was not overwritten when using `preserve-symlinks=True` and `overwrite=true`. This handles both cases  on the destination where the regular file was not overwritten and also the case with an already existing symlink. 

See links below for full description and reproduction: 
[Bug 04 ](https://msazure.visualstudio.com/One/_workitems/edit/37724845)
[Bug 05](https://msazure.visualstudio.com/One/_workitems/edit/37724889/)

#### How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

Added e2e test to validate this 

Thank you for your contribution to AzCopy!
