### PR TITLE
TASK 38260338: Restored release pipeline stage gates.

### DIFF
--- a/build-1es-pipeline.yaml
+++ b/build-1es-pipeline.yaml
@@ -1214,61 +1214,61 @@ extends:
                       remoteImage: azcopycontainers.azurecr.io/azure-azcopy-mariner-arm64.$(azcopy_version):latest
             # BuildAndPublishDockerImage ends here
 
-      - stage: ReleaseToGithub
-        dependsOn:
-          - AzCopyVersion
-          - VerifyArtifacts
-        jobs:
-          - job: ReleaseJob
-            templateContext:
-              type: releaseJob
-              isProduction: true
-            pool:
-              name: azcopy-pool
-              image: ubuntu22-1espt
-              os: linux
-            variables:
-              - name: azcopy_version
-                value: $[ stageDependencies.AzCopyVersion.GetAzCopyVersion.outputs['SetAzCopyVersion.azcopy_version'] ]
-            steps:
-              - checkout: none
+      - ${{ if eq(parameters.post_release, true) }}:
+        - stage: ReleaseToGithub
+          dependsOn:
+            - AzCopyVersion
+            - VerifyArtifacts
+          jobs:
+            - job: ReleaseJob
+              templateContext:
+                type: releaseJob
+                isProduction: true
+              pool:
+                name: azcopy-pool
+                image: ubuntu22-1espt
+                os: linux
+              variables:
+                - name: azcopy_version
+                  value: $[ stageDependencies.AzCopyVersion.GetAzCopyVersion.outputs['SetAzCopyVersion.azcopy_version'] ]
+              steps:
+                - checkout: none
 
-              - script: |
-                  echo "v$(azcopy_version)"
-                  # (~) to be replaced by (-) if azcopy version contains a tilde as this is not supported in github tags
-                  azcopy_github_tag=$(echo $(azcopy_version) | sed 's/~/-/')
-                  echo "##vso[task.setvariable variable=azcopy_github_tag]$azcopy_github_tag"
-                displayName: 'AzCopy Tag Name'
+                - script: |
+                    echo "v$(azcopy_version)"
+                    # (~) to be replaced by (-) if azcopy version contains a tilde as this is not supported in github tags
+                    azcopy_github_tag=$(echo $(azcopy_version) | sed 's/~/-/')
+                    echo "##vso[task.setvariable variable=azcopy_github_tag]$azcopy_github_tag"
+                  displayName: 'AzCopy Tag Name'
 
-              - task: 1ES.DownloadPipelineArtifact@1
-                displayName: 'Download Windows Build Artifacts'
-                inputs:
-                  artifactName: 'azcopy-windows-signed'
-                  targetPath: $(Build.ArtifactStagingDirectory)/azcopy-windows-signed
+                - task: 1ES.DownloadPipelineArtifact@1
+                  displayName: 'Download Windows Build Artifacts'
+                  inputs:
+                    artifactName: 'azcopy-windows-signed'
+                    targetPath: $(Build.ArtifactStagingDirectory)/azcopy-windows-signed
 
-              - task: 1ES.DownloadPipelineArtifact@1
-                displayName: 'Download Linux Build Artifacts'
-                inputs:
-                  artifactName: 'azcopy-linux-signed'
-                  targetPath: $(Build.ArtifactStagingDirectory)/azcopy-linux-signed
+                - task: 1ES.DownloadPipelineArtifact@1
+                  displayName: 'Download Linux Build Artifacts'
+                  inputs:
+                    artifactName: 'azcopy-linux-signed'
+                    targetPath: $(Build.ArtifactStagingDirectory)/azcopy-linux-signed
 
-              - script: |
-                  # In the initial release of FIPS-capable builds of AzCopy, we're not publishing those builds to GitHub.
-                  rm -r "$(Build.ArtifactStagingDirectory)/azcopy-linux-signed/"*-fips-*
-                  rm -r "$(Build.ArtifactStagingDirectory)/azcopy-linux-signed/"*_fips_*
-                displayName: 'Remove FIPS artifacts'
+                - script: |
+                    # In the initial release of FIPS-capable builds of AzCopy, we're not publishing those builds to GitHub.
+                    rm -r "$(Build.ArtifactStagingDirectory)/azcopy-linux-signed/"*-fips-*
+                    rm -r "$(Build.ArtifactStagingDirectory)/azcopy-linux-signed/"*_fips_*
+                  displayName: 'Remove FIPS artifacts'
 
-              - task: 1ES.DownloadPipelineArtifact@1
-                displayName: 'Download Mac Build Artifacts'
-                inputs:
-                  artifactName: 'azcopy-mac-signed'
-                  targetPath: $(Build.ArtifactStagingDirectory)/azcopy-mac-signed
+                - task: 1ES.DownloadPipelineArtifact@1
+                  displayName: 'Download Mac Build Artifacts'
+                  inputs:
+                    artifactName: 'azcopy-mac-signed'
+                    targetPath: $(Build.ArtifactStagingDirectory)/azcopy-mac-signed
 
-              - script: |
-                  sudo ls -lRt $(Build.ArtifactStagingDirectory)
-                displayName: 'List Artifacts'
+                - script: |
+                    sudo ls -lRt $(Build.ArtifactStagingDirectory)
+                  displayName: 'List Artifacts'
 
-              - ${{ if eq(parameters.post_release, true) }}:
                 - task: GithubRelease@1
                   inputs:
                     githubConnection: 'azcopy-github-connection'
@@ -1290,233 +1290,224 @@ extends:
                       $(Build.ArtifactStagingDirectory)/azcopy-mac-signed/*.zip
                       $(Build.ArtifactStagingDirectory)/azcopy-linux-signed/mariner/*
                     assetUploadMode: replace
-        # ReleaseToGithub ends here
+          # ReleaseToGithub ends here
 
-      - stage: PublishArtifacts
-        dependsOn:
-          - AzCopyVersion
-          - VerifyArtifacts
-        jobs:
-          - job: Job
-            timeoutInMinutes: 120
-            pool:
-              name: azcopy-pool
-              image: ubuntu22-1espt
-              os: linux
-            variables:
-              - group: AZCOPY_SECRET_VAULT
-              - name: signed
-                value: '$(System.DefaultWorkingDirectory)/signed'
-            steps:
-              - checkout: self
+      - ${{ if eq(parameters.publish_artifacts, true) }}:
+        - stage: PublishArtifacts
+          dependsOn:
+            - AzCopyVersion
+            - VerifyArtifacts
+          jobs:
+            - job: Job
+              timeoutInMinutes: 120
+              pool:
+                name: azcopy-pool
+                image: ubuntu22-1espt
+                os: linux
+              variables:
+                - group: AZCOPY_SECRET_VAULT
+                - name: signed
+                  value: '$(System.DefaultWorkingDirectory)/signed'
+              steps:
+                - checkout: self
 
-              - task: PipAuthenticate@1
-                inputs:
-                  artifactFeeds: 'DevExGlobalFeed'
-                displayName: 'Connect to PMC artifact'
+                - task: PipAuthenticate@1
+                  inputs:
+                    artifactFeeds: 'DevExGlobalFeed'
+                  displayName: 'Connect to PMC artifact'
 
-              - script: |
-                  sudo apt-get clean
-                  sudo apt-get update --fix-missing
-                  sudo apt-get install -y tree
-                displayName: 'Install Dependencies'
+                - script: |
+                    sudo apt-get clean
+                    sudo apt-get update --fix-missing
+                    sudo apt-get install -y tree
+                  displayName: 'Install Dependencies'
 
-              - script: |
-                  pip install pmc-cli
-                  echo '##vso[task.prependpath]$(HOME)/.local/bin'
-                displayName: 'Install pmc-cli'
+                - script: |
+                    pip install pmc-cli
+                    echo '##vso[task.prependpath]$(HOME)/.local/bin'
+                  displayName: 'Install pmc-cli'
 
-              - task: DownloadSecureFile@1
-                name: pmcCertificate
-                displayName: 'Download pmc pem file'
-                inputs:
-                  secureFile: 'azstorage-devex-kv-blobfuse-release-pmc1-10102025.pem'
+                - task: DownloadSecureFile@1
+                  name: pmcCertificate
+                  displayName: 'Download pmc pem file'
+                  inputs:
+                    secureFile: 'azstorage-devex-kv-blobfuse-release-pmc1-10102025.pem'
 
-              - task: DownloadSecureFile@1
-                name: settings
-                displayName: 'Download settings.toml file'
-                inputs:
-                  secureFile: 'settings.toml'
+                - task: DownloadSecureFile@1
+                  name: settings
+                  displayName: 'Download settings.toml file'
+                  inputs:
+                    secureFile: 'settings.toml'
 
-              - task: AzureCLI@2
-                displayName: 'Test PMC installation'
-                inputs:
-                  addSpnToEnvironment: true
-                  azureSubscription: 'azcopy-release'
-                  scriptType: bash
-                  scriptLocation: inlineScript
-                  inlineScript: |
-                    pmc --version
-                    pmc --auth-type wif --base-url "https://pmc-ingest.trafficmanager.net/api/v4" repo list --limit 1
-                    if [ $? -ne 0 ]; then
-                      exit 1
-                    fi
-
-              # DownloadPipelineArtifact AFTER checkout since checkout wipes out the DefaultWorkingDirectory
-              - task: DownloadPipelineArtifact@2
-                inputs:
-                  artifactName: azcopy-linux-signed
-                  targetPath: $(signed)
-                  displayName: "Download Linux Signed"
-
-              - script: |
-                  arm64file=$(ls "$(signed)/mariner/azcopy"*.arm64.rpm)
-                  amd64file=$(ls "$(signed)/mariner/azcopy"*.x86_64.rpm)
-                  marinerArmFileName="${arm64file/.arm64.rpm/-cm2.arm64.rpm}"
-                  marinerAmdFileName="${amd64file/.x86_64.rpm/-cm2.x86_64.rpm}"
-
-                  mv -v "$(signed)/mariner/azcopy"*.arm64.rpm "$marinerArmFileName"
-                  mv -v "$(signed)/mariner/azcopy"*.x86_64.rpm "$marinerAmdFileName"
-
-                  mv "$(signed)/mariner/azcopy"*.rpm "$(signed)/"
-                  rm -r "$(signed)/mariner/"
-                displayName: 'Rename Mariner binaries'
-
-              - script: |
-                  rm -r $(signed)/azcopy_linux_*.tar.gz
-                displayName: 'Remove tar gz files'
-
-              - script: |
-                  rm -r $(signed)/_manifest
-                displayName: 'Remove manifest'
-
-              - script: |
-                  # In the initial release of FIPS-capable builds of AzCopy, we're only publishing .rpm packages (and only for Azure Linux 3.0).
-                  # This task should be removed once we're ready to publish the .deb files..
-                  rm -r "$(signed)/azcopy-fips-"*.deb
-                displayName: 'Remove FIPS .deb files'
-
-              - script: |
-                  ls -lRt $(signed)
-                displayName: 'List artifacts'
-
-              - ${{ if and(eq(parameters.publish_artifacts, true), eq(parameters.test_pmc_connection, false)) }}:
                 - task: AzureCLI@2
-                  displayName: 'Upload files'
+                  displayName: 'Test PMC installation'
                   inputs:
                     addSpnToEnvironment: true
                     azureSubscription: 'azcopy-release'
                     scriptType: bash
                     scriptLocation: inlineScript
                     inlineScript: |
-                      pmc --auth-type wif --base-url "https://pmc-ingest.trafficmanager.net/api/v4" package upload signed
+                      pmc --version
+                      pmc --auth-type wif --base-url "https://pmc-ingest.trafficmanager.net/api/v4" repo list --limit 1
+                      if [ $? -ne 0 ]; then
+                        exit 1
+                      fi
 
-              - task: AzureCLI@2
-                displayName: 'Add uploaded packages to repository'
-                inputs:
-                  addSpnToEnvironment: true
-                  azureSubscription: 'azcopy-release'
-                  scriptType: bash
-                  scriptLocation: inlineScript
-                  workingDirectory: $(signed)
-                  inlineScript: |
-                    [ ${{ parameters.publish_artifacts }} == 'True' ] && [ ${{ parameters.test_pmc_connection }} == 'False' ]
-                    publish=$?
-                    
-                    azcopyAmdDebFile=$(ls azcopy-* | grep -vE 'fips|cm2' | grep '\.x86_64\.deb')
-                    echo "Azcopy AMD DEB File: $azcopyAmdDebFile"
-                    
-                    azcopyAmdRpmFile=$(ls azcopy-* | grep -vE 'fips|cm2' | grep '\.x86_64\.rpm')
-                    echo "Azcopy AMD RPM File: $azcopyAmdRpmFile"
-                    
-                    azcopyArmDebFile=$(ls azcopy-* | grep -vE 'fips|cm2' | grep '\.arm64\.deb')
-                    echo "Azcopy ARM DEB File: $azcopyArmDebFile"
+                # DownloadPipelineArtifact AFTER checkout since checkout wipes out the DefaultWorkingDirectory
+                - task: DownloadPipelineArtifact@2
+                  inputs:
+                    artifactName: azcopy-linux-signed
+                    targetPath: $(signed)
+                    displayName: "Download Linux Signed"
 
-                    azcopyArmRpmFile=$(ls azcopy-* | grep -vE 'fips|cm2' | grep '\.arm64\.rpm')
-                    echo "Azcopy ARM RPM File: $azcopyArmRpmFile"
-                    
-                    marinerAmdRpmFile=$(ls azcopy-* | grep 'cm2\.x86_64\.rpm')
-                    echo "Azcopy Mariner AMD RPM File: $marinerAmdRpmFile"
-                    
-                    marinerAarchRpmFile=$(ls azcopy-* | grep 'cm2\.arm64\.rpm')
-                    echo "Azcopy Mariner ARM RPM File: $marinerAarchRpmFile"
-                    
-                    azcopyFipsAmdRpmFile=$(ls azcopy-fips-* | grep '\.x86_64\.rpm')
-                    echo "Azcopy FIPS AMD RPM File: $azcopyFipsAmdRpmFile"
+                - script: |
+                    arm64file=$(ls "$(signed)/mariner/azcopy"*.arm64.rpm)
+                    amd64file=$(ls "$(signed)/mariner/azcopy"*.x86_64.rpm)
+                    marinerArmFileName="${arm64file/.arm64.rpm/-cm2.arm64.rpm}"
+                    marinerAmdFileName="${amd64file/.x86_64.rpm/-cm2.x86_64.rpm}"
 
-                    azcopyFipsArmRpmFile=$(ls azcopy-fips-* | grep '\.arm64\.rpm')
-                    echo "Azcopy FIPS ARM RPM File: $azcopyFipsArmRpmFile"
+                    mv -v "$(signed)/mariner/azcopy"*.arm64.rpm "$marinerArmFileName"
+                    mv -v "$(signed)/mariner/azcopy"*.x86_64.rpm "$marinerAmdFileName"
 
-                    if (( publish == 0 )); then
-                      # These pmc commands appear to be uploading package IDs for later reference in other pmc commands
+                    mv "$(signed)/mariner/azcopy"*.rpm "$(signed)/"
+                    rm -r "$(signed)/mariner/"
+                  displayName: 'Rename Mariner binaries'
+
+                - script: |
+                    rm -r $(signed)/azcopy_linux_*.tar.gz
+                  displayName: 'Remove tar gz files'
+
+                - script: |
+                    rm -r $(signed)/_manifest
+                  displayName: 'Remove manifest'
+
+                - script: |
+                    # In the initial release of FIPS-capable builds of AzCopy, we're only publishing .rpm packages (and only for Azure Linux 3.0).
+                    # This task should be removed once we're ready to publish the .deb files.
+                    rm -r "$(signed)/azcopy-fips-"*.deb
+                  displayName: 'Remove FIPS .deb files'
+
+                - script: |
+                    ls -lRt $(signed)
+                  displayName: 'List artifacts'
+
+                - ${{ if eq(parameters.test_pmc_connection, false) }}:
+                  - task: AzureCLI@2
+                    displayName: 'Upload files'
+                    inputs:
+                      addSpnToEnvironment: true
+                      azureSubscription: 'azcopy-release'
+                      scriptType: bash
+                      scriptLocation: inlineScript
+                      inlineScript: |
+                        pmc --auth-type wif --base-url "https://pmc-ingest.trafficmanager.net/api/v4" package upload signed
+
+                - ${{ if eq(parameters.test_pmc_connection, false) }}:
+                  - task: AzureCLI@2
+                    displayName: 'Add uploaded packages to repository'
+                    inputs:
+                      addSpnToEnvironment: true
+                      azureSubscription: 'azcopy-release'
+                      scriptType: bash
+                      scriptLocation: inlineScript
+                      workingDirectory: $(signed)
+                      inlineScript: |
+                        azcopyAmdDebFile=$(ls azcopy-* | grep -vE 'fips|cm2' | grep '\.x86_64\.deb')
+                        echo "Azcopy AMD DEB File: $azcopyAmdDebFile"
+                        
+                        azcopyAmdRpmFile=$(ls azcopy-* | grep -vE 'fips|cm2' | grep '\.x86_64\.rpm')
+                        echo "Azcopy AMD RPM File: $azcopyAmdRpmFile"
+                        
+                        azcopyArmDebFile=$(ls azcopy-* | grep -vE 'fips|cm2' | grep '\.arm64\.deb')
+                        echo "Azcopy ARM DEB File: $azcopyArmDebFile"
+
+                        azcopyArmRpmFile=$(ls azcopy-* | grep -vE 'fips|cm2' | grep '\.arm64\.rpm')
+                        echo "Azcopy ARM RPM File: $azcopyArmRpmFile"
+                        
+                        marinerAmdRpmFile=$(ls azcopy-* | grep 'cm2\.x86_64\.rpm')
+                        echo "Azcopy Mariner AMD RPM File: $marinerAmdRpmFile"
+                        
+                        marinerAarchRpmFile=$(ls azcopy-* | grep 'cm2\.arm64\.rpm')
+                        echo "Azcopy Mariner ARM RPM File: $marinerAarchRpmFile"
+                        
+                        azcopyFipsAmdRpmFile=$(ls azcopy-fips-* | grep '\.x86_64\.rpm')
+                        echo "Azcopy FIPS AMD RPM File: $azcopyFipsAmdRpmFile"
+
+                        azcopyFipsArmRpmFile=$(ls azcopy-fips-* | grep '\.arm64\.rpm')
+                        echo "Azcopy FIPS ARM RPM File: $azcopyFipsArmRpmFile"
+
+                        # These pmc commands appear to be uploading package IDs for later reference in other pmc commands
+                        
+                        azcopyAmdDeb=$(pmc --auth-type wif --base-url "https://pmc-ingest.trafficmanager.net/api/v4" --id-only package upload $azcopyAmdDebFile)
+                        echo "Azcopy AMD DEB ID: $azcopyAmdDeb"
+
+                        azcopyAmdRpm=$(pmc --auth-type wif --base-url "https://pmc-ingest.trafficmanager.net/api/v4" --id-only package upload $azcopyAmdRpmFile)
+                        echo "Azcopy AMD RPM ID: $azcopyAmdRpm"
+
+                        azcopyArmDeb=$(pmc --auth-type wif --base-url "https://pmc-ingest.trafficmanager.net/api/v4" --id-only package upload $azcopyArmDebFile)
+                        echo "Azcopy ARM DEB ID: $azcopyArmDeb"
+
+                        azcopyArmRpm=$(pmc --auth-type wif --base-url "https://pmc-ingest.trafficmanager.net/api/v4" --id-only package upload $azcopyArmRpmFile)
+                        echo "Azcopy ARM RPM ID: $azcopyArmRpm"
+
+                        marinerAmdRpm=$(pmc --auth-type wif --base-url "https://pmc-ingest.trafficmanager.net/api/v4" --id-only package upload $marinerAmdRpmFile)
+                        echo "Azcopy Mariner AMD RPM ID: $marinerAmdRpm"
                       
-                      azcopyAmdDeb=$(pmc --auth-type wif --base-url "https://pmc-ingest.trafficmanager.net/api/v4" --id-only package upload $azcopyAmdDebFile)
-                      echo "Azcopy AMD DEB ID: $azcopyAmdDeb"
+                        marinerAarchRpm=$(pmc --auth-type wif --base-url "https://pmc-ingest.trafficmanager.net/api/v4" --id-only package upload $marinerAarchRpmFile)
+                        echo "Azcopy Mariner ARM RPM ID: $marinerAarchRpm"
 
-                      azcopyAmdRpm=$(pmc --auth-type wif --base-url "https://pmc-ingest.trafficmanager.net/api/v4" --id-only package upload $azcopyAmdRpmFile)
-                      echo "Azcopy AMD RPM ID: $azcopyAmdRpm"
+                        azcopyFipsAmdRpm=$(pmc --auth-type wif --base-url "https://pmc-ingest.trafficmanager.net/api/v4" --id-only package upload $azcopyFipsAmdRpmFile)
+                        echo "Azcopy FIPS AMD RPM ID: $azcopyFipsAmdRpm"
 
-                      azcopyArmDeb=$(pmc --auth-type wif --base-url "https://pmc-ingest.trafficmanager.net/api/v4" --id-only package upload $azcopyArmDebFile)
-                      echo "Azcopy ARM DEB ID: $azcopyArmDeb"
+                        azcopyFipsArmRpm=$(pmc --auth-type wif --base-url "https://pmc-ingest.trafficmanager.net/api/v4" --id-only package upload $azcopyFipsArmRpmFile)
+                        echo "Azcopy FIPS ARM RPM ID: $azcopyFipsArmRpm"
 
-                      azcopyArmRpm=$(pmc --auth-type wif --base-url "https://pmc-ingest.trafficmanager.net/api/v4" --id-only package upload $azcopyArmRpmFile)
-                      echo "Azcopy ARM RPM ID: $azcopyArmRpm"
-
-                      marinerAmdRpm=$(pmc --auth-type wif --base-url "https://pmc-ingest.trafficmanager.net/api/v4" --id-only package upload $marinerAmdRpmFile)
-                      echo "Azcopy Mariner AMD RPM ID: $marinerAmdRpm"
-                    
-                      marinerAarchRpm=$(pmc --auth-type wif --base-url "https://pmc-ingest.trafficmanager.net/api/v4" --id-only package upload $marinerAarchRpmFile)
-                      echo "Azcopy Mariner ARM RPM ID: $marinerAarchRpm"
-
-                      azcopyFipsAmdRpm=$(pmc --auth-type wif --base-url "https://pmc-ingest.trafficmanager.net/api/v4" --id-only package upload $azcopyFipsAmdRpmFile)
-                      echo "Azcopy FIPS AMD RPM ID: $azcopyFipsAmdRpm"
-
-                      azcopyFipsArmRpm=$(pmc --auth-type wif --base-url "https://pmc-ingest.trafficmanager.net/api/v4" --id-only package upload $azcopyFipsArmRpmFile)
-                      echo "Azcopy FIPS ARM RPM ID: $azcopyFipsArmRpm"
-                    fi
-
-                    is_preview="false"
-                    echo "##vso[task.setvariable variable=is_preview]$is_preview"
-                    if [[ $marinerAmdRpmFile == *"preview"* ]]; then
-                      is_preview="true"
-                      echo "##vso[task.setvariable variable=is_preview]$is_preview"
-                    fi
-
-                    while IFS=, read -r distro archetype repoName releaseName; do
-                      # If the package is preview, publish to mariner preview package
-                      if [[ $distro == *"Mariner-"* ]]; then
-                        if [ $is_preview = "true" ]; then
-                          repoName=$(echo $repoName | sed 's/prod/preview/')
+                        is_preview="false"
+                        echo "##vso[task.setvariable variable=is_preview]$is_preview"
+                        if [[ $marinerAmdRpmFile == *"preview"* ]]; then
+                          is_preview="true"
+                          echo "##vso[task.setvariable variable=is_preview]$is_preview"
                         fi
-                      fi
-                      echo "Repo Name: $repoName"
-                      if (( publish == 0 )); then
-                        echo "Uploading packages for $distro"
-                        # This is reading a line from packages.csv and adding (to the repo) the package ID stored in the variable that has the name stored in the archetype field.
-                        # For example, if $archetype = azcopyAmdDeb (as read from the second field of packages.csv), scroll up to see where this script assigns a package ID to azcopyAmdDeb.
-                        pmc --auth-type wif --base-url "https://pmc-ingest.trafficmanager.net/api/v4" repo package update --add-packages ${!archetype} $repoName $releaseName
-                      fi
-                    done < <(tail -n +3 ../packages.csv)
 
-              - task: AzureCLI@2
-                displayName: 'Publish the repository'
-                inputs:
-                  addSpnToEnvironment: true
-                  azureSubscription: 'azcopy-release'
-                  scriptType: bash
-                  scriptLocation: inlineScript
-                  workingDirectory: $(signed)
-                  inlineScript: |
-                    [ ${{ parameters.publish_artifacts }} == 'True' ] && [ ${{ parameters.test_pmc_connection }} == 'False' ]
-                    publish=$?
-
-                    while IFS=, read -r distro archetype repoName releaseName; do
-                      if [[ $archetype == *"Arm"* ]]; then
-                        echo "Skipping for ARM type on $distro"
-                      else
-                        if [[ $distro == *"Mariner-"* ]]; then
-                          if [ "$(is_preview)" = "true" ]; then
-                            repoName=$(echo $repoName | sed 's/prod/preview/')
+                        while IFS=, read -r distro archetype repoName releaseName; do
+                          # If the package is preview, publish to mariner preview package
+                          if [[ $distro == *"Mariner-"* ]]; then
+                            if [ $is_preview = "true" ]; then
+                              repoName=$(echo $repoName | sed 's/prod/preview/')
+                            fi
                           fi
-                        fi
-                        echo "Repo Name: $repoName"
-                        if (( publish == 0 )); then
-                          echo "Publishing $repoName"
-                          pmc --auth-type wif --base-url "https://pmc-ingest.trafficmanager.net/api/v4" repo publish $repoName
-                        fi
-                      fi
-                    done < <(tail -n +3 ../packages.csv)
-        # PublishArtifacts ends here
+                          echo "Repo Name: $repoName"
+
+                          echo "Uploading packages for $distro"
+                          # This is reading a line from packages.csv and adding (to the repo) the package ID stored in the variable that has the name stored in the archetype field.
+                          # For example, if $archetype = azcopyAmdDeb (as read from the second field of packages.csv), scroll up to see where this script assigns a package ID to azcopyAmdDeb.
+                          pmc --auth-type wif --base-url "https://pmc-ingest.trafficmanager.net/api/v4" repo package update --add-packages ${!archetype} $repoName $releaseName
+                        done < <(tail -n +3 ../packages.csv)
+
+                - ${{ if eq(parameters.test_pmc_connection, false) }}:
+                  - task: AzureCLI@2
+                    displayName: 'Publish the repository'
+                    inputs:
+                      addSpnToEnvironment: true
+                      azureSubscription: 'azcopy-release'
+                      scriptType: bash
+                      scriptLocation: inlineScript
+                      workingDirectory: $(signed)
+                      inlineScript: |
+                        while IFS=, read -r distro archetype repoName releaseName; do
+                          if [[ $archetype == *"Arm"* ]]; then
+                            echo "Skipping for ARM type on $distro"
+                          else
+                            if [[ $distro == *"Mariner-"* ]]; then
+                              if [ "$(is_preview)" = "true" ]; then
+                                repoName=$(echo $repoName | sed 's/prod/preview/')
+                              fi
+                            fi
+                            echo "Publishing $repoName"
+                            pmc --auth-type wif --base-url "https://pmc-ingest.trafficmanager.net/api/v4" repo publish $repoName
+                          fi
+                        done < <(tail -n +3 ../packages.csv)
+          # PublishArtifacts ends here
 
       - ${{ if ne(trim(parameters.remove_packages), '') }}:
         - stage: RemovePackagesFromLinuxRepository


### PR DESCRIPTION
To make it easier to test the pipeline, the gates that were previously on the ReleaseToGithub and PublishArtifacts stages had been moved into those stages. Now that the correct way to test the pmc commands has been found (but not yet implemented) - Tux-dev - these gates have been moved back. When support for Tux-dev is added, we should look for a similar way to test the ReleaseToGithub stage.

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->
To compare the pipeline with these changes to the version of the pipeline before the gates were moved, see the diff for build-1es-pipeline.yaml at  https://github.com/Azure/azure-storage-azcopy/compare/341e26be9892dcd10380524d76af8552ea44c1df...al-msft/task-38260338-restoring-release-pipeline-gates
- The left side of that comparision uses the hash of the commit that preceded the commit that moved the gates. See https://github.com/Azure/azure-storage-azcopy/commits/main/

**Related Links**:
- [TASK 38260338](https://msazure.visualstudio.com/One/_workitems/edit/38260338) 
- [PR that moved the gates in the first place](https://github.com/Azure/azure-storage-azcopy/pull/3488)
- [Tux-dev documentation](https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/azcorelinux/pmc-package-ingestion/pmc-onboardingreference/onboard/tuxdev_onboarding)

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [x] Other (describe): Partial revert

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->
The stages were correctly omitted when the release pipeline was run with the default arguments for all pipeline parameters (all were unchecked): https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31230&view=results
The stages were correctly included and run ([on a version of this branch that was modified to allow these stages to run without publishing anything](https://github.com/Azure/azure-storage-azcopy/compare/al-msft/task-38260338-restoring-release-pipeline-gates...al-msft/task-38260338-restoring-release-pipeline-gates-testing)) when the release pipeline was run with post_release checked and publish_artifacts checked:
 - ...and test_pmc_connection unchecked: https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31231&view=results
 - ...and test_pmc_connection checked: https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31232&view=results