### PR TITLE
Fix readonly attribute handling for Azure Files uploads

### DIFF
--- a/ste/sender-azureFile.go
+++ b/ste/sender-azureFile.go
@@ -251,6 +251,9 @@ func (u *azureFileSenderBase) Prologue(state common.PrologueState) (destinationM
 		creationProperties.LastWriteTime = &minimalLwt
 	}
 
+	// Set this before file creation
+	createOptions.SMBProperties = &creationProperties
+
 	err := common.DoWithOverrideReadOnlyOnAzureFiles(u.ctx,
 		func() (interface{}, error) {
 			return u.getFileClient().Create(u.ctx, info.SourceSize, createOptions)
@@ -276,9 +279,6 @@ func (u *azureFileSenderBase) Prologue(state common.PrologueState) (destinationM
 			u.jptm.FailActiveUpload("Creating parent directory", err)
 		}
 
-		if creationProperties.Attributes != nil {
-			createOptions.SMBProperties = &creationProperties
-		}
 		// retrying file creation
 		err = common.DoWithOverrideReadOnlyOnAzureFiles(u.ctx,
 			func() (interface{}, error) {

--- a/ste/sender-azureFile.go
+++ b/ste/sender-azureFile.go
@@ -235,6 +235,8 @@ func (u *azureFileSenderBase) Prologue(state common.PrologueState) (destinationM
 	// able to upload any data to the file!). We'll set it in epilogue, if necessary.
 	creationProperties := u.smbPropertiesToApply
 	if creationProperties.Attributes != nil {
+		attrsCopy := *u.smbPropertiesToApply.Attributes
+		creationProperties.Attributes = &attrsCopy
 		creationProperties.Attributes.ReadOnly = false
 	}
 


### PR DESCRIPTION
## Description
Cherry pick commits from mover/stage2 to fix correct migration of readonly attribute
This pull request makes targeted improvements to the way SMB properties are handled during Azure File creation in `ste/sender-azureFile.go`. The changes ensure that SMB file attributes are correctly set before file creation, and that attribute values are safely copied to avoid unintended side effects.

**SMB Properties Handling:**

* Ensured that `SMBProperties` are set on `createOptions` before file creation, rather than conditionally after a failure, so that all attributes are applied correctly on the first attempt. [[1]](diffhunk://#diff-cdb8634511eb2c78ec955488e408efa4823b93089781d9e0dffa8a90dd7d5308R254-R256) [[2]](diffhunk://#diff-cdb8634511eb2c78ec955488e408efa4823b93089781d9e0dffa8a90dd7d5308L277-L279)
* Made a defensive copy of the `Attributes` struct before modifying its `ReadOnly` field, preventing accidental mutation of the original attributes.
- **Feature / Bug Fix**: Readonly attribute is not migrated to the target Azure Files

- **Related Links**:
- [Issues](<link>)
- [Team thread](<link>)
- [Documents](<link>)
- [Email Subject]

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

Thank you for your contribution to AzCopy!
