### PR TITLE
Add --dedup-copy flag to sync: avoid re-uploads via server-side copy when identical content exists on destination

### DIFF
--- a/azcopy/sync.go
+++ b/azcopy/sync.go
@@ -68,6 +68,7 @@ type SyncOptions struct {
 	Symlinks                common.SymlinkHandlingType
 	PreservePermissions     bool
 	Hardlinks               common.HardlinkHandlingType
+	DedupCopy               bool // Enable content-based dedup: use server-side copy within destination when identical content exists
 
 	dryrun                           bool
 	deleteDestinationFileIfNecessary bool

--- a/azcopy/syncDedupProcessor.go
+++ b/azcopy/syncDedupProcessor.go
@@ -1,0 +1,162 @@
+// Copyright © 2017 Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package azcopy
+
+import (
+	"reflect"
+	"sync/atomic"
+
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/traverser"
+)
+
+// syncDedupProcessor wraps the normal transfer scheduler and checks whether the content
+// to be transferred already exists elsewhere on the destination (by MD5 hash match).
+// When a match is found, it schedules an intra-destination server-side copy instead of
+// uploading from source, saving bandwidth and time.
+type syncDedupProcessor struct {
+	// hashIndex is the secondary index of destination objects keyed by MD5 hash.
+	hashIndex *traverser.HashIndexer
+
+	// dedupScheduler schedules server-side copies within the destination (e.g., BlobBlob).
+	dedupScheduler *CopyTransferProcessor
+
+	// normalScheduler schedules normal transfers (upload from source or S2S from source).
+	normalScheduler *CopyTransferProcessor
+
+	// dedupFromTo is the FromTo type for intra-destination copies (e.g., BlobBlob).
+	dedupFromTo common.FromTo
+
+	// Counters for reporting
+	dedupCount  int64
+	normalCount int64
+}
+
+// newSyncDedupProcessor creates a processor that routes transfers through either
+// the dedup path (server-side copy within destination) or the normal path.
+func newSyncDedupProcessor(
+	hashIndex *traverser.HashIndexer,
+	dedupScheduler *CopyTransferProcessor,
+	normalScheduler *CopyTransferProcessor,
+	dedupFromTo common.FromTo,
+) *syncDedupProcessor {
+	return &syncDedupProcessor{
+		hashIndex:       hashIndex,
+		dedupScheduler:  dedupScheduler,
+		normalScheduler: normalScheduler,
+		dedupFromTo:     dedupFromTo,
+	}
+}
+
+// ProcessTransfer checks if the object's content already exists on the destination
+// and routes to either dedup copy or normal transfer accordingly.
+func (p *syncDedupProcessor) ProcessTransfer(obj traverser.StoredObject) error {
+	// Only attempt dedup for files (not folders/symlinks) that have an MD5 hash
+	if obj.EntityType == common.EEntityType.File() && obj.Md5 != nil && len(obj.Md5) > 0 {
+		if matchingDest, found := p.hashIndex.Lookup(obj.Md5); found {
+			// Verify that it's not the same file (same path already handled by comparator as skip)
+			// and that the sizes match (extra safety check beyond MD5)
+			if matchingDest.RelativePath != obj.RelativePath &&
+				matchingDest.Size == obj.Size &&
+				reflect.DeepEqual(matchingDest.Md5, obj.Md5) {
+				return p.scheduleDedupCopy(obj, matchingDest)
+			}
+		}
+	}
+
+	// Fall through to normal transfer
+	atomic.AddInt64(&p.normalCount, 1)
+	return p.normalScheduler.ScheduleSyncRemoveSetPropertiesTransfer(obj)
+}
+
+// scheduleDedupCopy schedules a server-side copy from an existing destination blob
+// to the target path. The source of the copy is matchingDest (already on destination),
+// and the target is where obj should end up.
+func (p *syncDedupProcessor) scheduleDedupCopy(obj, matchingDest traverser.StoredObject) error {
+	atomic.AddInt64(&p.dedupCount, 1)
+
+	// Build source relative path (the existing blob on the destination)
+	srcRelativePath := PathEncodeRules(matchingDest.RelativePath, p.dedupFromTo, false, true)
+	if srcRelativePath != "" {
+		srcRelativePath = "/" + srcRelativePath
+	}
+
+	// Build destination relative path (where we want the file to end up)
+	dstRelativePath := PathEncodeRules(obj.RelativePath, p.dedupFromTo, false, false)
+	if dstRelativePath != "" {
+		dstRelativePath = "/" + dstRelativePath
+	}
+
+	// Create a StoredObject that represents the transfer with proper metadata from the source.
+	// We use the original source object's metadata (content-type, etc.) so the destination
+	// gets the correct properties, but size and MD5 from the matching destination blob.
+	dedupObj := traverser.StoredObject{
+		Name:               obj.Name,
+		EntityType:         obj.EntityType,
+		LastModifiedTime:   matchingDest.LastModifiedTime,
+		Size:               matchingDest.Size,
+		Md5:                matchingDest.Md5,
+		RelativePath:       obj.RelativePath,
+		ContainerName:      matchingDest.ContainerName,
+		DstContainerName:   obj.DstContainerName,
+		BlobType:           matchingDest.BlobType,
+		BlobAccessTier:     matchingDest.BlobAccessTier,
+		ContentType:        obj.ContentType,
+		ContentEncoding:    obj.ContentEncoding,
+		ContentDisposition: obj.ContentDisposition,
+		ContentLanguage:    obj.ContentLanguage,
+		CacheControl:       obj.CacheControl,
+		Metadata:           obj.Metadata,
+		BlobTags:           obj.BlobTags,
+	}
+
+	copyTransfer, shouldSendToSte := dedupObj.ToNewCopyTransfer(
+		false,
+		srcRelativePath,
+		dstRelativePath,
+		p.dedupScheduler.preserveAccessTier,
+		p.dedupScheduler.folderPropertiesOption,
+		p.dedupScheduler.symlinkHandlingType,
+		p.dedupScheduler.hardlinkHandlingType,
+	)
+
+	if !shouldSendToSte {
+		return nil
+	}
+
+	// Log the dedup action
+	if common.AzcopyScanningLogger != nil {
+		common.AzcopyScanningLogger.Log(common.LogInfo,
+			"File "+obj.RelativePath+" will be server-side copied from existing destination path "+matchingDest.RelativePath+" (content dedup)")
+	}
+
+	return p.dedupScheduler.scheduleTransfer(copyTransfer.Source, copyTransfer.Destination, dedupObj)
+}
+
+// DedupCount returns the number of transfers that were handled via server-side copy dedup.
+func (p *syncDedupProcessor) DedupCount() int64 {
+	return atomic.LoadInt64(&p.dedupCount)
+}
+
+// NormalCount returns the number of transfers that went through the normal upload path.
+func (p *syncDedupProcessor) NormalCount() int64 {
+	return atomic.LoadInt64(&p.normalCount)
+}

--- a/azcopy/syncDedupProcessor.go
+++ b/azcopy/syncDedupProcessor.go
@@ -21,7 +21,7 @@
 package azcopy
 
 import (
-	"reflect"
+	"bytes"
 	"sync/atomic"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
@@ -76,7 +76,7 @@ func (p *syncDedupProcessor) ProcessTransfer(obj traverser.StoredObject) error {
 			// and that the sizes match (extra safety check beyond MD5)
 			if matchingDest.RelativePath != obj.RelativePath &&
 				matchingDest.Size == obj.Size &&
-				reflect.DeepEqual(matchingDest.Md5, obj.Md5) {
+				bytes.Equal(matchingDest.Md5, obj.Md5) {
 				return p.scheduleDedupCopy(obj, matchingDest)
 			}
 		}

--- a/azcopy/syncDedupProcessor_test.go
+++ b/azcopy/syncDedupProcessor_test.go
@@ -1,0 +1,367 @@
+// Copyright © 2017 Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package azcopy
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/traverser"
+	"github.com/stretchr/testify/assert"
+)
+
+// helper to create a test CopyTransferProcessor in dry-run mode that captures transfers
+func newTestProcessor(fromTo common.FromTo) (*CopyTransferProcessor, *[]common.CopyTransfer) {
+	var captured []common.CopyTransfer
+
+	template := &common.CopyJobPartOrderRequest{
+		JobID:  common.NewJobID(),
+		FromTo: fromTo,
+		Fpo:    common.EFolderPropertiesOption.NoFolders(),
+		SourceRoot: common.ResourceString{
+			Value: "https://account.blob.core.windows.net/container",
+		},
+		DestinationRoot: common.ResourceString{
+			Value: "https://account.blob.core.windows.net/container",
+		},
+	}
+
+	dryrunHandler := func(req common.CopyJobPartOrderRequest) common.CopyJobPartOrderResponse {
+		captured = append(captured, req.Transfers.List...)
+		return common.CopyJobPartOrderResponse{JobStarted: true}
+	}
+
+	proc := NewCopyTransferProcessor(
+		false,
+		template,
+		10000,
+		template.SourceRoot,
+		template.DestinationRoot,
+		func(bool) {},
+		func() {},
+		false,
+		true, // dryrun mode
+		dryrunHandler,
+	)
+
+	return proc, &captured
+}
+
+func TestDedupProcessor_RoutesToDedupWhenHashMatches(t *testing.T) {
+	a := assert.New(t)
+
+	// Set up hash indexer with a destination object
+	hashIndexer := traverser.NewHashIndexer()
+	md5Hash := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+
+	existingDestObj := traverser.StoredObject{
+		Name:         "existing.txt",
+		RelativePath: "old/existing.txt",
+		Size:         1024,
+		Md5:          md5Hash,
+		EntityType:   common.EEntityType.File(),
+	}
+	hashIndexer.Store(existingDestObj)
+
+	// Create processors
+	dedupProc, dedupCaptures := newTestProcessor(common.EFromTo.BlobBlob())
+	normalProc, normalCaptures := newTestProcessor(common.EFromTo.LocalBlob())
+
+	// Create the dedup processor
+	dp := newSyncDedupProcessor(hashIndexer, dedupProc, normalProc, common.EFromTo.BlobBlob())
+
+	// Process a source object that has the same hash but different path
+	sourceObj := traverser.StoredObject{
+		Name:         "newname.txt",
+		RelativePath: "new/newname.txt",
+		Size:         1024,
+		Md5:          md5Hash,
+		EntityType:   common.EEntityType.File(),
+	}
+
+	err := dp.ProcessTransfer(sourceObj)
+	a.NoError(err)
+
+	// Should be routed to dedup (not normal)
+	a.Equal(int64(1), dp.DedupCount())
+	a.Equal(int64(0), dp.NormalCount())
+
+	// Force dispatch to see captured transfers
+	_, _ = dedupProc.DispatchFinalPart()
+	_, _ = normalProc.DispatchFinalPart()
+
+	a.Equal(1, len(*dedupCaptures))
+	a.Equal(0, len(*normalCaptures))
+}
+
+func TestDedupProcessor_RoutesToNormalWhenNoHashMatch(t *testing.T) {
+	a := assert.New(t)
+
+	// Set up hash indexer with a destination object
+	hashIndexer := traverser.NewHashIndexer()
+	destHash := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	sourceHash := []byte{0xff, 0xfe, 0xfd, 0xfc, 0xfb, 0xfa, 0xf9, 0xf8, 0xf7, 0xf6, 0xf5, 0xf4, 0xf3, 0xf2, 0xf1, 0xf0}
+
+	existingDestObj := traverser.StoredObject{
+		Name:         "existing.txt",
+		RelativePath: "old/existing.txt",
+		Size:         1024,
+		Md5:          destHash,
+		EntityType:   common.EEntityType.File(),
+	}
+	hashIndexer.Store(existingDestObj)
+
+	// Create processors
+	dedupProc, dedupCaptures := newTestProcessor(common.EFromTo.BlobBlob())
+	normalProc, normalCaptures := newTestProcessor(common.EFromTo.LocalBlob())
+
+	// Create the dedup processor
+	dp := newSyncDedupProcessor(hashIndexer, dedupProc, normalProc, common.EFromTo.BlobBlob())
+
+	// Process a source object with a DIFFERENT hash
+	sourceObj := traverser.StoredObject{
+		Name:         "newfile.txt",
+		RelativePath: "dir/newfile.txt",
+		Size:         2048,
+		Md5:          sourceHash,
+		EntityType:   common.EEntityType.File(),
+	}
+
+	err := dp.ProcessTransfer(sourceObj)
+	a.NoError(err)
+
+	// Should be routed to normal (not dedup)
+	a.Equal(int64(0), dp.DedupCount())
+	a.Equal(int64(1), dp.NormalCount())
+
+	// Force dispatch
+	_, _ = dedupProc.DispatchFinalPart()
+	_, _ = normalProc.DispatchFinalPart()
+
+	a.Equal(0, len(*dedupCaptures))
+	a.Equal(1, len(*normalCaptures))
+}
+
+func TestDedupProcessor_RoutesToNormalWhenSourceHasNoHash(t *testing.T) {
+	a := assert.New(t)
+
+	hashIndexer := traverser.NewHashIndexer()
+	destHash := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+
+	hashIndexer.Store(traverser.StoredObject{
+		RelativePath: "existing.txt",
+		Size:         1024,
+		Md5:          destHash,
+		EntityType:   common.EEntityType.File(),
+	})
+
+	dedupProc, _ := newTestProcessor(common.EFromTo.BlobBlob())
+	normalProc, _ := newTestProcessor(common.EFromTo.LocalBlob())
+
+	dp := newSyncDedupProcessor(hashIndexer, dedupProc, normalProc, common.EFromTo.BlobBlob())
+
+	// Process a source object with NO hash
+	sourceObj := traverser.StoredObject{
+		Name:         "nomd5.txt",
+		RelativePath: "dir/nomd5.txt",
+		Size:         1024,
+		Md5:          nil,
+		EntityType:   common.EEntityType.File(),
+	}
+
+	err := dp.ProcessTransfer(sourceObj)
+	a.NoError(err)
+
+	a.Equal(int64(0), dp.DedupCount())
+	a.Equal(int64(1), dp.NormalCount())
+}
+
+func TestDedupProcessor_SkipsSamePathMatch(t *testing.T) {
+	a := assert.New(t)
+
+	// If the hash matches but the path is the same, it's the same file — skip dedup
+	hashIndexer := traverser.NewHashIndexer()
+	md5Hash := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+
+	hashIndexer.Store(traverser.StoredObject{
+		RelativePath: "same/path.txt",
+		Size:         1024,
+		Md5:          md5Hash,
+		EntityType:   common.EEntityType.File(),
+	})
+
+	dedupProc, _ := newTestProcessor(common.EFromTo.BlobBlob())
+	normalProc, _ := newTestProcessor(common.EFromTo.LocalBlob())
+
+	dp := newSyncDedupProcessor(hashIndexer, dedupProc, normalProc, common.EFromTo.BlobBlob())
+
+	// Process source with same path and hash
+	sourceObj := traverser.StoredObject{
+		Name:         "path.txt",
+		RelativePath: "same/path.txt",
+		Size:         1024,
+		Md5:          md5Hash,
+		EntityType:   common.EEntityType.File(),
+	}
+
+	err := dp.ProcessTransfer(sourceObj)
+	a.NoError(err)
+
+	// Should NOT use dedup (same path = same file), should go to normal
+	a.Equal(int64(0), dp.DedupCount())
+	a.Equal(int64(1), dp.NormalCount())
+}
+
+func TestDedupProcessor_SkipsSizeMismatch(t *testing.T) {
+	a := assert.New(t)
+
+	// Hash match but different size should not trigger dedup (extra safety)
+	hashIndexer := traverser.NewHashIndexer()
+	md5Hash := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+
+	hashIndexer.Store(traverser.StoredObject{
+		RelativePath: "old/existing.txt",
+		Size:         1024, // different size
+		Md5:          md5Hash,
+		EntityType:   common.EEntityType.File(),
+	})
+
+	dedupProc, _ := newTestProcessor(common.EFromTo.BlobBlob())
+	normalProc, _ := newTestProcessor(common.EFromTo.LocalBlob())
+
+	dp := newSyncDedupProcessor(hashIndexer, dedupProc, normalProc, common.EFromTo.BlobBlob())
+
+	sourceObj := traverser.StoredObject{
+		Name:         "newname.txt",
+		RelativePath: "new/newname.txt",
+		Size:         2048, // different size from dest
+		Md5:          md5Hash,
+		EntityType:   common.EEntityType.File(),
+	}
+
+	err := dp.ProcessTransfer(sourceObj)
+	a.NoError(err)
+
+	// Should NOT use dedup due to size mismatch
+	a.Equal(int64(0), dp.DedupCount())
+	a.Equal(int64(1), dp.NormalCount())
+}
+
+func TestDedupProcessor_FoldersAlwaysGoNormal(t *testing.T) {
+	a := assert.New(t)
+
+	hashIndexer := traverser.NewHashIndexer()
+	dedupProc, _ := newTestProcessor(common.EFromTo.BlobBlob())
+	normalProc, _ := newTestProcessor(common.EFromTo.LocalBlob())
+
+	dp := newSyncDedupProcessor(hashIndexer, dedupProc, normalProc, common.EFromTo.BlobBlob())
+
+	// Folders should never go through dedup
+	folderObj := traverser.StoredObject{
+		Name:         "mydir",
+		RelativePath: "mydir",
+		EntityType:   common.EEntityType.Folder(),
+	}
+
+	err := dp.ProcessTransfer(folderObj)
+	a.NoError(err)
+
+	a.Equal(int64(0), dp.DedupCount())
+	a.Equal(int64(1), dp.NormalCount())
+}
+
+func TestDedupProcessor_MixedMD5OnDestination(t *testing.T) {
+	a := assert.New(t)
+
+	// Simulate destination where some blobs have MD5 and some don't.
+	// Only blobs WITH MD5 can serve as dedup sources.
+	hashIndexer := traverser.NewHashIndexer()
+
+	hashA := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+
+	// Blob with MD5 (will be indexed)
+	hashIndexer.Store(traverser.StoredObject{
+		RelativePath: "has-md5/A.txt",
+		Size:         100,
+		Md5:          hashA,
+		EntityType:   common.EEntityType.File(),
+	})
+
+	// Blob without MD5 (will NOT be indexed — just increments missing count)
+	hashIndexer.Store(traverser.StoredObject{
+		RelativePath: "no-md5/B.txt",
+		Size:         200,
+		Md5:          nil,
+		EntityType:   common.EEntityType.File(),
+	})
+
+	a.Equal(1, hashIndexer.IndexedCount())
+	a.Equal(int64(1), hashIndexer.MissingHashCount())
+
+	dedupProc, dedupCaptures := newTestProcessor(common.EFromTo.BlobBlob())
+	normalProc, normalCaptures := newTestProcessor(common.EFromTo.LocalBlob())
+
+	dp := newSyncDedupProcessor(hashIndexer, dedupProc, normalProc, common.EFromTo.BlobBlob())
+
+	// Source file 1: same hash as A.txt → should dedup
+	err := dp.ProcessTransfer(traverser.StoredObject{
+		Name:         "renamed.txt",
+		RelativePath: "new/renamed.txt",
+		Size:         100,
+		Md5:          hashA,
+		EntityType:   common.EEntityType.File(),
+	})
+	a.NoError(err)
+
+	// Source file 2: has a hash that matches B.txt's content, but B.txt has no MD5
+	// in the indexer so there's no match → should go normal
+	hashB := []byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0x00}
+	err = dp.ProcessTransfer(traverser.StoredObject{
+		Name:         "cant-dedup.txt",
+		RelativePath: "other/cant-dedup.txt",
+		Size:         200,
+		Md5:          hashB,
+		EntityType:   common.EEntityType.File(),
+	})
+	a.NoError(err)
+
+	// Source file 3: completely new content → should go normal
+	hashNew := []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00}
+	err = dp.ProcessTransfer(traverser.StoredObject{
+		Name:         "brand-new.txt",
+		RelativePath: "fresh/brand-new.txt",
+		Size:         300,
+		Md5:          hashNew,
+		EntityType:   common.EEntityType.File(),
+	})
+	a.NoError(err)
+
+	// Verify routing
+	a.Equal(int64(1), dp.DedupCount(), "Only 1 file should dedup (matches blob with MD5)")
+	a.Equal(int64(2), dp.NormalCount(), "2 files should go normal (no matching MD5 in index)")
+
+	// Verify actual transfers
+	_, _ = dedupProc.DispatchFinalPart()
+	_, _ = normalProc.DispatchFinalPart()
+
+	a.Equal(1, len(*dedupCaptures), "1 dedup transfer captured")
+	a.Equal(2, len(*normalCaptures), "2 normal transfers captured")
+}

--- a/azcopy/syncEnumerator.go
+++ b/azcopy/syncEnumerator.go
@@ -330,20 +330,8 @@ func (s *syncer) initEnumerator(ctx context.Context, logLevel common.LogLevel, m
 			}
 
 			// Dispatch dedup job final part if applicable
-			if dedupProc != nil {
-				_, dedupErr := dedupProc.dedupScheduler.DispatchFinalPart()
-				if dedupErr != nil && dedupErr != NothingScheduledError {
-					return dedupErr
-				}
-				// Log dedup stats
-				if hashIndexer.MissingHashCount() > 0 {
-					common.GetLifecycleMgr().Info(fmt.Sprintf(
-						"NOTE: %d destination file(s) lacked Content-MD5 and could not participate in dedup optimization. Upload with --put-md5 to enable full dedup coverage.",
-						hashIndexer.MissingHashCount()))
-				}
-				common.GetLifecycleMgr().Info(fmt.Sprintf(
-					"Dedup stats: %d file(s) via server-side copy (dedup), %d file(s) via normal transfer.",
-					dedupProc.DedupCount(), dedupProc.NormalCount()))
+			if err := finalizeDedup(dedupProc, hashIndexer); err != nil {
+				return err
 			}
 
 			_, err := transferScheduler.DispatchFinalPart()
@@ -376,20 +364,8 @@ func (s *syncer) initEnumerator(ctx context.Context, logLevel common.LogLevel, m
 			}
 
 			// Dispatch dedup job final part if applicable
-			if dedupProc != nil {
-				_, dedupErr := dedupProc.dedupScheduler.DispatchFinalPart()
-				if dedupErr != nil && dedupErr != NothingScheduledError {
-					return dedupErr
-				}
-				// Log dedup stats
-				if hashIndexer.MissingHashCount() > 0 {
-					common.GetLifecycleMgr().Info(fmt.Sprintf(
-						"NOTE: %d destination file(s) lacked Content-MD5 and could not participate in dedup optimization.",
-						hashIndexer.MissingHashCount()))
-				}
-				common.GetLifecycleMgr().Info(fmt.Sprintf(
-					"Dedup stats: %d file(s) via server-side copy (dedup), %d file(s) via normal transfer.",
-					dedupProc.DedupCount(), dedupProc.NormalCount()))
+			if err := finalizeDedup(dedupProc, hashIndexer); err != nil {
+				return err
 			}
 
 			// let the deletions happen first
@@ -408,4 +384,25 @@ func (s *syncer) initEnumerator(ctx context.Context, logLevel common.LogLevel, m
 
 func isDestinationCaseInsensitive(fromTo common.FromTo) bool {
 	return fromTo.IsDownload() && runtime.GOOS == "windows"
+}
+
+// finalizeDedup dispatches the dedup job's final part and logs dedup statistics.
+// This is called at the end of sync enumeration when dedup is enabled.
+func finalizeDedup(dedupProc *syncDedupProcessor, hashIndexer *traverser.HashIndexer) error {
+	if dedupProc == nil {
+		return nil
+	}
+	_, dedupErr := dedupProc.dedupScheduler.DispatchFinalPart()
+	if dedupErr != nil && dedupErr != NothingScheduledError {
+		return dedupErr
+	}
+	if hashIndexer.MissingHashCount() > 0 {
+		common.GetLifecycleMgr().Info(fmt.Sprintf(
+			"NOTE: %d destination file(s) lacked Content-MD5 and could not participate in dedup optimization. Upload with --put-md5 to enable full dedup coverage.",
+			hashIndexer.MissingHashCount()))
+	}
+	common.GetLifecycleMgr().Info(fmt.Sprintf(
+		"Dedup stats: %d file(s) via server-side copy (dedup), %d file(s) via normal transfer.",
+		dedupProc.DedupCount(), dedupProc.NormalCount()))
+	return nil
 }

--- a/azcopy/syncEnumerator.go
+++ b/azcopy/syncEnumerator.go
@@ -209,6 +209,67 @@ func (s *syncer) initEnumerator(ctx context.Context, logLevel common.LogLevel, m
 	// transferScheduler is responsible for batching up transfers and sending them to the job service
 	transferScheduler := s.newSyncTransferProcessor(NumOfFilesPerDispatchJobPart, copyJobTemplate)
 
+	// Set up dedup infrastructure if enabled
+	var hashIndexer *traverser.HashIndexer
+	var dedupProc *syncDedupProcessor
+	if s.opts.dedupCopy {
+		hashIndexer = traverser.NewHashIndexer()
+
+		// Determine the S2S FromTo type for intra-destination copies.
+		// This is always destination-to-destination (e.g., BlobBlob for Blob destinations).
+		destLocation := s.opts.fromTo.To()
+		dedupFromTo := common.FromToValue(destLocation, destLocation)
+
+		// Create a job template for intra-destination server-side copies.
+		dedupJobTemplate := &common.CopyJobPartOrderRequest{
+			JobID:               common.NewJobID(), // separate job for dedup copies
+			CommandString:       s.opts.commandString,
+			FromTo:              dedupFromTo,
+			Fpo:                 fpo,
+			SymlinkHandlingType: s.opts.symlinks,
+			SourceRoot:          s.opts.destination.CloneWithConsolidatedSeparators(), // source is the destination (copy within)
+			DestinationRoot:     s.opts.destination.CloneWithConsolidatedSeparators(),
+
+			BlobAttributes: common.BlobTransferAttributes{
+				PreserveLastModifiedTime:         s.opts.preserveInfo,
+				PutMd5:                           s.opts.putMd5,
+				MD5ValidationOption:              s.opts.checkMd5,
+				BlockSizeInBytes:                 s.opts.blockSize,
+				PutBlobSizeInBytes:               s.opts.putBlobSize,
+				DeleteDestinationFileIfNecessary: s.opts.deleteDestinationFileIfNecessary,
+			},
+			ForceWrite:                     common.EOverwriteOption.True(),
+			ForceIfReadOnly:                s.opts.forceIfReadOnly,
+			LogLevel:                       logLevel,
+			PreservePermissions:            s.opts.preservePermissions,
+			PreserveInfo:                   s.opts.preserveInfo,
+			PreservePOSIXProperties:        s.opts.preservePosixProperties,
+			PosixPropertiesStyle:           s.opts.posixPropertiesStyle,
+			S2SSourceChangeValidation:      false, // not needed for intra-destination copy
+			DestLengthValidation:           true,
+			S2SGetPropertiesInBackend:      true,
+			S2SInvalidMetadataHandleOption: common.EInvalidMetadataHandleOption.RenameIfInvalid(),
+			CpkOptions:                     s.opts.cpkOptions,
+			S2SPreserveBlobTags:            s.opts.s2SPreserveBlobTags,
+
+			S2SSourceCredentialType: s.srp.dstCredType, // source is the destination account
+			FileAttributes: common.FileTransferAttributes{
+				TrailingDot: s.opts.trailingDot,
+			},
+			JobErrorHandler:  mgr,
+			SrcServiceClient: s.srp.dstServiceClient, // source = destination (intra-account copy)
+			DstServiceClient: s.srp.dstServiceClient,
+		}
+
+		reportFirstPart := func(jobStarted bool) {} // no-op for dedup job
+		reportFinalPart := func() {}                // no-op for dedup job
+		dedupScheduler := NewCopyTransferProcessor(false, dedupJobTemplate, NumOfFilesPerDispatchJobPart,
+			s.opts.destination, s.opts.destination,
+			reportFirstPart, reportFinalPart, s.opts.s2SPreserveAccessTier, s.opts.dryrun, s.opts.dryrunJobPartOrderHandler)
+
+		dedupProc = newSyncDedupProcessor(hashIndexer, dedupScheduler, transferScheduler, dedupFromTo)
+	}
+
 	// indexer keeps track of the destination (source in case of upload) files and folders
 	indexer := traverser.NewObjectIndexer()
 	// deleter is responsible for deleting files at the destination that no longer exist at the source
@@ -235,6 +296,12 @@ func (s *syncer) initEnumerator(ctx context.Context, logLevel common.LogLevel, m
 	var comparator traverser.ObjectProcessor
 	var finalize func() error
 
+	// Determine the transfer function: either the dedup processor or normal scheduler.
+	transferFunc := transferScheduler.ScheduleSyncRemoveSetPropertiesTransfer
+	if dedupProc != nil {
+		transferFunc = dedupProc.ProcessTransfer
+	}
+
 	switch s.opts.fromTo {
 	case common.EFromTo.LocalBlob(), common.EFromTo.LocalFile(), common.EFromTo.LocalFileNFS():
 		// Upload implies transferring from a local disk to a remote resource.
@@ -244,12 +311,39 @@ func (s *syncer) initEnumerator(ctx context.Context, logLevel common.LogLevel, m
 		// when uploading, we can delete remote objects immediately, because as we traverse the remote location
 		// we ALREADY have available a complete map of everything that exists locally
 		// so as soon as we see a remote destination object we can know whether it exists in the local source
-		comparator = NewSyncDestinationComparator(indexer, transferScheduler.ScheduleSyncRemoveSetPropertiesTransfer, deleteScheduler, s.opts.compareHash, s.opts.preserveInfo, s.opts.mirrorMode).ProcessIfNecessary
+		comparator = NewSyncDestinationComparator(indexer, transferFunc, deleteScheduler, s.opts.compareHash, s.opts.preserveInfo, s.opts.mirrorMode).ProcessIfNecessary
+
+		// For dedup: wrap comparator to also feed the hash indexer with destination objects
+		if hashIndexer != nil {
+			originalComparator := comparator
+			comparator = func(obj traverser.StoredObject) error {
+				hashIndexer.Store(obj)
+				return originalComparator(obj)
+			}
+		}
+
 		finalize = func() error {
 			// schedule every local file that doesn't exist at the destination
-			err = indexer.Traverse(transferScheduler.ScheduleSyncRemoveSetPropertiesTransfer, filters)
+			err = indexer.Traverse(transferFunc, filters)
 			if err != nil {
 				return err
+			}
+
+			// Dispatch dedup job final part if applicable
+			if dedupProc != nil {
+				_, dedupErr := dedupProc.dedupScheduler.DispatchFinalPart()
+				if dedupErr != nil && dedupErr != NothingScheduledError {
+					return dedupErr
+				}
+				// Log dedup stats
+				if hashIndexer.MissingHashCount() > 0 {
+					common.GetLifecycleMgr().Info(fmt.Sprintf(
+						"NOTE: %d destination file(s) lacked Content-MD5 and could not participate in dedup optimization. Upload with --put-md5 to enable full dedup coverage.",
+						hashIndexer.MissingHashCount()))
+				}
+				common.GetLifecycleMgr().Info(fmt.Sprintf(
+					"Dedup stats: %d file(s) via server-side copy (dedup), %d file(s) via normal transfer.",
+					dedupProc.DedupCount(), dedupProc.NormalCount()))
 			}
 
 			_, err := transferScheduler.DispatchFinalPart()
@@ -263,14 +357,39 @@ func (s *syncer) initEnumerator(ctx context.Context, logLevel common.LogLevel, m
 		return traverser.NewSyncEnumerator(sourceTraverser, destinationTraverser, indexer, filters, comparator, finalize), nil
 	default:
 		indexer.IsDestinationCaseInsensitive = isDestinationCaseInsensitive(s.opts.fromTo)
+
+		// For dedup in S2S/download: feed the hash indexer as destination objects are stored in the indexer
+		if hashIndexer != nil {
+			indexer.OnStore = func(obj traverser.StoredObject) {
+				hashIndexer.Store(obj)
+			}
+		}
+
 		// in all other cases (download and S2S), the destination is scanned/indexed first
 		// then the source is scanned and filtered based on what the destination contains
-		comparator = NewSyncSourceComparator(indexer, transferScheduler.ScheduleSyncRemoveSetPropertiesTransfer, s.opts.compareHash, s.opts.preserveInfo, s.opts.mirrorMode).ProcessIfNecessary
+		comparator = NewSyncSourceComparator(indexer, transferFunc, s.opts.compareHash, s.opts.preserveInfo, s.opts.mirrorMode).ProcessIfNecessary
 
 		finalize = func() error {
 			err = indexer.Traverse(deleteScheduler, nil)
 			if err != nil {
 				return err
+			}
+
+			// Dispatch dedup job final part if applicable
+			if dedupProc != nil {
+				_, dedupErr := dedupProc.dedupScheduler.DispatchFinalPart()
+				if dedupErr != nil && dedupErr != NothingScheduledError {
+					return dedupErr
+				}
+				// Log dedup stats
+				if hashIndexer.MissingHashCount() > 0 {
+					common.GetLifecycleMgr().Info(fmt.Sprintf(
+						"NOTE: %d destination file(s) lacked Content-MD5 and could not participate in dedup optimization.",
+						hashIndexer.MissingHashCount()))
+				}
+				common.GetLifecycleMgr().Info(fmt.Sprintf(
+					"Dedup stats: %d file(s) via server-side copy (dedup), %d file(s) via normal transfer.",
+					dedupProc.DedupCount(), dedupProc.NormalCount()))
 			}
 
 			// let the deletions happen first

--- a/azcopy/syncOptions.go
+++ b/azcopy/syncOptions.go
@@ -204,8 +204,13 @@ func (s *cookedSyncOptions) applyDefaultsAndInferOptions(opts SyncOptions) (err 
 			common.GetLifecycleMgr().Info("WARNING: --dedup-copy is only effective when the destination is a remote resource. Ignoring for local destinations.")
 			s.dedupCopy = false
 		} else if s.compareHash == common.ESyncHashType.None() {
+			// Only auto-enable putMd5 for uploads (local source) where we can compute MD5 locally.
+			// For S2S syncs, the source may lack MD5s and forcing --compare-hash=MD5 could cause
+			// errors on missing hashes. In S2S, we rely on existing Content-MD5 headers.
 			s.compareHash = common.ESyncHashType.MD5()
-			s.putMd5 = true
+			if s.fromTo.From() == common.ELocation.Local() {
+				s.putMd5 = true
+			}
 			common.GetLifecycleMgr().Info("--dedup-copy requires hash comparison; auto-enabling --compare-hash=MD5")
 		}
 	}

--- a/azcopy/syncOptions.go
+++ b/azcopy/syncOptions.go
@@ -56,6 +56,7 @@ type cookedSyncOptions struct {
 	preservePermissions     common.PreservePermissionsOption
 	symlinks                common.SymlinkHandlingType
 	hardlinks               common.HardlinkHandlingType
+	dedupCopy               bool // content-based dedup: server-side copy within destination when identical content exists
 
 	// AzCopy internal use only
 	dryrun                           bool
@@ -182,6 +183,7 @@ func (s *cookedSyncOptions) applyDefaultsAndInferOptions(opts SyncOptions) (err 
 	s.preservePermissions = common.NewPreservePermissionsOption(opts.PreservePermissions, preserveOwner, s.fromTo)
 	s.symlinks = opts.Symlinks
 	s.hardlinks = opts.Hardlinks
+	s.dedupCopy = opts.DedupCopy
 	s.dryrun = opts.dryrun
 	s.deleteDestinationFileIfNecessary = opts.deleteDestinationFileIfNecessary
 	s.commandString = opts.commandString
@@ -194,6 +196,18 @@ func (s *cookedSyncOptions) applyDefaultsAndInferOptions(opts SyncOptions) (err 
 		// Save any new MD5s on files we download.
 		s.putMd5 = true
 	default: // no need to put a hash of any kind.
+	}
+
+	// dedup-copy inference: auto-enable hash comparison (MD5) if not already set
+	if s.dedupCopy {
+		if !s.fromTo.To().IsRemote() {
+			common.GetLifecycleMgr().Info("WARNING: --dedup-copy is only effective when the destination is a remote resource. Ignoring for local destinations.")
+			s.dedupCopy = false
+		} else if s.compareHash == common.ESyncHashType.None() {
+			s.compareHash = common.ESyncHashType.MD5()
+			s.putMd5 = true
+			common.GetLifecycleMgr().Info("--dedup-copy requires hash comparison; auto-enabling --compare-hash=MD5")
+		}
 	}
 
 	if !s.fromTo.IsS2S() {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -102,6 +102,7 @@ type rawSyncCmdArgs struct {
 	preserveInfo bool
 	hardlinks    string
 	hashMetaDir  string
+	dedupCopy    bool
 }
 
 func (raw rawSyncCmdArgs) toOptions() (opts azcopy.SyncOptions, err error) {
@@ -123,6 +124,7 @@ func (raw rawSyncCmdArgs) toOptions() (opts azcopy.SyncOptions, err error) {
 		IncludeRoot:             raw.includeRoot,
 		HashMetaDir:             raw.hashMetaDir,
 		PreservePermissions:     raw.preservePermissions,
+		DedupCopy:               raw.dedupCopy,
 	}
 	opts.FromTo, err = azcopy.InferAndValidateFromTo(raw.src, raw.dst, raw.fromTo)
 	if err != nil {
@@ -550,4 +552,12 @@ func init() {
 		"Follow by default. Preserve hardlinks for NFS resources. "+
 			"\n This flag is only applicable when the source is Azure NFS file share or the destination is NFS file share. "+
 			"\n Available options: skip, preserve, follow (default 'follow').")
+
+	syncCmd.PersistentFlags().BoolVar(&raw.dedupCopy, "dedup-copy", false,
+		"When a file needs to be transferred but identical content (by MD5 hash) already exists "+
+			"\n at a different path on the destination, perform a server-side copy within the destination "+
+			"\n instead of re-uploading from source. This saves bandwidth and transfer time for scenarios "+
+			"\n like file renames, moves, or duplicates. Requires Content-MD5 on destination blobs "+
+			"\n (upload with --put-md5). Auto-enables --compare-hash=MD5 if not set. "+
+			"\n Only effective when the destination is a remote resource.")
 }

--- a/cmd/zt_sync_dedup_test.go
+++ b/cmd/zt_sync_dedup_test.go
@@ -1,0 +1,420 @@
+// Copyright © 2017 Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cmd
+
+import (
+	"crypto/md5"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/traverser"
+	"github.com/stretchr/testify/assert"
+)
+
+// dedupInterceptor is a specialized interceptor that separates transfers by their FromTo type,
+// allowing us to distinguish between normal transfers and dedup (server-side copy) transfers.
+type dedupInterceptor struct {
+	normalTransfers []common.CopyTransfer // transfers from normal path (e.g., LocalBlob)
+	dedupTransfers  []common.CopyTransfer // transfers from dedup path (e.g., BlobBlob)
+	deletions       []traverser.StoredObject
+	normalFromTo    common.FromTo
+	dedupFromTo     common.FromTo
+}
+
+func (d *dedupInterceptor) init(normalFromTo, dedupFromTo common.FromTo) {
+	d.normalFromTo = normalFromTo
+	d.dedupFromTo = dedupFromTo
+	glcm = &mockedLifecycleManager{
+		infoLog: make(chan string, 5000),
+	}
+}
+
+func (d *dedupInterceptor) intercept(copyRequest common.CopyJobPartOrderRequest) common.CopyJobPartOrderResponse {
+	if copyRequest.FromTo == d.dedupFromTo {
+		d.dedupTransfers = append(d.dedupTransfers, copyRequest.Transfers.List...)
+	} else {
+		d.normalTransfers = append(d.normalTransfers, copyRequest.Transfers.List...)
+	}
+
+	totalTransfers := len(d.normalTransfers) + len(d.dedupTransfers)
+	if totalTransfers != 0 || !copyRequest.IsFinalPart {
+		return common.CopyJobPartOrderResponse{JobStarted: true}
+	}
+	return common.CopyJobPartOrderResponse{JobStarted: false, ErrorMsg: common.ECopyJobPartOrderErrorType.NoTransfersScheduledErr()}
+}
+
+func (d *dedupInterceptor) delete(_ string, _ common.Location, object traverser.StoredObject) error {
+	d.deletions = append(d.deletions, object)
+	return nil
+}
+
+// TestSyncUploadWithDedupCopy tests that the --dedup-copy flag correctly routes
+// transfers to the server-side copy path when identical content exists on the destination.
+//
+// Scenario:
+// - Destination has blobs A.txt and B.txt with different content, both with Content-MD5
+// - Source has C.txt (same content as A.txt, different path) and D.txt (completely new content)
+// - Expected: C.txt should be transferred via dedup (BlobBlob copy from A.txt), D.txt via normal upload
+func TestSyncUploadWithDedupCopy(t *testing.T) {
+	a := assert.New(t)
+	bsc := getBlobServiceClient()
+	cc, containerName := createNewContainer(a, bsc)
+	defer deleteContainer(a, cc)
+
+	// Content for the test files
+	contentA := "This is the content of file A - used for dedup testing"
+	contentB := "This is completely different content for file B"
+	contentD := "This is brand new content that doesn't exist on destination"
+
+	// Compute MD5 hashes
+	md5A := md5.Sum([]byte(contentA))
+	md5B := md5.Sum([]byte(contentB))
+
+	// Upload blobs to destination WITH Content-MD5
+	blobClientA := cc.NewBlockBlobClient("existing/A.txt")
+	_, err := blobClientA.Upload(ctx, streaming.NopCloser(strings.NewReader(contentA)),
+		&blockblob.UploadOptions{
+			HTTPHeaders: &blob.HTTPHeaders{
+				BlobContentMD5: md5A[:],
+			},
+		})
+	a.Nil(err)
+
+	blobClientB := cc.NewBlockBlobClient("existing/B.txt")
+	_, err = blobClientB.Upload(ctx, streaming.NopCloser(strings.NewReader(contentB)),
+		&blockblob.UploadOptions{
+			HTTPHeaders: &blob.HTTPHeaders{
+				BlobContentMD5: md5B[:],
+			},
+		})
+	a.Nil(err)
+
+	// Wait a bit for the blobs to be visible
+	time.Sleep(time.Millisecond * 1050)
+
+	// Set up local source directory
+	// C.txt has SAME content as A.txt (should trigger dedup)
+	// D.txt has NEW content (should trigger normal upload)
+	srcDirName := scenarioHelper{}.generateLocalDirectory(a)
+	defer os.RemoveAll(srcDirName)
+
+	scenarioHelper{}.generateLocalFilesFromList(a, srcDirName, []string{"renamed/C.txt", "new/D.txt"})
+	// Overwrite with specific content
+	err = os.WriteFile(srcDirName+"/renamed/C.txt", []byte(contentA), 0644)
+	a.Nil(err)
+	err = os.WriteFile(srcDirName+"/new/D.txt", []byte(contentD), 0644)
+	a.Nil(err)
+
+	// Set up the dedup interceptor
+	mockedRPC := &dedupInterceptor{}
+	mockedRPC.init(common.EFromTo.LocalBlob(), common.EFromTo.BlobBlob())
+
+	// Construct sync command args with --dedup-copy
+	rawContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(a, containerName)
+	raw := getDefaultSyncRawInput(srcDirName, rawContainerURLWithSAS.String())
+	raw.dedupCopy = true
+	raw.putMd5 = true
+	raw.compareHash = "MD5"
+
+	// Run sync
+	runSyncAndVerify(a, raw, mockedRPC.intercept, mockedRPC.delete, func(err error) {
+		a.Nil(err)
+
+		// C.txt should be routed through dedup (BlobBlob) because its content matches A.txt
+		// D.txt should be routed through normal upload (LocalBlob) because its content is new
+		a.Equal(1, len(mockedRPC.dedupTransfers), "Expected 1 dedup transfer for renamed/C.txt")
+		a.Equal(1, len(mockedRPC.normalTransfers), "Expected 1 normal transfer for new/D.txt")
+
+		// Verify the dedup transfer has the correct destination path
+		dedupDst := mockedRPC.dedupTransfers[0].Destination
+		a.Contains(dedupDst, "renamed/C.txt", "Dedup transfer should target renamed/C.txt")
+
+		// Verify the normal transfer has the correct destination
+		normalDst := mockedRPC.normalTransfers[0].Destination
+		a.Contains(normalDst, "new/D.txt", "Normal transfer should target new/D.txt")
+	})
+}
+
+// TestSyncUploadWithDedupCopyNoBlobsHaveMD5 tests that when no destination blobs
+// have Content-MD5, all transfers go through the normal path.
+func TestSyncUploadWithDedupCopyNoBlobsHaveMD5(t *testing.T) {
+	a := assert.New(t)
+	bsc := getBlobServiceClient()
+	cc, containerName := createNewContainer(a, bsc)
+	defer deleteContainer(a, cc)
+
+	// Upload blob then CLEAR its Content-MD5 (the Go SDK auto-sets MD5 on Upload,
+	// so we must explicitly remove it to test the "no MD5" scenario)
+	blobClientA := cc.NewBlockBlobClient("existing/A.txt")
+	_, err := blobClientA.Upload(ctx, streaming.NopCloser(strings.NewReader("content A")), nil)
+	a.Nil(err)
+	// Clear the auto-set Content-MD5
+	_, err = blobClientA.SetHTTPHeaders(ctx, blob.HTTPHeaders{BlobContentMD5: []byte{}}, nil)
+	a.Nil(err)
+
+	time.Sleep(time.Millisecond * 1050)
+
+	// Set up local source with a file that has same content as A.txt
+	srcDirName := scenarioHelper{}.generateLocalDirectory(a)
+	defer os.RemoveAll(srcDirName)
+	scenarioHelper{}.generateLocalFilesFromList(a, srcDirName, []string{"renamed/C.txt"})
+	err = os.WriteFile(srcDirName+"/renamed/C.txt", []byte("content A"), 0644)
+	a.Nil(err)
+
+	// Set up interceptor
+	mockedRPC := &dedupInterceptor{}
+	mockedRPC.init(common.EFromTo.LocalBlob(), common.EFromTo.BlobBlob())
+
+	rawContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(a, containerName)
+	raw := getDefaultSyncRawInput(srcDirName, rawContainerURLWithSAS.String())
+	raw.dedupCopy = true
+	raw.putMd5 = true
+	raw.compareHash = "MD5"
+
+	runSyncAndVerify(a, raw, mockedRPC.intercept, mockedRPC.delete, func(err error) {
+		a.Nil(err)
+
+		// No dedup should happen since destination blobs lack Content-MD5
+		a.Equal(0, len(mockedRPC.dedupTransfers), "No dedup transfers when destination lacks MD5")
+		a.Equal(1, len(mockedRPC.normalTransfers), "All transfers should be normal")
+	})
+}
+
+// TestSyncUploadWithDedupCopyDisabled tests that without --dedup-copy, all transfers
+// go through the normal path even when hash matches exist.
+func TestSyncUploadWithDedupCopyDisabled(t *testing.T) {
+	a := assert.New(t)
+	bsc := getBlobServiceClient()
+	cc, containerName := createNewContainer(a, bsc)
+	defer deleteContainer(a, cc)
+
+	contentA := "dedup test content that will match"
+	md5A := md5.Sum([]byte(contentA))
+
+	// Upload blob WITH Content-MD5
+	blobClientA := cc.NewBlockBlobClient("existing/A.txt")
+	_, err := blobClientA.Upload(ctx, streaming.NopCloser(strings.NewReader(contentA)),
+		&blockblob.UploadOptions{
+			HTTPHeaders: &blob.HTTPHeaders{
+				BlobContentMD5: md5A[:],
+			},
+		})
+	a.Nil(err)
+	time.Sleep(time.Millisecond * 1050)
+
+	// Set up local source with a file that has same content
+	srcDirName := scenarioHelper{}.generateLocalDirectory(a)
+	defer os.RemoveAll(srcDirName)
+	scenarioHelper{}.generateLocalFilesFromList(a, srcDirName, []string{"renamed/C.txt"})
+	err = os.WriteFile(srcDirName+"/renamed/C.txt", []byte(contentA), 0644)
+	a.Nil(err)
+
+	// Interceptor - using standard interceptor since no dedup expected
+	mockedRPC := interceptor{}
+	mockedRPC.init()
+
+	rawContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(a, containerName)
+	raw := getDefaultSyncRawInput(srcDirName, rawContainerURLWithSAS.String())
+	// explicitly NOT setting raw.dedupCopy = true
+	raw.compareHash = "MD5"
+	raw.putMd5 = true
+
+	runSyncAndVerify(a, raw, mockedRPC.intercept, mockedRPC.delete, func(err error) {
+		a.Nil(err)
+
+		// Without dedup-copy, the transfer should happen normally (LocalBlob)
+		a.Equal(1, len(mockedRPC.transfers), "Should have 1 normal transfer")
+	})
+}
+
+// TestSyncUploadWithDedupCopyMultipleMatches tests that when multiple destination blobs
+// share the same content, dedup still works correctly (uses first match).
+func TestSyncUploadWithDedupCopyMultipleMatches(t *testing.T) {
+	a := assert.New(t)
+	bsc := getBlobServiceClient()
+	cc, containerName := createNewContainer(a, bsc)
+	defer deleteContainer(a, cc)
+
+	sharedContent := "This content appears in multiple destination blobs"
+	md5Shared := md5.Sum([]byte(sharedContent))
+
+	// Upload multiple blobs with the same content and MD5
+	for _, path := range []string{"dup1/file.txt", "dup2/file.txt", "dup3/file.txt"} {
+		blobClient := cc.NewBlockBlobClient(path)
+		_, err := blobClient.Upload(ctx, streaming.NopCloser(strings.NewReader(sharedContent)),
+			&blockblob.UploadOptions{
+				HTTPHeaders: &blob.HTTPHeaders{
+					BlobContentMD5: md5Shared[:],
+				},
+			})
+		a.Nil(err)
+	}
+	time.Sleep(time.Millisecond * 1050)
+
+	// Local source with two files that have the same content
+	srcDirName := scenarioHelper{}.generateLocalDirectory(a)
+	defer os.RemoveAll(srcDirName)
+	scenarioHelper{}.generateLocalFilesFromList(a, srcDirName, []string{"newpath1/x.txt", "newpath2/y.txt"})
+	_ = os.WriteFile(srcDirName+"/newpath1/x.txt", []byte(sharedContent), 0644)
+	_ = os.WriteFile(srcDirName+"/newpath2/y.txt", []byte(sharedContent), 0644)
+
+	mockedRPC := &dedupInterceptor{}
+	mockedRPC.init(common.EFromTo.LocalBlob(), common.EFromTo.BlobBlob())
+
+	rawContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(a, containerName)
+	raw := getDefaultSyncRawInput(srcDirName, rawContainerURLWithSAS.String())
+	raw.dedupCopy = true
+	raw.putMd5 = true
+	raw.compareHash = "MD5"
+
+	runSyncAndVerify(a, raw, mockedRPC.intercept, mockedRPC.delete, func(err error) {
+		a.Nil(err)
+
+		// Both files should be dedup-copied since their content matches existing destination blobs
+		a.Equal(2, len(mockedRPC.dedupTransfers), "Expected 2 dedup transfers")
+		a.Equal(0, len(mockedRPC.normalTransfers), "Expected 0 normal transfers")
+	})
+}
+
+// TestSyncUploadDedupCopyAutoEnablesCompareHash tests that --dedup-copy automatically
+// enables --compare-hash=MD5 if not explicitly set by verifying the raw args passthrough.
+func TestSyncUploadDedupCopyAutoEnablesCompareHash(t *testing.T) {
+	a := assert.New(t)
+
+	// Verify that dedupCopy is correctly passed through options
+	raw := getDefaultSyncRawInput("/tmp/src", "https://account.blob.core.windows.net/container?sv=2021-06-08&se=2030-01-01&sr=c&sp=rwdlacx&sig=fake")
+	raw.dedupCopy = true
+	// compareHash defaults to "None" - auto-enable happens in cooked options
+
+	opts, err := raw.toOptions()
+	a.Nil(err)
+	a.True(opts.DedupCopy)
+}
+
+// TestSyncUploadWithDedupCopyMixedMD5 tests the scenario where some destination blobs
+// have Content-MD5 metadata and some do not. Only files matching blobs WITH MD5 should
+// be dedup-copied; files matching blobs WITHOUT MD5 cannot participate in dedup and
+// should be uploaded normally.
+func TestSyncUploadWithDedupCopyMixedMD5(t *testing.T) {
+	a := assert.New(t)
+	bsc := getBlobServiceClient()
+	cc, containerName := createNewContainer(a, bsc)
+	defer deleteContainer(a, cc)
+
+	// Content for test files
+	contentWithMD5 := "This blob has Content-MD5 set and can be used for dedup"
+	contentWithoutMD5 := "This blob does NOT have Content-MD5 set"
+	contentNew := "Completely new content that exists nowhere on destination"
+
+	md5WithHash := md5.Sum([]byte(contentWithMD5))
+
+	// Upload blob A WITH Content-MD5 (can participate in dedup)
+	blobClientA := cc.NewBlockBlobClient("has-md5/A.txt")
+	_, err := blobClientA.Upload(ctx, streaming.NopCloser(strings.NewReader(contentWithMD5)),
+		&blockblob.UploadOptions{
+			HTTPHeaders: &blob.HTTPHeaders{
+				BlobContentMD5: md5WithHash[:],
+			},
+		})
+	a.Nil(err)
+
+	// Upload blob B WITHOUT Content-MD5 (cannot participate in dedup)
+	// Note: The Go SDK auto-computes Content-MD5 on Upload, so we must clear it explicitly
+	blobClientB := cc.NewBlockBlobClient("no-md5/B.txt")
+	_, err = blobClientB.Upload(ctx, streaming.NopCloser(strings.NewReader(contentWithoutMD5)), nil)
+	a.Nil(err)
+	_, err = blobClientB.SetHTTPHeaders(ctx, blob.HTTPHeaders{BlobContentMD5: []byte{}}, nil)
+	a.Nil(err)
+
+	time.Sleep(time.Millisecond * 1050)
+
+	// Set up local source:
+	// - "dedup-me.txt" has same content as A.txt (which has MD5) -> should dedup
+	// - "cant-dedup.txt" has same content as B.txt (which lacks MD5) -> must upload normally
+	// - "brand-new.txt" has content not on destination at all -> must upload normally
+	srcDirName := scenarioHelper{}.generateLocalDirectory(a)
+	defer os.RemoveAll(srcDirName)
+
+	scenarioHelper{}.generateLocalFilesFromList(a, srcDirName, []string{
+		"dedup-me.txt",
+		"cant-dedup.txt",
+		"brand-new.txt",
+	})
+	err = os.WriteFile(srcDirName+"/dedup-me.txt", []byte(contentWithMD5), 0644)
+	a.Nil(err)
+	err = os.WriteFile(srcDirName+"/cant-dedup.txt", []byte(contentWithoutMD5), 0644)
+	a.Nil(err)
+	err = os.WriteFile(srcDirName+"/brand-new.txt", []byte(contentNew), 0644)
+	a.Nil(err)
+
+	// Set up dedup interceptor
+	mockedRPC := &dedupInterceptor{}
+	mockedRPC.init(common.EFromTo.LocalBlob(), common.EFromTo.BlobBlob())
+
+	rawContainerURLWithSAS := scenarioHelper{}.getRawContainerURLWithSAS(a, containerName)
+	raw := getDefaultSyncRawInput(srcDirName, rawContainerURLWithSAS.String())
+	raw.dedupCopy = true
+	raw.putMd5 = true
+	raw.compareHash = "MD5"
+
+	runSyncAndVerify(a, raw, mockedRPC.intercept, mockedRPC.delete, func(err error) {
+		a.Nil(err)
+
+		// dedup-me.txt should be server-side copied (content matches A.txt which has MD5)
+		a.Equal(1, len(mockedRPC.dedupTransfers),
+			"Expected 1 dedup transfer for dedup-me.txt (matches blob with MD5)")
+
+		// cant-dedup.txt and brand-new.txt should go through normal upload:
+		// - cant-dedup.txt: content matches B.txt but B.txt lacks MD5 so no dedup possible
+		// - brand-new.txt: content doesn't exist anywhere on destination
+		a.Equal(2, len(mockedRPC.normalTransfers),
+			"Expected 2 normal transfers for cant-dedup.txt and brand-new.txt")
+
+		// Verify the dedup transfer targets the correct file
+		dedupDst := mockedRPC.dedupTransfers[0].Destination
+		a.Contains(dedupDst, "dedup-me.txt")
+	})
+}
+
+// Helper to expose cooked options for testing. We'll add this as a test-only export.
+// (Note: This test function validates that toOptions() correctly passes dedupCopy through)
+func TestSyncRawArgsDedupCopyFieldPassthrough(t *testing.T) {
+	a := assert.New(t)
+
+	raw := getDefaultSyncRawInput("/tmp/src", "https://account.blob.core.windows.net/container?sv=2021-06-08&se=2030-01-01&sr=c&sp=rwdlacx&sig=fake")
+	raw.dedupCopy = true
+
+	opts, err := raw.toOptions()
+	a.Nil(err)
+	a.True(opts.DedupCopy)
+
+	// Without dedupCopy
+	raw.dedupCopy = false
+	opts, err = raw.toOptions()
+	a.Nil(err)
+	a.False(opts.DedupCopy)
+}

--- a/cmd/zt_sync_dedup_test.go
+++ b/cmd/zt_sync_dedup_test.go
@@ -306,7 +306,8 @@ func TestSyncUploadDedupCopyAutoEnablesCompareHash(t *testing.T) {
 	a := assert.New(t)
 
 	// Verify that dedupCopy is correctly passed through options
-	raw := getDefaultSyncRawInput("/tmp/src", "https://account.blob.core.windows.net/container?sv=2021-06-08&se=2030-01-01&sr=c&sp=rwdlacx&sig=fake")
+	tmpDir := t.TempDir()
+	raw := getDefaultSyncRawInput(tmpDir, "https://account.blob.core.windows.net/container?sv=2021-06-08&se=2030-01-01&sr=c&sp=rwdlacx&sig=fake")
 	raw.dedupCopy = true
 	// compareHash defaults to "None" - auto-enable happens in cooked options
 
@@ -405,7 +406,8 @@ func TestSyncUploadWithDedupCopyMixedMD5(t *testing.T) {
 func TestSyncRawArgsDedupCopyFieldPassthrough(t *testing.T) {
 	a := assert.New(t)
 
-	raw := getDefaultSyncRawInput("/tmp/src", "https://account.blob.core.windows.net/container?sv=2021-06-08&se=2030-01-01&sr=c&sp=rwdlacx&sig=fake")
+	tmpDir := t.TempDir()
+	raw := getDefaultSyncRawInput(tmpDir, "https://account.blob.core.windows.net/container?sv=2021-06-08&se=2030-01-01&sr=c&sp=rwdlacx&sig=fake")
 	raw.dedupCopy = true
 
 	opts, err := raw.toOptions()

--- a/traverser/syncHashIndexer.go
+++ b/traverser/syncHashIndexer.go
@@ -22,17 +22,22 @@ package traverser
 
 import (
 	"encoding/hex"
+	"sync"
 	"sync/atomic"
 )
 
 // HashIndexer builds a secondary index of destination objects by their content hash (MD5).
 // This enables the sync command to detect when identical content already exists
 // at a different path on the destination, allowing a server-side copy instead of re-upload.
+// It is safe for concurrent use.
 type HashIndexer struct {
 	// hashToObject maps hex-encoded MD5 -> first StoredObject found with that hash.
 	// Only the first occurrence is stored; subsequent duplicates are ignored since
 	// any one of them is sufficient as a copy source.
 	hashToObject map[string]StoredObject
+
+	// mu protects hashToObject for concurrent access.
+	mu sync.RWMutex
 
 	// missingHashCount tracks the number of destination objects that lacked a content hash.
 	// This is reported to the user as a warning since these objects cannot participate in dedup.
@@ -54,9 +59,11 @@ func (h *HashIndexer) Store(obj StoredObject) {
 		return
 	}
 	key := hex.EncodeToString(obj.Md5)
+	h.mu.Lock()
 	if _, exists := h.hashToObject[key]; !exists {
 		h.hashToObject[key] = obj
 	}
+	h.mu.Unlock()
 }
 
 // Lookup finds a destination object with the given MD5 hash.
@@ -66,7 +73,9 @@ func (h *HashIndexer) Lookup(md5 []byte) (StoredObject, bool) {
 		return StoredObject{}, false
 	}
 	key := hex.EncodeToString(md5)
+	h.mu.RLock()
 	obj, ok := h.hashToObject[key]
+	h.mu.RUnlock()
 	return obj, ok
 }
 
@@ -78,5 +87,8 @@ func (h *HashIndexer) MissingHashCount() int64 {
 
 // IndexedCount returns the number of unique hashes indexed.
 func (h *HashIndexer) IndexedCount() int {
-	return len(h.hashToObject)
+	h.mu.RLock()
+	n := len(h.hashToObject)
+	h.mu.RUnlock()
+	return n
 }

--- a/traverser/syncHashIndexer.go
+++ b/traverser/syncHashIndexer.go
@@ -1,0 +1,82 @@
+// Copyright © 2017 Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package traverser
+
+import (
+	"encoding/hex"
+	"sync/atomic"
+)
+
+// HashIndexer builds a secondary index of destination objects by their content hash (MD5).
+// This enables the sync command to detect when identical content already exists
+// at a different path on the destination, allowing a server-side copy instead of re-upload.
+type HashIndexer struct {
+	// hashToObject maps hex-encoded MD5 -> first StoredObject found with that hash.
+	// Only the first occurrence is stored; subsequent duplicates are ignored since
+	// any one of them is sufficient as a copy source.
+	hashToObject map[string]StoredObject
+
+	// missingHashCount tracks the number of destination objects that lacked a content hash.
+	// This is reported to the user as a warning since these objects cannot participate in dedup.
+	missingHashCount int64
+}
+
+// NewHashIndexer creates a new HashIndexer ready to index objects by content hash.
+func NewHashIndexer() *HashIndexer {
+	return &HashIndexer{
+		hashToObject: make(map[string]StoredObject),
+	}
+}
+
+// Store indexes a StoredObject by its MD5 hash. Objects without an MD5 are counted
+// as missing and skipped. Only the first object with a given hash is stored.
+func (h *HashIndexer) Store(obj StoredObject) {
+	if obj.Md5 == nil || len(obj.Md5) == 0 {
+		atomic.AddInt64(&h.missingHashCount, 1)
+		return
+	}
+	key := hex.EncodeToString(obj.Md5)
+	if _, exists := h.hashToObject[key]; !exists {
+		h.hashToObject[key] = obj
+	}
+}
+
+// Lookup finds a destination object with the given MD5 hash.
+// Returns the StoredObject and true if found, or an empty object and false otherwise.
+func (h *HashIndexer) Lookup(md5 []byte) (StoredObject, bool) {
+	if md5 == nil || len(md5) == 0 {
+		return StoredObject{}, false
+	}
+	key := hex.EncodeToString(md5)
+	obj, ok := h.hashToObject[key]
+	return obj, ok
+}
+
+// MissingHashCount returns the number of destination objects that had no content hash
+// and thus could not participate in deduplication.
+func (h *HashIndexer) MissingHashCount() int64 {
+	return atomic.LoadInt64(&h.missingHashCount)
+}
+
+// IndexedCount returns the number of unique hashes indexed.
+func (h *HashIndexer) IndexedCount() int {
+	return len(h.hashToObject)
+}

--- a/traverser/syncHashIndexer_test.go
+++ b/traverser/syncHashIndexer_test.go
@@ -1,0 +1,222 @@
+// Copyright © 2017 Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package traverser
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHashIndexer_StoreAndLookup(t *testing.T) {
+	a := assert.New(t)
+	indexer := NewHashIndexer()
+
+	md5Hash := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+
+	obj := StoredObject{
+		Name:         "file1.txt",
+		RelativePath: "dir/file1.txt",
+		Size:         1024,
+		Md5:          md5Hash,
+		EntityType:   common.EEntityType.File(),
+	}
+
+	indexer.Store(obj)
+
+	// Should be able to look up by the same hash
+	found, ok := indexer.Lookup(md5Hash)
+	a.True(ok)
+	a.Equal("dir/file1.txt", found.RelativePath)
+	a.Equal(int64(1024), found.Size)
+
+	// Should have 1 indexed entry
+	a.Equal(1, indexer.IndexedCount())
+	a.Equal(int64(0), indexer.MissingHashCount())
+}
+
+func TestHashIndexer_LookupNotFound(t *testing.T) {
+	a := assert.New(t)
+	indexer := NewHashIndexer()
+
+	md5Hash := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	differentHash := []byte{0xff, 0xfe, 0xfd, 0xfc, 0xfb, 0xfa, 0xf9, 0xf8, 0xf7, 0xf6, 0xf5, 0xf4, 0xf3, 0xf2, 0xf1, 0xf0}
+
+	obj := StoredObject{
+		Name:         "file1.txt",
+		RelativePath: "dir/file1.txt",
+		Size:         1024,
+		Md5:          md5Hash,
+		EntityType:   common.EEntityType.File(),
+	}
+
+	indexer.Store(obj)
+
+	// Should not find a different hash
+	_, ok := indexer.Lookup(differentHash)
+	a.False(ok)
+}
+
+func TestHashIndexer_NilHashSkipped(t *testing.T) {
+	a := assert.New(t)
+	indexer := NewHashIndexer()
+
+	// Object with no MD5 should be skipped and counted as missing
+	obj := StoredObject{
+		Name:         "file1.txt",
+		RelativePath: "dir/file1.txt",
+		Size:         1024,
+		Md5:          nil,
+		EntityType:   common.EEntityType.File(),
+	}
+
+	indexer.Store(obj)
+
+	a.Equal(0, indexer.IndexedCount())
+	a.Equal(int64(1), indexer.MissingHashCount())
+}
+
+func TestHashIndexer_EmptyHashSkipped(t *testing.T) {
+	a := assert.New(t)
+	indexer := NewHashIndexer()
+
+	// Object with empty MD5 slice should be skipped
+	obj := StoredObject{
+		Name:         "file1.txt",
+		RelativePath: "dir/file1.txt",
+		Size:         1024,
+		Md5:          []byte{},
+		EntityType:   common.EEntityType.File(),
+	}
+
+	indexer.Store(obj)
+
+	a.Equal(0, indexer.IndexedCount())
+	a.Equal(int64(1), indexer.MissingHashCount())
+}
+
+func TestHashIndexer_LookupNilHash(t *testing.T) {
+	a := assert.New(t)
+	indexer := NewHashIndexer()
+
+	// Lookup with nil hash should return not found
+	_, ok := indexer.Lookup(nil)
+	a.False(ok)
+
+	// Lookup with empty hash should return not found
+	_, ok = indexer.Lookup([]byte{})
+	a.False(ok)
+}
+
+func TestHashIndexer_FirstObjectWins(t *testing.T) {
+	a := assert.New(t)
+	indexer := NewHashIndexer()
+
+	md5Hash := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+
+	// Store two objects with the same hash - first should win
+	obj1 := StoredObject{
+		Name:         "file1.txt",
+		RelativePath: "dir/file1.txt",
+		Size:         1024,
+		Md5:          md5Hash,
+		EntityType:   common.EEntityType.File(),
+	}
+	obj2 := StoredObject{
+		Name:         "file2.txt",
+		RelativePath: "other/file2.txt",
+		Size:         1024,
+		Md5:          md5Hash,
+		EntityType:   common.EEntityType.File(),
+	}
+
+	indexer.Store(obj1)
+	indexer.Store(obj2)
+
+	// Should return the first object stored
+	found, ok := indexer.Lookup(md5Hash)
+	a.True(ok)
+	a.Equal("dir/file1.txt", found.RelativePath)
+
+	// Only one unique hash indexed
+	a.Equal(1, indexer.IndexedCount())
+}
+
+func TestHashIndexer_MultipleUniqueHashes(t *testing.T) {
+	a := assert.New(t)
+	indexer := NewHashIndexer()
+
+	hash1 := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	hash2 := []byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20}
+	hash3 := []byte{0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30}
+
+	indexer.Store(StoredObject{RelativePath: "a.txt", Md5: hash1, EntityType: common.EEntityType.File()})
+	indexer.Store(StoredObject{RelativePath: "b.txt", Md5: hash2, EntityType: common.EEntityType.File()})
+	indexer.Store(StoredObject{RelativePath: "c.txt", Md5: hash3, EntityType: common.EEntityType.File()})
+	indexer.Store(StoredObject{RelativePath: "d.txt", Md5: nil, EntityType: common.EEntityType.File()}) // no hash
+
+	a.Equal(3, indexer.IndexedCount())
+	a.Equal(int64(1), indexer.MissingHashCount())
+
+	found1, ok1 := indexer.Lookup(hash1)
+	a.True(ok1)
+	a.Equal("a.txt", found1.RelativePath)
+
+	found2, ok2 := indexer.Lookup(hash2)
+	a.True(ok2)
+	a.Equal("b.txt", found2.RelativePath)
+
+	found3, ok3 := indexer.Lookup(hash3)
+	a.True(ok3)
+	a.Equal("c.txt", found3.RelativePath)
+}
+
+func TestObjectIndexer_OnStoreHook(t *testing.T) {
+	a := assert.New(t)
+	indexer := NewObjectIndexer()
+
+	var hookedObjects []StoredObject
+	indexer.OnStore = func(obj StoredObject) {
+		hookedObjects = append(hookedObjects, obj)
+	}
+
+	obj1 := StoredObject{RelativePath: "file1.txt", EntityType: common.EEntityType.File()}
+	obj2 := StoredObject{RelativePath: "file2.txt", EntityType: common.EEntityType.File()}
+
+	_ = indexer.Store(obj1)
+	_ = indexer.Store(obj2)
+
+	a.Equal(2, len(hookedObjects))
+	a.Equal("file1.txt", hookedObjects[0].RelativePath)
+	a.Equal("file2.txt", hookedObjects[1].RelativePath)
+}
+
+func TestObjectIndexer_OnStoreHookNil(t *testing.T) {
+	a := assert.New(t)
+	indexer := NewObjectIndexer()
+
+	// Should not panic when OnStore is nil
+	obj := StoredObject{RelativePath: "file1.txt", EntityType: common.EEntityType.File()}
+	err := indexer.Store(obj)
+	a.NoError(err)
+	a.Equal(1, len(indexer.IndexMap))
+}

--- a/traverser/syncIndexer.go
+++ b/traverser/syncIndexer.go
@@ -37,6 +37,10 @@ type ObjectIndexer struct {
 	// Apple File System (APFS) can be configured to be case-sensitive or case-insensitive.
 	// So for such locations, the key in the IndexMap will be lowercase to avoid infinite syncing.
 	IsDestinationCaseInsensitive bool
+
+	// OnStore is an optional callback invoked for each object stored in the index.
+	// It can be used to feed secondary indexes (e.g., a HashIndexer for dedup).
+	OnStore func(StoredObject)
 }
 
 func NewObjectIndexer() *ObjectIndexer {
@@ -58,6 +62,10 @@ func (i *ObjectIndexer) Store(storedObject StoredObject) (err error) {
 		i.IndexMap[storedObject.RelativePath] = storedObject
 	}
 	i.counter += 1
+
+	if i.OnStore != nil {
+		i.OnStore(storedObject)
+	}
 	return
 }
 


### PR DESCRIPTION
## Summary

Adds a new `--dedup-copy` flag to the `sync` command that enables content-based deduplication. When a file needs to be transferred but identical content (by MD5 hash) already exists at a **different path** on the destination, AzCopy performs a **server-side copy within the destination** instead of re-uploading from source.

## Motivation

Common scenarios where this saves significant bandwidth and time:
- **File renames** — user renames `report-v1.pdf` to `report-final.pdf`; without dedup, sync re-uploads the entire file
- **Directory reorganizations** — files moved between folders
- **Duplicate content** — same file present at multiple paths in the source

In all these cases, the content already exists on the destination. A server-side copy (e.g., `CopyFromURL` / `StageBlockFromURL`) is essentially free: no data flows through the client, and it completes in milliseconds regardless of file size.

## Usage

```bash
azcopy sync /local/dir "https://account.blob.core.windows.net/container?<SAS>" --dedup-copy
```

## Key Behaviors

| Behavior | Detail |
|----------|--------|
| Opt-in | Off by default; enable with `--dedup-copy` |
| Hash requirement | Auto-enables `--compare-hash=MD5` if not set |
| Destination scope | Only effective for remote destinations (Blob, File, BlobFS, S3, GCP) |
| MD5 dependency | Uses existing `Content-MD5` headers on destination blobs; warns about blobs without MD5 |
| Fallback | Falls through to normal upload when no hash match is found |
| Server-side copy | Uses a separate job with the appropriate S2S `FromTo` (e.g., `BlobBlob`) |

## How It Works

1. During destination enumeration, each blob's MD5 is indexed in a `HashIndexer` (O(1) lookup by content hash)
2. When a file needs to be transferred, the `syncDedupProcessor` checks if its content hash matches any existing destination blob at a different path
3. **If match found**: schedules a server-side copy from the matching blob to the target path
4. **If no match**: falls through to normal upload from source
5. At completion, logs stats: `"Dedup stats: X file(s) via server-side copy (dedup), Y file(s) via normal transfer."`

## Files Changed

| File | Change |
|------|--------|
| `traverser/syncHashIndexer.go` | **NEW** — `HashIndexer` indexes destination objects by MD5 |
| `azcopy/syncDedupProcessor.go` | **NEW** — Routes transfers to dedup or normal path |
| `azcopy/sync.go` | Added `DedupCopy` to `SyncOptions` |
| `azcopy/syncOptions.go` | Added validation, auto-enables `--compare-hash=MD5` |
| `azcopy/syncEnumerator.go` | Wires hash indexer, dedup job template, dedup processor |
| `cmd/sync.go` | Registers `--dedup-copy` CLI flag |
| `traverser/syncIndexer.go` | Added `OnStore` hook to `ObjectIndexer` |

## Test Coverage

### Unit Tests (16 tests, all pass locally)
- **9 HashIndexer tests**: store/lookup, nil/empty hash handling, first-wins dedup source, multiple hashes, `OnStore` hook
- **7 syncDedupProcessor tests**: hash match routing, no match fallback, nil hash, same-path skip, size mismatch safety, folder handling, **mixed MD5 scenario**

### Integration Tests (7 tests, validated against live Azure Blob Storage)
- Dedup copy routes correctly when content matches existing destination blob
- No dedup when destination blobs lack `Content-MD5` (with user warning)
- Dedup disabled: all transfers go through normal path
- Multiple destination blobs with same hash: dedup still works
- Auto-enables `--compare-hash=MD5` when `--dedup-copy` is set
- **Mixed MD5 scenario**: only blobs WITH `Content-MD5` participate in dedup; others fall back to normal upload
- CLI flag passthrough validation

> **Note**: The Go SDK auto-computes `Content-MD5` on `Upload()`, so integration tests that need "no MD5" blobs explicitly clear it via `SetHTTPHeaders`.
