### PR TITLE
Remove 0-padding in mode with SetUID 

### DIFF
--- a/ste/downloader-azureFiles.go
+++ b/ste/downloader-azureFiles.go
@@ -165,7 +165,7 @@ func (bd *azureFilesDownloader) preservePermissions(info *TransferInfo) (string,
 		if spdl, ok := interface{}(bd).(nfsPermissionsAwareDownloader); ok {
 			// We don't need to worry about the sip not being a INFSPropertyBearingSourceInfoProvider as Azure Files always is.
 			err := spdl.PutNFSPermissions(bd.sip.(INFSPropertyBearingSourceInfoProvider), bd.txInfo)
-			if err == errorNoNFSPermissionsFound {
+			if errors.Is(err, errorNoNFSPermissionsFound) {
 				bd.jptm.LogAtLevelForCurrentTransfer(common.LogDebug, "No NFS permissions were downloaded because none were found at the source")
 			} else if err != nil {
 				return "Setting destination file nfs permissions", err

--- a/ste/sourceInfoProvider-Local_linux.go
+++ b/ste/sourceInfoProvider-Local_linux.go
@@ -57,7 +57,7 @@ func (f localFileSourceInfoProvider) GetUNIXProperties() (common.UnixStatAdapter
 		err = unix.Stat(f.transferInfo.Source, &stat)
 	}
 	if err != nil {
-		return nil, err 	 	
+		return nil, err
 	}
 
 	return StatTAdapter(stat), nil
@@ -280,7 +280,9 @@ func (h HandleNFSPermissions) GetGroup() *string {
 
 func (h HandleNFSPermissions) GetFileMode() *string {
 	fileMode := h.FileMode() &^ unix.S_IFMT // Remove file type bits
-	return to.Ptr(fmt.Sprintf("%#o", fileMode))
+	// 4 digits because service max is 12-bits:
+	// https://learn.microsoft.com/en-us/rest/api/storageservices/create-file#nfs-only-request-headers
+	return to.Ptr(fmt.Sprintf("%04o", fileMode))
 }
 
 var (
@@ -312,7 +314,9 @@ func (f localFileSourceInfoProvider) GetNFSDefaultPerms() (fileMode, owner, grou
 	// Get the default file mode
 	currFileMode := defaultStats.FileMode() &^ unix.S_IFMT
 	defaultMode := int(currFileMode) &^ getUmask()
-	fileMode = to.Ptr(fmt.Sprintf("%#o", defaultMode))
+	// 4 digits because service max is 12-bits:
+	// https://learn.microsoft.com/en-us/rest/api/storageservices/create-file#nfs-only-request-headers
+	fileMode = to.Ptr(fmt.Sprintf("%04o", defaultMode))
 
 	currentUser, err := user.Current()
 	owner = to.Ptr(currentUser.Uid)

--- a/ste/sourceInfoProvider-Local_linux_filemode_test.go
+++ b/ste/sourceInfoProvider-Local_linux_filemode_test.go
@@ -18,56 +18,52 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-
 package ste
 
-import  (
+import (
 	"testing"
-	"github.com/Azure/azure-storage-azcopy/v10/common"
+
 	"github.com/stretchr/testify/assert"
 )
-
 
 func TestSetUIDNoOverflow(t *testing.T) {
 	a := assert.New(t)
 
 	nfsperms := HandleNFSPermissions{
-		common.UnixStatContainer{
-			mode: uint32(04775),
-		}
-
-		fileMode := nfsperms.GetFileMode()
-		a.NotNil(fileMode)
-		a.Equal("4775")
+		StatxTAdapter{
+			Mode: uint16(04775),
+		},
 	}
-}
 
+	fileMode := nfsperms.GetFileMode()
+	a.NotNil(fileMode)
+	a.Equal("4775", *fileMode)
+}
 
 func TestSetGIDNoOverflow(t *testing.T) {
 	a := assert.New(t)
 
 	nfsperms := HandleNFSPermissions{
-		common.UnixStatContainer{
-			mode: uint32(02775),
-		}
-
-		fileMode := nfsperms.GetFileMode()
-		a.NotNil(fileMode)
-		a.Equal("2775")
+		StatxTAdapter{
+			Mode: uint16(02775),
+		},
 	}
+
+	fileMode := nfsperms.GetFileMode()
+	a.NotNil(fileMode)
+	a.Equal("2775", *fileMode)
 }
 
 func TestStickyBitsNoOverflow(t *testing.T) {
 	a := assert.New(t)
 
 	nfsperms := HandleNFSPermissions{
-		common.UnixStatContainer{
-			mode: uint32(01775),
-		}
-
-		fileMode := nfsperms.GetFileMode()
-		a.NotNil(fileMode)
-		a.Equal("1775")
+		StatxTAdapter{
+			Mode: uint16(01775),
+		},
 	}
-}
 
+	fileMode := nfsperms.GetFileMode()
+	a.NotNil(fileMode)
+	a.Equal("1775", *fileMode)
+}

--- a/ste/sourceInfoProvider-Local_linux_filemode_test.go
+++ b/ste/sourceInfoProvider-Local_linux_filemode_test.go
@@ -1,0 +1,73 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+
+package ste
+
+import  (
+	"testing"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/stretchr/testify/assert"
+)
+
+
+func TestSetUIDNoOverflow(t *testing.T) {
+	a := assert.New(t)
+
+	nfsperms := HandleNFSPermissions{
+		common.UnixStatContainer{
+			mode: uint32(04775),
+		}
+
+		fileMode := nfsperms.GetFileMode()
+		a.NotNil(fileMode)
+		a.Equal("4775")
+	}
+}
+
+
+func TestSetGIDNoOverflow(t *testing.T) {
+	a := assert.New(t)
+
+	nfsperms := HandleNFSPermissions{
+		common.UnixStatContainer{
+			mode: uint32(02775),
+		}
+
+		fileMode := nfsperms.GetFileMode()
+		a.NotNil(fileMode)
+		a.Equal("2775")
+	}
+}
+
+func TestStickyBitsNoOverflow(t *testing.T) {
+	a := assert.New(t)
+
+	nfsperms := HandleNFSPermissions{
+		common.UnixStatContainer{
+			mode: uint32(01775),
+		}
+
+		fileMode := nfsperms.GetFileMode()
+		a.NotNil(fileMode)
+		a.Equal("1775")
+	}
+}
+


### PR DESCRIPTION
## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**: (Brief description of the feature or issue being addressed)

We were always prepending the x-ms-mode with a '0'. This becomes a problem in the case when the left most bit is non-zero (e.g setuid, getuid or sticky), the mode becomes 15 bits and exceeds the service 12-bit max. The fix I added is to pad the mode with a 0 only if its less than 12 bits.

- **Related Links**:
- [ADO Item](https://msazure.visualstudio.com/One/_backlogs/backlog/XStore-DevExp/Epics?showParents=false&workitem=38129420)


## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

Ran existing NFS tests

Thank you for your contribution to AzCopy!
