### PR TITLE
Merge cherry-picked SetUID fix into mover/stage2

### DIFF
--- a/ste/downloader-azureFiles.go
+++ b/ste/downloader-azureFiles.go
@@ -182,7 +182,7 @@ func (bd *azureFilesDownloader) preservePermissions(info *TransferInfo) (string,
 		if spdl, ok := interface{}(bd).(nfsPermissionsAwareDownloader); ok {
 			// We don't need to worry about the sip not being a INFSPropertyBearingSourceInfoProvider as Azure Files always is.
 			err := spdl.PutNFSPermissions(bd.sip.(INFSPropertyBearingSourceInfoProvider), bd.txInfo)
-			if err == errorNoNFSPermissionsFound {
+			if errors.Is(err, errorNoNFSPermissionsFound) {
 				bd.jptm.LogAtLevelForCurrentTransfer(common.LogDebug, "No NFS permissions were downloaded because none were found at the source")
 			} else if err != nil {
 				return "Setting destination file nfs permissions", err

--- a/ste/sourceInfoProvider-Local_linux.go
+++ b/ste/sourceInfoProvider-Local_linux.go
@@ -281,7 +281,9 @@ func (h HandleNFSPermissions) GetGroup() *string {
 
 func (h HandleNFSPermissions) GetFileMode() *string {
 	fileMode := h.FileMode() &^ unix.S_IFMT // Remove file type bits
-	return to.Ptr(fmt.Sprintf("%#o", fileMode))
+	// 4 digits because service max is 12-bits:
+	// https://learn.microsoft.com/en-us/rest/api/storageservices/create-file#nfs-only-request-headers
+	return to.Ptr(fmt.Sprintf("%04o", fileMode))
 }
 
 var (
@@ -313,7 +315,9 @@ func (f localFileSourceInfoProvider) GetNFSDefaultPerms() (fileMode, owner, grou
 	// Get the default file mode
 	currFileMode := defaultStats.FileMode() &^ unix.S_IFMT
 	defaultMode := int(currFileMode) &^ getUmask()
-	fileMode = to.Ptr(fmt.Sprintf("%#o", defaultMode))
+	// 4 digits because service max is 12-bits:
+	// https://learn.microsoft.com/en-us/rest/api/storageservices/create-file#nfs-only-request-headers
+	fileMode = to.Ptr(fmt.Sprintf("%04o", defaultMode))
 
 	currentUser, err := user.Current()
 	owner = to.Ptr(currentUser.Uid)

--- a/ste/sourceInfoProvider-Local_linux_filemode_test.go
+++ b/ste/sourceInfoProvider-Local_linux_filemode_test.go
@@ -1,0 +1,69 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ste
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetUIDNoOverflow(t *testing.T) {
+	a := assert.New(t)
+
+	nfsperms := HandleNFSPermissions{
+		StatxTAdapter{
+			Mode: uint16(04775),
+		},
+	}
+
+	fileMode := nfsperms.GetFileMode()
+	a.NotNil(fileMode)
+	a.Equal("4775", *fileMode)
+}
+
+func TestSetGIDNoOverflow(t *testing.T) {
+	a := assert.New(t)
+
+	nfsperms := HandleNFSPermissions{
+		StatxTAdapter{
+			Mode: uint16(02775),
+		},
+	}
+
+	fileMode := nfsperms.GetFileMode()
+	a.NotNil(fileMode)
+	a.Equal("2775", *fileMode)
+}
+
+func TestStickyBitsNoOverflow(t *testing.T) {
+	a := assert.New(t)
+
+	nfsperms := HandleNFSPermissions{
+		StatxTAdapter{
+			Mode: uint16(01775),
+		},
+	}
+
+	fileMode := nfsperms.GetFileMode()
+	a.NotNil(fileMode)
+	a.Equal("1775", *fileMode)
+}


### PR DESCRIPTION
Cherry-picked @wonwuakpa-msft's fix for the setuid bug, merging into mover/stage2 for next Storage Mover on-prem release

Original PR merging the fix into main can be found here: https://github.com/Azure/azure-storage-azcopy/pull/3467