### PR TITLE
help output

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -207,7 +207,8 @@ var rootCmd = &cobra.Command{
 				// don't wait too long
 			}
 		}
-		return nil
+		// Print out help command on just `azcopy`
+		return cmd.Help()
 	},
 }
 

--- a/e2etest/zt_newe2e_basic_functionality_test.go
+++ b/e2etest/zt_newe2e_basic_functionality_test.go
@@ -697,7 +697,7 @@ func (*BasicFunctionalitySuite) Scenario_DisabledCheckVersion(svm *ScenarioVaria
 		versionAssertion.False(foundVersionInOutput())
 	}
 
-	ValidateMessageOutput(svm, stdout, "version", false)
+	ValidateMessageOutput(svm, stdout, "INFO: ", false)
 }
 
 // Scenario_SkipVersionCheckDisabledBackCompat validates we are backwards compatible with skip-version-check now deprecated.


### PR DESCRIPTION
`azcopy` outputs help when run

<img width="1880" height="420" alt="image" src="https://github.com/user-attachments/assets/fc01a4b3-81a9-4518-a5db-7d8a12da57fd" />

(right terminal view is after the fix)