### PR TITLE
Add zstd decompression

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -1512,8 +1512,8 @@ func init() {
 			"will be overwritten if this flag is 'true' or if a positive response is provided to the prompt.")
 	cpCmd.PersistentFlags().BoolVar(&raw.autoDecompress, "decompress", false,
 		"False by default. Automatically decompress files when downloading, if their content-encoding indicates"+
-			"that they are compressed.\n  The supported content-encoding values are 'gzip' and 'deflate'. "+
-			"\n File extensions of '.gz'/'.gzip' or '.zz' aren't necessary, but will be removed if present.")
+			"that they are compressed.\n  The supported content-encoding values are 'gzip', 'deflate', and 'zstd'. "+
+			"\n File extensions of '.gz'/'.gzip', '.zz', '.zst' or '.zstd' aren't necessary, but will be removed if present.")
 
 	cpCmd.PersistentFlags().BoolVar(&raw.recursive, "recursive", false,
 		"False by default. Look into sub-directories recursively when uploading from local file system.")

--- a/common/decompressingWriter.go
+++ b/common/decompressingWriter.go
@@ -26,6 +26,8 @@ import (
 	"errors"
 	"io"
 	"time"
+
+	"github.com/klauspost/compress/zstd"
 )
 
 type decompressingWriter struct {
@@ -38,8 +40,8 @@ var decompressingWriterBufferPool = NewMultiSizeSlicePool(decompressingWriterCop
 
 // NewDecompressingWriter returns a WriteCloser which decompresses the data
 // that is written to it, before passing the decompressed data on to a final destination.
-// This decompressor is intended to work with compressed data wrapped in either the ZLib headers or the slightly larger
-// Gzip headers. Both of those formats compress a single file (often a .tar archive in the case of Gzip).
+// This decompressor is intended to work with compressed data wrapped in either the ZLib headers, Gzip headers,
+// or Zstandard (zstd) framing. These formats compress a single file (often a .tar archive in the case of Gzip).
 // So there is no need to to expand the decompressed info out into multiple files (as we would have to do,
 // if we were to support "zip" compression). See https://stackoverflow.com/a/20765054
 func NewDecompressingWriter(destination io.WriteCloser, ct CompressionType) io.WriteCloser {
@@ -62,6 +64,12 @@ func (d decompressingWriter) decompressorFactory(tp CompressionType, preader *io
 		return zlib.NewReader(preader)
 	case ECompressionType.GZip():
 		return gzip.NewReader(preader)
+	case ECompressionType.ZStd():
+		dec, err := zstd.NewReader(preader)
+		if err != nil {
+			return nil, err
+		}
+		return dec.IOReadCloser(), nil
 	default:
 		return nil, errors.New("unexpected compression type")
 	}
@@ -80,7 +88,7 @@ func (d decompressingWriter) worker(tp CompressionType, preader *io.PipeReader, 
 
 	// make the decompressor. Must be in the worker method because,
 	// like the rest of read, this reads from the pipe.
-	// (Factory reads from pipe to read the zip/gzip file header)
+	// (Factory reads from pipe to read format headers)
 	dec, err = d.decompressorFactory(tp, preader)
 	if err != nil {
 		return

--- a/common/fe-ste-models.go
+++ b/common/fe-ste-models.go
@@ -1647,6 +1647,7 @@ type CompressionType uint8
 func (CompressionType) None() CompressionType        { return CompressionType(0) }
 func (CompressionType) ZLib() CompressionType        { return CompressionType(1) }
 func (CompressionType) GZip() CompressionType        { return CompressionType(2) }
+func (CompressionType) ZStd() CompressionType        { return CompressionType(3) }
 func (CompressionType) Unsupported() CompressionType { return CompressionType(255) }
 
 func (ct CompressionType) String() string {
@@ -1661,6 +1662,8 @@ func GetCompressionType(contentEncoding string) (CompressionType, error) {
 		return ECompressionType.GZip(), nil
 	case "deflate":
 		return ECompressionType.ZLib(), nil
+	case "zstd":
+		return ECompressionType.ZStd(), nil
 	default:
 		return ECompressionType.Unsupported(), fmt.Errorf("encoding type '%s' is not recognised as a supported encoding type for auto-decompression", contentEncoding)
 	}

--- a/common/zt_decompressingWriter_test.go
+++ b/common/zt_decompressingWriter_test.go
@@ -141,7 +141,7 @@ func getTestData(a *assert.Assertions, tp CompressionType, originalSize int) (or
 	case ECompressionType.ZLib():
 		comp = zlib.NewWriter(compBuf)
 	default:
-		a.Fail("unexpected compression type")
+		a.FailNow("unexpected compression type")
 		return originalData, nil
 	}
 	_, err = io.Copy(comp, bytes.NewReader(originalData))

--- a/common/zt_decompressingWriter_test.go
+++ b/common/zt_decompressingWriter_test.go
@@ -24,11 +24,13 @@ import (
 	"bytes"
 	"compress/gzip"
 	"compress/zlib"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"math/rand"
 	"sync/atomic"
 	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
 )
 
 type closeableBuffer struct {
@@ -63,6 +65,10 @@ func TestDecompressingWriter_SuccessCases(t *testing.T) {
 		{"big zlib", ECompressionType.ZLib(), 10 * 1024 * 1024, rand.Intn(1024*1024) + 1},
 		{"sml zlib", ECompressionType.ZLib(), 1024, rand.Intn(1024*1024) + 1},
 		{"1bytzlib", ECompressionType.ZLib(), 1234, 1},
+
+		{"big zstd", ECompressionType.ZStd(), 10 * 1024 * 1024, rand.Intn(1024*1024) + 1},
+		{"sml zstd", ECompressionType.ZStd(), 1024, rand.Intn(1024*1024) + 1},
+		{"1bytzstd", ECompressionType.ZStd(), 1234, 1},
 	}
 
 	for _, cs := range cases {
@@ -93,6 +99,7 @@ func TestDecompressingWriter_EarlyClose(t *testing.T) {
 	cases := []CompressionType{
 		ECompressionType.GZip(),
 		ECompressionType.ZLib(),
+		ECompressionType.ZStd(),
 	}
 	for _, tp := range cases {
 		// given:
@@ -121,11 +128,23 @@ func getTestData(a *assert.Assertions, tp CompressionType, originalSize int) (or
 	originalData := genCompressibleTestData(originalSize)
 	// and from that we have original compressed data
 	compBuf := &bytes.Buffer{}
-	var comp io.WriteCloser = zlib.NewWriter(compBuf)
-	if tp == ECompressionType.GZip() {
+	var (
+		comp io.WriteCloser
+		err  error
+	)
+	switch tp {
+	case ECompressionType.GZip():
 		comp = gzip.NewWriter(compBuf)
+	case ECompressionType.ZStd():
+		comp, err = zstd.NewWriter(compBuf)
+		a.Nil(err)
+	case ECompressionType.ZLib():
+		comp = zlib.NewWriter(compBuf)
+	default:
+		a.Fail("unexpected compression type")
+		return originalData, nil
 	}
-	_, err := io.Copy(comp, bytes.NewReader(originalData))
+	_, err = io.Copy(comp, bytes.NewReader(originalData))
 	// write into buf by way of comp
 	a.Nil(err)
 	a.Nil(comp.Close())

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/google/uuid v1.6.0
 	github.com/hillu/go-ntdll v0.0.0-20240418173803-69345773b582
+	github.com/klauspost/compress v1.18.6
 	github.com/mattn/go-ieproxy v0.0.12
 	github.com/minio/minio-go v6.0.14+incompatible
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
+github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
+github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=

--- a/traverser/zc_enumerator.go
+++ b/traverser/zc_enumerator.go
@@ -230,7 +230,8 @@ func stripCompressionExtension(dest string, contentEncoding string) string {
 	ext := strings.ToLower(filepath.Ext(dest))
 	stripGzip := ct == common.ECompressionType.GZip() && (ext == ".gz" || ext == ".gzip")
 	stripZlib := ct == common.ECompressionType.ZLib() && ext == ".zz" // "standard" extension for zlib-wrapped files, according to pigz doc and Stack Overflow
-	if stripGzip || stripZlib {
+	stripZstd := ct == common.ECompressionType.ZStd() && (ext == ".zst" || ext == ".zstd")
+	if stripGzip || stripZlib || stripZstd {
 		return strings.TrimSuffix(dest, filepath.Ext(dest))
 	}
 	return dest

--- a/traverser/zc_enumerator_test.go
+++ b/traverser/zc_enumerator_test.go
@@ -1,0 +1,60 @@
+package traverser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStripCompressionExtension_ZStdCases(t *testing.T) {
+	tests := []struct {
+		name            string
+		destinationName string
+		contentEncoding string
+		expected        string
+	}{
+		{
+			name:            "zstd strips lowercase zst",
+			destinationName: "file.zst",
+			contentEncoding: "zstd",
+			expected:        "file",
+		},
+		{
+			name:            "zstd strips lowercase zstd",
+			destinationName: "file.zstd",
+			contentEncoding: "zstd",
+			expected:        "file",
+		},
+		{
+			name:            "zstd strips mixed case extension",
+			destinationName: "file.ZsTd",
+			contentEncoding: "zstd",
+			expected:        "file",
+		},
+		{
+			name:            "zstd strips with mixed case encoding",
+			destinationName: "file.zst",
+			contentEncoding: "ZsTd",
+			expected:        "file",
+		},
+		{
+			name:            "zstd strips multi extension tar zst",
+			destinationName: "file.tar.zst",
+			contentEncoding: "zstd",
+			expected:        "file.tar",
+		},
+		{
+			name:            "zstd does not strip unrelated extension",
+			destinationName: "file.tar.gz",
+			contentEncoding: "zstd",
+			expected:        "file.tar.gz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+			a.Equal(tt.expected, stripCompressionExtension(tt.destinationName, tt.contentEncoding))
+		})
+	}
+}


### PR DESCRIPTION
## Description

- **Feature**: Automatic decompression of files with the zstd compression. This feature is supported when downloading in browser, but is not available for azcopy.

I picked `klauspost/compress/zstd` as it is the most common go zstd compression library which is not cgo based. This should make it cross platform compatible and future proof.

I would also like to add support for brotli compression in another PR.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?

This has been tested with unit integration tests, and I have built and tested the compiled app on Windows only.