### PR TITLE
Dedupe Prototype to c2c-stage

### DIFF
--- a/common/dedupeHashTable.go
+++ b/common/dedupeHashTable.go
@@ -1,0 +1,277 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package common
+
+import (
+	"sync"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+// BlockEntry is a single block recorded in the dedupe hash table. Each entry
+// describes a block of content that already exists at some target location, so
+// that a later candidate block with identical content can reference it instead
+// of being transferred again.
+type BlockEntry struct {
+	// JobID identifies the migration job that recorded this block.
+	JobID JobID
+	// CRC64 is a fast, weak checksum of the block content. It is used as the
+	// first-pass bucketing key: cheap to compute for every candidate, but not
+	// collision-free, so a match must always be confirmed with SHA256.
+	CRC64 uint64
+	// SHA256 is the strong content hash of the block. Two blocks are considered
+	// identical (a dedupe hit) only when both CRC64 and SHA256 match.
+	SHA256 [32]byte
+	// TargetURI is the location of the already-stored block content that a hit
+	// can be served from / referenced against.
+	TargetURI string
+	// TargetOffset and TargetLength locate the block's content within TargetURI.
+	// Because Azure block IDs are blob-scoped, a hit cannot reuse another blob's
+	// block by ID; instead it is served by staging from this sub-range of the
+	// already-migrated target blob (Put Block From URL over
+	// [TargetOffset, TargetOffset+TargetLength)). Both are therefore required to
+	// address content inside an existing blob.
+	TargetOffset int64
+	TargetLength int64
+	// ETag is the concurrency/version token of the target, used to detect whether
+	// the referenced content has changed since it was recorded.
+	ETag azcore.ETag
+	// TTL is the lifetime of this entry relative to CreatedAt. A non-positive
+	// TTL means the entry never expires.
+	TTL time.Duration
+	// CreatedAt is the time the entry was recorded. It is set automatically on
+	// insert when left as the zero value.
+	CreatedAt time.Time
+	// RefCount is the number of candidate blocks currently referencing this entry.
+	RefCount int64
+}
+
+// IsExpired reports whether the entry has outlived its TTL. A non-positive TTL
+// is treated as "never expires".
+func (e *BlockEntry) IsExpired() bool {
+	if e.TTL <= 0 {
+		return false
+	}
+	return time.Since(e.CreatedAt) > e.TTL
+}
+
+// DedupeHashTable is an in-memory, concurrency-safe table of recorded blocks
+// used for dedupe candidate lookup during a migration.
+//
+// Lifecycle: create one table per migration with NewDedupeHashTable, use it for
+// the duration of the migration, then drop the reference (or call Clear) once the
+// migration completes so the memory is released until the next migration starts.
+//
+// Entries are bucketed by their CRC64 so that a caller can do a cheap first-pass
+// check (LookupByCRC64) using only the weak checksum, and confirm a true match
+// with the strong SHA256 hash (Lookup). Within a bucket, entries are uniquely
+// identified by their SHA256, so CRC64 collisions are handled correctly.
+type DedupeHashTable struct {
+	mu sync.RWMutex
+	// buckets maps a CRC64 checksum to the entries sharing it. The slice is
+	// almost always of length one; it only grows when distinct blocks happen to
+	// share a CRC64 value.
+	buckets map[uint64][]*BlockEntry
+}
+
+// NewDedupeHashTable returns an empty hash table ready for a single migration.
+func NewDedupeHashTable() *DedupeHashTable {
+	return &DedupeHashTable{
+		buckets: make(map[uint64][]*BlockEntry),
+	}
+}
+
+// findLocked returns the entry matching both crc64 and sha256 along with its
+// index inside its bucket, or (nil, -1) if not present. Callers must hold the
+// appropriate lock.
+func (t *DedupeHashTable) findLocked(crc64 uint64, sha256 [32]byte) (*BlockEntry, int) {
+	for i, e := range t.buckets[crc64] {
+		if e.SHA256 == sha256 {
+			return e, i
+		}
+	}
+	return nil, -1
+}
+
+// removeAtLocked removes the entry at index idx from the bucket for crc64,
+// deleting the bucket entirely once it becomes empty. Callers must hold the
+// write lock.
+func (t *DedupeHashTable) removeAtLocked(crc64 uint64, idx int) {
+	bucket := t.buckets[crc64]
+	bucket = append(bucket[:idx], bucket[idx+1:]...)
+	if len(bucket) == 0 {
+		delete(t.buckets, crc64)
+	} else {
+		t.buckets[crc64] = bucket
+	}
+}
+
+// Insert records a block in the table.
+//
+// If a block with the same CRC64 and SHA256 is already present, its RefCount is
+// incremented and the existing (now updated) entry is returned with inserted set
+// to false. Otherwise the supplied entry is stored — defaulting CreatedAt to the
+// current time and RefCount to 1 when left unset — and returned with inserted set
+// to true.
+func (t *DedupeHashTable) Insert(entry BlockEntry) (stored BlockEntry, inserted bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if existing, _ := t.findLocked(entry.CRC64, entry.SHA256); existing != nil {
+		existing.RefCount++
+		return *existing, false
+	}
+
+	if entry.CreatedAt.IsZero() {
+		entry.CreatedAt = time.Now()
+	}
+	if entry.RefCount < 1 {
+		entry.RefCount = 1
+	}
+
+	e := entry // store a copy so the caller cannot mutate table state by reference
+	t.buckets[entry.CRC64] = append(t.buckets[entry.CRC64], &e)
+	return e, true
+}
+
+// Lookup reports whether a candidate block with the given CRC64 and SHA256 has a
+// matching, non-expired entry in the table. The returned BlockEntry is a snapshot
+// copy; use IncrementRefCount / DecrementRefCount to mutate reference counts.
+func (t *DedupeHashTable) Lookup(crc64 uint64, sha256 [32]byte) (BlockEntry, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	e, _ := t.findLocked(crc64, sha256)
+	if e == nil || e.IsExpired() {
+		return BlockEntry{}, false
+	}
+	return *e, true
+}
+
+// LookupByCRC64 returns snapshot copies of all non-expired entries that share the
+// given CRC64. It is intended as a cheap first-pass filter: compute the weak
+// checksum for a candidate, and only compute the strong SHA256 (and call Lookup)
+// when this returns one or more potential matches.
+func (t *DedupeHashTable) LookupByCRC64(crc64 uint64) []BlockEntry {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	var out []BlockEntry
+	for _, e := range t.buckets[crc64] {
+		if !e.IsExpired() {
+			out = append(out, *e)
+		}
+	}
+	return out
+}
+
+// IncrementRefCount increases the reference count of the matching entry and
+// returns the new count. The boolean is false if no matching entry exists.
+func (t *DedupeHashTable) IncrementRefCount(crc64 uint64, sha256 [32]byte) (int64, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	e, _ := t.findLocked(crc64, sha256)
+	if e == nil {
+		return 0, false
+	}
+	e.RefCount++
+	return e.RefCount, true
+}
+
+// DecrementRefCount decreases the reference count of the matching entry. When the
+// count reaches zero the entry is evicted and (0, true) is returned. The boolean
+// is false if no matching entry exists.
+func (t *DedupeHashTable) DecrementRefCount(crc64 uint64, sha256 [32]byte) (int64, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	e, idx := t.findLocked(crc64, sha256)
+	if e == nil {
+		return 0, false
+	}
+	e.RefCount--
+	if e.RefCount <= 0 {
+		t.removeAtLocked(crc64, idx)
+		return 0, true
+	}
+	return e.RefCount, true
+}
+
+// Remove deletes the matching entry regardless of its reference count. It returns
+// true if an entry was removed.
+func (t *DedupeHashTable) Remove(crc64 uint64, sha256 [32]byte) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if _, idx := t.findLocked(crc64, sha256); idx >= 0 {
+		t.removeAtLocked(crc64, idx)
+		return true
+	}
+	return false
+}
+
+// EvictExpired removes every entry whose TTL has elapsed and returns the number
+// of entries removed.
+func (t *DedupeHashTable) EvictExpired() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	removed := 0
+	for crc64, bucket := range t.buckets {
+		kept := bucket[:0]
+		for _, e := range bucket {
+			if e.IsExpired() {
+				removed++
+				continue
+			}
+			kept = append(kept, e)
+		}
+		if len(kept) == 0 {
+			delete(t.buckets, crc64)
+		} else {
+			t.buckets[crc64] = kept
+		}
+	}
+	return removed
+}
+
+// Len returns the number of entries currently stored in the table.
+func (t *DedupeHashTable) Len() int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	n := 0
+	for _, bucket := range t.buckets {
+		n += len(bucket)
+	}
+	return n
+}
+
+// Clear removes all entries from the table. Call this when a migration finishes
+// to release the table's memory until the next migration begins.
+func (t *DedupeHashTable) Clear() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.buckets = make(map[uint64][]*BlockEntry)
+}

--- a/common/environment.go
+++ b/common/environment.go
@@ -493,3 +493,28 @@ func (EnvironmentVariable) DisableBlobTransferResume() EnvironmentVariable {
 		Description:  "An incomplete transfer to blob endpoint will be resumed from start if set to true",
 	}
 }
+
+// DedupeObserve gates a read-only prototype diagnostic. When set to "true", block-blob to
+// block-blob S2S transfers log how the source blob's committed block boundaries line up with
+// AzCopy's uniform chunk grid. It never changes transfer behavior. Intentionally not listed in
+// VisibleEnvironmentVariables because it is an internal prototype switch, not a supported feature.
+func (EnvironmentVariable) DedupeObserve() EnvironmentVariable {
+	return EnvironmentVariable{
+		Name:         "AZCOPY_DEDUPE_OBSERVE",
+		DefaultValue: "false",
+		Description:  "Prototype diagnostic: when true, logs how source block-blob committed block boundaries align with AzCopy's uniform chunk grid (read-only, no transfer behavior change).",
+	}
+}
+
+func (EnvironmentVariable) DedupeAct() EnvironmentVariable {
+	return EnvironmentVariable{
+		Name:         "AZCOPY_DEDUPE_ACT",
+		DefaultValue: "",
+		Description: "Prototype (block-blob -> block-blob S2S only): act on block-level dedupe. " +
+			"\"shadow\" chunks on the source's committed block boundaries and logs which blocks WOULD be served " +
+			"from an already-migrated destination block (no behavior change to the bytes written). " +
+			"\"enforce\" additionally stages those blocks from the destination (Put Block From URL over the recorded " +
+			"target sub-range, guarded by an If-Match ETag, with automatic fallback to the source on any failure). " +
+			"Any other value disables it. Requires the service GetHash feature so GetBlockList returns per-block crc64/sha256.",
+	}
+}

--- a/common/zt_dedupeHashTable_test.go
+++ b/common/zt_dedupeHashTable_test.go
@@ -1,0 +1,196 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package common
+
+import (
+	"crypto/sha256"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/stretchr/testify/assert"
+)
+
+func sha256Of(s string) [32]byte {
+	return sha256.Sum256([]byte(s))
+}
+
+func newTestEntry(crc64 uint64, content string) BlockEntry {
+	return BlockEntry{
+		JobID:        NewJobID(),
+		CRC64:        crc64,
+		SHA256:       sha256Of(content),
+		TargetURI:    "https://acct.blob.core.windows.net/c/" + content,
+		TargetOffset: 100,
+		TargetLength: 200,
+		ETag:         azcore.ETag("etag-" + content),
+		RefCount:     1,
+	}
+}
+
+func TestDedupeHashTable_InsertAndLookup(t *testing.T) {
+	a := assert.New(t)
+	tbl := NewDedupeHashTable()
+
+	e := newTestEntry(100, "alpha")
+	stored, inserted := tbl.Insert(e)
+	a.True(inserted)
+	a.Equal(int64(1), stored.RefCount)
+	a.False(stored.CreatedAt.IsZero()) // defaulted on insert
+	a.Equal(1, tbl.Len())
+
+	// Hit: both CRC64 and SHA256 match.
+	got, ok := tbl.Lookup(e.CRC64, e.SHA256)
+	a.True(ok)
+	a.Equal(e.TargetURI, got.TargetURI)
+	a.Equal(e.TargetOffset, got.TargetOffset)
+	a.Equal(e.TargetLength, got.TargetLength)
+	a.Equal(e.ETag, got.ETag)
+
+	// Miss: SHA256 differs even though CRC64 matches.
+	_, ok = tbl.Lookup(e.CRC64, sha256Of("different"))
+	a.False(ok)
+
+	// Miss: unknown CRC64.
+	_, ok = tbl.Lookup(999, e.SHA256)
+	a.False(ok)
+}
+
+func TestDedupeHashTable_InsertDuplicateIncrementsRefCount(t *testing.T) {
+	a := assert.New(t)
+	tbl := NewDedupeHashTable()
+
+	e := newTestEntry(100, "alpha")
+	_, inserted := tbl.Insert(e)
+	a.True(inserted)
+
+	stored, inserted := tbl.Insert(e)
+	a.False(inserted) // already present
+	a.Equal(int64(2), stored.RefCount)
+	a.Equal(1, tbl.Len()) // still a single entry
+}
+
+func TestDedupeHashTable_CRC64Collision(t *testing.T) {
+	a := assert.New(t)
+	tbl := NewDedupeHashTable()
+
+	// Two distinct blocks that share a CRC64 bucket but differ in SHA256.
+	e1 := newTestEntry(100, "alpha")
+	e2 := newTestEntry(100, "beta")
+	tbl.Insert(e1)
+	tbl.Insert(e2)
+	a.Equal(2, tbl.Len())
+
+	// First-pass filter returns both candidates.
+	candidates := tbl.LookupByCRC64(100)
+	a.Len(candidates, 2)
+
+	// Confirmation by SHA256 resolves to the correct entry.
+	got1, ok := tbl.Lookup(100, e1.SHA256)
+	a.True(ok)
+	a.Equal(e1.TargetURI, got1.TargetURI)
+
+	got2, ok := tbl.Lookup(100, e2.SHA256)
+	a.True(ok)
+	a.Equal(e2.TargetURI, got2.TargetURI)
+}
+
+func TestDedupeHashTable_RefCounting(t *testing.T) {
+	a := assert.New(t)
+	tbl := NewDedupeHashTable()
+
+	e := newTestEntry(100, "alpha")
+	tbl.Insert(e) // RefCount = 1
+
+	count, ok := tbl.IncrementRefCount(e.CRC64, e.SHA256)
+	a.True(ok)
+	a.Equal(int64(2), count)
+
+	count, ok = tbl.DecrementRefCount(e.CRC64, e.SHA256)
+	a.True(ok)
+	a.Equal(int64(1), count)
+
+	// Final decrement drops to zero and evicts the entry.
+	count, ok = tbl.DecrementRefCount(e.CRC64, e.SHA256)
+	a.True(ok)
+	a.Equal(int64(0), count)
+	a.Equal(0, tbl.Len())
+
+	_, ok = tbl.Lookup(e.CRC64, e.SHA256)
+	a.False(ok)
+}
+
+func TestDedupeHashTable_Remove(t *testing.T) {
+	a := assert.New(t)
+	tbl := NewDedupeHashTable()
+
+	e := newTestEntry(100, "alpha")
+	tbl.Insert(e)
+
+	a.True(tbl.Remove(e.CRC64, e.SHA256))
+	a.Equal(0, tbl.Len())
+	a.False(tbl.Remove(e.CRC64, e.SHA256)) // already gone
+}
+
+func TestDedupeHashTable_Expiry(t *testing.T) {
+	a := assert.New(t)
+	tbl := NewDedupeHashTable()
+
+	expired := newTestEntry(100, "alpha")
+	expired.TTL = time.Millisecond
+	expired.CreatedAt = time.Now().Add(-time.Hour) // already past its TTL
+	tbl.Insert(expired)
+
+	// Expired entries are treated as a miss.
+	_, ok := tbl.Lookup(expired.CRC64, expired.SHA256)
+	a.False(ok)
+	a.Empty(tbl.LookupByCRC64(expired.CRC64))
+
+	// A non-positive TTL never expires.
+	permanent := newTestEntry(200, "beta")
+	permanent.TTL = 0
+	permanent.CreatedAt = time.Now().Add(-time.Hour)
+	tbl.Insert(permanent)
+	_, ok = tbl.Lookup(permanent.CRC64, permanent.SHA256)
+	a.True(ok)
+
+	// EvictExpired purges only the expired entry.
+	removed := tbl.EvictExpired()
+	a.Equal(1, removed)
+	a.Equal(1, tbl.Len())
+}
+
+func TestDedupeHashTable_Clear(t *testing.T) {
+	a := assert.New(t)
+	tbl := NewDedupeHashTable()
+
+	tbl.Insert(newTestEntry(100, "alpha"))
+	tbl.Insert(newTestEntry(200, "beta"))
+	a.Equal(2, tbl.Len())
+
+	tbl.Clear()
+	a.Equal(0, tbl.Len())
+
+	// Table is reusable after clearing (e.g. for the next migration).
+	_, inserted := tbl.Insert(newTestEntry(300, "gamma"))
+	a.True(inserted)
+	a.Equal(1, tbl.Len())
+}

--- a/jobsAdmin/init.go
+++ b/jobsAdmin/init.go
@@ -194,6 +194,8 @@ func ExecuteNewCopyJobPartOrder(order common.CopyJobPartOrderRequest) common.Cop
 		PartNum:           order.PartNum,
 		PlanFile:          jppfn,
 		ExistingPlanMMF:   nil,
+		SourceSAS:         order.SourceRoot.SAS,
+		DestinationSAS:    order.DestinationRoot.SAS,
 		SrcClient:         order.SrcServiceClient,
 		DstClient:         order.DstServiceClient,
 		SrcIsOAuth:        order.S2SSourceCredentialType.IsAzureOAuth(),

--- a/jobsAdmin/init_test.go
+++ b/jobsAdmin/init_test.go
@@ -1,0 +1,176 @@
+// Copyright © 2017 Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package jobsAdmin
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
+)
+
+type executeJobPartOrderTestAdmin struct {
+	*jobsAdmin
+	jobMgr *executeJobPartOrderTestJobMgr
+}
+
+func (a *executeJobPartOrderTestAdmin) NewJobPartPlanFileName(
+	jobID common.JobID,
+	partNumber common.PartNumber,
+) ste.JobPartPlanFileName {
+	return ste.JobPartPlanFileName(fmt.Sprintf(
+		ste.JobPartPlanFileNameFormat,
+		jobID.String(),
+		partNumber,
+		ste.DataSchemaVersion,
+	))
+}
+
+func (a *executeJobPartOrderTestAdmin) JobMgrEnsureExists(
+	common.JobID,
+	common.LogLevel,
+	string,
+) ste.IJobMgr {
+	return a.jobMgr
+}
+
+func (*executeJobPartOrderTestAdmin) RegisterStatsMonitorIfNotDone() {}
+
+type executeJobPartOrderTestJobMgr struct {
+	ste.IJobMgr
+	totalFiles int64
+	jobPart    *executeJobPartOrderTestJobPartMgr
+}
+
+func (*executeJobPartOrderTestJobMgr) SetInMemoryTransitJobState(ste.InMemoryTransitJobState) {}
+
+func (jm *executeJobPartOrderTestJobMgr) AddTotalNumFilesProcessed(numFiles int64) {
+	jm.totalFiles += numFiles
+}
+
+func (jm *executeJobPartOrderTestJobMgr) GetTotalNumFilesProcessed() int64 {
+	return jm.totalFiles
+}
+
+func (jm *executeJobPartOrderTestJobMgr) AddJobPart(args *ste.AddJobPartArgs) ste.IJobPartMgr {
+	jm.jobPart = &executeJobPartOrderTestJobPartMgr{
+		sourceSAS:      args.SourceSAS,
+		destinationSAS: args.DestinationSAS,
+	}
+	return jm.jobPart
+}
+
+func (*executeJobPartOrderTestJobMgr) SendJobPartCreatedMsg(ste.JobPartCreatedMsg) {}
+
+type executeJobPartOrderTestJobPartMgr struct {
+	ste.IJobPartMgr
+	sourceSAS      string
+	destinationSAS string
+}
+
+func (jpm *executeJobPartOrderTestJobPartMgr) SAS() (string, string) {
+	return jpm.sourceSAS, jpm.destinationSAS
+}
+
+func TestExecuteNewCopyJobPartOrderPreservesRuntimeSASWithoutPersistingIt(t *testing.T) {
+	const (
+		sourceSAS      = "sp=rl&sig=source-runtime-sentinel"
+		destinationSAS = "sp=rcwdl&sig=destination-runtime-sentinel"
+	)
+
+	originalJobsAdmin := JobsAdmin
+	originalPlanFolder := common.AzcopyJobPlanFolder
+	common.AzcopyJobPlanFolder = t.TempDir()
+	t.Cleanup(func() {
+		JobsAdmin = originalJobsAdmin
+		common.AzcopyJobPlanFolder = originalPlanFolder
+	})
+
+	jobMgr := &executeJobPartOrderTestJobMgr{}
+	testAdmin := &executeJobPartOrderTestAdmin{jobMgr: jobMgr}
+	JobsAdmin = testAdmin
+
+	order := common.CopyJobPartOrderRequest{
+		JobID:   common.NewJobID(),
+		PartNum: 0,
+		FromTo:  common.EFromTo.BlobBlob(),
+		Fpo:     common.EFolderPropertiesOption.NoFolders(),
+		SourceRoot: common.ResourceString{
+			Value: "https://source.blob.core.windows.net/container",
+			SAS:   sourceSAS,
+		},
+		DestinationRoot: common.ResourceString{
+			Value: "https://destination.blob.core.windows.net/container",
+			SAS:   destinationSAS,
+		},
+	}
+
+	response := ExecuteNewCopyJobPartOrder(order)
+	if !response.JobStarted {
+		t.Fatal("expected job part order to start")
+	}
+	if jobMgr.jobPart == nil {
+		t.Fatal("expected AddJobPart to receive the job part")
+	}
+
+	actualSourceSAS, actualDestinationSAS := jobMgr.jobPart.SAS()
+	if actualSourceSAS != sourceSAS {
+		t.Fatalf("source SAS mismatch: got %q", actualSourceSAS)
+	}
+	if actualDestinationSAS != destinationSAS {
+		t.Fatalf("destination SAS mismatch: got %q", actualDestinationSAS)
+	}
+
+	planFile := testAdmin.NewJobPartPlanFileName(order.JobID, order.PartNum)
+	planBytes, err := os.ReadFile(filepath.Join(common.AzcopyJobPlanFolder, string(planFile)))
+	if err != nil {
+		t.Fatalf("reading generated plan file: %v", err)
+	}
+	for _, sentinel := range []string{sourceSAS, destinationSAS} {
+		if bytes.Contains(planBytes, []byte(sentinel)) {
+			t.Fatalf("generated plan file contains runtime SAS sentinel %q", sentinel)
+		}
+	}
+
+	nonSASJobMgr := &executeJobPartOrderTestJobMgr{}
+	testAdmin.jobMgr = nonSASJobMgr
+	nonSASOrder := order
+	nonSASOrder.JobID = common.NewJobID()
+	nonSASOrder.SourceRoot.SAS = ""
+	nonSASOrder.DestinationRoot.SAS = ""
+
+	response = ExecuteNewCopyJobPartOrder(nonSASOrder)
+	if !response.JobStarted {
+		t.Fatal("expected non-SAS job part order to start")
+	}
+	actualSourceSAS, actualDestinationSAS = nonSASJobMgr.jobPart.SAS()
+	if actualSourceSAS != "" || actualDestinationSAS != "" {
+		t.Fatalf(
+			"expected non-SAS job part to remain empty, got source %q destination %q",
+			actualSourceSAS,
+			actualDestinationSAS,
+		)
+	}
+}

--- a/ste/dedupeAct.go
+++ b/ste/dedupeAct.go
@@ -1,0 +1,163 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ste
+
+import (
+	"encoding/binary"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
+
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+)
+
+// This file implements "Phase 2/3" of the block-level dedupe prototype: acting on dedupe hits.
+//
+// It builds on the read-only Phase 0/1 observer+recorder. When AZCOPY_DEDUPE_ACT is set, a
+// block-blob -> block-blob S2S transfer is chunked on the source's committed block boundaries
+// (Phase 3) instead of AzCopy's uniform grid, so that every chunk lines up with a source block
+// that carries content hashes. Each such chunk is then looked up against the job's committed
+// table (Phase 2): on a hit, the block can be staged from the already-migrated destination blob
+// instead of re-read from the source.
+//
+// Everything here is gated behind AZCOPY_DEDUPE_ACT and is a no-op when it is unset.
+
+// dedupeActMode selects how aggressively the dedupe prototype acts on a hit.
+type dedupeActMode int
+
+const (
+	// dedupeActOff is the default (zero value): no dedupe behavior at all.
+	dedupeActOff dedupeActMode = iota
+	// dedupeActShadow chunks on source boundaries and LOGS which blocks would be referenced from
+	// the destination, but still stages every block from the source (no change to the bytes written).
+	dedupeActShadow
+	// dedupeActEnforce additionally stages a referenced block from the destination sub-range, with
+	// an If-Match ETag guard and automatic fallback to the source on any failure.
+	dedupeActEnforce
+)
+
+func (m dedupeActMode) String() string {
+	switch m {
+	case dedupeActShadow:
+		return "shadow"
+	case dedupeActEnforce:
+		return "enforce"
+	default:
+		return "off"
+	}
+}
+
+// dedupeActModeFromEnv parses AZCOPY_DEDUPE_ACT. "shadow" and "enforce" select the matching mode
+// (case-insensitive); "true" is treated as enforce for convenience; anything else is off.
+func dedupeActModeFromEnv() dedupeActMode {
+	return parseDedupeActMode(common.GetEnvironmentVariable(common.EEnvironmentVariable.DedupeAct()))
+}
+
+// parseDedupeActMode is the pure core of dedupeActModeFromEnv, split out so it can be unit tested.
+func parseDedupeActMode(raw string) dedupeActMode {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "shadow":
+		return dedupeActShadow
+	case "enforce", "true":
+		return dedupeActEnforce
+	default:
+		return dedupeActOff
+	}
+}
+
+// getSourceBlockList fetches the source blob's committed block list, requesting the per-block
+// content hashes (include=crc64,sha256). The hashes are only populated when the service GetHash
+// feature is enabled; otherwise the fields come back empty and callers simply see zero hashes.
+// It is shared by the read-only observer and the act path.
+func getSourceBlockList(jptm IJobPartTransferMgr) (blockblob.GetBlockListResponse, error) {
+	info := jptm.Info()
+	bsc, err := jptm.SrcServiceClient().BlobServiceClient()
+	if err != nil {
+		return blockblob.GetBlockListResponse{}, err
+	}
+	srcClient := bsc.NewContainerClient(info.SrcContainer).NewBlockBlobClient(info.SrcFilePath)
+	return srcClient.GetBlockList(jptm.Context(), blockblob.BlockListTypeCommitted, &blockblob.GetBlockListOptions{
+		Include: []blockblob.BlockListIncludeItem{
+			blockblob.BlockListIncludeItemCrc64,
+			blockblob.BlockListIncludeItemSha256,
+		},
+	})
+}
+
+// rawCommittedBlocksFromResponse extracts the minimal per-block info (name, size, and the optional
+// content hashes) from a committed block list response. Azure Storage encodes the per-block CRC64
+// little-endian.
+func rawCommittedBlocksFromResponse(resp blockblob.GetBlockListResponse) []rawCommittedBlock {
+	raw := make([]rawCommittedBlock, 0, len(resp.CommittedBlocks))
+	for _, b := range resp.CommittedBlocks {
+		rb := rawCommittedBlock{
+			Name: common.IffNotNil(b.Name, ""),
+			Size: common.IffNotNil(b.Size, 0),
+		}
+		if len(b.Crc64) == 8 {
+			rb.CRC64 = binary.LittleEndian.Uint64(b.Crc64)
+		}
+		copy(rb.SHA256[:], b.Sha256)
+		raw = append(raw, rb)
+	}
+	return raw
+}
+
+// fetchSourceGridPlan fetches the source committed block list and turns it into a SourceGridPlan
+// (boundaries plus any per-block hashes). It returns a nil plan with no error when the source has no
+// committed named blocks (e.g. a single-PutBlob or empty blob), which simply means the blob is not
+// eligible for source-grid chunking.
+func fetchSourceGridPlan(jptm IJobPartTransferMgr) (*SourceGridPlan, error) {
+	resp, err := getSourceBlockList(jptm)
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.CommittedBlocks) == 0 {
+		return nil, nil
+	}
+	return buildSourceGridPlan(rawCommittedBlocksFromResponse(resp))
+}
+
+// chunkSpec is a single source-grid chunk: a contiguous [offset, offset+size) range of the source
+// blob whose boundaries match a source committed block rather than AzCopy's uniform grid.
+type chunkSpec struct {
+	offset int64
+	size   int64
+}
+
+// sourceGridChunker is implemented by senders that can override AzCopy's uniform chunk grid with a
+// content-defined one. When dedupeChunkSpecs returns a non-empty slice, scheduleSendChunks iterates
+// those specs instead of the uniform startIndex loop.
+type sourceGridChunker interface {
+	dedupeChunkSpecs() []chunkSpec
+}
+
+// chunkSpecsFromPlan converts a SourceGridPlan into the ordered chunk specs used by the scheduler.
+func chunkSpecsFromPlan(plan *SourceGridPlan) []chunkSpec {
+	if plan == nil {
+		return nil
+	}
+	specs := make([]chunkSpec, len(plan.Blocks))
+	for i, b := range plan.Blocks {
+		specs[i] = chunkSpec{offset: b.Offset, size: b.Size}
+	}
+	return specs
+}

--- a/ste/dedupeAct_test.go
+++ b/ste/dedupeAct_test.go
@@ -1,0 +1,171 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ste
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func ptrTo[T any](v T) *T { return &v }
+
+func TestParseDedupeActMode(t *testing.T) {
+	a := assert.New(t)
+
+	a.Equal(dedupeActShadow, parseDedupeActMode("shadow"))
+	a.Equal(dedupeActShadow, parseDedupeActMode("  SHADOW ")) // trimmed + case-insensitive
+	a.Equal(dedupeActEnforce, parseDedupeActMode("enforce"))
+	a.Equal(dedupeActEnforce, parseDedupeActMode("Enforce"))
+	a.Equal(dedupeActEnforce, parseDedupeActMode("true")) // convenience alias
+
+	a.Equal(dedupeActOff, parseDedupeActMode(""))
+	a.Equal(dedupeActOff, parseDedupeActMode("false"))
+	a.Equal(dedupeActOff, parseDedupeActMode("on"))
+	a.Equal(dedupeActOff, parseDedupeActMode("1"))
+}
+
+func TestDedupeActModeString(t *testing.T) {
+	a := assert.New(t)
+
+	a.Equal("off", dedupeActOff.String())
+	a.Equal("shadow", dedupeActShadow.String())
+	a.Equal("enforce", dedupeActEnforce.String())
+}
+
+func TestChunkSpecsFromPlan(t *testing.T) {
+	a := assert.New(t)
+
+	a.Nil(chunkSpecsFromPlan(nil))
+
+	plan := &SourceGridPlan{Blocks: []PlannedBlock{
+		{Offset: 0, Size: 100},
+		{Offset: 100, Size: 250},
+		{Offset: 350, Size: 50},
+	}}
+	specs := chunkSpecsFromPlan(plan)
+
+	a.Equal([]chunkSpec{{0, 100}, {100, 250}, {350, 50}}, specs)
+}
+
+func TestDedupeChunkSpecs_OffReturnsNil(t *testing.T) {
+	a := assert.New(t)
+
+	plan := &SourceGridPlan{Blocks: []PlannedBlock{{Offset: 0, Size: 100}}}
+
+	// dedupeActOff (the zero value) must never expose a source-grid plan, even if one is set.
+	off := &blockBlobSenderBase{dedupeMode: dedupeActOff, dedupePlan: plan}
+	a.Nil(off.dedupeChunkSpecs())
+
+	shadow := &blockBlobSenderBase{dedupeMode: dedupeActShadow, dedupePlan: plan}
+	a.Equal([]chunkSpec{{0, 100}}, shadow.dedupeChunkSpecs())
+}
+
+func TestRawCommittedBlocksFromResponse(t *testing.T) {
+	a := assert.New(t)
+
+	var crc [8]byte
+	binary.LittleEndian.PutUint64(crc[:], 0x0102030405060708)
+	sha := make([]byte, 32)
+	sha[0], sha[31] = 0xAA, 0xBB
+
+	resp := blockblob.GetBlockListResponse{}
+	resp.CommittedBlocks = []*blockblob.Block{
+		{Name: ptrTo("blk-0"), Size: ptrTo(int64(100)), Crc64: crc[:], Sha256: sha},
+		{Name: ptrTo("blk-1"), Size: ptrTo(int64(200))}, // no hashes (GetHash off for this block)
+	}
+
+	raw := rawCommittedBlocksFromResponse(resp)
+
+	a.Len(raw, 2)
+	a.Equal("blk-0", raw[0].Name)
+	a.EqualValues(100, raw[0].Size)
+	a.Equal(uint64(0x0102030405060708), raw[0].CRC64) // decoded little-endian
+	a.Equal(byte(0xAA), raw[0].SHA256[0])
+	a.Equal(byte(0xBB), raw[0].SHA256[31])
+
+	a.Equal("blk-1", raw[1].Name)
+	a.EqualValues(200, raw[1].Size)
+	a.EqualValues(0, raw[1].CRC64)
+	a.Equal([32]byte{}, raw[1].SHA256)
+}
+
+func TestRecordCommittedBlocks_PopulatesCommittedTableForReference(t *testing.T) {
+	a := assert.New(t)
+
+	jobID := common.NewJobID()
+	defer clearDedupeStateForJob(jobID)
+
+	plan := &SourceGridPlan{Blocks: []PlannedBlock{
+		hashedBlock("alpha", 0, 100),
+		hashedBlock("beta", 100, 200),
+		{Offset: 300, Size: 50}, // no hashes -> must be skipped
+	}}
+	const dest = "https://acct.blob.core.windows.net/c/migrated?sig=secret"
+
+	recorded := recordCommittedBlocks(jobID, dest, "etag-xyz", plan)
+	a.Equal(2, recorded) // only the two hashed blocks
+
+	committed := dedupeStateForJob(jobID).committed
+	a.Equal(2, committed.Len())
+
+	// A later identical block must now resolve to a reference against the recorded target, with the
+	// SAS stripped from the stored TargetURI and the destination ETag preserved.
+	idx := buildSourceBlockHashIndex(plan)
+	target, reference := decideStaging(idx, committed, 0, 100)
+	a.True(reference)
+	a.Equal("https://acct.blob.core.windows.net/c/migrated", target.TargetURI)
+	a.EqualValues(0, target.TargetOffset)
+	a.EqualValues(100, target.TargetLength)
+	a.EqualValues("etag-xyz", target.ETag)
+}
+
+func TestRecordCommittedBlocks_NilPlanIsNoOp(t *testing.T) {
+	a := assert.New(t)
+
+	jobID := common.NewJobID()
+	defer clearDedupeStateForJob(jobID)
+
+	a.Equal(0, recordCommittedBlocks(jobID, "uri", "etag", nil))
+}
+
+func TestDedupeJobStateCounters(t *testing.T) {
+	a := assert.New(t)
+	st := &dedupeJobState{}
+
+	st.addReferenced(100)
+	st.addReferenced(50)
+	st.addWouldReference(200)
+	st.addSourceStaged(30)
+	st.addSourceStaged(70)
+	st.addFallback()
+
+	a.EqualValues(2, st.referencedBlocks)
+	a.EqualValues(150, st.referencedBytes) // source-read bytes avoided under enforce
+	a.EqualValues(1, st.wouldReferenceBlocks)
+	a.EqualValues(200, st.wouldReferenceBytes)
+	a.EqualValues(2, st.sourceStagedBlocks)
+	a.EqualValues(100, st.sourceStagedBytes)
+	a.EqualValues(1, st.fallbackBlocks)
+}

--- a/ste/dedupeRecorder.go
+++ b/ste/dedupeRecorder.go
@@ -1,0 +1,339 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ste
+
+import (
+	"fmt"
+	"net/url"
+	"sync"
+	"sync/atomic"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+)
+
+// This file implements "Phase 1" of the block-level dedupe prototype: "record + measure".
+//
+// Building on the read-only Phase 0 observer (sourceGridObserver.go), it records each
+// source committed block that carries content hashes into a per-job DedupeHashTable, and
+// measures the "would-be" dedupe hit rate: how many migrated blocks have content identical
+// to a block already recorded earlier in the same job (within a blob or across blobs).
+//
+// Like Phase 0, it is gated on AZCOPY_DEDUPE_OBSERVE=true and NEVER changes transfer
+// behavior. Its only job is to prove the real, end-to-end dedupe potential with hard numbers
+// before any bytes are actually skipped (Phase 2) or the chunk grid is changed (Phase 3).
+
+// dedupeJobState holds a single job's dedupe tables plus cumulative would-be-hit counters.
+type dedupeJobState struct {
+	// table is the Phase 1 measurement table: blocks are recorded pre-write purely to count the
+	// would-be-hit rate, so it must NOT be used to decide a real reference (the content may not yet
+	// exist at the destination).
+	table *common.DedupeHashTable
+
+	// committed is the Phase 2 table: it holds only blocks confirmed committed at the destination
+	// (recorded in the sender Epilogue after a successful CommitBlockList). A reference is only ever
+	// served from an entry in this table, so the target content is guaranteed to exist.
+	committed *common.DedupeHashTable
+
+	// Counters are cumulative across every blob processed for the job, and are updated
+	// atomically because transfers (and therefore observeSourceGrid calls) run concurrently.
+	hashedBlocks   int64 // blocks that carried crc64+sha256 (i.e. were eligible for dedupe)
+	wouldBeHits    int64 // eligible blocks whose content was already recorded by an earlier block
+	dedupableBytes int64 // total size of would-be-hit blocks: bytes that need not be re-transferred
+
+	// Phase 2 "act" counters (also cumulative + atomic). Together they quantify how many source
+	// reads dedupe actually avoided (enforce) or would avoid (shadow).
+	referencedBlocks     int64 // enforce: blocks staged from the destination instead of the source
+	referencedBytes      int64 // enforce: source-read bytes avoided
+	wouldReferenceBlocks int64 // shadow: blocks that would be referenced under enforce
+	wouldReferenceBytes  int64 // shadow: source-read bytes that would be avoided under enforce
+	sourceStagedBlocks   int64 // blocks staged from the source (real source reads)
+	sourceStagedBytes    int64 // bytes staged from the source
+	fallbackBlocks       int64 // enforce: hits whose target reference failed and fell back to source
+}
+
+// addReferenced records a block that enforce mode staged from the destination (a source read avoided).
+func (s *dedupeJobState) addReferenced(size int64) {
+	atomic.AddInt64(&s.referencedBlocks, 1)
+	atomic.AddInt64(&s.referencedBytes, size)
+}
+
+// addWouldReference records a block that shadow mode would have referenced under enforce.
+func (s *dedupeJobState) addWouldReference(size int64) {
+	atomic.AddInt64(&s.wouldReferenceBlocks, 1)
+	atomic.AddInt64(&s.wouldReferenceBytes, size)
+}
+
+// addSourceStaged records a block that was actually staged from the source (a real source read).
+func (s *dedupeJobState) addSourceStaged(size int64) {
+	atomic.AddInt64(&s.sourceStagedBlocks, 1)
+	atomic.AddInt64(&s.sourceStagedBytes, size)
+}
+
+// addFallback records an enforce hit whose target reference failed and fell back to the source.
+func (s *dedupeJobState) addFallback() {
+	atomic.AddInt64(&s.fallbackBlocks, 1)
+}
+
+var (
+	dedupeJobsMu sync.Mutex
+	dedupeJobs   = make(map[common.JobID]*dedupeJobState)
+)
+
+// dedupeStateForJob returns the dedupe state for a job, creating it on first use. The map is
+// only ever populated when the prototype flag is on (observeSourceGrid is the sole caller), so
+// no per-job memory is allocated in the default code path.
+func dedupeStateForJob(jobID common.JobID) *dedupeJobState {
+	dedupeJobsMu.Lock()
+	defer dedupeJobsMu.Unlock()
+
+	st, ok := dedupeJobs[jobID]
+	if !ok {
+		st = &dedupeJobState{
+			table:     common.NewDedupeHashTable(),
+			committed: common.NewDedupeHashTable(),
+		}
+		dedupeJobs[jobID] = st
+	}
+	return st
+}
+
+// clearDedupeStateForJob drops a job's dedupe table to release its memory. It is safe to call
+// when no state exists. Wiring this to a job-teardown hook is a follow-up; for the opt-in
+// prototype (one job per process invocation) the table is released at process exit.
+func clearDedupeStateForJob(jobID common.JobID) {
+	dedupeJobsMu.Lock()
+	defer dedupeJobsMu.Unlock()
+
+	if st, ok := dedupeJobs[jobID]; ok {
+		st.table.Clear()
+		st.committed.Clear()
+		delete(dedupeJobs, jobID)
+	}
+}
+
+// recordCommittedBlocks records a freshly-committed destination blob's hashed blocks into the job's
+// committed table, so that later blocks with identical content can be served from this blob. It is
+// called from the sender Epilogue after CommitBlockList succeeds, with the destination's real ETag.
+// Because the destination is a byte-identical copy of the source, each block lives at the same
+// offset/length in the target blob as in the source.
+func recordCommittedBlocks(jobID common.JobID, destURI string, etag azcore.ETag, plan *SourceGridPlan) (recorded int) {
+	if plan == nil {
+		return 0
+	}
+	st := dedupeStateForJob(jobID)
+	target := sanitizedDestForDedupe(destURI)
+	for _, b := range plan.Blocks {
+		if !blockHasHashes(b) {
+			continue
+		}
+		st.committed.Insert(common.BlockEntry{
+			JobID:        jobID,
+			CRC64:        b.CRC64,
+			SHA256:       b.SHA256,
+			TargetURI:    target,
+			TargetOffset: b.Offset,
+			TargetLength: b.Size,
+			ETag:         etag,
+		})
+		recorded++
+	}
+	return recorded
+}
+
+// logDedupeActSummary logs the job's cumulative Phase 2 savings. It is emitted once per committed
+// blob (from the sender Epilogue), so the final line for a job is the job total — mirroring the
+// Phase 1 running-total pattern and avoiding the need for a job-teardown hook. It reports how many
+// source reads dedupe avoided (enforce) or would avoid (shadow).
+func logDedupeActSummary(jptm IJobPartTransferMgr, mode dedupeActMode) {
+	st := dedupeStateForJob(jptm.Info().JobID)
+
+	referencedBlocks := atomic.LoadInt64(&st.referencedBlocks)
+	referencedBytes := atomic.LoadInt64(&st.referencedBytes)
+	wouldRefBlocks := atomic.LoadInt64(&st.wouldReferenceBlocks)
+	wouldRefBytes := atomic.LoadInt64(&st.wouldReferenceBytes)
+	sourceBlocks := atomic.LoadInt64(&st.sourceStagedBlocks)
+	sourceBytes := atomic.LoadInt64(&st.sourceStagedBytes)
+	fallbacks := atomic.LoadInt64(&st.fallbackBlocks)
+
+	switch mode {
+	case dedupeActEnforce:
+		// Referenced blocks were staged from the destination; source-staged blocks were read from the
+		// source. Total = referenced + source; avoided source-read bytes = referencedBytes.
+		totalStagedBytes := referencedBytes + sourceBytes
+		jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
+			"dedupe-summary(enforce): avoided %d source-read bytes across %d block(s) = %.1f%% of %d staged bytes; "+
+				"staged %d block(s)/%d bytes from source; %d fallback(s)",
+			referencedBytes, referencedBlocks, dedupePercent(referencedBytes, totalStagedBytes), totalStagedBytes,
+			sourceBlocks, sourceBytes, fallbacks))
+	case dedupeActShadow:
+		// Every block is staged from the source in shadow mode, so sourceBytes is the total; the
+		// would-reference blocks are the subset that enforce would have avoided.
+		jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
+			"dedupe-summary(shadow): %d block(s)/%d bytes WOULD be avoided under enforce = %.1f%% of %d staged bytes "+
+				"(all currently staged from source)",
+			wouldRefBlocks, wouldRefBytes, dedupePercent(wouldRefBytes, sourceBytes), sourceBytes))
+	}
+}
+
+// blockHasHashes reports whether a planned block carries content hashes from the extended
+// GetBlockList response. When the service GetHash feature is off (or include was not honored),
+// both hashes are left zero and the block is not eligible for dedupe measurement.
+func blockHasHashes(b PlannedBlock) bool {
+	return b.CRC64 != 0 || b.SHA256 != ([32]byte{})
+}
+
+// measureAndRecord performs the Phase 1 lookup-then-record over a set of planned blocks against
+// the given table. For each block that carries hashes it (1) looks the content up, counting a
+// would-be hit when identical content was already recorded, then (2) records the block keyed to
+// where it is being migrated (targetURI). It returns the number of eligible (hashed) blocks, the
+// number of would-be hits, and the total size of those hit blocks.
+//
+// It is deliberately free of any jptm/logging dependency so it can be unit tested directly.
+//
+// Note: between the Lookup and Insert of a given block another goroutine may insert identical
+// content, so concurrent identical blocks can be under-counted as misses. That is acceptable for a
+// measurement phase — the reported hit rate is conservative (never over-counted).
+func measureAndRecord(table *common.DedupeHashTable, jobID common.JobID, targetURI string, blocks []PlannedBlock) (hashed, hits, dedupableBytes int64) {
+	for _, b := range blocks {
+		if !blockHasHashes(b) {
+			continue
+		}
+		hashed++
+
+		if _, hit := table.Lookup(b.CRC64, b.SHA256); hit {
+			hits++
+			dedupableBytes += b.Size
+		}
+
+		table.Insert(common.BlockEntry{
+			JobID:     jobID,
+			CRC64:     b.CRC64,
+			SHA256:    b.SHA256,
+			TargetURI: targetURI,
+			// The destination is a byte-identical copy of the source, so the block lives
+			// at the same offset/length in the target blob as in the source.
+			TargetOffset: b.Offset,
+			TargetLength: b.Size,
+			// ETag is populated in Phase 2, where recording happens after a successful
+			// destination write; Phase 1 records pre-write, for measurement only.
+		})
+	}
+	return hashed, hits, dedupableBytes
+}
+
+// sanitizedDestForDedupe returns the destination blob URL with any query string (e.g. a SAS
+// token) stripped, so credentials are never stored in the table. If the URL cannot be parsed it
+// is returned unchanged (the table is in-memory and prototype-only).
+func sanitizedDestForDedupe(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	u.RawQuery = ""
+	return u.String()
+}
+
+// dedupePercent returns hits/total as a percentage, treating total==0 as 0%.
+func dedupePercent(hits, total int64) float64 {
+	if total == 0 {
+		return 0
+	}
+	return 100 * float64(hits) / float64(total)
+}
+
+// recordSourceGridForDedupe implements Phase 1 for a single transfer (blob). It records the
+// source's committed blocks into the per-job table, accumulates the would-be-hit counters, and
+// logs both this blob's contribution and the running job-wide hit rate. It changes no transfer
+// behavior.
+func recordSourceGridForDedupe(jptm IJobPartTransferMgr, plan *SourceGridPlan) {
+	info := jptm.Info()
+	st := dedupeStateForJob(info.JobID)
+	targetURI := sanitizedDestForDedupe(info.Destination)
+
+	hashed, hits, dedupableBytes := measureAndRecord(st.table, info.JobID, targetURI, plan.Blocks)
+	if hashed == 0 {
+		return // nothing eligible (service GetHash feature off, or include not honored)
+	}
+
+	totalHashed := atomic.AddInt64(&st.hashedBlocks, hashed)
+	totalHits := atomic.AddInt64(&st.wouldBeHits, hits)
+	totalBytes := atomic.AddInt64(&st.dedupableBytes, dedupableBytes)
+
+	jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
+		"dedupe-phase1: blob %q would-be-hits=%d/%d blocks; job cumulative would-be-hits=%d/%d blocks (%.1f%%), dedupable bytes=%d, table entries=%d",
+		info.SrcFilePath, hits, hashed,
+		totalHits, totalHashed, dedupePercent(totalHits, totalHashed),
+		totalBytes, st.table.Len()))
+}
+
+// --- Phase 2 core: staging-time hit decision (pure; not yet wired into the transfer path) ---
+
+// srcBlockKey identifies a source committed block by its position and length. A uniform AzCopy
+// chunk can be matched to a source block (and so to its content hashes) only when the two share the
+// same offset and size — until source-grid chunking (Phase 3) makes every chunk a source block, the
+// index therefore only resolves chunks that already align with the source's committed boundaries.
+type srcBlockKey struct {
+	offset int64
+	size   int64
+}
+
+// srcBlockHashes are the content hashes of a single source committed block.
+type srcBlockHashes struct {
+	crc64  uint64
+	sha256 [32]byte
+}
+
+// buildSourceBlockHashIndex turns a source-grid plan into a lookup from a block's (offset,size) to
+// its content hashes, including only blocks that actually carry hashes. The staging path consults it
+// to discover whether the chunk it is about to send has a known hash to look up.
+func buildSourceBlockHashIndex(plan *SourceGridPlan) map[srcBlockKey]srcBlockHashes {
+	idx := make(map[srcBlockKey]srcBlockHashes, len(plan.Blocks))
+	for _, b := range plan.Blocks {
+		if !blockHasHashes(b) {
+			continue
+		}
+		idx[srcBlockKey{offset: b.Offset, size: b.Size}] = srcBlockHashes{crc64: b.CRC64, sha256: b.SHA256}
+	}
+	return idx
+}
+
+// decideStaging is the core Phase 2 "act on a hit" decision for a single block about to be staged at
+// [offset, offset+size) of the source. It returns the matching target entry with reference=true when
+// (a) the chunk exactly matches a hashed source block, and (b) that content is already recorded as
+// committed at the destination — meaning the block can be staged from the target blob (Put Block
+// From URL over the target's sub-range) instead of re-read from the source. Otherwise it returns
+// reference=false and the caller stages from the source as normal.
+//
+// It is pure (no I/O, no jptm) so the decision can be unit tested exhaustively before being wired
+// into generatePutBlockFromURL.
+func decideStaging(index map[srcBlockKey]srcBlockHashes, committed *common.DedupeHashTable, offset, size int64) (target common.BlockEntry, reference bool) {
+	h, ok := index[srcBlockKey{offset: offset, size: size}]
+	if !ok {
+		return common.BlockEntry{}, false // no known hash for this chunk (not aligned to a source block)
+	}
+	entry, hit := committed.Lookup(h.crc64, h.sha256)
+	if !hit {
+		return common.BlockEntry{}, false // identical content not yet migrated to the destination
+	}
+	return entry, true
+}

--- a/ste/dedupeRecorder_test.go
+++ b/ste/dedupeRecorder_test.go
@@ -1,0 +1,257 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ste
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/stretchr/testify/assert"
+)
+
+// hashedBlock builds a PlannedBlock whose hashes are derived from content, so identical content
+// produces identical CRC64+SHA256 (and therefore a dedupe hit).
+func hashedBlock(content string, offset, size int64) PlannedBlock {
+	sum := sha256.Sum256([]byte(content))
+	// Derive a stable, content-dependent CRC64 surrogate from the first 8 bytes of the SHA256.
+	var crc uint64
+	for i := 0; i < 8; i++ {
+		crc = crc<<8 | uint64(sum[i])
+	}
+	return PlannedBlock{
+		Offset:       offset,
+		Size:         size,
+		SrcBlockName: content,
+		CRC64:        crc,
+		SHA256:       sum,
+	}
+}
+
+func TestBlockHasHashes(t *testing.T) {
+	a := assert.New(t)
+
+	a.True(blockHasHashes(hashedBlock("alpha", 0, 10)))
+	a.True(blockHasHashes(PlannedBlock{CRC64: 1}))
+	a.True(blockHasHashes(PlannedBlock{SHA256: [32]byte{0: 1}}))
+	a.False(blockHasHashes(PlannedBlock{Offset: 0, Size: 100})) // no hashes -> not eligible
+}
+
+func TestMeasureAndRecord_SkipsBlocksWithoutHashes(t *testing.T) {
+	a := assert.New(t)
+	tbl := common.NewDedupeHashTable()
+
+	blocks := []PlannedBlock{
+		{Offset: 0, Size: 100},   // no hashes
+		{Offset: 100, Size: 200}, // no hashes
+	}
+	hashed, hits, bytes := measureAndRecord(tbl, common.NewJobID(), "https://acct.blob.core.windows.net/c/b", blocks)
+
+	a.EqualValues(0, hashed)
+	a.EqualValues(0, hits)
+	a.EqualValues(0, bytes)
+	a.Equal(0, tbl.Len())
+}
+
+func TestMeasureAndRecord_DistinctBlocksProduceNoHits(t *testing.T) {
+	a := assert.New(t)
+	tbl := common.NewDedupeHashTable()
+
+	blocks := []PlannedBlock{
+		hashedBlock("a", 0, 10),
+		hashedBlock("b", 10, 20),
+		hashedBlock("c", 30, 30),
+	}
+	hashed, hits, bytes := measureAndRecord(tbl, common.NewJobID(), "uri", blocks)
+
+	a.EqualValues(3, hashed)
+	a.EqualValues(0, hits)
+	a.EqualValues(0, bytes)
+	a.Equal(3, tbl.Len())
+}
+
+func TestMeasureAndRecord_IntraBlobDuplicate(t *testing.T) {
+	a := assert.New(t)
+	tbl := common.NewDedupeHashTable()
+
+	// The third block repeats the content of the first -> one would-be hit of size 10.
+	blocks := []PlannedBlock{
+		hashedBlock("dup", 0, 10),
+		hashedBlock("other", 10, 20),
+		hashedBlock("dup", 30, 10),
+	}
+	hashed, hits, bytes := measureAndRecord(tbl, common.NewJobID(), "uri", blocks)
+
+	a.EqualValues(3, hashed)
+	a.EqualValues(1, hits)
+	a.EqualValues(10, bytes)
+	a.Equal(2, tbl.Len()) // only two distinct contents stored
+}
+
+func TestMeasureAndRecord_CrossBlobAccumulation(t *testing.T) {
+	a := assert.New(t)
+	tbl := common.NewDedupeHashTable()
+	job := common.NewJobID()
+
+	// First blob: two distinct blocks, no hits.
+	h1, hit1, b1 := measureAndRecord(tbl, job, "uri-blob1", []PlannedBlock{
+		hashedBlock("shared", 0, 50),
+		hashedBlock("unique1", 50, 25),
+	})
+	a.EqualValues(2, h1)
+	a.EqualValues(0, hit1)
+	a.EqualValues(0, b1)
+
+	// Second blob: re-uses "shared" content from the first blob -> one cross-blob would-be hit.
+	h2, hit2, b2 := measureAndRecord(tbl, job, "uri-blob2", []PlannedBlock{
+		hashedBlock("shared", 0, 50),
+		hashedBlock("unique2", 50, 25),
+	})
+	a.EqualValues(2, h2)
+	a.EqualValues(1, hit2)
+	a.EqualValues(50, b2)
+
+	a.Equal(3, tbl.Len()) // shared + unique1 + unique2
+}
+
+func TestMeasureAndRecord_PopulatesTargetRange(t *testing.T) {
+	a := assert.New(t)
+	tbl := common.NewDedupeHashTable()
+
+	// A recorded block must carry the target sub-range so Phase 2 can later stage it
+	// from [TargetOffset, TargetOffset+TargetLength) of the already-migrated dest blob.
+	b := hashedBlock("x", 4096, 1000)
+	measureAndRecord(tbl, common.NewJobID(), "https://acct.blob.core.windows.net/c/b", []PlannedBlock{b})
+
+	got, ok := tbl.Lookup(b.CRC64, b.SHA256)
+	a.True(ok)
+	a.Equal("https://acct.blob.core.windows.net/c/b", got.TargetURI)
+	a.EqualValues(4096, got.TargetOffset)
+	a.EqualValues(1000, got.TargetLength)
+}
+
+func TestSanitizedDestForDedupe_StripsSAS(t *testing.T) {
+	a := assert.New(t)
+
+	got := sanitizedDestForDedupe("https://acct.blob.core.windows.net/c/b.bin?sv=2021&sig=SECRET")
+	a.Equal("https://acct.blob.core.windows.net/c/b.bin", got)
+
+	// No query string is left unchanged.
+	plain := "https://acct.blob.core.windows.net/c/b.bin"
+	a.Equal(plain, sanitizedDestForDedupe(plain))
+}
+
+func TestDedupePercent(t *testing.T) {
+	a := assert.New(t)
+
+	a.EqualValues(0, dedupePercent(0, 0))
+	a.EqualValues(0, dedupePercent(0, 10))
+	a.EqualValues(50, dedupePercent(5, 10))
+	a.EqualValues(100, dedupePercent(10, 10))
+}
+
+func TestDedupeStateForJob_IsolatesAndClears(t *testing.T) {
+	a := assert.New(t)
+
+	jobA := common.NewJobID()
+	jobB := common.NewJobID()
+
+	stA := dedupeStateForJob(jobA)
+	stB := dedupeStateForJob(jobB)
+	a.NotSame(stA, stB)                  // distinct jobs get distinct tables
+	a.Same(stA, dedupeStateForJob(jobA)) // same job returns the same state
+
+	measureAndRecord(stA.table, jobA, "uri", []PlannedBlock{hashedBlock("x", 0, 10)})
+	a.Equal(1, stA.table.Len())
+
+	clearDedupeStateForJob(jobA)
+	clearDedupeStateForJob(jobB)
+
+	// A fresh state is created after clearing, with an empty table.
+	a.Equal(0, dedupeStateForJob(jobA).table.Len())
+	clearDedupeStateForJob(jobA)
+}
+
+func TestBuildSourceBlockHashIndex(t *testing.T) {
+	a := assert.New(t)
+
+	plan := &SourceGridPlan{Blocks: []PlannedBlock{
+		hashedBlock("a", 0, 100),
+		hashedBlock("b", 100, 200),
+		{Offset: 300, Size: 50}, // no hashes -> excluded from the index
+	}}
+	idx := buildSourceBlockHashIndex(plan)
+
+	a.Len(idx, 2)
+	_, ok := idx[srcBlockKey{offset: 0, size: 100}]
+	a.True(ok)
+	_, ok = idx[srcBlockKey{offset: 100, size: 200}]
+	a.True(ok)
+	_, ok = idx[srcBlockKey{offset: 300, size: 50}]
+	a.False(ok)
+}
+
+func TestDecideStaging_NoHashForChunk(t *testing.T) {
+	a := assert.New(t)
+
+	idx := buildSourceBlockHashIndex(&SourceGridPlan{Blocks: []PlannedBlock{hashedBlock("a", 0, 100)}})
+	committed := common.NewDedupeHashTable()
+
+	// A chunk whose (offset,size) matches no source block has no known hash -> stage from source.
+	_, reference := decideStaging(idx, committed, 0, 64)
+	a.False(reference)
+}
+
+func TestDecideStaging_HashButNotYetCommitted(t *testing.T) {
+	a := assert.New(t)
+
+	b := hashedBlock("a", 0, 100)
+	idx := buildSourceBlockHashIndex(&SourceGridPlan{Blocks: []PlannedBlock{b}})
+	committed := common.NewDedupeHashTable() // nothing migrated yet
+
+	_, reference := decideStaging(idx, committed, 0, 100)
+	a.False(reference) // hash known, but content not present at the destination -> stage from source
+}
+
+func TestDecideStaging_Hit(t *testing.T) {
+	a := assert.New(t)
+
+	b := hashedBlock("a", 0, 100)
+	idx := buildSourceBlockHashIndex(&SourceGridPlan{Blocks: []PlannedBlock{b}})
+
+	committed := common.NewDedupeHashTable()
+	committed.Insert(common.BlockEntry{
+		CRC64:        b.CRC64,
+		SHA256:       b.SHA256,
+		TargetURI:    "https://acct.blob.core.windows.net/c/already-migrated",
+		TargetOffset: 0,
+		TargetLength: 100,
+		ETag:         azcore.ETag("etag-1"),
+	})
+
+	target, reference := decideStaging(idx, committed, 0, 100)
+	a.True(reference)
+	a.Equal("https://acct.blob.core.windows.net/c/already-migrated", target.TargetURI)
+	a.EqualValues(0, target.TargetOffset)
+	a.EqualValues(100, target.TargetLength)
+	a.Equal(azcore.ETag("etag-1"), target.ETag)
+}

--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -529,6 +529,10 @@ type AddJobPartArgs struct {
 	PlanFile        JobPartPlanFileName
 	ExistingPlanMMF *JobPartPlanMMF
 
+	// SAS values are runtime-only and must never be persisted in the plan file.
+	SourceSAS      string
+	DestinationSAS string
+
 	// this is required in S2S transfers authenticating to src
 	// via oAuth
 	SourceTokenCred *string
@@ -550,6 +554,8 @@ func (jm *jobMgr) AddJobPart(args *AddJobPartArgs) IJobPartMgr {
 	jpm := &jobPartMgr{
 		jobMgr:            jm,
 		filename:          args.PlanFile,
+		sourceSAS:         args.SourceSAS,
+		destinationSAS:    args.DestinationSAS,
 		srcServiceClient:  args.SrcClient,
 		dstServiceClient:  args.DstClient,
 		pacer:             jm.pacer,

--- a/ste/mgr-JobPartMgr_test.go
+++ b/ste/mgr-JobPartMgr_test.go
@@ -21,9 +21,14 @@
 package ste
 
 import (
-	"github.com/stretchr/testify/assert"
+	"context"
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
+
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInferContentType(t *testing.T) {
@@ -52,5 +57,90 @@ func TestInferContentType(t *testing.T) {
 		// make sure the inferred type is correct
 		// we use Contains to check because charset is also in contentType
 		a.True(strings.Contains(contentType, expectedType))
+	}
+}
+
+func TestAddJobPartRuntimeSAS(t *testing.T) {
+	const (
+		sourceSAS      = "sp=rl&sig=source-runtime-sentinel"
+		destinationSAS = "sp=rcwdl&sig=destination-runtime-sentinel"
+	)
+
+	originalPlanFolder := common.AzcopyJobPlanFolder
+	common.AzcopyJobPlanFolder = t.TempDir()
+	t.Cleanup(func() {
+		common.AzcopyJobPlanFolder = originalPlanFolder
+	})
+
+	tests := []struct {
+		name              string
+		existingPlan      bool
+		sourceSAS         string
+		destinationSAS    string
+		expectedSourceSAS string
+		expectedDestSAS   string
+	}{
+		{
+			name:              "new part with runtime SAS",
+			sourceSAS:         sourceSAS,
+			destinationSAS:    destinationSAS,
+			expectedSourceSAS: sourceSAS,
+			expectedDestSAS:   destinationSAS,
+		},
+		{
+			name: "new non-SAS part",
+		},
+		{
+			name:         "resumed part without runtime SAS",
+			existingPlan: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			order := common.CopyJobPartOrderRequest{
+				JobID:           common.NewJobID(),
+				PartNum:         0,
+				FromTo:          common.EFromTo.LocalBlob(),
+				Fpo:             common.EFolderPropertiesOption.NoFolders(),
+				SourceRoot:      common.ResourceString{Value: "source"},
+				DestinationRoot: common.ResourceString{Value: "https://account.blob.core.windows.net/container"},
+			}
+			planFile := JobPartPlanFileName(fmt.Sprintf(
+				JobPartPlanFileNameFormat,
+				order.JobID.String(),
+				order.PartNum,
+				DataSchemaVersion,
+			))
+			planFile.Create(order)
+
+			var existingPlanMMF *JobPartPlanMMF
+			if test.existingPlan {
+				existingPlanMMF = planFile.Map()
+			}
+
+			jm := &jobMgr{
+				ctx:         context.Background(),
+				jobPartMgrs: newJobPartToJobPartMgr(),
+				initMu:      &sync.Mutex{},
+			}
+			jpm := jm.AddJobPart(&AddJobPartArgs{
+				PartNum:         order.PartNum,
+				PlanFile:        planFile,
+				ExistingPlanMMF: existingPlanMMF,
+				SourceSAS:       test.sourceSAS,
+				DestinationSAS:  test.destinationSAS,
+			})
+			t.Cleanup(jpm.Close)
+
+			actualSourceSAS, actualDestinationSAS := jpm.SAS()
+			assert.Equal(t, test.expectedSourceSAS, actualSourceSAS)
+			assert.Equal(t, test.expectedDestSAS, actualDestinationSAS)
+
+			jptm := &jobPartTransferMgr{jobPartMgr: jpm}
+			actualSourceSAS, actualDestinationSAS = jptm.SAS()
+			assert.Equal(t, test.expectedSourceSAS, actualSourceSAS)
+			assert.Equal(t, test.expectedDestSAS, actualDestinationSAS)
+		})
 	}
 }

--- a/ste/sender-blockBlob.go
+++ b/ste/sender-blockBlob.go
@@ -25,7 +25,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 	"strconv"
 	"strings"
 	"sync"
@@ -33,7 +32,9 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/file"
 
@@ -64,6 +65,13 @@ type blockBlobSenderBase struct {
 	muBlockIDs             *sync.Mutex
 	blockNamePrefix        string
 	completedBlockList     map[int]string
+
+	// Block-level dedupe prototype (AZCOPY_DEDUPE_ACT). These are only populated for an eligible
+	// block-blob -> block-blob S2S copy; they stay at their zero values (dedupeMode == dedupeActOff)
+	// for every other transfer, so the default code path is unaffected.
+	dedupeMode  dedupeActMode
+	dedupePlan  *SourceGridPlan
+	dedupeIndex map[srcBlockKey]srcBlockHashes
 }
 
 func getVerifiedChunkParams(transferInfo *TransferInfo, memLimit int64, strictMemLimit int64) (chunkSize int64, numChunks uint32, err error) {
@@ -215,6 +223,15 @@ func (s *blockBlobSenderBase) NumChunks() uint32 {
 	return s.numChunks
 }
 
+// dedupeChunkSpecs implements sourceGridChunker. It returns the source-grid chunk boundaries when the
+// dedupe prototype is active for this transfer, and nil otherwise (so the uniform chunk grid is used).
+func (s *blockBlobSenderBase) dedupeChunkSpecs() []chunkSpec {
+	if s.dedupeMode == dedupeActOff {
+		return nil
+	}
+	return chunkSpecsFromPlan(s.dedupePlan)
+}
+
 func (s *blockBlobSenderBase) RemoteFileExists() (bool, time.Time, error) {
 	properties, err := s.destBlockBlobClient.GetProperties(s.jptm.Context(), &blob.GetPropertiesOptions{CPKInfo: s.jptm.CpkInfo()})
 	return remoteObjectExists(blobPropertiesResponseAdapter{properties}, err)
@@ -266,7 +283,7 @@ func (s *blockBlobSenderBase) Epilogue() {
 			destBlobTier = nil
 		}
 
-		_, err := s.destBlockBlobClient.CommitBlockList(jptm.Context(), blockIDs,
+		resp, err := s.destBlockBlobClient.CommitBlockList(jptm.Context(), blockIDs,
 			&blockblob.CommitBlockListOptions{
 				HTTPHeaders:  &s.headersToApply,
 				Metadata:     s.metadataToApply,
@@ -331,6 +348,21 @@ func (s *blockBlobSenderBase) Epilogue() {
 			}
 
 			return
+		}
+
+		// Block-level dedupe prototype (AZCOPY_DEDUPE_ACT): record this freshly-committed blob's hashed
+		// blocks into the job's committed table so that later identical blocks can be served from it.
+		// This only populates an in-memory lookup table and does not touch the bytes just written.
+		if s.dedupeMode != dedupeActOff && s.dedupePlan != nil {
+			var etag azcore.ETag
+			if resp.ETag != nil {
+				etag = *resp.ETag
+			}
+			recorded := recordCommittedBlocks(jptm.Info().JobID, jptm.Info().Destination, etag, s.dedupePlan)
+			jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
+				"dedupe-act(%s): recorded %d committed block(s) for %q into the job dedupe table",
+				s.dedupeMode, recorded, jptm.Info().DstFilePath))
+			logDedupeActSummary(jptm, s.dedupeMode)
 		}
 
 		if setTags {

--- a/ste/sender-blockBlobFromURL.go
+++ b/ste/sender-blockBlobFromURL.go
@@ -55,9 +55,61 @@ func newURLToBlockBlobCopier(jptm IJobPartTransferMgr, pacer pacer, srcInfoProvi
 		return nil, err
 	}
 
-	return &urlToBlockBlobCopier{
+	copier := &urlToBlockBlobCopier{
 		blockBlobSenderBase: *senderBase,
-		srcURL:              srcURL}, nil
+		srcURL:              srcURL,
+	}
+
+	// Block-level dedupe prototype (AZCOPY_DEDUPE_ACT): for an eligible block-blob -> block-blob S2S
+	// copy, chunk on the source's committed block boundaries and arm the per-block hit decision used in
+	// generatePutBlockFromURL. A no-op (uniform grid) when the flag is unset or the source is not an
+	// eligible block blob.
+	configureBlockBlobDedupe(jptm, copier, srcInfoProvider)
+
+	return copier, nil
+}
+
+// configureBlockBlobDedupe arms source-grid chunking + the dedupe hit decision on a block-blob S2S
+// copier when AZCOPY_DEDUPE_ACT is set and the source is a block blob with a committed block list. It
+// overrides the sender's chunk count so every chunk lines up with a hashed source block. Any problem
+// leaves dedupe off and the copy proceeds on the uniform grid, so it can never break a transfer.
+func configureBlockBlobDedupe(jptm IJobPartTransferMgr, c *urlToBlockBlobCopier, srcInfoProvider IRemoteSourceInfoProvider) {
+	mode := dedupeActModeFromEnv()
+	if mode == dedupeActOff {
+		return
+	}
+	blobSrc, ok := srcInfoProvider.(IBlobSourceInfoProvider)
+	if !ok || blobSrc.BlobType() != blob.BlobTypeBlockBlob {
+		return
+	}
+
+	plan, err := fetchSourceGridPlan(jptm)
+	if err != nil {
+		jptm.LogAtLevelForCurrentTransfer(common.LogDebug, "dedupe-act: GetBlockList failed, using uniform grid: "+err.Error())
+		return
+	}
+	if plan == nil || len(plan.Blocks) == 0 {
+		return // single-PutBlob or empty source: no committed blocks to align to
+	}
+	if plan.TotalSize != jptm.Info().SourceSize {
+		jptm.LogAtLevelForCurrentTransfer(common.LogDebug, fmt.Sprintf(
+			"dedupe-act: source-grid total %d != source size %d, using uniform grid", plan.TotalSize, jptm.Info().SourceSize))
+		return
+	}
+	if len(plan.Blocks) > common.MaxNumberOfBlocksPerBlob {
+		return
+	}
+
+	// One chunk per source committed block.
+	c.numChunks = uint32(len(plan.Blocks))
+	c.blockIDs = make([]string, c.numChunks)
+	c.dedupeMode = mode
+	c.dedupePlan = plan
+	c.dedupeIndex = buildSourceBlockHashIndex(plan)
+
+	jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
+		"dedupe-act(%s): source-grid chunking armed: %d block(s), %d with hashes, totalSize=%d",
+		mode, len(plan.Blocks), len(c.dedupeIndex), plan.TotalSize))
 }
 
 // Returns a chunk-func for blob copies
@@ -72,7 +124,7 @@ func (c *urlToBlockBlobCopier) GenerateCopyFunc(id common.ChunkID, blockIndex in
 	 * for blobs of all sizes.
 	 */
 	// Small blobs from all sources will be copied over to destination using PutBlobFromUrl
-	if c.NumChunks() == 1 && adjustedChunkSize <= int64(common.MaxPutBlobSize) {
+	if c.dedupeMode == dedupeActOff && c.NumChunks() == 1 && adjustedChunkSize <= int64(common.MaxPutBlobSize) {
 		/*
 		 * siminsavani: FYI: For GCP, if the blob is the entirety of the file, GCP still returns
 		 * invalid error from service due to PutBlockFromUrl.
@@ -94,7 +146,9 @@ func (c *urlToBlockBlobCopier) generatePutBlockFromURL(id common.ChunkID, blockI
 		// step 2: save the block ID into the list of block IDs
 		c.setBlockID(blockIndex, encodedBlockID)
 
-		if c.ChunkAlreadyTransferred(blockIndex) {
+		// In dedupe mode the chunk grid is content-defined, so the resume "already transferred" map
+		// (keyed by the uniform-grid block names) does not apply; always (re)stage the block.
+		if c.dedupeMode == dedupeActOff && c.ChunkAlreadyTransferred(blockIndex) {
 			c.jptm.LogAtLevelForCurrentTransfer(common.LogDebug, fmt.Sprintf("Skipping chunk %d as it was already transferred.", blockIndex))
 			atomic.AddInt32(&c.atomicChunksWritten, 1)
 			return
@@ -111,20 +165,85 @@ func (c *urlToBlockBlobCopier) generatePutBlockFromURL(id common.ChunkID, blockI
 			c.jptm.FailActiveS2SCopy("Getting source token credential", err)
 			return
 		}
-		_, err = c.destBlockBlobClient.StageBlockFromURL(c.jptm.Context(), encodedBlockID, c.srcURL,
-			&blockblob.StageBlockFromURLOptions{
-				Range:                   blob.HTTPRange{Offset: id.OffsetInFile(), Count: adjustedChunkSize},
-				CPKInfo:                 c.jptm.CpkInfo(),
-				CPKScopeInfo:            c.jptm.CpkScopeInfo(),
-				CopySourceAuthorization: token,
-			})
+
+		// Block-level dedupe prototype: if this chunk's content already exists at the destination, either
+		// log it (shadow) or stage it from there instead of the source (enforce, with fallback to source).
+		if c.dedupeMode != dedupeActOff && c.tryDedupeStage(id, encodedBlockID, adjustedChunkSize, token) {
+			atomic.AddInt32(&c.atomicChunksWritten, 1)
+			return
+		}
+
+		options := &blockblob.StageBlockFromURLOptions{
+			Range:                   blob.HTTPRange{Offset: id.OffsetInFile(), Count: adjustedChunkSize},
+			CPKInfo:                 c.jptm.CpkInfo(),
+			CPKScopeInfo:            c.jptm.CpkScopeInfo(),
+			CopySourceAuthorization: token,
+		}
+
+		_, err = c.destBlockBlobClient.StageBlockFromURL(c.jptm.Context(), encodedBlockID, c.srcURL, options)
 		if err != nil {
 			c.jptm.FailActiveSend("Staging block from URL", err)
 			return
 		}
 
+		if c.dedupeMode != dedupeActOff {
+			dedupeStateForJob(c.jptm.Info().JobID).addSourceStaged(adjustedChunkSize)
+		}
+
 		atomic.AddInt32(&c.atomicChunksWritten, 1)
 	})
+}
+
+// tryDedupeStage applies the block-level dedupe decision for one chunk. It returns true only when the
+// block was fully handled by staging it from an already-migrated destination block (enforce mode on a
+// successful reference). In shadow mode, or on any miss/failure, it returns false so the caller stages
+// the block from the source as usual.
+func (c *urlToBlockBlobCopier) tryDedupeStage(id common.ChunkID, encodedBlockID string, size int64, token *string) (handled bool) {
+	st := dedupeStateForJob(c.jptm.Info().JobID)
+	target, reference := decideStaging(c.dedupeIndex, st.committed, id.OffsetInFile(), size)
+	if !reference {
+		return false
+	}
+
+	if c.dedupeMode == dedupeActShadow {
+		st.addWouldReference(size)
+		c.jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
+			"dedupe-act(shadow): block at offset=%d size=%d WOULD be referenced from %s [%d,%d) (staging from source instead)",
+			id.OffsetInFile(), size, target.TargetURI, target.TargetOffset, target.TargetLength))
+		return false
+	}
+
+	// enforce: stage the block from the destination sub-range, guarded by the recorded ETag.
+	if err := c.stageBlockFromTarget(encodedBlockID, target, token); err != nil {
+		st.addFallback()
+		c.jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
+			"dedupe-act(enforce): reference to %s failed (%v); falling back to staging from source", target.TargetURI, err))
+		return false
+	}
+	st.addReferenced(size)
+	c.jptm.LogAtLevelForCurrentTransfer(common.LogDebug, fmt.Sprintf(
+		"dedupe-act(enforce): block at offset=%d size=%d staged from %s [%d,%d)",
+		id.OffsetInFile(), size, target.TargetURI, target.TargetOffset, target.TargetLength))
+	return true
+}
+
+// stageBlockFromTarget stages a block by copying a sub-range of an already-migrated destination blob
+// (Put Block From URL) instead of re-reading the bytes from the source. The recorded ETag is sent as an
+// If-Match on the copy source so a changed/replaced target fails fast (and the caller falls back to the
+// source). The chunk has already been paced by the caller, so it is not re-paced here.
+func (c *urlToBlockBlobCopier) stageBlockFromTarget(encodedBlockID string, target common.BlockEntry, token *string) error {
+	options := &blockblob.StageBlockFromURLOptions{
+		Range:                   blob.HTTPRange{Offset: target.TargetOffset, Count: target.TargetLength},
+		CPKInfo:                 c.jptm.CpkInfo(),
+		CPKScopeInfo:            c.jptm.CpkScopeInfo(),
+		CopySourceAuthorization: token,
+	}
+	if target.ETag != "" {
+		etag := target.ETag
+		options.SourceModifiedAccessConditions = &blob.SourceModifiedAccessConditions{SourceIfMatch: &etag}
+	}
+	_, err := c.destBlockBlobClient.StageBlockFromURL(c.jptm.Context(), encodedBlockID, target.TargetURI, options)
+	return err
 }
 
 func (c *urlToBlockBlobCopier) generateStartPutBlobFromURL(id common.ChunkID, blockIndex int32, adjustedChunkSize int64) chunkFunc {

--- a/ste/sourceGridObserver.go
+++ b/ste/sourceGridObserver.go
@@ -1,0 +1,239 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ste
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+)
+
+// This file implements "Phase 0" of the block-level dedupe prototype: a read-only,
+// opt-in diagnostic (AZCOPY_DEDUPE_OBSERVE=true) that, for block-blob -> block-blob S2S
+// transfers, builds a "source-grid" chunk plan from the source's committed block list and
+// logs how those content-defined boundaries compare to AzCopy's uniform chunk grid.
+//
+// It never changes transfer behavior. Its purpose is to gather real alignment / would-be
+// dedupe-hit numbers before any scheduling change is attempted (Phase 1+).
+
+// PlannedBlock describes one block of a source-grid chunk plan: a contiguous range of the
+// source blob whose boundaries match the source's committed block list rather than AzCopy's
+// uniform chunk grid.
+type PlannedBlock struct {
+	Offset       int64
+	Size         int64
+	SrcBlockName string
+
+	// CRC64 and SHA256 are intended to be populated from the extended GetBlockList response
+	// (include=crc64,sha256). They are left zero until that service extension is available;
+	// Phase 0 only needs the boundaries (offset/size), not the hashes.
+	CRC64  uint64
+	SHA256 [32]byte
+}
+
+// SourceGridPlan is an ordered, contiguous set of blocks covering [0, TotalSize) of a source
+// blob, derived from its committed block list.
+type SourceGridPlan struct {
+	Blocks    []PlannedBlock
+	TotalSize int64
+}
+
+// rawCommittedBlock is the minimal block info needed to build a plan: the committed block name
+// and its size, plus the optional per-block content hashes returned when the service supports the
+// include=crc64,sha256 extension. Offsets are derived (committed block lists are returned in order).
+type rawCommittedBlock struct {
+	Name   string
+	Size   int64
+	CRC64  uint64
+	SHA256 [32]byte
+}
+
+// buildSourceGridPlan converts an ordered committed block list into a SourceGridPlan, assigning
+// each block a contiguous offset equal to the prefix sum of the preceding block sizes.
+func buildSourceGridPlan(blocks []rawCommittedBlock) (*SourceGridPlan, error) {
+	plan := &SourceGridPlan{Blocks: make([]PlannedBlock, 0, len(blocks))}
+	var offset int64
+	for i, b := range blocks {
+		if b.Size < 0 {
+			return nil, fmt.Errorf("committed block %d (%q) has negative size %d", i, b.Name, b.Size)
+		}
+		plan.Blocks = append(plan.Blocks, PlannedBlock{
+			Offset:       offset,
+			Size:         b.Size,
+			SrcBlockName: b.Name,
+			CRC64:        b.CRC64,
+			SHA256:       b.SHA256,
+		})
+		offset += b.Size
+	}
+	plan.TotalSize = offset
+	return plan, nil
+}
+
+// GridAlignmentStats summarizes how a SourceGridPlan's content-defined boundaries compare to a
+// uniform chunk grid of a given size.
+type GridAlignmentStats struct {
+	SourceBlockCount  int
+	UniformChunkSize  int64
+	UniformChunkCount int64
+	TotalSize         int64
+
+	// AlignedStarts is the number of source blocks whose Offset is a multiple of UniformChunkSize.
+	AlignedStarts int
+
+	// ExactChunkMatches is the key metric: the number of source blocks whose [Offset, Offset+Size)
+	// range exactly equals a uniform-grid chunk. These are the blocks a uniform-grid hashing scheme
+	// could dedupe identically; everything else needs source-grid chunking to ever produce a hit.
+	ExactChunkMatches int
+}
+
+// AlignmentToUniformGrid reports how the plan lines up with AzCopy's uniform chunk grid of the
+// given size. It is a pure function (no I/O), which keeps it easy to unit test.
+func (p *SourceGridPlan) AlignmentToUniformGrid(uniformChunkSize int64) GridAlignmentStats {
+	stats := GridAlignmentStats{
+		SourceBlockCount: len(p.Blocks),
+		UniformChunkSize: uniformChunkSize,
+		TotalSize:        p.TotalSize,
+	}
+	if uniformChunkSize <= 0 {
+		return stats
+	}
+	if p.TotalSize > 0 {
+		stats.UniformChunkCount = (p.TotalSize + uniformChunkSize - 1) / uniformChunkSize
+	}
+	for _, b := range p.Blocks {
+		if b.Offset%uniformChunkSize != 0 {
+			continue
+		}
+		stats.AlignedStarts++
+
+		// The uniform chunk that starts at b.Offset ends at min(b.Offset+chunk, TotalSize).
+		uniformEnd := b.Offset + uniformChunkSize
+		if uniformEnd > p.TotalSize {
+			uniformEnd = p.TotalSize
+		}
+		if b.Offset+b.Size == uniformEnd {
+			stats.ExactChunkMatches++
+		}
+	}
+	return stats
+}
+
+// String renders the stats as a single log line, including the percentage of source blocks that
+// would dedupe on AzCopy's current uniform grid.
+func (s GridAlignmentStats) String() string {
+	pct := 0.0
+	if s.SourceBlockCount > 0 {
+		pct = 100 * float64(s.ExactChunkMatches) / float64(s.SourceBlockCount)
+	}
+	return fmt.Sprintf(
+		"dedupe-observe: sourceBlocks=%d uniformChunkSize=%d uniformChunks=%d totalSize=%d alignedStarts=%d exactChunkMatches=%d (%.1f%% of source blocks would dedupe on AzCopy's uniform grid)",
+		s.SourceBlockCount, s.UniformChunkSize, s.UniformChunkCount, s.TotalSize,
+		s.AlignedStarts, s.ExactChunkMatches, pct)
+}
+
+// dedupeObserveEnabled reports whether the read-only source-grid diagnostic is turned on.
+func dedupeObserveEnabled() bool {
+	return common.GetEnvironmentVariable(common.EEnvironmentVariable.DedupeObserve()) == "true"
+}
+
+// observeSourceGrid is the Phase 0 diagnostic hook. For block-blob -> block-blob S2S transfers
+// (and only when AZCOPY_DEDUPE_OBSERVE=true) it fetches the source committed block list, builds a
+// SourceGridPlan, and logs how the source boundaries align with AzCopy's uniform chunk grid.
+//
+// It is intentionally defensive: it never returns an error and swallows every failure (logging at
+// debug level), so it cannot affect transfer correctness and is safe to call unconditionally.
+func observeSourceGrid(jptm IJobPartTransferMgr) {
+	if !dedupeObserveEnabled() {
+		return
+	}
+
+	info := jptm.Info()
+
+	// Scope to block-blob -> block-blob S2S only.
+	ft := jptm.FromTo()
+	if ft.From() != common.ELocation.Blob() || ft.To() != common.ELocation.Blob() {
+		return
+	}
+	if info.SrcBlobType != blob.BlobTypeBlockBlob {
+		return
+	}
+
+	// Fetch the source committed block list, requesting the per-block content hashes
+	// (include=crc64,sha256). The service only returns them when the GetHash feature is enabled;
+	// otherwise the fields are nil and we simply observe zero hashes.
+	resp, err := getSourceBlockList(jptm)
+	if err != nil {
+		jptm.LogAtLevelForCurrentTransfer(common.LogDebug, "dedupe-observe: GetBlockList(committed, include=crc64,sha256) failed: "+err.Error())
+		return
+	}
+
+	if len(resp.CommittedBlocks) == 0 {
+		jptm.LogAtLevelForCurrentTransfer(common.LogInfo,
+			"dedupe-observe: source has no committed named blocks (e.g. single-PutBlob or empty blob); not eligible for source-grid chunking")
+		return
+	}
+
+	raw := make([]rawCommittedBlock, 0, len(resp.CommittedBlocks))
+	hashedBlocks := 0
+	for i, b := range resp.CommittedBlocks {
+		rb := rawCommittedBlock{
+			Name: common.IffNotNil(b.Name, ""),
+			Size: common.IffNotNil(b.Size, 0),
+		}
+		// Azure Storage encodes CRC64 little-endian (matches crc64.Checksum(content, azure table)).
+		if len(b.Crc64) == 8 {
+			rb.CRC64 = binary.LittleEndian.Uint64(b.Crc64)
+		}
+		copy(rb.SHA256[:], b.Sha256)
+		if len(b.Crc64) > 0 || len(b.Sha256) > 0 {
+			hashedBlocks++
+		}
+		raw = append(raw, rb)
+
+		// Phase 0 read-only log of the extended per-block fields exactly as returned by the service.
+		jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
+			"dedupe-observe: block[%d] name=%s offset=%d size=%d crc64=%s sha256=%s",
+			i, rb.Name, common.IffNotNil(b.Offset, -1), rb.Size,
+			hex.EncodeToString(b.Crc64), hex.EncodeToString(b.Sha256)))
+	}
+
+	jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
+		"dedupe-observe: %d/%d committed blocks carried crc64+sha256 hashes (0 means the service GetHash feature is off or include was not honored)",
+		hashedBlocks, len(resp.CommittedBlocks)))
+
+	plan, err := buildSourceGridPlan(raw)
+	if err != nil {
+		jptm.LogAtLevelForCurrentTransfer(common.LogDebug, "dedupe-observe: "+err.Error())
+		return
+	}
+
+	stats := plan.AlignmentToUniformGrid(info.BlockSize)
+	jptm.LogAtLevelForCurrentTransfer(common.LogInfo, stats.String())
+
+	// Phase 1: record these committed blocks into the per-job dedupe table and log the running
+	// would-be-hit rate. This is still read-only with respect to the transfer (no bytes skipped).
+	recordSourceGridForDedupe(jptm, plan)
+}

--- a/ste/sourceGridObserver_test.go
+++ b/ste/sourceGridObserver_test.go
@@ -1,0 +1,173 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ste
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildSourceGridPlan_AssignsContiguousOffsets(t *testing.T) {
+	a := assert.New(t)
+
+	plan, err := buildSourceGridPlan([]rawCommittedBlock{
+		{Name: "b0", Size: 100},
+		{Name: "b1", Size: 250},
+		{Name: "b2", Size: 50},
+	})
+	a.NoError(err)
+	a.EqualValues(400, plan.TotalSize)
+	a.Len(plan.Blocks, 3)
+
+	a.EqualValues(0, plan.Blocks[0].Offset)
+	a.EqualValues(100, plan.Blocks[0].Size)
+	a.Equal("b0", plan.Blocks[0].SrcBlockName)
+
+	a.EqualValues(100, plan.Blocks[1].Offset)
+	a.EqualValues(250, plan.Blocks[1].Size)
+
+	a.EqualValues(350, plan.Blocks[2].Offset)
+	a.EqualValues(50, plan.Blocks[2].Size)
+}
+
+func TestBuildSourceGridPlan_Empty(t *testing.T) {
+	a := assert.New(t)
+
+	plan, err := buildSourceGridPlan(nil)
+	a.NoError(err)
+	a.EqualValues(0, plan.TotalSize)
+	a.Empty(plan.Blocks)
+}
+
+func TestBuildSourceGridPlan_NegativeSizeIsError(t *testing.T) {
+	a := assert.New(t)
+
+	_, err := buildSourceGridPlan([]rawCommittedBlock{
+		{Name: "ok", Size: 10},
+		{Name: "bad", Size: -1},
+	})
+	a.Error(err)
+}
+
+func TestAlignment_UniformBlocksAllMatch(t *testing.T) {
+	a := assert.New(t)
+
+	// Four blocks of exactly the uniform chunk size -> every block matches a uniform chunk.
+	plan, err := buildSourceGridPlan([]rawCommittedBlock{
+		{Name: "b0", Size: 1024},
+		{Name: "b1", Size: 1024},
+		{Name: "b2", Size: 1024},
+		{Name: "b3", Size: 1024},
+	})
+	a.NoError(err)
+
+	stats := plan.AlignmentToUniformGrid(1024)
+	a.Equal(4, stats.SourceBlockCount)
+	a.EqualValues(4, stats.UniformChunkCount)
+	a.Equal(4, stats.AlignedStarts)
+	a.Equal(4, stats.ExactChunkMatches)
+}
+
+func TestAlignment_FinalShortBlockMatches(t *testing.T) {
+	a := assert.New(t)
+
+	// Two full chunks plus a short final block that exactly equals the final (short) uniform chunk.
+	plan, err := buildSourceGridPlan([]rawCommittedBlock{
+		{Name: "b0", Size: 1024},
+		{Name: "b1", Size: 1024},
+		{Name: "b2", Size: 300},
+	})
+	a.NoError(err)
+
+	stats := plan.AlignmentToUniformGrid(1024)
+	a.EqualValues(2348, stats.TotalSize)
+	a.EqualValues(3, stats.UniformChunkCount) // ceil(2348/1024)
+	a.Equal(3, stats.AlignedStarts)
+	a.Equal(3, stats.ExactChunkMatches) // final 300-byte block == final 300-byte uniform chunk
+}
+
+func TestAlignment_MisalignedBlocksDoNotMatch(t *testing.T) {
+	a := assert.New(t)
+
+	// Blocks half the uniform size: starts alternate aligned/unaligned, and none span a whole chunk.
+	plan, err := buildSourceGridPlan([]rawCommittedBlock{
+		{Name: "b0", Size: 512},
+		{Name: "b1", Size: 512},
+		{Name: "b2", Size: 512},
+		{Name: "b3", Size: 512},
+	})
+	a.NoError(err)
+
+	stats := plan.AlignmentToUniformGrid(1024)
+	a.Equal(4, stats.SourceBlockCount)
+	// b0@0 and b2@1024 start on a 1024 boundary; b1@512 and b3@1536 do not.
+	a.Equal(2, stats.AlignedStarts)
+	// No block is a full 1024 chunk (and the file ends exactly on a boundary, so no short final chunk).
+	a.Equal(0, stats.ExactChunkMatches)
+}
+
+func TestAlignment_SingleBlockWholeFile(t *testing.T) {
+	a := assert.New(t)
+
+	// One committed block holding the whole blob, smaller than the chunk size -> it equals the single
+	// (short) uniform chunk that spans the whole file.
+	plan, err := buildSourceGridPlan([]rawCommittedBlock{
+		{Name: "only", Size: 4000},
+	})
+	a.NoError(err)
+
+	stats := plan.AlignmentToUniformGrid(8 * 1024 * 1024)
+	a.Equal(1, stats.SourceBlockCount)
+	a.EqualValues(1, stats.UniformChunkCount)
+	a.Equal(1, stats.AlignedStarts)
+	a.Equal(1, stats.ExactChunkMatches)
+}
+
+func TestAlignment_NonPositiveChunkSizeIsSafe(t *testing.T) {
+	a := assert.New(t)
+
+	plan, err := buildSourceGridPlan([]rawCommittedBlock{
+		{Name: "b0", Size: 100},
+		{Name: "b1", Size: 100},
+	})
+	a.NoError(err)
+
+	stats := plan.AlignmentToUniformGrid(0)
+	a.Equal(2, stats.SourceBlockCount)
+	a.EqualValues(0, stats.UniformChunkCount)
+	a.Equal(0, stats.AlignedStarts)
+	a.Equal(0, stats.ExactChunkMatches)
+}
+
+func TestGridAlignmentStats_StringMentionsPercentage(t *testing.T) {
+	a := assert.New(t)
+
+	plan, err := buildSourceGridPlan([]rawCommittedBlock{
+		{Name: "b0", Size: 1024},
+		{Name: "b1", Size: 512},
+	})
+	a.NoError(err)
+
+	s := plan.AlignmentToUniformGrid(1024).String()
+	a.Contains(s, "dedupe-observe:")
+	a.Contains(s, "exactChunkMatches=")
+}

--- a/ste/xfer-anyToRemote-file.go
+++ b/ste/xfer-anyToRemote-file.go
@@ -440,6 +440,10 @@ func anyToRemote_file(jptm IJobPartTransferMgr, info *TransferInfo, pacer pacer,
 	// stop tracking pseudo id (since real chunk id's will be tracked from here on)
 	jptm.LogChunkStatus(pseudoId, common.EWaitReason.ChunkDone())
 
+	// Read-only dedupe prototype diagnostic (opt-in via AZCOPY_DEDUPE_OBSERVE). No-op when
+	// disabled; never alters the transfer.
+	observeSourceGrid(jptm)
+
 	// Step 6: Go through the file and schedule chunk messages to send each chunk
 	scheduleSendChunks(jptm, info.Source, srcFile, srcSize, s, sourceFileFactory, srcInfoProvider)
 }
@@ -458,6 +462,15 @@ func scheduleSendChunks(jptm IJobPartTransferMgr, srcPath string, srcFile common
 	// For generic send
 	chunkSize := s.ChunkSize()
 	numChunks := s.NumChunks()
+
+	// Block-level dedupe prototype: when the sender provides a content-defined (source-grid) chunk
+	// plan, schedule those chunks instead of the uniform grid. S2S only (no local prefetch path).
+	if cg, ok := s.(sourceGridChunker); ok {
+		if specs := cg.dedupeChunkSpecs(); len(specs) > 0 {
+			scheduleSourceGridChunks(jptm, srcPath, s, specs)
+			return
+		}
+	}
 
 	// For upload
 	var md5Channel chan<- []byte
@@ -591,6 +604,32 @@ func createS3ChunkReader(
 		jptm.CacheLimiter(),
 	)
 	return s3ChunkReader
+}
+
+// scheduleSourceGridChunks schedules one send per source-grid chunk spec, used by the block-level
+// dedupe prototype. It mirrors the S2S branch of scheduleSendChunks (no local prefetch / md5) but
+// drives the chunk boundaries from the sender's content-defined plan instead of the uniform grid.
+func scheduleSourceGridChunks(jptm IJobPartTransferMgr, srcPath string, s sender, specs []chunkSpec) {
+	// Run the prologue before the first chunk (mirrors scheduleSendChunks). S2S has no leading bytes,
+	// so an empty prologue state is correct here.
+	if modified := s.Prologue(common.PrologueState{}); modified {
+		jptm.SetDestinationIsModified()
+	}
+
+	s2s, ok := s.(s2sCopier)
+	if !ok {
+		// Defensive: source-grid chunking is only armed for S2S copiers; fail loudly if misused.
+		jptm.FailActiveSend("source-grid chunking", errors.New("sender is not an s2sCopier"))
+		return
+	}
+
+	isWholeFile := len(specs) == 1
+	for i, sp := range specs {
+		id := common.NewChunkID(srcPath, sp.offset, sp.size)
+		jptm.LogChunkStatus(id, common.EWaitReason.WorkerGR())
+		cf := s2s.GenerateCopyFunc(id, int32(i), sp.size, isWholeFile)
+		jptm.ScheduleChunks(cf)
+	}
 }
 
 // Make reader for this chunk.


### PR DESCRIPTION
## Description

**This draft PR is for code review only and is not intended to be merged as-is.**

- Retrieves per-block CRC64 and SHA256 hashes
- Aligns transfer chunks with source block boundaries
- Reuses matching blocks from previously committed destination blobs
- Uses ETag validation and falls back to the original source on failure
- Tracks job-level dedupe hits and estimated source-read savings

This prototype depends on an unreleased `azblob` SDK extension. The machine-local SDK replacement is intentionally not included.