### PR TITLE
Add streaming merge-join for remote sync sources

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,89 @@
+# Streaming Merge-Join for Sync Orchestrator — Project Context
+
+## Branch: `users/pbanakar/streaming-merge-join`
+
+### What This Branch Does
+Adds a streaming merge-join algorithm to the sync orchestrator for remote-to-remote sync (Blob→Blob, S3→Blob, BlobFS→BlobFS). Replaces the O(N) memory indexMap-based comparison with O(1) streaming comparison for sources that guarantee lexicographic listing order.
+
+### Architecture
+
+**Two code paths in `syncOneDir`** (in `syncOrchestrator.go`):
+1. **Merge-join path** (Blob/S3/BlobFS sources): `useStreamingMergeJoin(fromTo)` returns true → calls `mergeJoinSyncDir()`
+2. **IndexMap path** (local filesystem): Keeps existing store-all-then-compare flow
+
+**Merge-join flow per directory:**
+```
+TreeCrawler (parallelism=500) → syncOneDir → mergeJoinSyncDir
+  ├─ traverserToChannel(src) → srcCh (buffer=10,000)
+  ├─ traverserToChannel(dst) → dstCh (buffer=10,000)
+  └─ Lockstep merge-join:
+       srcPath < dstPath → source-only → scheduleCopyTransfer
+       srcPath > dstPath → dest-only → deleteDestination policy
+       srcPath == dstPath → compare LMT → transfer if stale
+```
+
+**Key design decisions:**
+- Source-driven crawl: TreeCrawler discovers directories from source listing, so dest-only subtrees are never visited (O(1) skip)
+- Per-directory hierarchy listing (not flat listing) — preserves the ability to skip entire dest-only prefixes without iterating them
+- Throttling disabled for merge-join: no ReadMemStats STW, no file/goroutine limits
+- `EnumerationParallelism = 1`: inner blob traverser doesn't spawn 16 goroutines per flat directory
+- Default parallelism: 500 (env var `AZCOPY_MERGE_JOIN_PARALLELISM` for override)
+
+### Files Modified
+
+| File | Change |
+|------|--------|
+| `cmd/syncMergeJoin.go` | **NEW** — core merge-join algorithm (327 lines) |
+| `cmd/syncOrchestrator.go` | Fork syncOneDir into merge-join vs indexMap paths, CrawlWithStats, diagnostic logging |
+| `cmd/syncThrottler.go` | Disable throttling for merge-join, `getMergeJoinParallelism()`, EnumerationParallelism=1 |
+| `cmd/syncComparator.go` | Fix: both-zero change times no longer flags metadata changed |
+| `common/parallel/TreeCrawler.go` | `CrawlWithStats()` with live ActiveWorkers/QueuedDirs counters |
+
+### Performance Results (500K arcgis-cache dataset, 514,500 files)
+
+| Metric | COPY | Sync: indexMap (ratio=1.0) | **Sync: Merge-join** |
+|--------|------|----------------------------|---------------------|
+| Files scanned | 514,500 | 514,500 | **514,500** |
+| Scan rate | 1,476/sec | 282/sec | **~995/sec** |
+| Scan duration | ~5.8 min | ~30.4 min | **~9.4 min** |
+| Container runtime | 16.4 min | 36.4 min | **11 min** |
+| Parallelism | N/A | 42 (auto) | **500** |
+
+### Known Issues / Gaps
+1. **`mergeJoinHandleBothExist` uses only LMT comparison** — does not call `processIfNecessaryWithOrchestrator` (size+changeTime checks). Fine for c2c blob sync, but not feature-complete vs indexMap path.
+2. **Diagnostic logging is verbose** — `[STEP]` logs emit for every directory. Should be removed or gated behind debug level before production merge.
+3. **5000 parallelism OOM'd** — at 5000 workers, goroutine+connection overhead exceeded 8GB Go heap. 500 is the safe default.
+
+### Scaling Discussion (100B objects)
+- **Current per-directory approach works** but at 10B directories → 20B API calls → 11.6 days at 20K req/sec throttle
+- **Pure flat listing fails** for dest-only subtrees: must iterate all dest blobs even when not needed
+- **Best approach for 100B**: Adaptive prefix-sharded flat listing with source-driven discovery
+  - Use hierarchy listing to discover prefixes until ~500-1000 shards exist
+  - Each shard does flat listing merge-join of its subtree
+  - Source-only shards → schedule all, Dest-only shards → skip (or delete), Both → flat merge-join
+  - Estimated: ~1-2 hours for 100B (vs 11.6 days with per-directory)
+
+### Agent Repo (Storage-XDataMove-Agent-Linux)
+- Branch: `users/pbanakar/streaming-merge-join` on Azure DevOps
+- `xdatamoved/go.mod`: points to azcopy commit `9bcedfb746cf` (this branch)
+- New test: `xdatamoved/cloud2cloud/e2etests/dataplane_merge_join_e2e_test.go`
+- **For local dev**: uncomment line 18 in go.mod (`replace => ../azure-storage-azcopy`), run `go mod tidy`
+
+### Deployment (c2cbiceptest2 environment)
+- ACR: `c2ccontainerregistry3.azurecr.io/worker:latest`
+- ACA job: `worker-sm-dp-test-westus2`, RG: `c2cbiceptest2`, Sub: `31347be8-d066-464e-9866-7e58d85027b7`
+- LAW ID: `f89e271d-10af-46dc-b281-0ab2f7fa71c5`
+- Source dataset: `a2asource/arcgis-cache-500k` — 514,500 files in ~348K virtual directories
+- Dataset structure: `arcgiscache/layer_XX(70)/tile_XX(70)/chunk_XX(70)/tile_N.dat(1-2 files)`
+- Container: 30GB memory, 7.5 CPU
+- Docker build: `docker build -t worker -f xdatamoved/cloud2cloud/worker/Dockerfile .` from Agent root
+
+### Build Tag
+All syncOrchestrator code requires build tag `smslidingwindow`. The Docker build includes it.
+
+### Pending Work
+- [ ] Get a clean perf run with 500 parallelism in container (last run was poisoned by OOM retries)
+- [ ] Consider adding size+changeTime comparison to `mergeJoinHandleBothExist`
+- [ ] Remove/reduce verbose [STEP] diagnostic logging
+- [ ] Test with `deleteDestination=true` scenario
+- [ ] Investigate future optimization: batch listing at higher prefix levels for deep hierarchies

--- a/cmd/syncComparator.go
+++ b/cmd/syncComparator.go
@@ -358,7 +358,14 @@ func (f *syncDestinationComparator) compareSourceAndDestinationObject(
 
 	// if its not NFS copy, we assume reliable change time is available in target
 
+	if sourceObject.changeTime.IsZero() && destinationObject.changeTime.IsZero() {
+		// Both change times are zero (e.g., blobs copied from S3 without hdi_ct metadata).
+		// We can't detect metadata changes, so assume no change.
+		return false, false
+	}
+
 	if sourceObject.changeTime.IsZero() || destinationObject.changeTime.IsZero() {
+		// One side has change time but the other doesn't — assume metadata changed
 		return false, true
 	}
 

--- a/cmd/syncMergeJoin.go
+++ b/cmd/syncMergeJoin.go
@@ -1,0 +1,374 @@
+//go:build smslidingwindow
+// +build smslidingwindow
+
+// Copyright © 2017 Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+)
+
+// activeMergeJoinDirs tracks how many mergeJoinSyncDir calls are in-flight.
+var activeMergeJoinDirs atomic.Int64
+
+// mergeJoinChannelBufferSize controls the buffer size of channels used to bridge
+// push-based traversers into pull-based iteration for the merge-join algorithm.
+// A larger buffer reduces goroutine context switches but uses more memory.
+// Each slot holds one StoredObject (~800 bytes), so 10K slots ≈ 8MB per channel.
+const mergeJoinChannelBufferSize = 10_000
+
+// traverserResult wraps a StoredObject emitted by a traverser goroutine.
+// When done is true, the channel has been drained and obj is invalid.
+type traverserResult struct {
+	obj StoredObject
+	err error
+}
+
+// useStreamingMergeJoin returns true if the source type guarantees lexicographic
+// listing order, which is required for the streaming merge-join algorithm.
+// Local filesystem (ext4/XFS) does NOT guarantee sorted order, so it stays on
+// the existing indexMap-based flow.
+func useStreamingMergeJoin(fromTo common.FromTo) bool {
+	switch fromTo.From() {
+	case common.ELocation.S3(), common.ELocation.Blob(), common.ELocation.BlobFS():
+		return true
+	default:
+		return false
+	}
+}
+
+// traverserToChannel starts a goroutine that runs a ResourceTraverser and bridges
+// its push-based callback into a pull-based channel. The caller receives objects
+// one at a time via the returned channel. The traverser goroutine blocks when the
+// channel buffer is full, providing natural back-pressure.
+//
+// The error channel receives at most one error if the traversal fails.
+// Both channels are closed when the traverser goroutine exits.
+func traverserToChannel(
+	ctx context.Context,
+	t ResourceTraverser,
+	filters []ObjectFilter,
+	label string,
+) (<-chan StoredObject, <-chan error) {
+
+	objCh := make(chan StoredObject, mergeJoinChannelBufferSize)
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer close(objCh)
+		defer close(errCh)
+
+		start := time.Now()
+		firstObj := true
+		count := 0
+
+		err := t.Traverse(noPreProccessor, func(obj StoredObject) error {
+			if firstObj {
+				firstObj = false
+				elapsed := time.Since(start)
+				if elapsed > 30*time.Second {
+					mergeJoinSyncOneDirLog(common.LogWarning,
+						fmt.Sprintf("[SLOW] %s first object took %v (goroutines=%d)", label, elapsed, runtime.NumGoroutine()), true)
+				}
+			}
+			count++
+			select {
+			case objCh <- obj:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}, filters)
+
+		if firstObj {
+			// Traverser returned 0 objects — log how long it took
+			elapsed := time.Since(start)
+			if elapsed > 30*time.Second {
+				mergeJoinSyncOneDirLog(common.LogWarning,
+					fmt.Sprintf("[SLOW] %s returned 0 objects in %v (goroutines=%d)", label, elapsed, runtime.NumGoroutine()), true)
+			}
+		}
+
+		if err != nil {
+			mergeJoinSyncOneDirLog(common.LogError,
+				fmt.Sprintf("%s traversal error after %d objects: %v", label, count, err), true)
+			errCh <- err
+		}
+	}()
+
+	return objCh, errCh
+}
+
+// mergeJoinSyncDir performs a streaming merge-join of source and destination
+// object listings for a single directory. Both sides must emit objects in
+// lexicographic order (guaranteed by all remote storage APIs: S3, Blob, BlobFS).
+//
+// The algorithm walks both sorted streams in lockstep:
+//   - srcPath < dstPath → source-only object: schedule transfer (new file)
+//   - srcPath > dstPath → dest-only object: handle via delete-destination policy
+//   - srcPath == dstPath → both exist: compare properties, transfer if stale
+//
+// This replaces the indexMap-based processor/comparator/finalize flow for remote
+// sources, eliminating O(N) memory usage in favor of O(1) streaming.
+func mergeJoinSyncDir(
+	ctx context.Context,
+	enumerator *syncEnumerator,
+	cca *cookedSyncCmdArgs,
+	dir string,
+	pt ResourceTraverser,
+	st ResourceTraverser,
+	isDestinationPresent bool,
+) (subDirs []minimalStoredObject, err error) {
+
+	subDirs = make([]minimalStoredObject, 0, 64)
+	activeMergeJoinDirs.Add(1)
+	defer activeMergeJoinDirs.Add(-1)
+
+	// Bridge both traversers into channels
+	srcLabel := fmt.Sprintf("SRC[%s]", dir)
+	dstLabel := fmt.Sprintf("DST[%s]", dir)
+	srcCh, srcErrCh := traverserToChannel(ctx, pt, enumerator.filters, srcLabel)
+	var dstCh <-chan StoredObject
+	var dstErrCh <-chan error
+
+	if isDestinationPresent {
+		dstCh, dstErrCh = traverserToChannel(ctx, st, enumerator.filters, dstLabel)
+	} else {
+		// Destination doesn't exist yet — all source objects are new
+		emptyCh := make(chan StoredObject)
+		close(emptyCh)
+		emptyErrCh := make(chan error)
+		close(emptyErrCh)
+		dstCh = emptyCh
+		dstErrCh = emptyErrCh
+	}
+
+	// Build the comparator for property comparison (size, LWT, changeTime)
+	comparator := &syncDestinationComparator{
+		sourceIndex:             enumerator.objectIndexer, // not used in merge-join path but required by struct
+		copyTransferScheduler:   enumerator.ctp.scheduleCopyTransfer,
+		destinationCleaner:      enumerator.objectComparator, // will be replaced below
+		deleteDestination:       cca.deleteDestination,
+		incrementNotTransferred: enumerator.primaryTraverserTemplate.options.IncrementNotTransferred,
+		orchestratorOptions:     enumerator.orchestratorOptions,
+	}
+
+	// Pull first object from each side
+	srcObj, srcOk := <-srcCh
+	dstObj, dstOk := <-dstCh
+
+	for srcOk && dstOk {
+		srcPath := buildChildPath(dir, srcObj.relativePath, srcObj.entityType == common.EEntityType.Folder())
+		dstPath := buildChildPath(dir, dstObj.relativePath, dstObj.entityType == common.EEntityType.Folder())
+
+		cmp := strings.Compare(srcPath, dstPath)
+
+		switch {
+		case cmp < 0:
+			// Source-only: new object at source → schedule transfer
+			srcObj.relativePath = srcPath
+			subDirs, err = mergeJoinHandleSourceOnly(enumerator, cca, srcObj, subDirs)
+			if err != nil {
+				return subDirs, err
+			}
+			srcObj, srcOk = <-srcCh
+
+		case cmp > 0:
+			// Dest-only: extra object at destination → handle based on delete-destination policy
+			dstObj.relativePath = dstPath
+			err = mergeJoinHandleDestOnly(enumerator, cca, dstObj)
+			if err != nil {
+				return subDirs, err
+			}
+			dstObj, dstOk = <-dstCh
+
+		default:
+			// Both exist: compare properties and decide
+			srcObj.relativePath = srcPath
+			dstObj.relativePath = dstPath
+			subDirs, err = mergeJoinHandleBothExist(enumerator, cca, comparator, srcObj, dstObj, subDirs)
+			if err != nil {
+				return subDirs, err
+			}
+			srcObj, srcOk = <-srcCh
+			dstObj, dstOk = <-dstCh
+		}
+	}
+
+	// Drain remaining source-only objects
+	for srcOk {
+		srcObj.relativePath = buildChildPath(dir, srcObj.relativePath, srcObj.entityType == common.EEntityType.Folder())
+		subDirs, err = mergeJoinHandleSourceOnly(enumerator, cca, srcObj, subDirs)
+		if err != nil {
+			return subDirs, err
+		}
+		srcObj, srcOk = <-srcCh
+	}
+
+	// Drain remaining dest-only objects
+	for dstOk {
+		dstObj.relativePath = buildChildPath(dir, dstObj.relativePath, dstObj.entityType == common.EEntityType.Folder())
+		err = mergeJoinHandleDestOnly(enumerator, cca, dstObj)
+		if err != nil {
+			return subDirs, err
+		}
+		dstObj, dstOk = <-dstCh
+	}
+
+	// Check for traversal errors from either side
+	if srcErr := <-srcErrCh; srcErr != nil {
+		return subDirs, fmt.Errorf("source traversal error during merge-join: %w", srcErr)
+	}
+	if dstErr := <-dstErrCh; dstErr != nil {
+		return subDirs, fmt.Errorf("destination traversal error during merge-join: %w", dstErr)
+	}
+
+	return subDirs, nil
+}
+
+// mergeJoinHandleSourceOnly processes an object that exists at the source but not
+// the destination. Files are scheduled for transfer. Folders are added to the
+// subdirectory list for recursive traversal.
+func mergeJoinHandleSourceOnly(
+	enumerator *syncEnumerator,
+	cca *cookedSyncCmdArgs,
+	srcObj StoredObject,
+	subDirs []minimalStoredObject,
+) ([]minimalStoredObject, error) {
+
+	if srcObj.entityType == common.EEntityType.Folder() {
+		// Skip GCP self-referential directory placeholders
+		if isGCPSource && srcObj.relativePath == "" {
+			return subDirs, nil
+		}
+
+		subDirs = append(subDirs, minimalStoredObject{
+			relativePath:           common.AZCOPY_PATH_SEPARATOR_STRING + srcObj.relativePath,
+			changeTime:             srcObj.changeTime,
+			isVirtualPrefix:        srcObj.isVirtualPrefix,
+			isPresentAtDestination: false, // not at destination
+		})
+
+		// Schedule folder transfer (for ACLs, metadata, etc.)
+		err := enumerator.ctp.scheduleCopyTransfer(srcObj)
+		if err != nil {
+			return subDirs, err
+		}
+
+		return subDirs, nil
+	}
+
+	// File: schedule transfer
+	err := enumerator.ctp.scheduleCopyTransfer(srcObj)
+	return subDirs, err
+}
+
+// mergeJoinHandleDestOnly processes an object that exists at the destination but
+// not the source. Behavior depends on the --delete-destination flag:
+//   - True: pass to destination cleaner for deletion
+//   - False/Prompt: log and skip
+func mergeJoinHandleDestOnly(
+	enumerator *syncEnumerator,
+	cca *cookedSyncCmdArgs,
+	dstObj StoredObject,
+) error {
+	if cca.deleteDestination == common.EDeleteDestination.True() {
+		// Pass to the destination cleaner (same function used by the indexMap path)
+		return enumerator.objectComparator(dstObj)
+	}
+
+	// Not deleting destination — this object is extra but we leave it alone
+	return nil
+}
+
+// mergeJoinHandleBothExist processes an object that exists at both source and destination.
+// It compares properties (size, LWT, changeTime) to determine if a transfer is needed.
+// Folders are always added to subdirectories for recursive traversal.
+func mergeJoinHandleBothExist(
+	enumerator *syncEnumerator,
+	cca *cookedSyncCmdArgs,
+	comparator *syncDestinationComparator,
+	srcObj StoredObject,
+	dstObj StoredObject,
+	subDirs []minimalStoredObject,
+) ([]minimalStoredObject, error) {
+
+	if srcObj.entityType == common.EEntityType.Folder() {
+		// Skip GCP self-referential directory placeholders
+		if isGCPSource && srcObj.relativePath == "" {
+			return subDirs, nil
+		}
+
+		subDirs = append(subDirs, minimalStoredObject{
+			relativePath:           common.AZCOPY_PATH_SEPARATOR_STRING + srcObj.relativePath,
+			changeTime:             srcObj.changeTime,
+			isVirtualPrefix:        srcObj.isVirtualPrefix,
+			isPresentAtDestination: true,
+		})
+	}
+
+	// For remote sources (Blob, S3, BlobFS, GCP), use isMoreRecentThan on LMT.
+	// This mirrors the default comparison in processIfNecessary (indexMap path).
+	// LWT/changeTime are not reliable for remote sources (e.g., blob Last-Modified
+	// is always updated to copy time, and POSIX metadata keys may not exist).
+	if srcObj.isMoreRecentThan(dstObj, comparator.preferSMBTime) {
+		syncComparatorLog(srcObj.relativePath, syncStatusOverwritten, syncOverwriteReasonNewerLMT, false)
+		err := enumerator.ctp.scheduleCopyTransfer(srcObj)
+		return subDirs, err
+	}
+
+	// No change — skip transfer
+	if enumerator.primaryTraverserTemplate.options.IncrementNotTransferred != nil && !srcObj.isVirtualPrefix {
+		enumerator.primaryTraverserTemplate.options.IncrementNotTransferred(srcObj.entityType)
+	}
+
+	syncComparatorLog(srcObj.relativePath, syncStatusSkipped, syncSkipReasonNoChangeInLWTorCT, false)
+	return subDirs, nil
+}
+
+// mergeJoinSyncOneDirLog logs messages specific to the merge-join sync path.
+// Set toConsole=true to also emit to stdout (visible in LAW container logs).
+func mergeJoinSyncOneDirLog(level common.LogLevel, msg string, toConsole ...bool) {
+	console := false
+	if len(toConsole) > 0 {
+		console = toConsole[0]
+	}
+	syncOrchestratorLog(level, fmt.Sprintf("[MergeJoin] %s", msg), console)
+}
+
+// mergeJoinElapsedSinceLog logs elapsed time for a merge-join directory operation.
+// Only logs directories that took longer than 5 seconds to reduce noise.
+func mergeJoinElapsedSinceLog(dir string, start time.Time) {
+	elapsed := time.Since(start)
+	if elapsed > 5*time.Second {
+		mergeJoinSyncOneDirLog(
+			common.LogInfo,
+			fmt.Sprintf("Dir '%s' completed in %v", dir, elapsed))
+	}
+}

--- a/cmd/syncMergeJoin.go
+++ b/cmd/syncMergeJoin.go
@@ -40,8 +40,9 @@ var activeMergeJoinDirs atomic.Int64
 // mergeJoinChannelBufferSize controls the buffer size of channels used to bridge
 // push-based traversers into pull-based iteration for the merge-join algorithm.
 // A larger buffer reduces goroutine context switches but uses more memory.
-// Each slot holds one StoredObject (~800 bytes), so 10K slots ≈ 8MB per channel.
-const mergeJoinChannelBufferSize = 10_000
+// Each slot holds one StoredObject (~430 bytes), so 1K slots ≈ 430KB per channel.
+// With 500 workers × 2 channels, total buffer memory ≈ 430MB.
+const mergeJoinChannelBufferSize = 1_000
 
 // traverserResult wraps a StoredObject emitted by a traverser goroutine.
 // When done is true, the channel has been drained and obj is invalid.
@@ -184,6 +185,7 @@ func mergeJoinSyncDir(
 	dstObj, dstOk := <-dstCh
 
 	for srcOk && dstOk {
+		srcOrigPath := srcObj.relativePath
 		srcPath := buildChildPath(dir, srcObj.relativePath, srcObj.entityType == common.EEntityType.Folder())
 		dstPath := buildChildPath(dir, dstObj.relativePath, dstObj.entityType == common.EEntityType.Folder())
 
@@ -193,7 +195,7 @@ func mergeJoinSyncDir(
 		case cmp < 0:
 			// Source-only: new object at source → schedule transfer
 			srcObj.relativePath = srcPath
-			subDirs, err = mergeJoinHandleSourceOnly(enumerator, cca, srcObj, subDirs)
+			subDirs, err = mergeJoinHandleSourceOnly(enumerator, cca, srcObj, srcOrigPath, subDirs)
 			if err != nil {
 				return subDirs, err
 			}
@@ -212,7 +214,7 @@ func mergeJoinSyncDir(
 			// Both exist: compare properties and decide
 			srcObj.relativePath = srcPath
 			dstObj.relativePath = dstPath
-			subDirs, err = mergeJoinHandleBothExist(enumerator, cca, comparator, srcObj, dstObj, subDirs)
+			subDirs, err = mergeJoinHandleBothExist(enumerator, cca, comparator, srcObj, dstObj, srcOrigPath, subDirs)
 			if err != nil {
 				return subDirs, err
 			}
@@ -223,8 +225,9 @@ func mergeJoinSyncDir(
 
 	// Drain remaining source-only objects
 	for srcOk {
+		srcOrigPath := srcObj.relativePath
 		srcObj.relativePath = buildChildPath(dir, srcObj.relativePath, srcObj.entityType == common.EEntityType.Folder())
-		subDirs, err = mergeJoinHandleSourceOnly(enumerator, cca, srcObj, subDirs)
+		subDirs, err = mergeJoinHandleSourceOnly(enumerator, cca, srcObj, srcOrigPath, subDirs)
 		if err != nil {
 			return subDirs, err
 		}
@@ -252,6 +255,26 @@ func mergeJoinSyncDir(
 	return subDirs, nil
 }
 
+// isSelfReferentialDirSentinel returns true when a BlobFS (HNS) traverser emits
+// the current directory itself as a Folder StoredObject with empty relativePath.
+// This sentinel carries root/directory ACLs but must NOT be re-enqueued as a
+// subdirectory — otherwise the same directory would be processed again, causing
+// duplicate folder counts, failed transfers, and potential infinite loops.
+func isSelfReferentialDirSentinel(obj StoredObject, originalRelativePath string, fromTo common.FromTo) bool {
+	if obj.entityType != common.EEntityType.Folder() {
+		return false
+	}
+	// GCP S3-compatible source emits directory placeholders with empty relativePath
+	if isGCPSource && originalRelativePath == "" {
+		return true
+	}
+	// BlobFS (HNS) traverser emits the current directory as a folder with empty relativePath
+	if fromTo.From() == common.ELocation.BlobFS() && originalRelativePath == "" {
+		return true
+	}
+	return false
+}
+
 // mergeJoinHandleSourceOnly processes an object that exists at the source but not
 // the destination. Files are scheduled for transfer. Folders are added to the
 // subdirectory list for recursive traversal.
@@ -259,13 +282,16 @@ func mergeJoinHandleSourceOnly(
 	enumerator *syncEnumerator,
 	cca *cookedSyncCmdArgs,
 	srcObj StoredObject,
+	originalRelativePath string,
 	subDirs []minimalStoredObject,
 ) ([]minimalStoredObject, error) {
 
 	if srcObj.entityType == common.EEntityType.Folder() {
-		// Skip GCP self-referential directory placeholders
-		if isGCPSource && srcObj.relativePath == "" {
-			return subDirs, nil
+		// Skip self-referential directory sentinels (GCP/HNS) from subDirs
+		// but still schedule the transfer for ACL propagation
+		if isSelfReferentialDirSentinel(srcObj, originalRelativePath, cca.fromTo) {
+			err := enumerator.ctp.scheduleCopyTransfer(srcObj)
+			return subDirs, err
 		}
 
 		subDirs = append(subDirs, minimalStoredObject{
@@ -316,13 +342,18 @@ func mergeJoinHandleBothExist(
 	comparator *syncDestinationComparator,
 	srcObj StoredObject,
 	dstObj StoredObject,
+	originalRelativePath string,
 	subDirs []minimalStoredObject,
 ) ([]minimalStoredObject, error) {
 
 	if srcObj.entityType == common.EEntityType.Folder() {
-		// Skip GCP self-referential directory placeholders
-		if isGCPSource && srcObj.relativePath == "" {
-			return subDirs, nil
+		// Skip self-referential directory sentinels (GCP/HNS) from subDirs
+		if isSelfReferentialDirSentinel(srcObj, originalRelativePath, cca.fromTo) {
+			// Always schedule transfer for ACL propagation (matches indexMap path behavior
+			// where the root sentinel with BlobName="" routes through SetContainerACL).
+			// Do NOT re-enqueue as subdirectory — that would cause infinite loops.
+			err := enumerator.ctp.scheduleCopyTransfer(srcObj)
+			return subDirs, err
 		}
 
 		subDirs = append(subDirs, minimalStoredObject{

--- a/cmd/syncOrchestrator.go
+++ b/cmd/syncOrchestrator.go
@@ -35,6 +35,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
@@ -647,6 +648,12 @@ func (cca *cookedSyncCmdArgs) runSyncOrchestrator(enumerator *syncEnumerator, ct
 			cca.destination.Value,
 			orchestratorOptions.ToStringMap()))
 
+	// Log merge-join mode to console (visible in LAW)
+	if useStreamingMergeJoin(cca.fromTo) {
+		syncOrchestratorLog(common.LogInfo,
+			fmt.Sprintf("[MergeJoin] Streaming merge-join ENABLED for %s source (fromTo=%s)", cca.fromTo.From(), cca.fromTo), true)
+	}
+
 	var crawlWg sync.WaitGroup // WaitGroup for all directory processing tasks
 
 	// syncOneDir processes a single directory by creating source and destination traversers,
@@ -662,16 +669,27 @@ func (cca *cookedSyncCmdArgs) runSyncOrchestrator(enumerator *syncEnumerator, ct
 		defer totalDirectoriesProcessed.Add(1)
 
 		var err error
+		var stepStart time.Time
 
 		// Acquire semaphore slot to limit concurrent directory processing
 		if enableThrottling {
+			syncOrchestratorLog(common.LogInfo,
+				fmt.Sprintf("[STEP] dir='%s' → AcquireSourceSlot START (activeMJ=%d, goroutines=%d)",
+					dir.(minimalStoredObject).relativePath, activeMergeJoinDirs.Load(), runtime.NumGoroutine()), true)
+			stepStart = time.Now()
 			err = semaphore.AcquireSourceSlot(mainCtx)
+			if elapsed := time.Since(stepStart); elapsed > 5*time.Second {
+				syncOrchestratorLog(common.LogWarning,
+					fmt.Sprintf("[SLOW-STEP] dir='%s' AcquireSourceSlot took %v", dir.(minimalStoredObject).relativePath, elapsed), true)
+			}
 			if err != nil {
 				syncOrchestratorLog(
 					common.LogError,
 					fmt.Sprintf("Failed to acquire source slot for dir '%s': %s", dir.(minimalStoredObject).relativePath, err))
 				return err
 			}
+			syncOrchestratorLog(common.LogInfo,
+				fmt.Sprintf("[STEP] dir='%s' → AcquireSourceSlot DONE", dir.(minimalStoredObject).relativePath), true)
 		}
 
 		srcDirEnumerating.Add(1) // Increment active directory count
@@ -699,6 +717,9 @@ func (cca *cookedSyncCmdArgs) runSyncOrchestrator(enumerator *syncEnumerator, ct
 		var errMsg string
 
 		// Create source traverser for current directory
+		syncOrchestratorLog(common.LogInfo,
+			fmt.Sprintf("[STEP] dir='%s' → InitResourceTraverser(src) START", dir.(minimalStoredObject).relativePath), true)
+		stepStart = time.Now()
 		pt, err := InitResourceTraverser(
 			pt_src,
 			ptt.location,
@@ -715,8 +736,15 @@ func (cca *cookedSyncCmdArgs) runSyncOrchestrator(enumerator *syncEnumerator, ct
 			})
 			return err
 		}
+		if elapsed := time.Since(stepStart); elapsed > 10*time.Second {
+			syncOrchestratorLog(common.LogWarning,
+				fmt.Sprintf("[SLOW-STEP] dir='%s' InitResourceTraverser(src) took %v", dir.(minimalStoredObject).relativePath, elapsed), true)
+		}
 
 		// Create destination traverser for current directory
+		syncOrchestratorLog(common.LogInfo,
+			fmt.Sprintf("[STEP] dir='%s' → InitResourceTraverser(dst) START", dir.(minimalStoredObject).relativePath), true)
+		stepStart = time.Now()
 		st, err := InitResourceTraverser(
 			st_src,
 			stt.location,
@@ -733,6 +761,67 @@ func (cca *cookedSyncCmdArgs) runSyncOrchestrator(enumerator *syncEnumerator, ct
 			})
 			return err
 		}
+		if elapsed := time.Since(stepStart); elapsed > 10*time.Second {
+			syncOrchestratorLog(common.LogWarning,
+				fmt.Sprintf("[SLOW-STEP] dir='%s' InitResourceTraverser(dst) took %v", dir.(minimalStoredObject).relativePath, elapsed), true)
+		}
+
+		isDestinationPresent := dir.(minimalStoredObject).isPresentAtDestination
+
+		// Fork: use streaming merge-join for remote sources (sorted listings),
+		// keep existing indexMap-based flow for local filesystem (unsorted).
+		if useStreamingMergeJoin(cca.fromTo) {
+			// ── Streaming merge-join path (S3, Blob, BlobFS sources) ──
+			// Both source and destination listings are lexicographically ordered,
+			// enabling O(1) memory streaming comparison instead of O(N) indexMap.
+
+			mergeJoinSyncOneDirLog(common.LogDebug,
+				fmt.Sprintf("Processing dir '%s'", dir.(minimalStoredObject).relativePath))
+
+			subDirs, mergeErr := mergeJoinSyncDir(
+				mainCtx,
+				enumerator,
+				cca,
+				dir.(minimalStoredObject).relativePath,
+				pt,
+				st,
+				isDestinationPresent,
+			)
+
+			srcDirEnumerating.Add(-1) // Decrement active directory count after merge-join completes
+
+			// Release source slot after merge-join completes (source was actively listed during merge-join)
+			if enableThrottling {
+				semaphore.ReleaseSourceSlot()
+			}
+
+			if mergeErr != nil {
+				errMsg = fmt.Sprintf("Merge-join sync failed for dir %s: %s", pt_src.Value, mergeErr)
+				syncOrchestratorLog(common.LogError, errMsg, true)
+				writeSyncErrToChannel(ptt.options.ErrorChannel, SyncOrchErrorInfo{
+					DirPath:           pt_src.Value,
+					DirName:           dir.(minimalStoredObject).relativePath,
+					ErrorMsg:          errors.New(errMsg),
+					TraverserLocation: cca.fromTo.From(),
+				})
+				return mergeErr
+			}
+
+			// Enqueue discovered subdirectories for processing
+			for _, sub_dir := range subDirs {
+				crawlWg.Add(1)
+				enqueueDir(minimalStoredObject{
+					relativePath:           sub_dir.relativePath,
+					changeTime:             sub_dir.changeTime,
+					isPresentAtDestination: sub_dir.isPresentAtDestination,
+				})
+			}
+			return nil
+		}
+
+		// ── Existing indexMap-based path (local filesystem sources) ──
+		// Local filesystem does not guarantee lexicographic listing order,
+		// so we use the traditional store-all-then-compare approach.
 
 		// Create sync traverser for this directory
 		stra := newSyncTraverser(enumerator, dir.(minimalStoredObject).relativePath, enumerator.objectComparator)
@@ -761,9 +850,6 @@ func (cca *cookedSyncCmdArgs) runSyncOrchestrator(enumerator *syncEnumerator, ct
 		// Flag to control whether we traverse the destination
 		traverseDestination := true
 
-		// Flag to check if destination exists
-		// We will use the parent directory flag as the seed value to avoid redundant checks
-		isDestinationPresent := dir.(minimalStoredObject).isPresentAtDestination
 		finalize := true // Flag to control whether we finalize
 		// Before proceeding, check if we need to enumerate the destination
 		if isDestinationPresent &&
@@ -953,7 +1039,33 @@ func (cca *cookedSyncCmdArgs) runSyncOrchestrator(enumerator *syncEnumerator, ct
 	crawlWg.Add(1) // Add the root directory to the WaitGroup
 
 	// Start parallel crawling with specified concurrency
-	parallel.Crawl(mainCtx, root, syncOneDir, int(crawlParallelism))
+	crawlCh, crawlStats := parallel.CrawlWithStats(mainCtx, root, syncOneDir, int(crawlParallelism))
+
+	// Log active worker and queue stats periodically
+	statsCtx, stopStats := context.WithCancel(mainCtx)
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-statsCtx.Done():
+				return
+			case <-ticker.C:
+				active := atomic.LoadInt64(&crawlStats.ActiveWorkers)
+				queued := atomic.LoadInt64(&crawlStats.QueuedDirs)
+				activeMJ := activeMergeJoinDirs.Load()
+				goroutines := runtime.NumGoroutine()
+				syncOrchestratorLog(common.LogInfo, fmt.Sprintf(
+					"[CrawlStats] activeWorkers=%d/%d, queuedDirs=%d, activeMergeJoin=%d, goroutines=%d",
+					active, int(crawlParallelism), queued, activeMJ, goroutines), true)
+			}
+		}
+	}()
+
+	// Drain crawl results (required — Crawl blocks if channel isn't consumed)
+	for range crawlCh {
+	}
+	stopStats()
 
 	// Cancellation-aware wait
 	done := make(chan struct{})
@@ -966,6 +1078,9 @@ func (cca *cookedSyncCmdArgs) runSyncOrchestrator(enumerator *syncEnumerator, ct
 	case <-done:
 		// All goroutines completed normally
 		syncOrchestratorLog(common.LogInfo, "All sync traversers exited.")
+		if useStreamingMergeJoin(cca.fromTo) {
+			syncOrchestratorLog(common.LogInfo, "[MergeJoin] Streaming merge-join scan completed", true)
+		}
 
 	case <-mainCtx.Done():
 		// Cancellation occurred

--- a/cmd/syncThrottler.go
+++ b/cmd/syncThrottler.go
@@ -27,7 +27,9 @@ import (
 	"context"
 	"fmt"
 	_ "net/http/pprof"
+	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -48,6 +50,7 @@ const (
 	throttleLogIntervalSecs       int           = 60 * 60                               // How often to log during throttling
 	semaphoreThrottleWaitInterval time.Duration = time.Duration(time.Millisecond * 100) // How often to check semaphore after throttle limit is hit
 	semaphoreWaitInterval         time.Duration = time.Duration(time.Millisecond * 50)  // How often to check semaphore status
+
 
 	// Performance tuning constants
 	filesPerGBMemory = 1_000_000 // Files per GB of memory
@@ -158,6 +161,26 @@ func initializeLimits(orchestratorOptions *SyncOrchestratorOptions) {
 		crawlParallelism = orchestratorOptions.parallelTraversers
 	}
 
+	// For merge-join (remote sources), parallelism is not bound by memory/indexMap constraints
+	// since objects are streamed and not accumulated. Use env var override with a high default.
+	if useStreamingMergeJoin(orchestratorOptions.fromTo) {
+		crawlParallelism = getMergeJoinParallelism()
+		// Merge-join streams objects — no indexMap accumulation — so memory/file/goroutine
+		// throttling is unnecessary. Disabling avoids the ReadMemStats STW bottleneck
+		// that serializes all workers through a global mutex+STW pause.
+		enableMemoryBasedThrottling = false
+		enableFileBasedThrottling = false
+		enableGoroutineBasedThrottling = false
+		// Each merge-join worker processes one flat directory — no recursive sub-tree.
+		// The blob traverser internally does parallel.Crawl(..., EnumerationParallelism)
+		// which spawns 16 goroutines per traverser. With 5000 workers × 2 traversers × 16
+		// = 160K goroutines, most idle. Set to 1 since outer crawl already provides parallelism.
+		EnumerationParallelism = 1
+		syncOrchestratorLog(common.LogInfo,
+			fmt.Sprintf("[MergeJoin] Using merge-join parallelism: %d, throttling disabled, inner enum=1", crawlParallelism),
+			true)
+	}
+
 	if maxDirectoryDirectChildCount > maxActiveFiles {
 		syncOrchestratorLog(
 			common.LogWarning,
@@ -167,13 +190,16 @@ func initializeLimits(orchestratorOptions *SyncOrchestratorOptions) {
 
 	// Validate if the crawl parallelism is within acceptable limits
 	// We need to check how many directories can be enumerated in parallel based on system memory
-	safeParallelismLimit := GetSafeParallelismLimit(maxActiveFiles, maxDirectoryDirectChildCount, orchestratorOptions.fromTo)
-	if crawlParallelism > safeParallelismLimit {
-		syncOrchestratorLog(
-			common.LogWarning,
-			fmt.Sprintf("Crawl parallelism (%d) exceeds safe limit (%d), adjusting to prevent OOM", crawlParallelism, safeParallelismLimit),
-			true)
-		crawlParallelism = safeParallelismLimit
+	// Skip for merge-join — parallelism is set independently via env var
+	if !useStreamingMergeJoin(orchestratorOptions.fromTo) {
+		safeParallelismLimit := GetSafeParallelismLimit(maxActiveFiles, maxDirectoryDirectChildCount, orchestratorOptions.fromTo)
+		if crawlParallelism > safeParallelismLimit {
+			syncOrchestratorLog(
+				common.LogWarning,
+				fmt.Sprintf("Crawl parallelism (%d) exceeds safe limit (%d), adjusting to prevent OOM", crawlParallelism, safeParallelismLimit),
+				true)
+			crawlParallelism = safeParallelismLimit
+		}
 	}
 
 	syncOrchestratorLog(common.LogInfo, fmt.Sprintf(
@@ -213,6 +239,21 @@ func GetSafeParallelismLimit(maxActiveFiles, maxChildCount int64, fromTo common.
 	default:
 		return min(limit, 48)
 	}
+}
+
+const defaultMergeJoinParallelism int32 = 500
+
+// getMergeJoinParallelism returns the parallelism for merge-join crawling.
+// It reads from AZCOPY_MERGE_JOIN_PARALLELISM env var, defaulting to 500.
+// Merge-join streams objects without accumulating them in memory, so parallelism
+// is not constrained by memory/indexMap limits.
+func getMergeJoinParallelism() int32 {
+	if val := os.Getenv("AZCOPY_MERGE_JOIN_PARALLELISM"); val != "" {
+		if p, err := strconv.Atoi(val); err == nil && p > 0 {
+			return int32(p)
+		}
+	}
+	return defaultMergeJoinParallelism
 }
 
 // GetNumCPU returns the number of logical CPU cores available on the system.
@@ -255,6 +296,8 @@ type ThrottleSemaphore struct {
 	fileThrottleActive      bool
 	memoryThrottleActive    bool
 	goroutineThrottleActive bool
+
+
 
 	// Context-based cancellation instead of channel
 	ctx    context.Context
@@ -439,9 +482,9 @@ func (ds *ThrottleSemaphore) shouldThrottle() bool {
 		}
 
 		if ds.isThrottling {
-			syncOrchestratorLog(common.LogWarning, fmt.Sprintf("THROTTLE ENGAGED: %s", strings.Join(reasons, ", ")))
+			syncOrchestratorLog(common.LogWarning, fmt.Sprintf("THROTTLE ENGAGED: %s", strings.Join(reasons, ", ")), true)
 		} else {
-			syncOrchestratorLog(common.LogInfo, "THROTTLE RELEASED: All resources below release thresholds")
+			syncOrchestratorLog(common.LogInfo, "THROTTLE RELEASED: All resources below release thresholds", true)
 		}
 	}
 

--- a/common/parallel/TreeCrawler.go
+++ b/common/parallel/TreeCrawler.go
@@ -23,13 +23,22 @@ package parallel
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 )
+
+// CrawlStats exposes live counters for a running crawl. All fields are
+// atomically updated and safe to read from any goroutine.
+type CrawlStats struct {
+	ActiveWorkers int64 // number of workers currently processing a directory
+	QueuedDirs    int64 // approximate number of directories waiting to be processed
+}
 
 type crawler struct {
 	output      chan CrawlResult
 	workerBody  EnumerateOneDirFunc
 	parallelism int
+	stats       *CrawlStats
 	cond        *sync.Cond
 	// the following are protected by cond (and must only be accessed when cond.L is held)
 	unstartedDirs      []Directory // not a channel, because channels have length limits, and those get in our way
@@ -55,15 +64,24 @@ type EnumerateOneDirFunc func(dir Directory, enqueueDir func(Directory), enqueue
 // Crawl crawls an abstract directory tree, using the supplied enumeration function.  May be use for whatever
 // that function can enumerate (i.e. not necessarily a local file system, just anything tree-structured)
 func Crawl(ctx context.Context, root Directory, worker EnumerateOneDirFunc, parallelism int) <-chan CrawlResult {
+	ch, _ := CrawlWithStats(ctx, root, worker, parallelism)
+	return ch
+}
+
+// CrawlWithStats is like Crawl but also returns live CrawlStats that the
+// caller can poll to observe active worker count and queue depth.
+func CrawlWithStats(ctx context.Context, root Directory, worker EnumerateOneDirFunc, parallelism int) (<-chan CrawlResult, *CrawlStats) {
+	stats := &CrawlStats{}
 	c := &crawler{
 		unstartedDirs: make([]Directory, 0, 1024),
 		output:        make(chan CrawlResult, 1000),
 		workerBody:    worker,
 		parallelism:   parallelism,
+		stats:         stats,
 		cond:          sync.NewCond(&sync.Mutex{}),
 	}
 	go c.start(ctx, root)
-	return c.output
+	return c.output, stats
 }
 
 func (c *crawler) start(ctx context.Context, root Directory) {
@@ -149,6 +167,9 @@ func (c *crawler) processOneDirectory(ctx context.Context, workerIndex int) (boo
 
 				c.dirInProgressCount++ // record that we are working on something
 				c.cond.Broadcast()     // and let other threads know of that fact
+				// Update live stats
+				atomic.AddInt64(&c.stats.ActiveWorkers, 1)
+				atomic.StoreInt64(&c.stats.QueuedDirs, int64(len(c.unstartedDirs)))
 			} else {
 				if c.dirInProgressCount > 0 {
 					// something has gone wrong in the design of this algorithm, because we should only get here if all done now
@@ -182,7 +203,10 @@ func (c *crawler) processOneDirectory(ctx context.Context, workerIndex int) (boo
 
 	c.unstartedDirs = append(c.unstartedDirs, foundDirectories...) // do NOT try to wait here if unstartedDirs is getting big. May cause deadlocks, due to all workers waiting and none processing the queue
 	c.dirInProgressCount--                                         // we were doing something, and now we have finished it
-	c.cond.Broadcast()                                             // let other workers know that the state has changed
+	// Update live stats
+	atomic.AddInt64(&c.stats.ActiveWorkers, -1)
+	atomic.StoreInt64(&c.stats.QueuedDirs, int64(len(c.unstartedDirs)))
+	c.cond.Broadcast() // let other workers know that the state has changed
 
 	// If our queue of unstarted stuff is getting really huge,
 	// reduce our parallelism in the hope of preventing further excessive RAM growth.


### PR DESCRIPTION
- New syncMergeJoin.go: O(1) memory streaming merge-join for Blob/S3/BlobFS sources that guarantee lexicographic listing order
- Disable memory/file/goroutine throttling for merge-join path to avoid ReadMemStats STW bottleneck
- Set inner EnumerationParallelism=1 (outer crawl provides parallelism)
- Default merge-join parallelism: 500 (configurable via AZCOPY_MERGE_JOIN_PARALLELISM)
- CrawlWithStats: expose live ActiveWorkers/QueuedDirs counters
- Fix syncComparator: both-zero change times no longer flags metadata changed
- Add diagnostic [STEP]/[SLOW-STEP] logging for performance analysis

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**: (Brief description of the feature or issue being addressed)

- **Related Links**:
- [Issues](<link>)
- [Team thread](<link>)
- [Documents](<link>)
- [Email Subject]

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

Thank you for your contribution to AzCopy!
