### PR TITLE
Refactor GetSDDL to return errors instead of panicking on unexpected errors

### DIFF
--- a/ste/sourceInfoProvider-Local_linux.go
+++ b/ste/sourceInfoProvider-Local_linux.go
@@ -199,11 +199,12 @@ func (f localFileSourceInfoProvider) GetSDDL() (string, error) {
 	if err != nil {
 		// Return the error instead of panicking. The DACL may legitimately contain ACE
 		// types our SDDL serializer does not yet support (e.g. conditional/callback ACEs
-		// 0x09-0x14 emitted by Dynamic Access Control rules, or SACL-only ACE types).
-		// Panicking here brings down the entire process; returning the error lets the
-		// caller record a per-file failure (matched on the "SecurityDescriptorToString:"
-		// substring in the wrapped error) and lets the rest of the job continue.
-		return "", fmt.Errorf("Cannot parse binary Security Descriptor returned by QuerySecurityObject(%s, 0x%x): %w", f.jptm.Info().Source, securityInfoFlags, err)
+		// 0x09-0x14 emitted by Dynamic Access Control rules). Panicking here brings down
+		// the entire process; returning the error lets the caller record a per-file
+		// failure (matched on the "SecurityDescriptorToString:" substring) and lets the
+		// rest of the job continue. The prefix is included explicitly here so the match
+		// does not depend on the wrapped error always carrying it.
+		return "", fmt.Errorf("SecurityDescriptorToString: failed to serialize binary Security Descriptor to SDDL for QuerySecurityObject(%s, 0x%x): %w", f.jptm.Info().Source, securityInfoFlags, err)
 	}
 
 	fSDDL, err := sddl.ParseSDDL(sdStr)

--- a/ste/sourceInfoProvider-Local_linux.go
+++ b/ste/sourceInfoProvider-Local_linux.go
@@ -197,8 +197,13 @@ func (f localFileSourceInfoProvider) GetSDDL() (string, error) {
 	// This is the Windows equivalent of ConvertSecurityDescriptorToStringSecurityDescriptorW().
 	sdStr, err := sddl.SecurityDescriptorToString(sd)
 	if err != nil {
-		// Panic, as it's unexpected and we would want to know.
-		panic(fmt.Errorf("Cannot parse binary Security Descriptor returned by QuerySecurityObject(%s, 0x%x): %v", f.jptm.Info().Source, securityInfoFlags, err))
+		// Return the error instead of panicking. The DACL may legitimately contain ACE
+		// types our SDDL serializer does not yet support (e.g. conditional/callback ACEs
+		// 0x09-0x14 emitted by Dynamic Access Control rules, or SACL-only ACE types).
+		// Panicking here brings down the entire process; returning the error lets the
+		// caller record a per-file failure (matched on the "SecurityDescriptorToString:"
+		// substring in the wrapped error) and lets the rest of the job continue.
+		return "", fmt.Errorf("Cannot parse binary Security Descriptor returned by QuerySecurityObject(%s, 0x%x): %w", f.jptm.Info().Source, securityInfoFlags, err)
 	}
 
 	fSDDL, err := sddl.ParseSDDL(sdStr)
@@ -207,7 +212,10 @@ func (f localFileSourceInfoProvider) GetSDDL() (string, error) {
 	}
 
 	if strings.TrimSpace(fSDDL.String()) != strings.TrimSpace(sdStr) {
-		panic("SDDL sanity check failed (parsed string output != original string)")
+		// Round-trip sanity check failed. Return the error rather than panicking so a
+		// single problematic file does not crash the whole transfer process.
+		return "", fmt.Errorf("SecurityDescriptorToString: SDDL sanity check failed for %s (parsed=%q, original=%q)",
+			f.jptm.Info().Source, fSDDL.String(), sdStr)
 	}
 
 	return fSDDL.PortableString(), nil


### PR DESCRIPTION
## Description

- **Feature / Bug Fix**: Refactor `localFileSourceInfoProvider.GetSDDL()` in sourceInfoProvider-Local_linux.go to return errors instead of `panic`ing when the Security Descriptor returned by `QuerySecurityObject` cannot be serialized to SDDL, or when the SDDL round-trip sanity check fails. A single problematic file (e.g. a DACL containing ACE types our SDDL serializer does not yet support — conditional/callback ACEs `0x09`–`0x14` emitted by Dynamic Access Control rules, or SACL-only ACE types) was bringing down the entire AzCopy process via `panic`. With this change the error is wrapped (using `%w`) and returned, allowing the caller to record a per-file failure (matched on the `SecurityDescriptorToString:` substring) while the rest of the job continues.

- **Related Links**: https://portal.microsofticm.com/imp/v5/incidents/details/21000001057544/summary
- Issues
- Team thread
- Documents
- [Email Subject]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?

Testing has not been performed yet. Planned validation:
- Manual run on Linux against source files whose Security Descriptors previously triggered the panic path (DACLs containing unsupported ACE types such as conditional/callback ACEs from Dynamic Access Control rules) — confirm `GetSDDL()` returns a wrapped error containing `SecurityDescriptorToString:` instead of crashing the process, the affected file is recorded as a per-file failure, and the rest of the job continues.
- Manual run against a file that triggers the SDDL round-trip sanity check failure — confirm the returned error includes the source path along with both the parsed and original SDDL strings, and the process stays alive.
- Regression run against files with well-formed Security Descriptors — confirm `GetSDDL()` still returns the expected portable SDDL string and transfers succeed.

Thank you for your contribution to AzCopy!