### PR TITLE
Upgraded test dependencies and increased mutex logging.

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -2819,24 +2819,27 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 github.com/jstemmer/go-junit-report
 
-The MIT License (MIT)
+Copyright (c) 2012 Joel Stemmer
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this
-software and associated documentation files (the "Software"), to deal in the Software
-without restriction, including without limitation the rights to use, copy, modify,
-merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to the following
-conditions:
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies
-or substantial portions of the Software.
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
-INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
-PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 **********
 
 github.com/chzyer/readline 
@@ -9470,6 +9473,84 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+**********
+
+https://github.com/axw/gocov
+
+Copyright (c) 2012 The Gocov Authors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-------------------------------------------------------------------------------
+
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+**********
+
+https://github.com/AlekSi/gocov-xml
+
+Copyright (c) 2013 Alexey Palazhchenko
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 **********
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -177,11 +177,10 @@ jobs:
         name: ciGCSServiceAccountKey
         displayName: 'Download GCS Service Account Key'
 
-      - script: |
-          go install github.com/jstemmer/go-junit-report@v0.9.1
-          go install github.com/axw/gocov/gocov@v1.1.0
-          go install github.com/AlekSi/gocov-xml@v1.0.0
-          go install github.com/matm/gocov-html@v0.0.0-20200509184451-71874e2e203b
+      - bash: |
+          go install github.com/jstemmer/go-junit-report/v2@v2.1.0
+          go install github.com/axw/gocov/gocov@v1.1.0 # this version is required by gocov-xml@v1.2.0
+          go install github.com/AlekSi/gocov-xml@v1.2.0
         displayName: 'Install Code Coverage and Test Report Dependencies'
 
       - script: |
@@ -300,9 +299,8 @@ jobs:
         condition: and(succeededOrFailed(), eq(variables['isMutexSet'], 'true'))
 
       # Smoke Tests Publishing
-      - task: PublishCodeCoverageResults@1
+      - task: PublishCodeCoverageResults@2
         inputs:
-          codeCoverageTool: Cobertura
           summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/$(pythonCoverageReportName).xml'
         # Don't run if job is canceled or mutex wasn't acquired (in which case, test task didn't run, so no test results to report)
         condition: and(succeededOrFailed(), eq(variables['isMutexSet'], 'true'))

--- a/azurePipelineTemplates/run-e2e.yml
+++ b/azurePipelineTemplates/run-e2e.yml
@@ -49,11 +49,10 @@ jobs:
           version: $(AZCOPY_GOLANG_VERSION_COVERAGE)
         displayName: 'Install Go'
 
-      - script: |
-          go install github.com/jstemmer/go-junit-report@v0.9.1
-          go install github.com/axw/gocov/gocov@v1.1.0
-          go install github.com/AlekSi/gocov-xml@v1.0.0
-          go install github.com/matm/gocov-html@v0.0.0-20200509184451-71874e2e203b
+      - bash: |
+          go install github.com/jstemmer/go-junit-report/v2@v2.1.0
+          go install github.com/axw/gocov/gocov@v1.1.0 # this version is required by gocov-xml@v1.2.0
+          go install github.com/AlekSi/gocov-xml@v1.2.0
         displayName: 'Install Code Coverage and Test Report Dependencies'
 
       - bash: |
@@ -96,6 +95,8 @@ jobs:
             
             # Build the Go program
             Write-Output "Building executable"
+            # Normally, `go build` has no effect when `go test` is used to run unit tests,
+            # but we're using `go test` to run end-to-end tests that expect `go build` to have been run
             if ($tags -ne "") {
               go build -cover -tags $tags -o "$(build_name)"
             } else {
@@ -171,9 +172,7 @@ jobs:
           testRunTitle: '${{ parameters.job_name }}: $(display_name)'
         condition: succeededOrFailed()
 
-      - task: PublishCodeCoverageResults@1
+      - task: PublishCodeCoverageResults@2
         inputs:
-          codeCoverageTool: Cobertura
           summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/$(coverageReportName).xml'
-          additionalCodeCoverageFiles: '$(System.DefaultWorkingDirectory)/**/$(coverageReportName).html'
         condition: succeededOrFailed()

--- a/azurePipelineTemplates/run-ut.yml
+++ b/azurePipelineTemplates/run-ut.yml
@@ -111,9 +111,8 @@ steps:
     # Don't run if job is canceled or mutex wasn't acquired (in which case, test task didn't run, so no test results to report)
     condition: and(succeededOrFailed(), eq(${{ parameters.isMutexSet }}, 'true'))
 
-  - task: PublishCodeCoverageResults@1
+  - task: PublishCodeCoverageResults@2
     inputs:
-      codeCoverageTool: Cobertura
       summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/${{ parameters.coverage_name }}_coverage.xml'
     # Don't run if job is canceled or mutex wasn't acquired (in which case, test task didn't run, so no test coverage data to report)
     condition: and(succeededOrFailed(), eq(${{ parameters.isMutexSet }}, 'true'))

--- a/tool_distributed_mutex.py
+++ b/tool_distributed_mutex.py
@@ -29,16 +29,17 @@ def get_raw_input():
 
 def process():
     action, mutex_url = get_raw_input()
+    print(f"INFO: action: \"{action}\", mutex URL: \"{mutex_url}\"")
 
     # check whether the blob exists, if not quit right away to avoid wasting time
     blob_client = BlobClient.from_blob_url(mutex_url)
+    print("INFO: validating mutex URL")
     try:
         blob_client.get_blob_properties()
-        print("INFO: validated mutex url")
     except HttpResponseError as e:
         raise ValueError('please provide an existing and valid blob URL, failed to get properties with error: ' + e)
+    print("INFO: validated mutex URL")
 
-    # get a handle on the lease
     lease_client = BlobLeaseClient(blob_client)
     if action == UNLOCK:
         # make the lease free as soon as possible

--- a/tool_distributed_mutex.py
+++ b/tool_distributed_mutex.py
@@ -29,7 +29,6 @@ def get_raw_input():
 
 def process():
     action, mutex_url = get_raw_input()
-    print(f"INFO: action: \"{action}\", mutex URL: \"{mutex_url}\"")
 
     # check whether the blob exists, if not quit right away to avoid wasting time
     blob_client = BlobClient.from_blob_url(mutex_url)

--- a/tool_distributed_mutex.py
+++ b/tool_distributed_mutex.py
@@ -29,6 +29,7 @@ def get_raw_input():
 
 def process():
     action, mutex_url = get_raw_input()
+    print(f"INFO: action: \"{action}\"")
 
     # check whether the blob exists, if not quit right away to avoid wasting time
     blob_client = BlobClient.from_blob_url(mutex_url)


### PR DESCRIPTION
Upgraded test dependencies and increased mutex logging.
- PublishCodeCoverageResults@1 -> PublishCodeCoverageResults@2
- gocov-xml@v1.0.0 -> gocov-xml@v1.2.0
- gocov-html wasn't used and has been removed
- go-junit-report@v0.9.1 -> go-junit-report/v2@v2.1.0

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->
gocov wasn't upgraded, because the latest version of gocov-xml requires our current version of gocov (see https://github.com/AlekSi/gocov-xml/blob/v1.2.0/go.mod#L5)

This PR also applies the latest license for go-junit-report and adds two licenses that were missing, judging by the fact that NOTICE.txt already included the license for github.com/jstemmer/go-junit-report (another test-only dependency).

**For Future Reference:**

PublishCodeCoverageResults@2 appears to publish two copies of each code summary (see the Summary_* artifacts at [Pipelines - Run 20260715.9 artifacts](https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31252&view=artifacts&pathAsName=false&type=publishedArtifacts)). This may be a known issue: https://learn.microsoft.com/en-us/answers/questions/5608740/publishcodecoverageresults@2-duplicated-artifacts, but that page doesn't actually link to any of the "community reports and GitHub issues" it says mention this.

Like PublishCodeCoverageResults@1, PublishCodeCoverageResults@2 still overwrites earlier results with the most recent PublishCodeCoverageResults task's results, which appears to have the effect of merging all code coverage files into the same top-level coverage folder, overwriting common files and preserving/adding unique files ([Pipelines - Run 20260715.9](https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31252&view=codecoverage-tab) was only showing the results of [Pipelines - Run 20260715.9 logs](https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31252&view=logs&j=9a4fe81a-16b6-5be8-ba1c-883c3703d02d&t=3bcc595d-ae6d-5b1c-09f1-817a585d73c5&s=96ac2280-8cb4-5df5-99de-dd2da759617d) before the re-run).
- We may need to publish the xml coverage files as artifacts at the end of each test task (like the release pipeline's use of "unsigned" folders), then have a single PublishCodeCoverageResults@2 task at the end of the pipeline (in a final stage?) that takes all the xml summary files as inputs and merges them to create a single report with a combined index.html file. See https://go.dev/blog/integration-test-coverage#merging-raw-profiles-with-go-tool-covdata-merge

**Related Links**:
- [PublishCodeCoverageResults@2](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/publish-code-coverage-results-v2)
- [Merging multiple results](https://learn.microsoft.com/en-us/azure/devops/pipelines/test/review-code-coverage-results?view=azure-devops#how-do-i-publish-the-code-coverage-summary-with-proper-details-by-merging-multiple-summary-files)
- The following PR can be closed if this PR updates the code coverage task and https://github.com/Azure/azure-storage-azcopy/pull/3504 updates the job names: https://github.com/Azure/azure-storage-azcopy/pull/3256
- https://github.com/axw/gocov
- https://github.com/AlekSi/gocov-xml
- https://github.com/matm/gocov-html
- https://github.com/jstemmer/go-junit-report

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [x] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->
A limited test run: https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31279&view=results
A full test run: https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31280&view=results
 - Compare with https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31240&view=results (ignore the low code coverage in that run; the coverage was lowered by re-runs)