### PR TITLE
TASK 38260338: Updated the release pipeline to sign the FIPS RPM files with the Mariner signing key.

### DIFF
--- a/build-1es-pipeline.yaml
+++ b/build-1es-pipeline.yaml
@@ -421,15 +421,33 @@ extends:
                 parameters:
                   FolderPath: $(fips-amd64)
                   ESRP_AZCOPY_KEY_CODE: $(ESRP_AZCOPY_KEY_CODE)
-                  Pattern: '*.rpm, *.deb'
-                  DisplayName: 'ESRP CodeSigning azcopy linux fips amd64'
+                  Pattern: '*.deb'
+                  DisplayName: 'ESRP CodeSigning azcopy linux fips amd64 deb'
 
               - template: setup/esrp_sign_linux.yml@self
                 parameters:
                   FolderPath: $(fips-arm64)
                   ESRP_AZCOPY_KEY_CODE: $(ESRP_AZCOPY_KEY_CODE)
-                  Pattern: '*.rpm, *.deb'
-                  DisplayName: 'ESRP CodeSigning azcopy linux fips arm64'
+                  Pattern: '*.deb'
+                  DisplayName: 'ESRP CodeSigning azcopy linux fips arm64 deb'
+
+              # When we're ready to support the FIPS RPM packages on other distros,
+              # like the RHEL and CentOS distros already listed in packages.csv,
+              # the pipeline will need to be revised to copy and sign the RPM files for the other distros with ESRP_AZCOPY_KEY_CODE,
+              # unless we can sign a single RPM file with multiple signing keys (in which case, we'll need to do that).
+              - template: setup/esrp_sign_linux.yml@self
+                parameters:
+                  FolderPath: $(fips-amd64)
+                  ESRP_AZCOPY_KEY_CODE: $(ESRP_AZCOPY_MARINER_KEY_CODE)
+                  Pattern: '*.rpm'
+                  DisplayName: 'ESRP CodeSigning azcopy linux fips amd64 rpm'
+
+              - template: setup/esrp_sign_linux.yml@self
+                parameters:
+                  FolderPath: $(fips-arm64)
+                  ESRP_AZCOPY_KEY_CODE: $(ESRP_AZCOPY_MARINER_KEY_CODE)
+                  Pattern: '*.rpm'
+                  DisplayName: 'ESRP CodeSigning azcopy linux fips arm64 rpm'
 
               - script: |
                   mkdir -p $(signed)


### PR DESCRIPTION
This is required to upload the files to the Azure Linux 3.0 repo at packages.microsoft.com. We'll need to make additional changes to the release pipeline to be able to upload those files to other Linux distros.

## Type of Change 
<!-- Place an 'x' in the relevant box(es) --> 
- [x] Bug fix 
- [ ] New feature 
- [ ] Documentation update required 
- [ ] Code quality improvement 
- [ ] Other (describe): 

## How Has This Been Tested?
- The following pipeline run successfully completed with these changes: https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31195&view=results.
- During an earlier pipeline run, the same signing key was used on the non-FIPS RPM files the pipeline uploaded for Azure Linux 3.0 just before this bug surfaced on the FIPS RPM files: https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31190&view=logs&j=020ea8c4-40f7-50e9-e0db-66ba4fe1a18c&t=b99d8e26-1cdb-522d-186a-f61ec686163e.