### PR TITLE
Improved task naming in the release pipeline and performance-test pipeline

### DIFF
--- a/azurePipelineTemplates/build_macos.yml
+++ b/azurePipelineTemplates/build_macos.yml
@@ -4,6 +4,7 @@ steps:
       GO111MODULE: 'on'
     inputs:
       version: $(AZCOPY_GOLANG_VERSION)
+    displayName: 'Install Go'
 
   - script: |
       CGO_ENABLED=1 go build -o "$(System.DefaultWorkingDirectory)/azcopy_darwin_amd64"

--- a/azurePipelineTemplates/build_macos_m1.yml
+++ b/azurePipelineTemplates/build_macos_m1.yml
@@ -4,12 +4,13 @@ steps:
       GO111MODULE: 'on'
     inputs:
       version: $(AZCOPY_GOLANG_VERSION)
+    displayName: 'Install Go'
 
   - script: |
       sudo apt-get clean
       sudo apt-get update --fix-missing
       sudo apt-get install -y zip unzip
-    displayName: "Installing Dependencies"
+    displayName: 'Install Dependencies'
 
   - template: ../setup/trigger_m1_build.yml@self
     parameters:

--- a/azurePipelineTemplates/build_windows.yml
+++ b/azurePipelineTemplates/build_windows.yml
@@ -4,6 +4,7 @@ steps:
       GO111MODULE: 'on'
     inputs:
       version: $(AZCOPY_GOLANG_VERSION)
+    displayName: 'Install Go'
 
   - script: |
       mkdir -p $(binaries)

--- a/azurePipelineTemplates/verify_linux.yml
+++ b/azurePipelineTemplates/verify_linux.yml
@@ -18,7 +18,7 @@ steps:
       sudo apt-get clean
       sudo apt-get update --fix-missing
       sudo apt-get install build-essential -y
-    displayName: "Installing Dependencies"
+    displayName: 'Install Dependencies'
   - script: |
       sudo dpkg --info $(signed)/azcopy${{ parameters.package_suffix }}-*${{ parameters.host_suffix }}.deb
       sudo dpkg -i $(signed)/azcopy${{ parameters.package_suffix }}-*${{ parameters.host_suffix }}.deb
@@ -33,7 +33,7 @@ steps:
     displayName: 'Verify tar gz'
   - script: |
       sudo apt-get install libsecret-1-dev -y
-    displayName: "Installing Dependencies"
+    displayName: 'Install Dependencies'
   - script: |
       mkdir -p $(extracted)
       tar xf $(signed)/azcopy_linux_se${{ parameters.build_suffix }}_${{ parameters.host_architecture }}*.tar.gz -C $(extracted)

--- a/build-1es-pipeline.yaml
+++ b/build-1es-pipeline.yaml
@@ -86,6 +86,7 @@ extends:
                 inputs:
                   version: $(AZCOPY_GOLANG_VERSION)
                   # We use the Microsoft build of Go to produce FIPS-capable Linux builds, but that should not affect the output of azcopy --version.
+                displayName: 'Install Go'
 
               - script: |
                   go build -tags "netgo" -o azcopy_bin
@@ -1000,6 +1001,7 @@ extends:
                 inputs:
                   version: $(AZCOPY_GOLANG_VERSION)
                   # We use the Microsoft build of Go to produce FIPS-capable Linux builds, but that should not affect the text file this job copies.
+                displayName: 'Install Go'
 
               - script: |
                   go build -tags "netgo" -o azcopy_bin
@@ -1010,19 +1012,19 @@ extends:
                 inputs:
                   artifactName: azcopy-linux-signed
                   targetPath: $(System.DefaultWorkingDirectory)/input/azcopy-linux-signed
-                  displayName: "Download Linux Signed"
+                displayName: 'Download Linux Signed'
 
               - task: DownloadPipelineArtifact@2
                 inputs:
                   artifactName: azcopy-windows-signed
                   targetPath: $(System.DefaultWorkingDirectory)/input/azcopy-windows-signed
-                  displayName: "Download Windows Signed"
+                displayName: 'Download Windows Signed'
 
               - task: DownloadPipelineArtifact@2
                 inputs:
                   artifactName: azcopy-mac-signed
                   targetPath: $(System.DefaultWorkingDirectory)/input/azcopy-mac-signed
-                  displayName: "Download Mac Signed"
+                displayName: 'Download Mac Signed'
 
               - script: |
                   mkdir -p $(release)
@@ -1035,37 +1037,37 @@ extends:
                 inputs:
                   artifactName: azcopy-binaries-linux-amd64
                   targetPath: $(System.DefaultWorkingDirectory)/input/azcopy-binaries-linux-amd64
-                  displayName: "Download Linux AMD64 Binaries"
+                displayName: 'Download Linux AMD64 Binaries'
 
               - task: DownloadPipelineArtifact@2
                 inputs:
                   artifactName: azcopy-binaries-linux-arm64
                   targetPath: $(System.DefaultWorkingDirectory)/input/azcopy-binaries-linux-arm64
-                  displayName: "Download Linux ARM64 Binaries"
+                displayName: 'Download Linux ARM64 Binaries'
 
               - task: DownloadPipelineArtifact@2
                 inputs:
                   artifactName: azcopy-binaries-linux-fips-amd64
                   targetPath: $(System.DefaultWorkingDirectory)/input/azcopy-binaries-linux-fips-amd64
-                  displayName: "Download Linux FIPS AMD64 Binaries"
+                displayName: 'Download Linux FIPS AMD64 Binaries'
 
               - task: DownloadPipelineArtifact@2
                 inputs:
                   artifactName: azcopy-binaries-linux-fips-arm64
                   targetPath: $(System.DefaultWorkingDirectory)/input/azcopy-binaries-linux-fips-arm64
-                  displayName: "Download Linux FIPS ARM64 Binaries"
+                displayName: 'Download Linux FIPS ARM64 Binaries'
 
               - task: DownloadPipelineArtifact@2
                 inputs:
                   artifactName: azcopy-binaries-windows
                   targetPath: $(System.DefaultWorkingDirectory)/input/azcopy-binaries-windows
-                  displayName: "Download Windows Binaries"
+                displayName: 'Download Windows Binaries'
 
               - task: DownloadPipelineArtifact@2
                 inputs:
                   artifactName: azcopy-binaries-mac
                   targetPath: $(System.DefaultWorkingDirectory)/input/azcopy-binaries-mac
-                  displayName: "Download Mac Binaries"
+                displayName: 'Download Mac Binaries'
 
               - script: |
                   mkdir -p $(drop)
@@ -1076,13 +1078,13 @@ extends:
                   cp $(input)/azcopy-binaries-windows/azcopy* $(drop)
                   cp $(input)/azcopy-binaries-mac/azcopy* $(drop)
                   cp $(System.DefaultWorkingDirectory)/NOTICE.txt $(drop)
-                displayName: 'Prepare drop folder'
+                displayName: 'Prepare Drop Folder'
 
               - task: ArchiveFiles@2
-                displayName: 'Archive drop'
                 inputs:
                   rootFolderOrFile: '$(drop)'
                   archiveFile: '$(release)/drop.zip'
+                displayName: 'Archive Drop'
 
               - task: AzureCLI@2
                 inputs:
@@ -1099,6 +1101,7 @@ extends:
                       m1_container_url="https://azcopyvnextrelease.blob.core.windows.net/%24web/azcopy-m1-drops/azcopy-$(azcopy_version)-$today"
                     AZCOPY_AUTO_LOGIN_TYPE=AzCLI ./azcopy_bin cp "$(input)/azcopy-binaries-mac/azcopy_darwin_m1_arm64" "$m1_container_url" --recursive --put-md5=true
                     fi
+                displayName: 'Upload Artifacts'
         # UploadToStorage ends here
 
       - ${{ if eq(parameters.publish_docker_image, true) }}:
@@ -1129,7 +1132,7 @@ extends:
                       artifactName: azcopy-binaries-linux-amd64
                       targetPath: $(System.DefaultWorkingDirectory)
                       itemPattern: 'azcopy_linux_amd64'
-                      displayName: "Download Linux AMD64 Binary"
+                    displayName: 'Download Linux AMD64 Binary'
 
                   - script: |
                       mv azcopy_linux_amd64 azcopy_bin
@@ -1182,7 +1185,7 @@ extends:
                       artifactName: azcopy-binaries-linux-arm64
                       targetPath: $(System.DefaultWorkingDirectory)
                       itemPattern: 'azcopy_linux_arm64'
-                      displayName: "Download Linux ARM64 Binary"
+                    displayName: 'Download Linux ARM64 Binary'
 
                   - script: |
                       mv azcopy_linux_arm64 azcopy_bin
@@ -1358,7 +1361,7 @@ extends:
                   inputs:
                     artifactName: azcopy-linux-signed
                     targetPath: $(signed)
-                    displayName: "Download Linux Signed"
+                  displayName: 'Download Linux Signed'
 
                 - script: |
                     arm64file=$(ls "$(signed)/mariner/azcopy"*.arm64.rpm)

--- a/perf-test.yaml
+++ b/perf-test.yaml
@@ -31,6 +31,7 @@ stages:
         - task: GoTool@0
           inputs:
             version: '1.25.11'
+          displayName: 'Install Go'
 
         - script: |
             go build -o $GOROOT/bin/azcopy


### PR DESCRIPTION
## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->
Various other PRs (especially https://github.com/Azure/azure-storage-azcopy/pull/3504) improve task naming in the test pipeline.

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [x] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->
https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31244&view=results
 - Contrast this with https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31196&view=results

The performance-test pipeline doesn't seem to have been run in almost two years, and the UI says I lack the necessary permissions to run it or there's a problem with the YAML.