### PR TITLE
TASK 38260338: Fixed a bug in the release pipeline. 

### DIFF
--- a/build-1es-pipeline.yaml
+++ b/build-1es-pipeline.yaml
@@ -1518,98 +1518,98 @@ extends:
                     done < <(tail -n +3 ../packages.csv)
         # PublishArtifacts ends here
 
-      - ${{ if ne(parameters.remove_packages, '') }}:
-          - stage: RemovePackagesFromLinuxRepository
-            jobs:
-              - job: RemovePackages
-                timeoutInMinutes: 120
-                pool:
-                  name: azcopy-pool
-                  image: ubuntu22-1espt
-                  os: linux
-                variables:
-                  - group: AZCOPY_SECRET_VAULT
-                steps:
-                  - checkout: none
+      - ${{ if ne(trim(parameters.remove_packages), '') }}:
+        - stage: RemovePackagesFromLinuxRepository
+          jobs:
+            - job: RemovePackages
+              timeoutInMinutes: 120
+              pool:
+                name: azcopy-pool
+                image: ubuntu22-1espt
+                os: linux
+              variables:
+                - group: AZCOPY_SECRET_VAULT
+              steps:
+                - checkout: none
 
-                  - task: PipAuthenticate@1
-                    inputs:
-                      artifactFeeds: 'DevExGlobalFeed'
-                    displayName: 'Connect to PMC artifact'
+                - task: PipAuthenticate@1
+                  inputs:
+                    artifactFeeds: 'DevExGlobalFeed'
+                  displayName: 'Connect to PMC artifact'
 
-                  - script: |
-                      sudo apt-get clean
-                      sudo apt-get update --fix-missing
-                      sudo apt-get install -y tree
-                    displayName: 'Install Dependencies'
+                - script: |
+                    sudo apt-get clean
+                    sudo apt-get update --fix-missing
+                    sudo apt-get install -y tree
+                  displayName: 'Install Dependencies'
 
-                  - script: |
-                      pip install pmc-cli
-                      echo '##vso[task.prependpath]$(HOME)/.local/bin'
-                    displayName: 'Install pmc-cli'
+                - script: |
+                    pip install pmc-cli
+                    echo '##vso[task.prependpath]$(HOME)/.local/bin'
+                  displayName: 'Install pmc-cli'
 
-                  - task: DownloadSecureFile@1
-                    name: pmcCertificate
-                    displayName: 'Download pmc pem file'
-                    inputs:
-                      secureFile: 'azstorage-devex-kv-blobfuse-release-pmc1-10102025.pem'
+                - task: DownloadSecureFile@1
+                  name: pmcCertificate
+                  displayName: 'Download pmc pem file'
+                  inputs:
+                    secureFile: 'azstorage-devex-kv-blobfuse-release-pmc1-10102025.pem'
 
-                  - task: DownloadSecureFile@1
-                    name: settings
-                    displayName: 'Download settings.toml file'
-                    inputs:
-                      secureFile: 'settings.toml'
+                - task: DownloadSecureFile@1
+                  name: settings
+                  displayName: 'Download settings.toml file'
+                  inputs:
+                    secureFile: 'settings.toml'
 
-                  - task: AzureCLI@2
-                    displayName: 'Test PMC installation'
-                    inputs:
-                      addSpnToEnvironment: true
-                      azureSubscription: 'azcopy-release'
-                      scriptType: bash
-                      scriptLocation: inlineScript
-                      inlineScript: |
-                        pmc --version
-                        pmc --auth-type wif --base-url "https://pmc-ingest.trafficmanager.net/api/v4" repo list --limit 1
-                        if [ $? -ne 0 ]; then
-                          exit 1
-                        fi
-
-                  - script: |
-                      # Validate remove_packages param
-                      if [[ "${{parameters.remove_packages}}" != " " ]] && [[ -n "${{parameters.remove_packages}}" ]]; then
-                        if ! [[ "${{parameters.remove_packages}}" =~ ^[a-zA-Z0-9._~-]+$ ]]; then 
-                          echo "Error: remove_packages param contains invalid chars. Double check its value." 
-                          exit 1
-                        fi
+                - task: AzureCLI@2
+                  displayName: 'Test PMC installation'
+                  inputs:
+                    addSpnToEnvironment: true
+                    azureSubscription: 'azcopy-release'
+                    scriptType: bash
+                    scriptLocation: inlineScript
+                    inlineScript: |
+                      pmc --version
+                      pmc --auth-type wif --base-url "https://pmc-ingest.trafficmanager.net/api/v4" repo list --limit 1
+                      if [ $? -ne 0 ]; then
+                        exit 1
                       fi
-                      pkg_id_list=$(pmc --msal-cert-path $(pmcCertificate.secureFilePath) --config $(settings.secureFilePath) package deb list --name azcopy --version ${{parameters.remove_packages}})
-                      
-                      # Loop over all the results and extract the package id for each one
-                      for PKG_ID in $(echo "$pkg_id_list" | jq -r '.results[].id'); do
-                          echo "Processing Package ID: $PKG_ID"  # Debugging line
-                          pkg_repo_names=$(pmc --msal-cert-path $(pmcCertificate.secureFilePath) --config $(settings.secureFilePath) repo list --package "$PKG_ID")
-                      
-                          for REPO_NAME in $(echo "$pkg_repo_names" | jq -r '.results[].name'); do
-                              echo "Found repo: $REPO_NAME $PKG_ID" # Debugging line
-                              pmc --msal-cert-path $(pmcCertificate.secureFilePath) --config $(settings.secureFilePath) repo package update --remove-packages $PKG_ID $REPO_NAME
-                              pmc --msal-cert-path $(pmcCertificate.secureFilePath) --config $(settings.secureFilePath) repo publish $REPO_NAME
-                          done
-                      done
-                    displayName: 'Remove deb packages from the repository'
 
-                  - script: |
-                      pkg_id_list=$(pmc --msal-cert-path $(pmcCertificate.secureFilePath) --config $(settings.secureFilePath) package rpm list --name azcopy --version ${{parameters.remove_packages}})
-                      
-                      # Loop over all the results and extract the package id for each one
-                      for PKG_ID in $(echo "$pkg_id_list" | jq -r '.results[].id'); do
-                          echo "Processing Package ID: $PKG_ID"  # Debugging line
-                          pkg_repo_names=$(pmc --msal-cert-path $(pmcCertificate.secureFilePath) --config $(settings.secureFilePath) repo list --package "$PKG_ID")
-                      
-                          for REPO_NAME in $(echo "$pkg_repo_names" | jq -r '.results[].name'); do
-                              echo "Found repo: $REPO_NAME $PKG_ID" # Debugging line
-                              pmc --msal-cert-path $(pmcCertificate.secureFilePath) --config $(settings.secureFilePath) repo package update --remove-packages $PKG_ID $REPO_NAME
-                              pmc --msal-cert-path $(pmcCertificate.secureFilePath) --config $(settings.secureFilePath) repo publish $REPO_NAME
-                          done
-                      done
-                    displayName: 'Remove rpm packages from the repository'
-            # RemovePackagesFromLinuxRepository ends here
+                - script: |
+                    if ! [[ "${{parameters.remove_packages}}" =~ ^[a-zA-Z0-9._~-]+$ ]]; then 
+                      echo "Error: remove_packages parameter contains invalid chars. Double check its value: \"${{parameters.remove_packages}}\"." 
+                      exit 1
+                    fi
+                  displayName: 'Validate remove_packages parameter'
+
+                - script: |
+                    pkg_id_list=$(pmc --msal-cert-path $(pmcCertificate.secureFilePath) --config $(settings.secureFilePath) package deb list --name azcopy --version ${{parameters.remove_packages}})
+                    
+                    # Loop over all the results and extract the package id for each one
+                    for PKG_ID in $(echo "$pkg_id_list" | jq -r '.results[].id'); do
+                        echo "Processing Package ID: $PKG_ID"  # Debugging line
+                        pkg_repo_names=$(pmc --msal-cert-path $(pmcCertificate.secureFilePath) --config $(settings.secureFilePath) repo list --package "$PKG_ID")
+                    
+                        for REPO_NAME in $(echo "$pkg_repo_names" | jq -r '.results[].name'); do
+                            echo "Found repo: $REPO_NAME $PKG_ID" # Debugging line
+                            pmc --msal-cert-path $(pmcCertificate.secureFilePath) --config $(settings.secureFilePath) repo package update --remove-packages $PKG_ID $REPO_NAME
+                            pmc --msal-cert-path $(pmcCertificate.secureFilePath) --config $(settings.secureFilePath) repo publish $REPO_NAME
+                        done
+                    done
+                  displayName: 'Remove deb packages from the repository'
+
+                - script: |
+                    pkg_id_list=$(pmc --msal-cert-path $(pmcCertificate.secureFilePath) --config $(settings.secureFilePath) package rpm list --name azcopy --version ${{parameters.remove_packages}})
+                    
+                    # Loop over all the results and extract the package id for each one
+                    for PKG_ID in $(echo "$pkg_id_list" | jq -r '.results[].id'); do
+                        echo "Processing Package ID: $PKG_ID"  # Debugging line
+                        pkg_repo_names=$(pmc --msal-cert-path $(pmcCertificate.secureFilePath) --config $(settings.secureFilePath) repo list --package "$PKG_ID")
+                    
+                        for REPO_NAME in $(echo "$pkg_repo_names" | jq -r '.results[].name'); do
+                            echo "Found repo: $REPO_NAME $PKG_ID" # Debugging line
+                            pmc --msal-cert-path $(pmcCertificate.secureFilePath) --config $(settings.secureFilePath) repo package update --remove-packages $PKG_ID $REPO_NAME
+                            pmc --msal-cert-path $(pmcCertificate.secureFilePath) --config $(settings.secureFilePath) repo publish $REPO_NAME
+                        done
+                    done
+                  displayName: 'Remove rpm packages from the repository'
+          # RemovePackagesFromLinuxRepository ends here


### PR DESCRIPTION
## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->
The release pipeline no longer runs stage RemovePackagesFromLinuxRepository when the pipeline parameter "remove_packages" is left with its default value of ' '. That parameter doesn't default to '', because that causes the UI to require the user to enter a value, even if they don't want to run this stage. I noticed this bug while updating the release pipeline for TASK 38260338. This commit also removes unnecesary indentation from that stage and improves its error reporting by splitting a task and updating an error message. 

**Related Links**:
- [TASK 38260338](https://msazure.visualstudio.com/One/_workitems/edit/38260338) 

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->
I tested this stage in a modified version of the release pipeline that removed all stages other than AzCopyVersion and RemovePackagesFromLinuxRepository and replaced the package removal scripts with print statements. Modifying the pipeline in this way reduced the run time without impacting the bug fix. 

**Test cases:**
- parameter.remove_packages, link to pipeline run, notes 
- '', [Pipelines - Run 20260707.3](https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31146&view=results), As intended, the RemovePackagesFromLinuxRepository stage wasn't included. 
- ' ', [Pipelines - Run 20260707.4](https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31147&view=results), As intended, the RemovePackagesFromLinuxRepository stage wasn't included. 
- 'test', [Pipelines - Run 20260707.5](https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31148&view=results), As intended, the RemovePackagesFromLinuxRepository stage was included, and all its tasks ran. 
- ' a', [Pipelines - Run 20260707.6](https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31149&view=results), As expected, the RemovePackagesFromLinuxRepository stage was included, and its validation reported the parameter value as invalid (due to the leading space) and prevented the removal tasks from running. This was before I updated the validation to print the parameter value in quotes so the spaces would be harder to overlook. 
- 'a b', [Pipelines - Run 20260707.7](https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31150&view=results), As expected, the RemovePackagesFromLinuxRepository stage was included, and its validation reported the parameter value as invalid (due to the middle space) and prevented the removal tasks from running. This was before I updated the validation to print the parameter value in quotes so the spaces would be harder to overlook. 
- 'a ', [Pipelines - Run 20260707.8](https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31151&view=results), As expected, the RemovePackagesFromLinuxRepository stage was included, and its validation reported the parameter value as invalid (due to the trailing space) and prevented the removal tasks from running. This was after I updated the validation to print the parameter value in quotes so the spaces would be harder to overlook.

After resolving merge conflicts and updating the validation message: 
- ' ', [Pipelines - Run 20260710.3](https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31203&view=results), As intended, the RemovePackagesFromLinuxRepository stage wasn't included. 
- 'a b', [Pipelines - Run 20260710.4](https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31205&view=results), As expected, the RemovePackagesFromLinuxRepository stage was included, and its validation reported the parameter value as invalid (due to the middle space) and prevented the removal tasks from running.