### PR TITLE
TASK 38260338: Corrected a bug in the release pipeline.

### DIFF
--- a/build-1es-pipeline.yaml
+++ b/build-1es-pipeline.yaml
@@ -1392,7 +1392,7 @@ extends:
                   scriptLocation: inlineScript
                   workingDirectory: $(signed)
                   inlineScript: |
-                    [ ${{ parameters.publish_artifacts }} == 'true' ] && [ ${{ parameters.test_pmc_connection }} == 'false' ]
+                    [ ${{ parameters.publish_artifacts }} == 'True' ] && [ ${{ parameters.test_pmc_connection }} == 'False' ]
                     publish=$?
                     
                     azcopyAmdDebFile=$(ls azcopy-* | grep -vE 'fips|cm2' | grep '\.x86_64\.deb')
@@ -1479,7 +1479,7 @@ extends:
                   scriptLocation: inlineScript
                   workingDirectory: $(signed)
                   inlineScript: |
-                    [ ${{ parameters.publish_artifacts }} == 'true' ] && [ ${{ parameters.test_pmc_connection }} == 'false' ]
+                    [ ${{ parameters.publish_artifacts }} == 'True' ] && [ ${{ parameters.test_pmc_connection }} == 'False' ]
                     publish=$?
 
                     while IFS=, read -r distro archetype repoName releaseName; do


### PR DESCRIPTION
Apparently, in bash, Boolean pipeline parameters are converted into strings that begin with a capital letter - "True" and "False", not "true" and "false".

## Type of Change 
<!-- Place an 'x' in the relevant box(es) --> 
- [x] Bug fix 
- [ ] New feature 
- [ ] Documentation update required 
- [ ] Code quality improvement 
- [ ] Other (describe): 

## How Has This Been Tested?
Tested in https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31189&view=logs&j=792982d5-3bb1-5d82-222e-228148b73448&t=6dbac551-d26b-5f96-c3b0-7b66d83f8cbf
