### PR TITLE
Fix blob traverser to use isSyncDestination instead of UseSyncOrchestrator

### DIFF
--- a/cmd/syncEnumerator.go
+++ b/cmd/syncEnumerator.go
@@ -192,6 +192,7 @@ func (cca *cookedSyncCmdArgs) InitEnumerator(ctx context.Context, enumeratorOpti
 		PreserveBlobTags:        cca.s2sPreserveBlobTags,
 		HardlinkHandling:        common.EHardlinkHandlingType.Follow(),
 		ErrorChannel:            enumeratorOptions.ErrorChannel,
+		IsSyncDestination:       true,
 	}
 	dstTraverserTemplate := ResourceTraverserTemplate{
 		location: cca.fromTo.To(),

--- a/cmd/zc_enumerator.go
+++ b/cmd/zc_enumerator.go
@@ -415,6 +415,10 @@ type InitResourceTraverserOptions struct {
 	HardlinkHandling  common.HardlinkHandlingType
 
 	IncrementNotTransferred enumerationCounterFunc
+
+	// IsSyncDestination indicates this traverser is enumerating the destination side of a sync job.
+	// Used to return specific not-found errors that the sync orchestrator handles gracefully.
+	IsSyncDestination bool
 }
 
 // XDM: These templates are used to create directory level non-recursive traversers

--- a/cmd/zc_traverser_blob.go
+++ b/cmd/zc_traverser_blob.go
@@ -68,6 +68,9 @@ type blobTraverser struct {
 
 	errorChannel chan<- TraverserErrorItemInfo
 
+	// isSyncDestination indicates this traverser is enumerating the destination side of a sync job.
+	isSyncDestination bool
+
 	// includeDirectoryOrPrefix is used to determine if we should enqueue directories or prefixes
 	// in the traversal process. If true, prefixes will be enqueued as well even if location
 	// is not folder aware.
@@ -299,9 +302,10 @@ func (t *blobTraverser) Traverse(preprocessor objectMorpher, processor objectPro
 		} else if respErr.StatusCode == 403 { // Some nature of auth error-- Whatever the user is pointing at, they don't have access to, regardless of whether it's a file or a dir stub.
 			t.writeToBlobErrorChannel(errorBlobInfo)
 			return fmt.Errorf("cannot list files due to reason %s", respErr)
-		} else if UseSyncOrchestrator && t.isDFS && respErr.StatusCode == 404 {
-			// If we're using the sync orchestrator and we get a 404, it means the blob doesn't exist
-			// in the destination. We need to explicitly return the error.
+		} else if t.isSyncDestination && t.isDFS && respErr.StatusCode == 404 {
+			// If this is a sync destination traversal and we get a 404, it means the blob doesn't exist
+			// in the destination. We need to explicitly return the error so the sync orchestrator
+			// can handle it gracefully (e.g. set isDestinationPresent = false).
 			return fmt.Errorf("blob %s not found in destination. Err %s", blobName, respErr)
 		}
 	}
@@ -623,8 +627,8 @@ func (t *blobTraverser) parallelList(containerClient *container.Client, containe
 		}
 	}
 
-	if UseSyncOrchestrator && !t.isDFS && emptyPrefix {
-		// In case of sync orchestrator, we want to let the orchestrator know that the prefix was not found
+	if t.isSyncDestination && !t.isDFS && emptyPrefix {
+		// In case of sync destination traversal, we want to let the orchestrator know that the prefix was not found
 		// for a flat blob destination. This will help in optimizing the sync process by avoiding redundant
 		// target traversals.
 		return fmt.Errorf("blob %s not found in destination. Err %s", t.rawURL, common.BLOB_NOT_FOUND)
@@ -756,6 +760,7 @@ func newBlobTraverser(rawURL string, serviceClient *service.Client, ctx context.
 		isDFS:                       common.DerefOrZero(common.FirstOrZero(blobOpts).isDFS),
 		destResourceType:            opts.DestResourceType,
 		errorChannel:                opts.ErrorChannel,
+		isSyncDestination:          opts.IsSyncDestination,
 	}
 
 	t.includeDirectoryOrPrefix = UseSyncOrchestrator && !t.recursive


### PR DESCRIPTION
# Fix blob traverser to use isSyncDestination instead of UseSyncOrchestrator

## Problem
`zc_traverser_blob.go` uses `UseSyncOrchestrator` (a build-time constant, always `true` in the mover build) to decide whether to return \"blob not found in destination\" errors. This causes **copy** jobs on empty source containers to fail with:\n```\nblob https://<account>.blob.core.windows.net/<container> not found in destination. Err BlobNotFound\n```\nThe error is incorrect because the traverser is enumerating the **source**, not the destination — but `UseSyncOrchestrator=true` makes it think it's always a sync destination traverser.\n\n## Fix\n- Added `isSyncDestination bool` field to `blobTraverser` struct\n- Added `IsSyncDestination bool` field to `InitResourceTraverserOptions`\n- Set `IsSyncDestination: true` only in `syncEnumerator` when creating the **destination** traverser\n- Replaced `UseSyncOrchestrator` checks with `t.isSyncDestination` in two error-return paths:\n  - DFS 404 check (line ~297)\n  - Flat blob empty prefix check (line ~619)\n\n## Files Changed\n- `cmd/zc_traverser_blob.go` — Use per-traverser `isSyncDestination` flag instead of global `UseSyncOrchestrator`\n- `cmd/zc_enumerator.go` — Add `IsSyncDestination` to traverser options struct\n- `cmd/syncEnumerator.go` — Set `IsSyncDestination: true` for destination traverser\n\n## Testing\n- Verified with empty source container: copy job succeeds (was failing before)\n- Verified sync job still works correctly with the flag\n- E2E test added in mover repo (Storage-XDataMove-Agent-Linux)"