### PR TITLE
Fixed bug with sync command where hardlinks were not appropriately created/merged on destination

### DIFF
--- a/azcopy/syncComparator.go
+++ b/azcopy/syncComparator.go
@@ -303,10 +303,12 @@ func (f *syncDestinationComparator) normalizeHardlinkTarget(sourceObj *traverser
 /*
 Example sync --hardlinks=preserve:
 Before run:
+
 	Source: A + B (hardlink group)
 	Dest: A only
 
 After run:
+
 	Dest: A + B (CreateHardlink called on B)
 */
 func (f *syncDestinationComparator) NormalizeAndSchedule(

--- a/azcopy/syncComparator.go
+++ b/azcopy/syncComparator.go
@@ -303,10 +303,12 @@ func (f *syncDestinationComparator) normalizeHardlinkTarget(sourceObj *traverser
 /*
 Example sync --hardlinks=preserve:
 Before run:
+
 	Source: A + B (hardlink group)
 	Dest: A only
 
 After run:
+
 	Dest: A + B (CreateHardlink called on B)
 */
 func (f *syncDestinationComparator) NormalizeAndSchedule(
@@ -410,6 +412,24 @@ func (f *syncDestinationComparator) ProcessPendingHardlinks() error {
 		}
 	}
 
+	// destPathToInode maps each pending destination hardlink path to its destination inode.
+	// This is used to determine where the srcAnchor is in the same group as a shared member at the destination
+	// It lets us ask per member, "At the destination, is the source anchor already in the same hardlink group as
+	// this member?"
+	// (needsRecreate condition (d) )
+	destPathToInode := make(map[string]string, len(f.destPendingHardlinkObjects.IndexMap))
+	for _, obj := range f.destPendingHardlinkObjects.IndexMap {
+		if obj.Inode == "" {
+			continue
+		}
+		key := obj.RelativePath
+		if f.sourceIndex.IsDestinationCaseInsensitive {
+			key = strings.ToLower(key)
+		}
+
+		destPathToInode[key] = obj.Inode
+	}
+
 	for _, destHardlinkObj := range f.destPendingHardlinkObjects.IndexMap {
 
 		// Normalize the key upfront for case-insensitive destinations so the
@@ -455,6 +475,15 @@ func (f *syncDestinationComparator) ProcessPendingHardlinks() error {
 		//       group → true re-target or group split with a live anchor.
 		//   (b) Source group spans multiple dest inodes → group merge, must unify.
 		//   (c) Dest group spans multiple source inodes → group split, must break up.
+		// 	 (d) srcAnchor is NOT in this member's hardlink group at the destination
+		//		 (either it is absent or in a different group) The member is linked to the
+		//		 wrong group and must be re-pointed. This handles merges whose groups overlap
+		//		 on a single shared member.
+		//		 This is the case (b)/(c) can't see:
+		//		 when source group {A,B} and destination group {B,C} overlap on only the
+		//		 single shared file B, the source-only member A and the
+		//		 destination-only member C are invisible to the multi-inode
+		//		 counters, so without (d) B would be wrongly left linked to C
 		//
 		// Skip (no recreate) when srcAnchor ≠ dstAnchor but none of (a)-(c) apply:
 		//   • dstAnchor was deleted from source (srcInode="") AND group is intact
@@ -525,9 +554,17 @@ func (f *syncDestinationComparator) ProcessPendingHardlinks() error {
 				}
 			} else {
 				dstAnchorInSrc := f.srcPathToInode[normDstAnchor]
+				// srcAnchorDstInode is the destination inode the source anchor
+				// currently points at, or "" if the source anchor is not at the
+				// destination yet. A member is correctly linked only when it is in
+				// the SAME destination hardlink group as the source anchor i.e.
+				// they share this inode.
+				srcAnchorDstInode := destPathToInode[normSrcAnchor]
+
 				needsRecreate = (dstAnchorInSrc != "" && dstAnchorInSrc != sourceObjectInMap.Inode) || // (a)
 					srcInodeIsMultiGroup[sourceObjectInMap.Inode] || // (b)
-					destGroupIsMultiSource[destHardlinkObj.Inode] // (c)
+					destGroupIsMultiSource[destHardlinkObj.Inode] || // (c)
+					srcAnchorDstInode != destHardlinkObj.Inode // (d)
 			}
 		}
 

--- a/azcopy/syncComparator.go
+++ b/azcopy/syncComparator.go
@@ -289,30 +289,30 @@ func (f *syncDestinationComparator) normalizeHardlinkTarget(sourceObj *traverser
 }
 
 // NormalizeAndSchedule wraps an object scheduler.
-// This is to handle leftover source objects
+// This is to make sure leftover source objects
 // (those with no destination counterpart, scheduled directly
-// from indexer.Traverse in finalize) get the same TargetHardlinkFile
+// from indexer.Traverser) get the same TargetHardlinkFile
 // normalization that ProcessIfNecessary applies to matched source
 // objects.
 //
 // Without this, a source hardlink whose firstSeen-anchor
 // (TargetHardlinkFile=="") and InodeStore-anchor disagree is routed
-// into PendingTransfers as a data carrier rather than into
+// into PendingTransfers as a regular data carrier rather than into
 // PendingHardlinksTransfers, so CreateHardlink never runs.
 
 /*
-Example copy --hardlinks=preserve:
-
+Example sync --hardlinks=preserve:
+Before run:
 	Source: A + B (hardlink group)
 	Dest: A only
+
+After run:
+	Dest: A + B (CreateHardlink called on B)
 */
 func (f *syncDestinationComparator) NormalizeAndSchedule(
 	scheduler traverser.ObjectProcessor,
 ) traverser.ObjectProcessor {
 	return func(o traverser.StoredObject) error {
-		// Ensure srcPathToInode is built. ProcessIfNecessary normally
-		// does this lazily; if the destination was empty (or had no
-		// matching object) it may not have run yet.
 		if f.srcPathToInode == nil {
 			f.srcPathToInode = buildSrcPathToInode(f.sourceIndex.IndexMap)
 		}

--- a/azcopy/syncComparator.go
+++ b/azcopy/syncComparator.go
@@ -288,6 +288,42 @@ func (f *syncDestinationComparator) normalizeHardlinkTarget(sourceObj *traverser
 	}
 }
 
+// NormalizeAndSchedule wraps an object scheduler.
+// This is to handle leftover source objects
+// (those with no destination counterpart, scheduled directly
+// from indexer.Traverse in finalize) get the same TargetHardlinkFile
+// normalization that ProcessIfNecessary applies to matched source
+// objects.
+//
+// Without this, a source hardlink whose firstSeen-anchor
+// (TargetHardlinkFile=="") and InodeStore-anchor disagree is routed
+// into PendingTransfers as a data carrier rather than into
+// PendingHardlinksTransfers, so CreateHardlink never runs.
+
+/*
+Example copy --hardlinks=preserve:
+
+	Source: A + B (hardlink group)
+	Dest: A only
+*/
+func (f *syncDestinationComparator) NormalizeAndSchedule(
+	scheduler traverser.ObjectProcessor,
+) traverser.ObjectProcessor {
+	return func(o traverser.StoredObject) error {
+		// Ensure srcPathToInode is built. ProcessIfNecessary normally
+		// does this lazily; if the destination was empty (or had no
+		// matching object) it may not have run yet.
+		if f.srcPathToInode == nil {
+			f.srcPathToInode = buildSrcPathToInode(f.sourceIndex.IndexMap)
+		}
+		if o.EntityType == common.EEntityType.Hardlink() &&
+			f.inodeStore != nil && o.Inode != "" {
+			f.normalizeHardlinkTarget(&o)
+		}
+		return scheduler(o)
+	}
+}
+
 func (f *syncDestinationComparator) ProcessPendingHardlinks() error {
 
 	// Build two flat lookup tables to detect structural mismatches between

--- a/azcopy/syncComparator.go
+++ b/azcopy/syncComparator.go
@@ -348,6 +348,13 @@ func (f *syncDestinationComparator) ProcessPendingHardlinks() error {
 	destInodeFirstSrc := make(map[string]string)
 	destGroupIsMultiSource := make(map[string]bool)
 
+	// destGroupHasForeignMember: dest inode → true when at least one member of that
+	// dest hardlink group is NOT a hardlink in the source (it was deleted, or
+	// converted to a regular file). Such a group is not a clean subset of a single
+	// source group, so a shared member whose source anchor is absent may be linked
+	// to the wrong group and needs re-pointing (needsRecreate condition (d2)).
+	destGroupHasForeignMember := make(map[string]bool)
+
 	for _, obj := range f.destPendingHardlinkObjects.IndexMap {
 		if obj.Inode == "" {
 			continue
@@ -358,6 +365,11 @@ func (f *syncDestinationComparator) ProcessPendingHardlinks() error {
 		}
 		srcInode := f.srcPathToInode[srcKey]
 		if srcInode == "" {
+			// This dest member has no source hardlink counterpart, so its dest
+			// group only partially overlaps the source. Flag the group so a shared
+			// member whose source anchor is absent can still be detected as needing
+			// a re-point (overlap-merge condition (d2)).
+			destGroupHasForeignMember[obj.Inode] = true
 			continue // not present in source; will be deleted below
 		}
 		if first, seen := srcInodeFirstDest[srcInode]; !seen {
@@ -475,15 +487,20 @@ func (f *syncDestinationComparator) ProcessPendingHardlinks() error {
 		//       group → true re-target or group split with a live anchor.
 		//   (b) Source group spans multiple dest inodes → group merge, must unify.
 		//   (c) Dest group spans multiple source inodes → group split, must break up.
-		// 	 (d) srcAnchor is NOT in this member's hardlink group at the destination
-		//		 (either it is absent or in a different group) The member is linked to the
-		//		 wrong group and must be re-pointed. This handles merges whose groups overlap
-		//		 on a single shared member.
-		//		 This is the case (b)/(c) can't see:
-		//		 when source group {A,B} and destination group {B,C} overlap on only the
-		//		 single shared file B, the source-only member A and the
-		//		 destination-only member C are invisible to the multi-inode
-		//		 counters, so without (d) B would be wrongly left linked to C
+		// 	 (d) The member is linked to the WRONG group at the destination and must
+		//		 be re-pointed. Split into two sub-cases:
+		//		 (d1) srcAnchor exists at the destination but in a DIFFERENT dest inode
+		//		      group → a real retarget.
+		//		 (d2) srcAnchor is ABSENT from the destination AND this member's dest
+		//		      group contains a foreign member (a dest hardlink with no source
+		//		      hardlink counterpart) → overlap merge.
+		//		 (d2) covers what (b)/(c) can't see: when source group {A,B} and
+		//		 destination group {B,C} overlap on only the single shared file B, the
+		//		 source-only member A and the destination-only member C are invisible to
+		//		 the multi-inode counters, so without (d2) B would be wrongly left linked
+		//		 to C. Requiring a foreign member keeps (d2) from over-firing when a new
+		//		 lex-smaller anchor is merely added to an otherwise-intact group
+		//		 (srcAnchor absent, no foreign member → skip).
 		//
 		// Skip (no recreate) when srcAnchor ≠ dstAnchor but none of (a)-(c) apply:
 		//   • dstAnchor was deleted from source (srcInode="") AND group is intact
@@ -564,7 +581,8 @@ func (f *syncDestinationComparator) ProcessPendingHardlinks() error {
 				needsRecreate = (dstAnchorInSrc != "" && dstAnchorInSrc != sourceObjectInMap.Inode) || // (a)
 					srcInodeIsMultiGroup[sourceObjectInMap.Inode] || // (b)
 					destGroupIsMultiSource[destHardlinkObj.Inode] || // (c)
-					srcAnchorDstInode != destHardlinkObj.Inode // (d)
+					(srcAnchorDstInode != "" && srcAnchorDstInode != destHardlinkObj.Inode) || // (d1) retarget: src anchor lives in a different dest group
+					(srcAnchorDstInode == "" && destGroupHasForeignMember[destHardlinkObj.Inode]) // (d2) overlap merge: src anchor absent AND dest group has a foreign member
 			}
 		}
 

--- a/azcopy/syncEnumerator.go
+++ b/azcopy/syncEnumerator.go
@@ -264,7 +264,8 @@ func (s *syncer) initEnumerator(ctx context.Context, logLevel common.LogLevel, m
 	switch s.opts.fromTo {
 	case common.EFromTo.LocalBlob(), common.EFromTo.LocalFile(), common.EFromTo.LocalFileNFS():
 		// Upload implies transferring from a local disk to a remote resource.
-		// In this scenario, the local disk (source) is scanned/indexed first because it is assumed that local file systems will be faster to enumerate than remote resources
+		// In this scenario, the local disk (source) is scanned/indexed first because it is assumed that local file systems
+		// will be faster to enumerate than remote resources.
 		// Then the destination is scanned and filtered based on what the destination contains
 
 		// when uploading, we can delete remote objects immediately, because as we traverse the remote location

--- a/azcopy/syncEnumerator.go
+++ b/azcopy/syncEnumerator.go
@@ -296,7 +296,8 @@ func (s *syncer) initEnumerator(ctx context.Context, logLevel common.LogLevel, m
 			}
 
 			// schedule every local file that doesn't exist at the destination
-			err = indexer.Traverse(transferScheduler.ScheduleSyncRemoveSetPropertiesTransfer, filters)
+			// Normalize the TargetHardlinkFile to ensure it points to lex-smallest anchor
+			err = indexer.Traverse(comparatorInstance.NormalizeAndSchedule(transferScheduler.ScheduleSyncRemoveSetPropertiesTransfer), filters)
 			if err != nil {
 				return err
 			}

--- a/azcopy/zc_processor.go
+++ b/azcopy/zc_processor.go
@@ -106,8 +106,10 @@ func (s *CopyTransferProcessor) ScheduleSyncRemoveSetPropertiesTransfer(storedOb
 	return s.scheduleTransfer(srcRelativePath, dstRelativePath, storedObject)
 }
 
-func (s *CopyTransferProcessor) scheduleTransfer(srcRelativePath, dstRelativePath string, storedObject traverser.StoredObject) (err error) {
-	copyTransfer, shouldSendToSte := storedObject.ToNewCopyTransfer(false, srcRelativePath, dstRelativePath, s.preserveAccessTier, s.folderPropertiesOption, s.symlinkHandlingType, s.hardlinkHandlingType)
+func (s *CopyTransferProcessor) scheduleTransfer(srcRelativePath, dstRelativePath string,
+	storedObject traverser.StoredObject) (err error) {
+	copyTransfer, shouldSendToSte := storedObject.ToNewCopyTransfer(false, srcRelativePath, dstRelativePath,
+		s.preserveAccessTier, s.folderPropertiesOption, s.symlinkHandlingType, s.hardlinkHandlingType)
 
 	// set properties specific code
 	if s.CopyJobTemplate.FromTo.To() == common.ELocation.None() {

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -1456,7 +1456,8 @@ func init() {
 
 	// filters change which files get transferred
 	cpCmd.PersistentFlags().BoolVar(&raw.followSymlinks, "follow-symlinks", false,
-		"False by default. Follow symbolic links when uploading from local file system.")
+		"False by default. Follow symbolic links when uploading from local file system.\n"+
+			"If neither --follow-symlinks or --preserve-symlinks are not set, symlinks are skipped.")
 
 	cpCmd.PersistentFlags().StringVar(&raw.includeBefore, common.IncludeBeforeFlagName, "",
 		"Include only those files were modified before or on the given date/time. \n "+

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -1457,7 +1457,7 @@ func init() {
 	// filters change which files get transferred
 	cpCmd.PersistentFlags().BoolVar(&raw.followSymlinks, "follow-symlinks", false,
 		"False by default. Follow symbolic links when uploading from local file system.\n"+
-			"If neither --follow-symlinks or --preserve-symlinks are not set, symlinks are skipped.")
+			"If neither --follow-symlinks nor --preserve-symlinks is set, symlinks are skipped.")
 
 	cpCmd.PersistentFlags().StringVar(&raw.includeBefore, common.IncludeBeforeFlagName, "",
 		"Include only those files were modified before or on the given date/time. \n "+

--- a/common/rpc-models.go
+++ b/common/rpc-models.go
@@ -255,7 +255,7 @@ type ListJobSummaryResponse struct {
 
 	TotalTransfers uint32 `json:",string"` // = FileTransfers + FolderPropertyTransfers. It also = TransfersCompleted + TransfersFailed + TransfersSkipped
 	// FileTransfers and FolderPropertyTransfers just break the total down into the two types.
-	// The name FolderPropertyTransfers is used to emphasise that is is only counting transferring the properties and existence of
+	// The name FolderPropertyTransfers is used to emphasize that it is only counting transferring the properties and existence of
 	// folders. A "folder property transfer" does not include any files that may be in the folder. Those are counted as
 	// FileTransfers.
 	FileTransfers           uint32 `json:",string"`

--- a/common/version.go
+++ b/common/version.go
@@ -1,6 +1,6 @@
 package common
 
-const AzcopyVersion = "25.25.2"
+const AzcopyVersion = "10.32.2"
 const UserAgent = "AzCopy/" + AzcopyVersion
 const S3ImportUserAgent = "S3Import " + UserAgent
 const GCPImportUserAgent = "GCPImport " + UserAgent

--- a/common/version.go
+++ b/common/version.go
@@ -1,6 +1,6 @@
 package common
 
-const AzcopyVersion = "10.32.2~preview1"
+const AzcopyVersion = "25.25.2"
 const UserAgent = "AzCopy/" + AzcopyVersion
 const S3ImportUserAgent = "S3Import " + UserAgent
 const GCPImportUserAgent = "GCPImport " + UserAgent

--- a/e2etest/zt_newe2e_nfs_hardlink_copy_sync_test.go
+++ b/e2etest/zt_newe2e_nfs_hardlink_copy_sync_test.go
@@ -3640,3 +3640,82 @@ func (s *FilesNFSTestSuite) Scenario_HardlinkSync_HardlinkBecomesFile_NoDeleteDe
 
 	_ = stdOut
 }
+
+// Source: (local)
+//	A.txt  (regular file, nlink=2)
+//	B.txt  (hardlink -> A.txt)
+//
+// Destination (before sync):
+//	A.txt  (regular file)
+//
+// Expected Destination after sync:
+//	A.txt  (regular file, nlink=2)
+//	B.txt  (hardlink -> A.txt)
+
+// Validates that sync creates the missing non-anchor member of a hardlink
+// group as a hardlink (CreateHardLink API), not as an independent inode.
+func (s *FilesNFSTestSuite) Scenario_HardlinkSync_HardlinkCreatedOnDestination(svm *ScenarioVariationManager) {
+	if runtime.GOOS != "linux" {
+		svm.InvalidateScenario()
+		return
+	}
+	srcContainer, dstContainer, rootDir := setupHardlinkSyncContainersForFromTo(svm, common.EFromTo.LocalFileNFS())
+	defer cleanupHardlinkSyncForFromTo(svm, common.EFromTo.LocalFileNFS(), srcContainer, dstContainer, rootDir)
+
+	anchorName := rootDir + "/A.txt"
+	linkName := rootDir + "/B.txt"
+
+	// ── Destination (before sync): anchor only, as a plain regular file ──────
+	dstDir := dstContainer.GetObject(svm, rootDir, common.EEntityType.Folder())
+	dstDir.Create(svm, nil, ObjectProperties{EntityType: common.EEntityType.Folder()})
+
+	dstAnchor := dstContainer.GetObject(svm, anchorName, common.EEntityType.File())
+	dstAnchor.Create(svm, NewRandomObjectContentContainer(1), ObjectProperties{})
+
+	setOldLMT(svm, dstAnchor, dstContainer)
+
+	if !svm.Dryrun() {
+		time.Sleep(5 * time.Second)
+	}
+
+	// ── Source: A.txt and B.txt share one inode ──────────────────────
+	CreateResource[ObjectResourceManager](svm, srcContainer, ResourceDefinitionObject{
+		ObjectName:       pointerTo(rootDir),
+		ObjectProperties: ObjectProperties{EntityType: common.EEntityType.Folder()},
+	})
+
+	CreateResource[ObjectResourceManager](svm, srcContainer, ResourceDefinitionObject{
+		ObjectName: pointerTo(anchorName),
+		Body:       NewRandomObjectContentContainer(1),
+		ObjectProperties: ObjectProperties{
+			EntityType: common.EEntityType.File(),
+		},
+	})
+	CreateResource[ObjectResourceManager](svm, srcContainer, ResourceDefinitionObject{
+		ObjectName: pointerTo(linkName),
+		ObjectProperties: ObjectProperties{
+			EntityType:         common.EEntityType.Hardlink(),
+			HardLinkedFileName: anchorName,
+		},
+	})
+	srcDirObj := srcContainer.GetObject(svm, rootDir, common.EEntityType.Folder())
+	stdOut := runHardlinkSyncForFromTo(svm, srcDirObj, dstDir, common.EFromTo.LocalFileNFS(), true)
+
+	ValidateResource[ContainerResourceManager](svm, dstContainer, ResourceDefinitionContainer{
+		Objects: ObjectResourceMappingFlat{
+			anchorName: ResourceDefinitionObject{
+				ObjectProperties: ObjectProperties{EntityType: common.EEntityType.File()},
+			},
+			linkName: ResourceDefinitionObject{
+				ObjectProperties: ObjectProperties{
+					EntityType:         common.EEntityType.Hardlink(),
+					HardLinkedFileName: anchorName,
+				},
+			},
+		},
+	}, ValidateResourceOptions{
+		fromTo:           common.EFromTo.LocalFileNFS(),
+		hardlinkHandling: common.PreserveHardlinkHandlingType,
+	})
+	ValidateHardlinksTransferCount(svm, stdOut, 2)
+}

--- a/e2etest/zt_newe2e_nfs_hardlink_copy_sync_test.go
+++ b/e2etest/zt_newe2e_nfs_hardlink_copy_sync_test.go
@@ -3719,3 +3719,108 @@ func (s *FilesNFSTestSuite) Scenario_HardlinkSync_HardlinkCreatedOnDestination(s
 	})
 	ValidateHardlinksTransferCount(svm, stdOut, 2)
 }
+
+// Scenario: PartialOverlapMerge — src: A-B  dst: B-C
+//
+// Source has a hardlink group {A,B}; destination has a different group {B,C}
+// that only partially overlaps. Sync must merge/re-point so B links to A and
+// delete the extra dest member C.
+//
+// Source:
+//
+//	A.txt  (anchor of A-B group)
+//	B.txt  (hardlink → A)
+//
+// Destination (before sync):
+//
+//	B.txt  (hardlink ↔ C)
+//	C.txt  (hardlink ↔ B)
+//
+// Expected (LocalFileNFS, --delete-destination=true):
+//
+//	A.txt  (File, data carrier)
+//	B.txt  (Hardlink → A)
+//	C.txt  absent
+func (s *FilesNFSTestSuite) Scenario_HardlinkSync_PartialOverlapMerge(svm *ScenarioVariationManager) {
+	fromTo := NamedResolveVariation(svm, map[string]common.FromTo{
+		"|fromTo=LocalFileNFS": common.EFromTo.LocalFileNFS(),
+	})
+	if runtime.GOOS != "linux" {
+		svm.InvalidateScenario()
+		return
+	}
+	srcContainer, dstContainer, rootDir := setupHardlinkSyncContainersForFromTo(svm, fromTo)
+	defer cleanupHardlinkSyncForFromTo(svm, fromTo, srcContainer, dstContainer, rootDir)
+	nameA := rootDir + "/A.txt"
+	nameB := rootDir + "/B.txt"
+	nameC := rootDir + "/C.txt"
+
+	// Use a shared LMT so source and dest is testing the hardlink restructuring and not
+	// potential overwrites from differing LMT
+	sharedLMT := time.Now().Add(-5 * time.Minute).Truncate(time.Second)
+
+	// ── Destination: B and C share an inode
+	dstDir := dstContainer.GetObject(svm, rootDir, common.EEntityType.Folder())
+	dstDir.Create(svm, nil, ObjectProperties{EntityType: common.EEntityType.Folder()})
+
+	dstC := dstContainer.GetObject(svm, nameC, common.EEntityType.File())
+	dstC.Create(svm, NewRandomObjectContentContainer(1), ObjectProperties{})
+
+	setSharedLMTIfNFS(svm, dstC, dstContainer, sharedLMT)
+	dstB := dstContainer.GetObject(svm, nameB, common.EEntityType.Hardlink())
+
+	dstB.Create(svm, nil, ObjectProperties{
+		EntityType:         common.EEntityType.Hardlink(),
+		HardLinkedFileName: nameC,
+	})
+	if !svm.Dryrun() {
+		time.Sleep(5 * time.Second)
+	}
+	// ── Source: A and B share an inode
+	srcBodyA := NewRandomObjectContentContainer(1)
+	CreateResource[ObjectResourceManager](svm, srcContainer, ResourceDefinitionObject{
+		ObjectName:       pointerTo(rootDir),
+		ObjectProperties: ObjectProperties{EntityType: common.EEntityType.Folder()},
+	})
+	CreateResource[ObjectResourceManager](svm, srcContainer, ResourceDefinitionObject{
+		ObjectName: pointerTo(nameA),
+		Body:       srcBodyA,
+		ObjectProperties: ObjectProperties{
+			EntityType:        common.EEntityType.File(),
+			FileNFSProperties: nfsPropsIfNFS(srcContainer, sharedLMT),
+		},
+	})
+	CreateResource[ObjectResourceManager](svm, srcContainer, ResourceDefinitionObject{
+		ObjectName: pointerTo(nameB),
+		ObjectProperties: ObjectProperties{
+			EntityType:         common.EEntityType.Hardlink(),
+			HardLinkedFileName: nameA,
+		},
+	})
+	srcDirObj := srcContainer.GetObject(svm, rootDir, common.EEntityType.Folder())
+	stdOut := runHardlinkSyncForFromTo(svm, srcDirObj, dstDir, fromTo, true)
+
+	// A is the data carrier; B must be re-pointed to A; C must be deleted.
+	ValidateResource[ContainerResourceManager](svm, dstContainer, ResourceDefinitionContainer{
+		Objects: ObjectResourceMappingFlat{
+			nameA: ResourceDefinitionObject{
+				Body:             srcBodyA,
+				ObjectProperties: ObjectProperties{EntityType: common.EEntityType.File()},
+			},
+			nameB: ResourceDefinitionObject{
+				Body: srcBodyA,
+				ObjectProperties: ObjectProperties{
+					EntityType:         common.EEntityType.Hardlink(),
+					HardLinkedFileName: nameA,
+				},
+			},
+			nameC: ResourceDefinitionObject{
+				ObjectShouldExist: pointerTo(false),
+			},
+		},
+	}, ValidateResourceOptions{fromTo: fromTo,
+		validateObjectContent: true,
+		hardlinkHandling:      common.PreserveHardlinkHandlingType})
+
+	ValidateHardlinksTransferCount(svm, stdOut, 2)
+}


### PR DESCRIPTION
## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

1. SR-1: Sync does not create new hardlinks
    <details>
    <summary>Description </summary>
    
    ````text
    Scenario A — sync must CREATE a link (SR-1 / A6):
    1. Source (local): A and B are hardlinked (one inode, nlink=2).
    2. Destination (NFS): only A exists (B absent).
    3. Run: azcopy sync <src> "<nfs-url>?<SAS>" --from-to=LocalFileNFS --hardlinks=preserve --preserve-info=true --delete-destination=true
    4. Expected: dest B created and hardlinked to A (A,B share one inode).
    5. Actual: B created as an INDEPENDENT inode; A,B not linked. azcopy exit code = 0 (silent).
    
      ````
    </details>

3. SM-2: Sync does not merge existing independent files
    <details>
    <summary>Description </summary>
    
    ````text
         Scenario B — sync must MERGE an existing independent file (SM-2):
      1. Source: A,B hardlinked. Destination: A and B both exist but are INDEPENDENT.
      2. Run the same sync command.
      3. Expected: dest reconciled so A,B share one inode. 
      4. Actual: they remain independent (rc=0).
          
      ````
    </details>
5. SM-3: Sync does not merge across hardlink groups
    <details>
    <summary>Description </summary>
    
    ````text

        Scenario C — sync must MERGE a whole group (SR-3) / re-point (SM-3):
        1. Source: A,B,C,D linked. Destination: A independent + B,C,D linked (or B linked to a different file C).
        2. Expected: all four share one inode (A merged / B re-pointed). 
        3. Actual: A stays independent / B not re-pointed (rc=0).
    
      ````
    </details>

5. SR-3: Sync does not merge groups together 
    <details>
    <summary>Description </summary>
    
    ````text

        Scenario  — sync must MERGE a whole group (SR-3) / re-point (SM-3):
        1. Source: A,B,C,D all linked
        2. Destination before: A independent + B,C,D linked
        3. Expected after: All 4 linked together
        4. Actual after: A still independent
    
      ````
    </details>


- [ADO Item with full description](<https://msazure.visualstudio.com/One/_workitems/edit/38400481>)

