### PR TITLE
POC: add Azure Storage Mover awareness nudge for copy

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -1383,6 +1383,10 @@ func init() {
 				glcm.Error("failed to parse --from-to user input due to error: " + err.Error())
 			}
 
+			// POC: surface an Azure Storage Mover awareness note for migration
+			// scenarios Storage Mover also covers (opt-in via AZCOPY_STORAGE_MOVER_NUDGE).
+			maybeSuggestStorageMover(cmd, userFromTo)
+
 			if azcopy.AreBothLocationsNFSAware(userFromTo) {
 				if (raw.preserveSMBInfo && runtime.GOOS == "linux") || raw.preserveSMBPermissions {
 					glcm.Error(InvalidFlagsForNFSMsg)

--- a/cmd/storageMoverNudge.go
+++ b/cmd/storageMoverNudge.go
@@ -1,0 +1,153 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cmd
+
+// -----------------------------------------------------------------------------
+//
+// Goal (GTM experiment): when a customer runs `azcopy copy` for a migration
+// scenario that Azure Storage Mover *also* covers, surface a one-line, dismissible
+// note pointing them at Storage Mover's fully-managed migration experience.
+//
+// The two questions this POC answers:
+//   1. Is the chosen source -> target pair covered by Storage Mover?
+//        -> answered by storageMoverCoverage[fromTo]   (the FromTo enum azcopy
+//           already infers from the user's arguments).
+//   2. Are all the flags the customer used exposed in Storage Mover?
+//        -> answered by walking cmd.Flags().Visit (only *changed* flags) and
+//           checking each against storageMoverCompatibleFlags. If the user relies
+//           on any azcopy-only behaviour, we stay silent so we never suggest a
+//           tool that can't reproduce their command.
+//
+// This is intentionally additive and side-effect free: it only ever emits an
+// informational line, and only when explicitly enabled via the
+// AZCOPY_STORAGE_MOVER_NUDGE=true environment variable, so the experiment can be
+// rolled out / rolled back without touching transfer behaviour.
+// -----------------------------------------------------------------------------
+
+import (
+	"strings"
+
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// storageMoverLearnLink is the Learn doc comparing AzCopy and Storage Mover.
+// TODO(POC): replace with the final, tracked GTM link before any real rollout.
+const storageMoverLearnLink = "https://learn.microsoft.com/azure/storage-mover/" // #nudge-link
+
+// storageMoverCoverage maps azcopy source->target combinations onto the migration
+// paths Azure Storage Mover supports today. Keep this list conservative: only
+// pairs Storage Mover can genuinely complete should be present, otherwise the
+// nudge becomes noise.
+//
+// Storage Mover supported paths (mapped to azcopy FromTo):
+//   - on-prem/agent source -> Azure Blob container  => Local* and S3 sources to Blob
+//   - on-prem/agent source -> Azure Files (SMB)      => Local source to File
+//   - on-prem/agent source -> Azure Files (NFS)      => Local source to FileNFS
+//
+// NOTE / known POC limitation: azcopy represents any local filesystem (including
+// a mounted SMB or NFS share) as ELocation.Local(), so it cannot by itself tell
+// an SMB mount from an NFS mount the way the Storage Mover agent can. For the POC
+// we treat local-source uploads to Azure storage as "potentially covered".
+var storageMoverCoverage = map[common.FromTo]bool{
+	common.EFromTo.LocalBlob():    true, // upload to Blob container
+	common.EFromTo.LocalFile():    true, // upload to Azure Files (SMB)
+	common.EFromTo.LocalFileNFS(): true, // upload to Azure Files (NFS)
+	common.EFromTo.S3Blob():       true, // Amazon S3 -> Blob container
+}
+
+// storageMoverCompatibleFlags is the set of azcopy flags whose intent Storage
+// Mover can reproduce (or which are migration-neutral, e.g. output/logging knobs
+// that don't change *what* gets moved). If the user changed any flag NOT in this
+// set, we assume their command depends on azcopy-specific behaviour that Storage
+// Mover does not expose, and we suppress the nudge.
+//
+// This deliberately errs on the side of silence: it is far better to miss a
+// genuine opportunity than to suggest Storage Mover for a command it cannot honour.
+var storageMoverCompatibleFlags = map[string]bool{
+	// Core migration semantics Storage Mover supports.
+	"recursive":                true, // Storage Mover always migrates the subtree
+	"from-to":                  true, // just disambiguates the pair we already vetted
+	"overwrite":                true, // Storage Mover has mirror/merge overwrite modes
+	"put-md5":                  true, // integrity validation
+	"check-md5":                true,
+	"preserve-info":            true, // metadata/timestamp preservation
+	"preserve-smb-info":        true,
+	"preserve-permissions":     true, // ACL preservation
+	"preserve-smb-permissions": true,
+
+	// Migration-neutral knobs: they affect logging / presentation / throughput,
+	// not which files land at the destination, so they don't disqualify a nudge.
+	"output-type":  true,
+	"output-level": true,
+	"log-level":    true,
+	"cap-mbps":     true,
+	"dry-run":      true,
+}
+
+func maybeSuggestStorageMover(cmd *cobra.Command, fromTo common.FromTo) {
+	if !storageMoverNudgeEnabled() {
+		return
+	}
+
+	eligible, reason := evaluateStorageMoverOpportunity(cmd, fromTo)
+	if !eligible {
+		// Surface the reason only in the (verbose) log so we can measure the
+		// funnel during the POC without spamming the user's console.
+		common.GetLifecycleMgr().Info("[storage-mover-nudge] not shown: " + reason)
+		return
+	}
+
+	common.GetLifecycleMgr().Info(storageMoverNudgeMessage())
+}
+
+func evaluateStorageMoverOpportunity(cmd *cobra.Command, fromTo common.FromTo) (eligible bool, reason string) {
+	if !storageMoverCoverage[fromTo] {
+		return false, "pair-not-covered:" + fromTo.String()
+	}
+
+	if incompatible := incompatibleFlagsUsed(cmd); len(incompatible) > 0 {
+		return false, "incompatible-flags:" + strings.Join(incompatible, ",")
+	}
+
+	return true, ""
+}
+
+func incompatibleFlagsUsed(cmd *cobra.Command) []string {
+	var incompatible []string
+	cmd.Flags().Visit(func(f *pflag.Flag) {
+		if !storageMoverCompatibleFlags[f.Name] {
+			incompatible = append(incompatible, f.Name)
+		}
+	})
+	return incompatible
+}
+
+func storageMoverNudgeEnabled() bool {
+	v := strings.TrimSpace(common.GetEnvironmentVariable(common.EEnvironmentVariable.StorageMoverNudge()))
+	return strings.EqualFold(v, "true") || v == "1"
+}
+
+func storageMoverNudgeMessage() string {
+	return "Tip: You can now use Azure Storage Mover for a fully managed migration " +
+		"experience to move this data. Learn more: " + storageMoverLearnLink
+}

--- a/cmd/storageMoverNudge_test.go
+++ b/cmd/storageMoverNudge_test.go
@@ -1,0 +1,131 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+// newNudgeTestCmd builds a cobra command exposing a representative subset of the
+// copy flags, then "sets" the given flags (so cmd.Flags().Visit treats them as
+// changed, exactly like real user input).
+func newNudgeTestCmd(t *testing.T, setFlags ...string) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{Use: "copy"}
+	var b bool
+	var s string
+	// A mix of Storage-Mover-compatible and azcopy-only flags.
+	cmd.Flags().BoolVar(&b, "recursive", false, "")
+	cmd.Flags().BoolVar(&b, "put-md5", false, "")
+	cmd.Flags().BoolVar(&b, "dry-run", false, "")
+	cmd.Flags().StringVar(&s, "include-pattern", "", "")
+	cmd.Flags().StringVar(&s, "blob-type", "", "")
+
+	for _, name := range setFlags {
+		if err := cmd.Flags().Set(name, flagValueFor(name)); err != nil {
+			t.Fatalf("failed to set flag %q: %v", name, err)
+		}
+	}
+	return cmd
+}
+
+func flagValueFor(name string) string {
+	switch name {
+	case "include-pattern", "blob-type":
+		return "x"
+	default:
+		return "true"
+	}
+}
+
+func TestEvaluateStorageMoverOpportunity(t *testing.T) {
+	a := assert.New(t)
+
+	cases := []struct {
+		name         string
+		fromTo       common.FromTo
+		setFlags     []string
+		wantEligible bool
+		wantReason   string
+	}{
+		{
+			name:         "covered pair, no flags",
+			fromTo:       common.EFromTo.LocalBlob(),
+			wantEligible: true,
+		},
+		{
+			name:         "covered pair, compatible flags only",
+			fromTo:       common.EFromTo.LocalBlob(),
+			setFlags:     []string{"recursive", "put-md5", "dry-run"},
+			wantEligible: true,
+		},
+		{
+			name:         "covered pair S3 to Blob",
+			fromTo:       common.EFromTo.S3Blob(),
+			wantEligible: true,
+		},
+		{
+			name:         "covered pair, incompatible flag",
+			fromTo:       common.EFromTo.LocalBlob(),
+			setFlags:     []string{"recursive", "include-pattern"},
+			wantEligible: false,
+			wantReason:   "incompatible-flags:include-pattern",
+		},
+		{
+			name:         "uncovered pair (download)",
+			fromTo:       common.EFromTo.BlobLocal(),
+			wantEligible: false,
+			wantReason:   "pair-not-covered:BlobLocal",
+		},
+		{
+			name:         "uncovered pair takes precedence over flags",
+			fromTo:       common.EFromTo.BlobLocal(),
+			setFlags:     []string{"include-pattern"},
+			wantEligible: false,
+			wantReason:   "pair-not-covered:BlobLocal",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newNudgeTestCmd(t, tc.setFlags...)
+			eligible, reason := evaluateStorageMoverOpportunity(cmd, tc.fromTo)
+			a.Equal(tc.wantEligible, eligible)
+			a.Equal(tc.wantReason, reason)
+		})
+	}
+}
+
+func TestIncompatibleFlagsUsed(t *testing.T) {
+	a := assert.New(t)
+
+	// Only compatible flags changed -> nothing reported.
+	cmd := newNudgeTestCmd(t, "recursive", "put-md5")
+	a.Empty(incompatibleFlagsUsed(cmd))
+
+	// An azcopy-only flag changed -> reported.
+	cmd = newNudgeTestCmd(t, "recursive", "blob-type")
+	a.Equal([]string{"blob-type"}, incompatibleFlagsUsed(cmd))
+}

--- a/common/environment.go
+++ b/common/environment.go
@@ -92,6 +92,7 @@ var VisibleEnvironmentVariables = []EnvironmentVariable{
 	EEnvironmentVariable.DisableSyslog(),
 	EEnvironmentVariable.MimeMapping(),
 	EEnvironmentVariable.DownloadToTempPath(),
+	EEnvironmentVariable.StorageMoverNudge(),
 }
 
 var EEnvironmentVariable = EnvironmentVariable{}
@@ -260,6 +261,16 @@ func (EnvironmentVariable) AutoTuneToCpu() EnvironmentVariable {
 	return EnvironmentVariable{
 		Name:        "AZCOPY_TUNE_TO_CPU",
 		Description: "Set to false to prevent AzCopy from taking CPU usage into account when auto-tuning its concurrency level (e.g. in the benchmark command).",
+	}
+}
+
+// StorageMoverNudge (POC) gates an informational note that points users at Azure
+// Storage Mover for migration scenarios that Storage Mover also covers.
+func (EnvironmentVariable) StorageMoverNudge() EnvironmentVariable {
+	return EnvironmentVariable{
+		Name:         "AZCOPY_STORAGE_MOVER_NUDGE",
+		DefaultValue: "false",
+		Description:  "Set to 'true' to show an informational note suggesting Azure Storage Mover for fully managed migration when the source/destination pair and flags are covered by Storage Mover.",
 	}
 }
 


### PR DESCRIPTION
Surface an opt-in informational note during 'azcopy copy' when the inferred source/destination pair and the flags used are covered by Azure Storage Mover, pointing users at the fully managed migration experience.

- Add cmd/storageMoverNudge.go: coverage matrix (FromTo), compatible-flag allow-list, and pure decision function evaluateStorageMoverOpportunity.

- Gate behind AZCOPY_STORAGE_MOVER_NUDGE env var (registered in azcopy env).

- Wire a single call into the copy command Run after FromTo inference.

- Add unit tests for covered/uncovered pairs and compatible/incompatible flags.

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**: (Brief description of the feature or issue being addressed)

- **Related Links**:
- [Issues](<link>)
- [Team thread](<link>)
- [Documents](<link>)
- [Email Subject]

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

Thank you for your contribution to AzCopy!
