### PR TITLE
Add Debian 13 (Trixie) package definition

### DIFF
--- a/packages.csv
+++ b/packages.csv
@@ -12,6 +12,7 @@ Debian-9.0,azcopyAmdDeb,microsoft-debian-stretch-prod-apt,stretch
 Debian-10.0,azcopyAmdDeb,microsoft-debian-buster-prod-apt,buster
 Debian-11.0,azcopyAmdDeb,microsoft-debian-bullseye-prod-apt,bullseye
 Debian-12.0,azcopyAmdDeb,microsoft-debian-bookworm-prod-apt,bookworm
+Debian-13.0,azcopyAmdDeb,microsoft-debian-trixie-prod-apt,trixie
 RHEL-7.5,azcopyAmdRpm,microsoft-rhel7.5-prod-yum,
 RHEL-7.8,azcopyAmdRpm,microsoft-rhel7.8-prod-yum,
 RHEL-8.1,azcopyAmdRpm,microsoft-rhel8.1-prod-yum,


### PR DESCRIPTION
Closes: #3354

## Description
Adds the Debian 13 (Trixie) package repository to the list of repositories that package is published.

- **Related Links**:
- #3354

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

Thank you for your contribution to AzCopy!
