### PR TITLE
Updated Old E2E tests to document why they're skipped.

### DIFF
--- a/e2etest/declarativeHelpers.go
+++ b/e2etest/declarativeHelpers.go
@@ -561,7 +561,7 @@ type hookHelper interface {
 	CreateSourceSnapshot()
 
 	// SkipTest skips the test
-	SkipTest()
+	SkipTest(reason string)
 
 	// Assert gives access to the asserter
 	GetAsserter() asserter

--- a/e2etest/declarativeScenario.go
+++ b/e2etest/declarativeScenario.go
@@ -949,8 +949,8 @@ func (s *scenario) CancelOnly() {
 	s.chToStdin <- "cancel"
 }
 
-func (s *scenario) SkipTest() {
-	s.a.Skip("Skipping test")
+func (s *scenario) SkipTest(reason string) {
+	s.a.Skip(reason)
 }
 
 func (s *scenario) GetAsserter() asserter {

--- a/e2etest/zt_basic_copy_sync_remove_test.go
+++ b/e2etest/zt_basic_copy_sync_remove_test.go
@@ -72,7 +72,7 @@ func TestBasic_CopyUploadLargeBlob(t *testing.T) {
 		recursive: true,
 	}, &hooks{
 		beforeTestRun: func(h hookHelper) {
-			h.SkipTest()
+			h.SkipTest("Consumes too much time and memory to run in pipeline.")
 		},
 	}, testFiles{
 		defaultSize: "1G",
@@ -187,10 +187,10 @@ func TestBasic_CopyDownloadLargeBlob(t *testing.T) {
 		recursive: true,
 	}, &hooks{
 		beforeTestRun: func(h hookHelper) {
-			h.SkipTest()
+			h.SkipTest("Consumes too much time and memory to run in pipeline.")
 		},
 	}, testFiles{
-		defaultSize: "1K",
+		defaultSize: "1G",
 		shouldTransfer: []interface{}{
 			folder(""),
 			f("file1.txt"),
@@ -226,7 +226,7 @@ func TestBasic_CopyS2SLargeBlob(t *testing.T) {
 		recursive: true,
 	}, &hooks{
 		beforeTestRun: func(h hookHelper) {
-			h.SkipTest()
+			h.SkipTest("Consumes too much time and memory to run in pipeline.")
 		},
 	}, testFiles{
 		defaultSize: "1G",
@@ -334,7 +334,7 @@ func TestBasic_CopyRemoveLargeFile(t *testing.T) {
 		relativeSourcePath: "file2.txt",
 	}, &hooks{
 		beforeTestRun: func(h hookHelper) {
-			h.SkipTest()
+			h.SkipTest("Consumes too much time and memory to run in pipeline.")
 		},
 	}, testFiles{
 		defaultSize: "1G",

--- a/e2etest/zt_preserve_smb_properties_test.go
+++ b/e2etest/zt_preserve_smb_properties_test.go
@@ -171,7 +171,7 @@ func TestProperties_SMBTimes(t *testing.T) {
 		&hooks{
 			beforeTestRun: func(h hookHelper) {
 				if runtime.GOOS != "windows" {
-					h.SkipTest()
+					h.SkipTest("Only applies to Windows.")
 				}
 			},
 		},


### PR DESCRIPTION
Also corrected a mistake in one of the tests. Requiring a reason makes it harder not to document for later developers why a test is being skipped and saves them the trouble of finding out for themselves. Some of these tests failed in the pipeline due to MD5 validation errors, so we should really either remove them or update them to work in the pipeline.

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->
Tried to enable a bunch of skipped unit and Old-E2E tests. Found out none can be enabled at this time. Noticed some didn't say why they're skipped and one used the wrong file size. Opened this PR to address what I noticed.

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [x] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->
https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31339&view=results
