### PR TITLE
bug_sc05: Fix hard link not being relinked on the destination to match the source

### DIFF
--- a/e2etest/zt_newe2e_nfs_scenarios_test.go
+++ b/e2etest/zt_newe2e_nfs_scenarios_test.go
@@ -1875,7 +1875,10 @@ func (s *FilesNFSTestSuite) Scenario_LocalToNFS_RetargetHardlinkGroup_Copy(svm *
 				},
 			},
 			cName: ResourceDefinitionObject{
-				ObjectProperties: ObjectProperties{},
+				Body: dstBody,
+				ObjectProperties: ObjectProperties{
+					EntityType: common.EEntityType.File(),
+				},
 			},
 		},
 	}, ValidateResourceOptions{

--- a/e2etest/zt_newe2e_nfs_scenarios_test.go
+++ b/e2etest/zt_newe2e_nfs_scenarios_test.go
@@ -1856,7 +1856,7 @@ func (s *FilesNFSTestSuite) Scenario_LocalToNFS_RetargetHardlinkGroup_Copy(svm *
 				FromTo:       pointerTo(fromTo),
 				HardlinkType: pointerTo(common.PreserveHardlinkHandlingType),
 			},
-			Overwrite: pointerTo(true),
+			AsSubdir: pointerTo(false),
 		},
 	})
 

--- a/e2etest/zt_newe2e_nfs_scenarios_test.go
+++ b/e2etest/zt_newe2e_nfs_scenarios_test.go
@@ -1789,6 +1789,11 @@ func (s *FilesNFSTestSuite) Scenario_LocalToNFS_RetargetHardlinkGroup_Copy(svm *
 		svm.InvalidateScenario()
 		return
 	}
+
+	if svm.Dryrun() {
+		return
+	}
+
 	fromTo := common.EFromTo.LocalFileNFS()
 
 	srcContainer, dstContainer, rootDir := setupHardlinkSyncContainersForFromTo(svm, fromTo)
@@ -1798,8 +1803,8 @@ func (s *FilesNFSTestSuite) Scenario_LocalToNFS_RetargetHardlinkGroup_Copy(svm *
 	bName := rootDir + "/b.txt"
 	cName := rootDir + "/c.txt"
 
-	srcBody := NewRandomObjectContentContainer(SizeFromString("1K"))
-	dstBody := NewRandomObjectContentContainer(SizeFromString("1K"))
+	srcBody := NewRandomObjectContentContainer(10)
+	dstBody := NewRandomObjectContentContainer(10)
 
 	// Source: {a, b}
 	CreateResource[ObjectResourceManager](svm, srcContainer, ResourceDefinitionObject{
@@ -1812,6 +1817,7 @@ func (s *FilesNFSTestSuite) Scenario_LocalToNFS_RetargetHardlinkGroup_Copy(svm *
 		ObjectProperties: ObjectProperties{EntityType: common.EEntityType.File()},
 	})
 	CreateResource[ObjectResourceManager](svm, srcContainer, ResourceDefinitionObject{
+		Body:       srcBody,
 		ObjectName: pointerTo(bName),
 		ObjectProperties: ObjectProperties{
 			EntityType:         common.EEntityType.Hardlink(),
@@ -1827,7 +1833,7 @@ func (s *FilesNFSTestSuite) Scenario_LocalToNFS_RetargetHardlinkGroup_Copy(svm *
 		Create(svm, dstBody, ObjectProperties{EntityType: common.EEntityType.File()})
 
 	dstContainer.GetObject(svm, cName, common.EEntityType.Hardlink()).
-		Create(svm, nil, ObjectProperties{
+		Create(svm, dstBody, ObjectProperties{
 			EntityType:         common.EEntityType.Hardlink(),
 			HardLinkedFileName: bName,
 		})
@@ -1850,6 +1856,7 @@ func (s *FilesNFSTestSuite) Scenario_LocalToNFS_RetargetHardlinkGroup_Copy(svm *
 				FromTo:       pointerTo(fromTo),
 				HardlinkType: pointerTo(common.PreserveHardlinkHandlingType),
 			},
+			Overwrite: pointerTo(true),
 		},
 	})
 
@@ -1857,7 +1864,9 @@ func (s *FilesNFSTestSuite) Scenario_LocalToNFS_RetargetHardlinkGroup_Copy(svm *
 	ValidateResource[ContainerResourceManager](svm, dstContainer, ResourceDefinitionContainer{
 		Objects: ObjectResourceMappingFlat{
 			aName: ResourceDefinitionObject{
-				ObjectProperties: ObjectProperties{EntityType: common.EEntityType.File()},
+				ObjectProperties: ObjectProperties{
+					EntityType: common.EEntityType.Hardlink(),
+				},
 			},
 			bName: ResourceDefinitionObject{
 				ObjectProperties: ObjectProperties{
@@ -1866,7 +1875,7 @@ func (s *FilesNFSTestSuite) Scenario_LocalToNFS_RetargetHardlinkGroup_Copy(svm *
 				},
 			},
 			cName: ResourceDefinitionObject{
-				ObjectProperties: ObjectProperties{EntityType: common.EEntityType.File()},
+				ObjectProperties: ObjectProperties{},
 			},
 		},
 	}, ValidateResourceOptions{

--- a/e2etest/zt_newe2e_nfs_scenarios_test.go
+++ b/e2etest/zt_newe2e_nfs_scenarios_test.go
@@ -1767,3 +1767,111 @@ func (s *FilesNFSTestSuite) Scenario_NFSToNFS_OverwriteSymlinkToFile(svm *Scenar
 		fromTo:                common.EFromTo.FileNFSFileNFS(),
 	})
 }
+
+/*
+ Source:
+	A.txt  -> anchor   (inode = 123) nlink = 2
+	B.txt  -> hardlink (inode = 123) nlink = 2
+
+ Dest:
+	B.txt -> anchor   (inode = 456) nlink = 2
+	C.txt -> hardlink (inode = 456) nlink = 2
+
+After Copy:
+	A.txt  -> anchor   (inode = 123) nlink = 2
+	B.txt  -> hardlink (inode = 123) nlink = 2
+    C.txt  -> hardlink (inode = 456) nlink = 1
+*/
+// Scenario_LocalToNFS_RetargetHardlinkGroup_Copy verifies that during copy with --hardlinks=preserve
+// existing hardlinks with the same path on the destination are retargeted to the correct inodes to match the source structure
+func (s *FilesNFSTestSuite) Scenario_LocalToNFS_RetargetHardlinkGroup_Copy(svm *ScenarioVariationManager) {
+	if runtime.GOOS != "linux" {
+		svm.InvalidateScenario()
+		return
+	}
+	fromTo := common.EFromTo.LocalFileNFS()
+
+	srcContainer, dstContainer, rootDir := setupHardlinkSyncContainersForFromTo(svm, fromTo)
+	defer cleanupHardlinkSyncForFromTo(svm, fromTo, srcContainer, dstContainer, rootDir)
+
+	aName := rootDir + "/a.txt"
+	bName := rootDir + "/b.txt"
+	cName := rootDir + "/c.txt"
+
+	srcBody := NewRandomObjectContentContainer(SizeFromString("1K"))
+	dstBody := NewRandomObjectContentContainer(SizeFromString("1K"))
+
+	// Source: {a, b}
+	CreateResource[ObjectResourceManager](svm, srcContainer, ResourceDefinitionObject{
+		ObjectName:       pointerTo(rootDir),
+		ObjectProperties: ObjectProperties{EntityType: common.EEntityType.Folder()},
+	})
+	CreateResource[ObjectResourceManager](svm, srcContainer, ResourceDefinitionObject{
+		ObjectName:       pointerTo(aName),
+		Body:             srcBody,
+		ObjectProperties: ObjectProperties{EntityType: common.EEntityType.File()},
+	})
+	CreateResource[ObjectResourceManager](svm, srcContainer, ResourceDefinitionObject{
+		ObjectName: pointerTo(bName),
+		ObjectProperties: ObjectProperties{
+			EntityType:         common.EEntityType.Hardlink(),
+			HardLinkedFileName: aName,
+		},
+	})
+
+	// Dest: {b, c}
+	dstDir := dstContainer.GetObject(svm, rootDir, common.EEntityType.Folder())
+	dstDir.Create(svm, nil, ObjectProperties{EntityType: common.EEntityType.Folder()})
+
+	dstContainer.GetObject(svm, bName, common.EEntityType.File()).
+		Create(svm, dstBody, ObjectProperties{EntityType: common.EEntityType.File()})
+
+	dstContainer.GetObject(svm, cName, common.EEntityType.Hardlink()).
+		Create(svm, nil, ObjectProperties{
+			EntityType:         common.EEntityType.Hardlink(),
+			HardLinkedFileName: bName,
+		})
+
+	srcDirObj := srcContainer.GetObject(svm, rootDir, common.EEntityType.Folder())
+
+	RunAzCopy(svm, AzCopyCommand{
+		Verb: AzCopyVerbCopy,
+		Targets: []ResourceManager{
+			srcDirObj,
+			dstDir.(RemoteResourceManager).WithSpecificAuthType(
+				ResolveVariation(svm, []ExplicitCredentialTypes{
+					EExplicitCredentialType.SASToken(),
+					//EExplicitCredentialType.OAuth(),
+				}), svm, CreateAzCopyTargetOptions{}),
+		},
+		Flags: CopyFlags{
+			CopySyncCommonFlags: CopySyncCommonFlags{
+				Recursive:    pointerTo(true),
+				FromTo:       pointerTo(fromTo),
+				HardlinkType: pointerTo(common.PreserveHardlinkHandlingType),
+			},
+		},
+	})
+
+	// (A+B), C (standalone file)
+	ValidateResource[ContainerResourceManager](svm, dstContainer, ResourceDefinitionContainer{
+		Objects: ObjectResourceMappingFlat{
+			aName: ResourceDefinitionObject{
+				ObjectProperties: ObjectProperties{EntityType: common.EEntityType.File()},
+			},
+			bName: ResourceDefinitionObject{
+				ObjectProperties: ObjectProperties{
+					EntityType:         common.EEntityType.Hardlink(),
+					HardLinkedFileName: aName,
+				},
+			},
+			cName: ResourceDefinitionObject{
+				ObjectProperties: ObjectProperties{EntityType: common.EEntityType.File()},
+			},
+		},
+	}, ValidateResourceOptions{
+		fromTo:                fromTo,
+		hardlinkHandling:      common.PreserveHardlinkHandlingType,
+		validateObjectContent: true,
+	})
+}

--- a/ste/xfer-anyToRemote-hardlink.go
+++ b/ste/xfer-anyToRemote-hardlink.go
@@ -124,7 +124,7 @@ func anyToRemote_hardlink(jptm IJobPartTransferMgr, info *TransferInfo, pacer pa
 				jptm.LogAtLevelForCurrentTransfer(common.LogWarning,
 					fmt.Sprintf("Could not delete the destination hardlink %s before creation: %s",
 						jptm.Info().Destination, delErr.Error()))
-				// Don't fail the transfer, let retry logic in DoWithCreateSymlinkOnAzureFilesNFS() take a shot
+				// Don't fail the transfer, let retry logic in DoWithCreateHardlinkOnAzureFilesNFS() take a shot
 			}
 		}
 	}

--- a/ste/xfer-anyToRemote-hardlink.go
+++ b/ste/xfer-anyToRemote-hardlink.go
@@ -20,6 +20,7 @@
 package ste
 
 import (
+	"fmt"
 	"net/url"
 	"path"
 	"strings"
@@ -70,6 +71,7 @@ func anyToRemote_hardlink(jptm IJobPartTransferMgr, info *TransferInfo, pacer pa
 	// if the force Write flags is set to false or prompt
 	// then check the file exists at the remote location
 	// if it does, react accordingly
+	shouldOverwrite := common.Iff(jptm.GetOverwriteOption() == common.EOverwriteOption.True(), true, false)
 	if jptm.GetOverwriteOption() != common.EOverwriteOption.True() {
 		exists, dstLmt, existenceErr := s.RemoteFileExists()
 		if existenceErr != nil {
@@ -79,7 +81,7 @@ func anyToRemote_hardlink(jptm IJobPartTransferMgr, info *TransferInfo, pacer pa
 			return
 		}
 		if exists {
-			shouldOverwrite := false
+			shouldOverwrite = false
 
 			// if necessary, prompt to confirm user's intent
 			if jptm.GetOverwriteOption() == common.EOverwriteOption.Prompt() {
@@ -110,6 +112,21 @@ func anyToRemote_hardlink(jptm IJobPartTransferMgr, info *TransferInfo, pacer pa
 		// Avoid calling CreateHardlink with an empty path, which could cause a secondary, less-informative failure.
 		commonSenderCompletion(jptm, baseSender, info)
 		return
+	}
+	// If the hardlink file already exists on the destination,
+	// we need to handle the case where it might be part of a different hardlink group than the source.
+	// E.g source (A+B) destination (B+C)
+	// So, we proactively unlink the file from the previous group (with Delete())
+	// before calling creating to reattach it to the correct group on the destination
+	if jptm.GetOverwriteOption() == common.EOverwriteOption.True() || shouldOverwrite {
+		if azFileSender, ok := baseSender.(interface{ DeleteDestInOverwrite() error }); ok {
+			if delErr := azFileSender.DeleteDestInOverwrite(); delErr != nil {
+				jptm.LogAtLevelForCurrentTransfer(common.LogWarning,
+					fmt.Sprintf("Could not delete the destination hardlink %s before creation: %s",
+						jptm.Info().Destination, delErr.Error()))
+				// Don't fail the transfer, let retry logic in DoWithCreateSymlinkOnAzureFilesNFS() take a shot
+			}
+		}
 	}
 	err = s.CreateHardlink(targetHardlinkFullPath)
 	if err != nil {

--- a/ste/xfer-anyToRemote-symlink.go
+++ b/ste/xfer-anyToRemote-symlink.go
@@ -130,7 +130,6 @@ func anyToRemote_symlink(jptm IJobPartTransferMgr, info *TransferInfo, pacer pac
 			}
 		}
 	}
-	
 	// write the symlink
 	err = s.SendSymlink(path)
 	if err != nil {

--- a/ste/xfer-anyToRemote-symlink.go
+++ b/ste/xfer-anyToRemote-symlink.go
@@ -130,7 +130,7 @@ func anyToRemote_symlink(jptm IJobPartTransferMgr, info *TransferInfo, pacer pac
 			}
 		}
 	}
-
+	
 	// write the symlink
 	err = s.SendSymlink(path)
 	if err != nil {


### PR DESCRIPTION
## Logs 
<details>
<summary>AzCopy run log </summary>

````text

=================================================================
RUNNING  L2N / s05   → log: /home/azureuser/hltest-results/20260610T122014Z/L2N-s05.log
=================================================================

====================================================================
  Scenario S05: Src B→A | Dst B→C (wrong target) → re-point B to A
  Direction: L2N
====================================================================
----- INITIAL -----
[SRC = /home/azureuser/hltest-local/src-s05]
  786940 2 /home/azureuser/hltest-local/src-s05/A
  786940 2 /home/azureuser/hltest-local/src-s05/B
[DST = /home/azureuser/nfsmp/dst-s05]
  12411990941777396277 2 /home/azureuser/nfsmp/dst-s05/B
  12411990941777396277 2 /home/azureuser/nfsmp/dst-s05/C
  14717833950991090227 1 /home/azureuser/nfsmp/dst-s05/A

----- AzCopy copy --hardlinks=preserve -----
Src: /home/azureuser/hltest-local/src-s05
Dst: https://ucexsapsat20py02cx.file.preprod.core.windows.net/nfssharetestazcopy1/dst-s05?XX
INFO: The --hardlinks option is set to 'preserve'. Hardlinked files will be preserved as hardlinks at the destination.
INFO: Note: The preserve-permissions flag is set to false. As a result, AzCopy will not copy NFS permissions between the source and destination.
INFO: Any empty folders will be processed, because source and destination both support folders. For the same reason, properties defined on folders will be processed
INFO: Scanning...

Job e88d55ca-dbda-b544-5bf1-8ca7f1582c12 has started
Log file is located at: /home/azureuser/.azcopy/e88d55ca-dbda-b544-5bf1-8ca7f1582c12.log

INFO: Trying 4 concurrent connections (initial starting point)
100.0 %, 3 Done, 0 Failed, 0 Pending, 0 Skipped, 3 Total, 2-sec Throughput (Mb/s): 0.0001


Job e88d55ca-dbda-b544-5bf1-8ca7f1582c12 summary
Elapsed Time (Minutes): 0.0334
Number of File Transfers: 0
Number of Folder Property Transfers: 1
Number of Symlink Transfers: 0
Total Number of Transfers: 3
Number of File Transfers Completed: 0
Number of Folder Transfers Completed: 1
Number of File Transfers Failed: 0
Number of Folder Transfers Failed: 0
Number of File Transfers Skipped: 0
Number of Folder Transfers Skipped: 0
Number of Symbolic Links Skipped: 0
Number of Hardlinks Converted: 0
Number of Hardlinks Transferred: 2
Number of Hardlinks Completed: 2
Number of Hardlinks Failed: 0
Number of Hardlinks Skipped: 0
Number of Special Files Skipped: 0
Total Number of Bytes Transferred: 48
Final Job Status: Completed

AzCopy exit code: 0
----- AFTER -----
[SRC = /home/azureuser/hltest-local/src-s05]
  786940 2 /home/azureuser/hltest-local/src-s05/A
  786940 2 /home/azureuser/hltest-local/src-s05/B
[DST = /home/azureuser/nfsmp/dst-s05]
  12411990941777396277 3 /home/azureuser/nfsmp/dst-s05/A
  12411990941777396277 3 /home/azureuser/nfsmp/dst-s05/B
  12411990941777396277 3 /home/azureuser/nfsmp/dst-s05/C

  [PASS] A,B linked: [/home/azureuser/nfsmp/dst-s05/A /home/azureuser/nfsmp/dst-s05/B] all share inode 12411990941777396277
  [FAIL] B unlinked from C: /home/azureuser/nfsmp/dst-s05/B and /home/azureuser/nfsmp/dst-s05/C share inode 12411990941777396277 (should be unlinked)
  [PASS] B content data1: /home/azureuser/nfsmp/dst-s05/B content matches expected
----- S05 result -----
  Pass: 2   Fail: 1
  RESULT: SCENARIO FAILED
  ````
</details>


## Bug  & Root Cause 
When performing `copy --hardlinks=preserve` with a source that has files A + B in a hardlink group and  B + C on the destination, the destination file B is not unlinked from C. It points to the wrong target when it should point to A

## Fix 
We call `.Delete()` on the file before proceeding to the existing Create call. This now leaves B as a new file to match the source hardlink grouping as expected.

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

Thank you for your contribution to AzCopy!
