### PR TITLE
Fix SIGTERM cancellation during enumeration

### DIFF
--- a/azcopy/copy.go
+++ b/azcopy/copy.go
@@ -206,6 +206,7 @@ func (c *Client) Copy(ctx context.Context, src, dest string, opts CopyOptions) (
 		if !t.opts.dryrun {
 			common.GetLifecycleMgr().Info("Scanning...")
 			mgr.InitiateProgressReporting(ctx, t.tpt)
+			common.GetLifecycleMgr().E2EAwaitEnumerationStart(ctx)
 		}
 		err = enumerator.Enumerate()
 		defer jobsAdmin.JobsAdmin.JobMgrCleanUp(jobID)

--- a/azcopy/jobLifecycleManager.go
+++ b/azcopy/jobLifecycleManager.go
@@ -204,21 +204,7 @@ func (j *jobLifecycleManager) InitiateProgressReporting(ctx context.Context, rep
 				cancelCalled = true
 				j.handler.Info("Cancellation requested. Beginning clean shutdown...")
 				if !reporter.CompletedEnumeration() {
-					answer := j.handler.Prompt("The enumeration (source only for copy, source/destination comparison for sync) is not complete, "+
-						"cancelling the job at this point means it cannot be resumed.",
-						common.PromptDetails{
-							PromptType: common.EPromptType.Cancel(),
-							ResponseOptions: []common.ResponseOption{
-								common.EResponseOption.Yes(),
-								common.EResponseOption.No(),
-							},
-						})
-
-					if answer != common.EResponseOption.Yes() {
-						// user aborted cancel - continue monitoring but don't cancel
-						cancelCalled = false
-						continue
-					}
+					j.handler.Info("The enumeration is not complete; cancelling the job at this point means it cannot be resumed.")
 				}
 				// schedule job cancellation
 				// reporter will continue to report progress until the job is fully cancelled or completed

--- a/azcopy/jobLifecycleManager_test.go
+++ b/azcopy/jobLifecycleManager_test.go
@@ -1,0 +1,68 @@
+package azcopy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type incompleteEnumerationProgressTracker struct{}
+
+func (incompleteEnumerationProgressTracker) Start() {}
+
+func (incompleteEnumerationProgressTracker) CheckProgress() (uint32, bool) {
+	return 0, false
+}
+
+func (incompleteEnumerationProgressTracker) CompletedEnumeration() bool {
+	return false
+}
+
+func (incompleteEnumerationProgressTracker) GetJobID() common.JobID {
+	return common.JobID{}
+}
+
+func (incompleteEnumerationProgressTracker) GetElapsedTime() time.Duration {
+	return 0
+}
+
+func TestContextCancellationDoesNotPromptDuringEnumeration(t *testing.T) {
+	promptCalled := make(chan struct{}, 1)
+	releasePrompt := make(chan struct{})
+	defer close(releasePrompt)
+
+	var infoMessages []string
+	hooks := common.NewJobUIHooks()
+	hooks.Info = func(message string) {
+		infoMessages = append(infoMessages, message)
+	}
+	hooks.Prompt = func(string, common.PromptDetails) common.ResponseOption {
+		promptCalled <- struct{}{}
+		<-releasePrompt
+		return common.EResponseOption.Yes()
+	}
+
+	manager := NewJobLifecycleManager(hooks)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	manager.InitiateProgressReporting(ctx, incompleteEnumerationProgressTracker{})
+
+	waitResult := make(chan error, 1)
+	go func() {
+		waitResult <- manager.Wait()
+	}()
+
+	select {
+	case <-promptCalled:
+		t.Fatal("context cancellation prompted for user input")
+	case err := <-waitResult:
+		require.ErrorContains(t, err, "cancel job requires the JobID")
+		assert.Contains(t, infoMessages, "The enumeration is not complete; cancelling the job at this point means it cannot be resumed.")
+	case <-time.After(time.Second):
+		t.Fatal("context cancellation did not reach job cancellation")
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,6 +58,7 @@ var SkipVersionCheck bool
 var TrustedSuffixes string
 var azcopyAwaitContinue bool
 var azcopyAwaitAllowOpenFiles bool
+var azcopyAwaitEnumerationStart bool
 var isPipeDownload bool
 var retryStatusCodes string
 var debugMemoryProfile string
@@ -108,6 +109,7 @@ var rootCmd = &cobra.Command{
 		ste.RetryStatusCodes = rsc
 
 		glcm.E2EEnableAwaitAllowOpenFiles(azcopyAwaitAllowOpenFiles)
+		glcm.E2EEnableAwaitEnumerationStart(azcopyAwaitEnumerationStart)
 		if azcopyAwaitContinue {
 			glcm.E2EAwaitContinue()
 		}
@@ -334,6 +336,8 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&azcopyAwaitAllowOpenFiles, "await-open", false,
 		"Used when debugging, to tell AzCopy to await `open` on stdin, after scanning but before opening the first file. "+
 			"\n Assists with testing cases around file modifications between scanning and usage")
+	rootCmd.PersistentFlags().BoolVar(&azcopyAwaitEnumerationStart, "await-enumeration", false,
+		"Used by E2E tests to pause immediately before enumeration until the command is cancelled.")
 	rootCmd.PersistentFlags().StringVar(&debugSkipFiles, "debug-skip-files", "",
 		"Used when debugging, to tell AzCopy to cancel the job midway."+
 			"\n List of relative paths to skip in the STE.")

--- a/cmd/uihooks.go
+++ b/cmd/uihooks.go
@@ -22,6 +22,7 @@ package cmd
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -66,10 +67,11 @@ var glcm LifecycleMgr = func() (lcmgr *lifecycleMgr) {
 	lcmgr.checkAndStartCPUProfiling()
 
 	common.SetUIHooks(&common.JobUIHooks{
-		Prompt:                 lcmgr.Prompt,
-		Info:                   lcmgr.Info,
-		Warn:                   lcmgr.Warn,
-		E2EAwaitAllowOpenFiles: lcmgr.E2EAwaitAllowOpenFiles,
+		Prompt:                   lcmgr.Prompt,
+		Info:                     lcmgr.Info,
+		Warn:                     lcmgr.Warn,
+		E2EAwaitAllowOpenFiles:   lcmgr.E2EAwaitAllowOpenFiles,
+		E2EAwaitEnumerationStart: lcmgr.E2EAwaitEnumerationStart,
 	})
 
 	return
@@ -100,6 +102,8 @@ type LifecycleMgr interface {
 	E2EAwaitContinue()                                                         // used by E2E tests
 	E2EAwaitAllowOpenFiles()                                                   // used by E2E tests
 	E2EEnableAwaitAllowOpenFiles(enable bool)                                  // used by E2E tests
+	E2EAwaitEnumerationStart(context.Context)                                  // used by E2E tests
+	E2EEnableAwaitEnumerationStart(enable bool)                                // used by E2E tests
 	RegisterCloseFunc(func())
 	MsgHandlerChannel() <-chan *common.LCMMsg
 	ReportAllJobPartsDone()
@@ -123,6 +127,7 @@ type lifecycleMgr struct {
 	allowCancelFromStdIn  bool           // allow user to send in 'cancel' from the stdin to stop the current job
 	e2eAllowAwaitContinue bool           // allow the user to send 'continue' from stdin to start the current job
 	e2eAllowAwaitOpen     bool           // allow the user to send 'open' from stdin to allow the opening of the first file
+	e2eAwaitEnumeration   bool           // pause before enumeration until the context is cancelled
 	closeFunc             func()         // used to close logs before exiting
 	waitForUserResponse   chan bool
 	msgHandlerChannel     chan *common.LCMMsg
@@ -691,6 +696,19 @@ func (lcm *lifecycleMgr) E2EEnableAwaitAllowOpenFiles(enable bool) {
 	} else {
 		close(lcm.e2eAllowOpenChannel) // so that E2EAwaitAllowOpenFiles will instantly return every time
 	}
+}
+
+func (lcm *lifecycleMgr) E2EAwaitEnumerationStart(ctx context.Context) {
+	if !lcm.e2eAwaitEnumeration {
+		return
+	}
+
+	lcm.Info("Awaiting cancellation during enumeration")
+	<-ctx.Done()
+}
+
+func (lcm *lifecycleMgr) E2EEnableAwaitEnumerationStart(enable bool) {
+	lcm.e2eAwaitEnumeration = enable
 }
 
 func (lcm *lifecycleMgr) MsgHandlerChannel() <-chan *common.LCMMsg {

--- a/cmd/zt_interceptors_for_test.go
+++ b/cmd/zt_interceptors_for_test.go
@@ -21,6 +21,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -146,6 +147,14 @@ func (*mockedLifecycleManager) E2EAwaitAllowOpenFiles() {
 }
 
 func (*mockedLifecycleManager) E2EEnableAwaitAllowOpenFiles(_ bool) {
+	// not implemented in mocked version
+}
+
+func (*mockedLifecycleManager) E2EAwaitEnumerationStart(context.Context) {
+	// not implemented in mocked version
+}
+
+func (*mockedLifecycleManager) E2EEnableAwaitEnumerationStart(_ bool) {
 	// not implemented in mocked version
 }
 

--- a/common/lifecyleMgr.go
+++ b/common/lifecyleMgr.go
@@ -1,5 +1,7 @@
 package common
 
+import "context"
+
 // JobErrorHandler defines a simple interface for handling errors that occur
 // during the job lifecycle.
 //
@@ -30,10 +32,11 @@ type JobErrorHandler interface {
 //   h.Warn("this uses the custom override")
 
 type JobUIHooks struct {
-	Prompt                 func(message string, details PromptDetails) ResponseOption
-	Info                   func(string)
-	Warn                   func(string)
-	E2EAwaitAllowOpenFiles func()
+	Prompt                   func(message string, details PromptDetails) ResponseOption
+	Info                     func(string)
+	Warn                     func(string)
+	E2EAwaitAllowOpenFiles   func()
+	E2EAwaitEnumerationStart func(context.Context)
 }
 
 func NewJobUIHooks() *JobUIHooks {
@@ -48,6 +51,9 @@ func NewJobUIHooks() *JobUIHooks {
 			// default: no-op
 		},
 		E2EAwaitAllowOpenFiles: func() {
+			// default: no-op
+		},
+		E2EAwaitEnumerationStart: func(context.Context) {
 			// default: no-op
 		},
 	}

--- a/e2etest/declarativeHelpers.go
+++ b/e2etest/declarativeHelpers.go
@@ -200,7 +200,8 @@ type params struct {
 	AutoLoginType string
 
 	// cancel params
-	ignoreErrorIfCompleted bool
+	ignoreErrorIfCompleted   bool
+	sigtermDuringEnumeration bool
 
 	// benchmark params
 	mode        string

--- a/e2etest/declarativeScenario.go
+++ b/e2etest/declarativeScenario.go
@@ -142,6 +142,9 @@ func (s *scenario) Run() {
 	if s.a.Failed() {
 		return // execution failed. No point in running validation
 	}
+	if s.p.sigtermDuringEnumeration {
+		return // this scenario validates process cancellation rather than transfer results
+	}
 
 	// resume if needed
 	if s.needResume {
@@ -339,6 +342,10 @@ func (s *scenario) runAzCopy(logDirectory string) {
 
 	if !wasClean {
 		s.a.AssertNoErr(err, "running AzCopy")
+	}
+	if s.p.sigtermDuringEnumeration {
+		s.a.Assert(strings.Contains(result.rawOutput, "The enumeration is not complete; cancelling the job at this point means it cannot be resumed."), equals(), true,
+			"SIGTERM must be sent before enumeration completes")
 	}
 
 	// Generally, a cancellation is done when auth fails.

--- a/e2etest/runner.go
+++ b/e2etest/runner.go
@@ -32,6 +32,9 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
+	"syscall"
+	"time"
 
 	"github.com/Azure/azure-storage-azcopy/v10/cmd"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
@@ -40,7 +43,10 @@ import (
 // encapsulates the interaction with the AzCopy instance that is being tested
 // the flag names should be captured here so that in case they change, only 1 place needs to be updated
 type TestRunner struct {
-	flags map[string]string
+	flags                  map[string]string
+	signalOnOutput         string
+	signal                 os.Signal
+	exitTimeoutAfterSignal time.Duration
 }
 
 func newTestRunner() TestRunner {
@@ -63,6 +69,11 @@ var isLaunchedByDebugger = func() bool {
 func (t *TestRunner) SetAllFlags(s *scenario) {
 	p := s.p
 	o := s.operation
+	if p.sigtermDuringEnumeration {
+		t.signalOnOutput = "Scanning..."
+		t.signal = syscall.SIGTERM
+		t.exitTimeoutAfterSignal = 10 * time.Second
+	}
 
 	set := func(key string, value interface{}, dflt interface{}, formats ...string) {
 		if value == dflt {
@@ -180,6 +191,40 @@ func (t *TestRunner) SetAllFlags(s *scenario) {
 	}
 }
 
+type outputMarkerBuffer struct {
+	bytes.Buffer
+	marker  []byte
+	matched chan struct{}
+	once    sync.Once
+	tail    []byte
+}
+
+func newOutputMarkerBuffer(marker string) *outputMarkerBuffer {
+	return &outputMarkerBuffer{
+		marker:  []byte(marker),
+		matched: make(chan struct{}),
+	}
+}
+
+func (b *outputMarkerBuffer) Write(p []byte) (int, error) {
+	if len(b.marker) > 0 {
+		searchBuffer := make([]byte, 0, len(b.tail)+len(p))
+		searchBuffer = append(searchBuffer, b.tail...)
+		searchBuffer = append(searchBuffer, p...)
+		if bytes.Contains(searchBuffer, b.marker) {
+			b.once.Do(func() { close(b.matched) })
+		}
+
+		tailLength := len(b.marker) - 1
+		if tailLength > len(searchBuffer) {
+			tailLength = len(searchBuffer)
+		}
+		b.tail = append(b.tail[:0], searchBuffer[len(searchBuffer)-tailLength:]...)
+	}
+
+	return b.Buffer.Write(p)
+}
+
 func (t *TestRunner) SetAwaitOpenFlag() {
 	t.flags["await-open"] = "true"
 }
@@ -208,14 +253,14 @@ func (t *TestRunner) execDebuggableWithOutput(name string, args []string, env []
 		c.Env = env
 	}
 
-	var stdout bytes.Buffer
+	stdout := newOutputMarkerBuffer(t.signalOnOutput)
 	var stderr bytes.Buffer
 	stdin, err := c.StdinPipe()
 	if err != nil {
 		return make([]byte, 0), err
 	}
 
-	c.Stdout = &stdout
+	c.Stdout = stdout
 	c.Stderr = &stderr
 
 	// instead of err := c.Run(), we do the following
@@ -224,6 +269,26 @@ func (t *TestRunner) execDebuggableWithOutput(name string, args []string, env []
 		defer func() {
 			_ = c.Process.Kill() // in case we never finish c.Wait() below, and get panicked or killed
 		}()
+
+		processDone := make(chan struct{})
+		waitResult := make(chan error, 1)
+		go func() {
+			waitResult <- c.Wait()
+			close(processDone)
+		}()
+
+		var signalResult <-chan error
+		if t.signalOnOutput != "" {
+			result := make(chan error, 1)
+			signalResult = result
+			go func() {
+				select {
+				case <-stdout.matched:
+					result <- c.Process.Signal(t.signal)
+				case <-processDone:
+				}
+			}()
+		}
 
 		if debug {
 			beginAzCopyDebugging(stdin)
@@ -251,8 +316,28 @@ func (t *TestRunner) execDebuggableWithOutput(name string, args []string, env []
 			}()
 		}
 
-		// wait for completion
-		runErr = c.Wait()
+		if signalResult == nil {
+			runErr = <-waitResult
+		} else {
+			select {
+			case runErr = <-waitResult:
+			case signalErr := <-signalResult:
+				if signalErr != nil {
+					_ = c.Process.Kill()
+					<-waitResult
+					runErr = fmt.Errorf("failed to signal AzCopy after output %q: %w", t.signalOnOutput, signalErr)
+					break
+				}
+
+				select {
+				case runErr = <-waitResult:
+				case <-time.After(t.exitTimeoutAfterSignal):
+					_ = c.Process.Kill()
+					<-waitResult
+					runErr = fmt.Errorf("AzCopy did not exit within %s after receiving %v", t.exitTimeoutAfterSignal, t.signal)
+				}
+			}
+		}
 	}
 
 	// back to normal exec.Cmd.Output() processing
@@ -385,6 +470,16 @@ func (t *TestRunner) ExecuteAzCopyCommand(operation Operation, src, dst string, 
 	}
 
 	out, err := t.execDebuggableWithOutput(GlobalInputManager{}.GetExecutablePath(), args, env, afterStart, chToStdin)
+	if t.signalOnOutput != "" {
+		if err != nil {
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) || len(exitErr.Stderr) > 0 {
+				return CopyOrSyncCommandResult{}, false,
+					fmt.Errorf("AzCopy signal test failed: %w\n  with stdout: %s\n  from args %v", err, out, args)
+			}
+		}
+		return CopyOrSyncCommandResult{rawOutput: string(out)}, true, nil
+	}
 
 	wasClean := true
 	stdErr := make([]byte, 0)
@@ -437,6 +532,7 @@ func (t *TestRunner) ExecuteJobsShowCommand(jobID common.JobID, azcopyDir string
 type CopyOrSyncCommandResult struct {
 	jobID       common.JobID
 	finalStatus common.ListSyncJobSummaryResponse
+	rawOutput   string
 }
 
 func newCopyOrSyncCommandResult(rawOutput string) (CopyOrSyncCommandResult, bool) {

--- a/e2etest/runner.go
+++ b/e2etest/runner.go
@@ -46,6 +46,7 @@ type TestRunner struct {
 	flags                  map[string]string
 	signalOnOutput         string
 	signal                 os.Signal
+	signalTriggerTimeout   time.Duration
 	exitTimeoutAfterSignal time.Duration
 }
 
@@ -70,8 +71,10 @@ func (t *TestRunner) SetAllFlags(s *scenario) {
 	p := s.p
 	o := s.operation
 	if p.sigtermDuringEnumeration {
-		t.signalOnOutput = "Scanning..."
+		t.flags["await-enumeration"] = "true"
+		t.signalOnOutput = "Awaiting cancellation during enumeration"
 		t.signal = syscall.SIGTERM
+		t.signalTriggerTimeout = 10 * time.Second
 		t.exitTimeoutAfterSignal = 10 * time.Second
 	}
 
@@ -192,7 +195,7 @@ func (t *TestRunner) SetAllFlags(s *scenario) {
 }
 
 type outputMarkerBuffer struct {
-	bytes.Buffer
+	buffer  bytes.Buffer
 	marker  []byte
 	matched chan struct{}
 	once    sync.Once
@@ -222,7 +225,11 @@ func (b *outputMarkerBuffer) Write(p []byte) (int, error) {
 		b.tail = append(b.tail[:0], searchBuffer[len(searchBuffer)-tailLength:]...)
 	}
 
-	return b.Buffer.Write(p)
+	return b.buffer.Write(p)
+}
+
+func (b *outputMarkerBuffer) Bytes() []byte {
+	return b.buffer.Bytes()
 }
 
 func (t *TestRunner) SetAwaitOpenFlag() {
@@ -286,6 +293,8 @@ func (t *TestRunner) execDebuggableWithOutput(name string, args []string, env []
 				case <-stdout.matched:
 					result <- c.Process.Signal(t.signal)
 				case <-processDone:
+				case <-time.After(t.signalTriggerTimeout):
+					result <- fmt.Errorf("AzCopy did not emit %q within %s", t.signalOnOutput, t.signalTriggerTimeout)
 				}
 			}()
 		}

--- a/e2etest/runner_test.go
+++ b/e2etest/runner_test.go
@@ -1,0 +1,45 @@
+package e2etest
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOutputMarkerBufferDetectsMarker(t *testing.T) {
+	const marker = "AZCOPY_E2E_ENUMERATION_READY"
+
+	for name, writes := range map[string][]string{
+		"single write": {"before " + marker + " after"},
+		"split writes": {"before AZCOPY_E2E_ENUM", "ERATION_READY after"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			buffer := newOutputMarkerBuffer(marker)
+			for _, value := range writes {
+				_, err := buffer.Write([]byte(value))
+				require.NoError(t, err)
+			}
+
+			select {
+			case <-buffer.matched:
+			case <-time.After(time.Second):
+				t.Fatal("output marker was not detected")
+			}
+		})
+	}
+
+	t.Run("io copy", func(t *testing.T) {
+		buffer := newOutputMarkerBuffer(marker)
+		_, err := io.Copy(buffer, strings.NewReader("before "+marker+" after"))
+		require.NoError(t, err)
+
+		select {
+		case <-buffer.matched:
+		case <-time.After(time.Second):
+			t.Fatal("output marker was not detected")
+		}
+	})
+}

--- a/e2etest/zt_error_handling_test.go
+++ b/e2etest/zt_error_handling_test.go
@@ -21,11 +21,44 @@
 package e2etest
 
 import (
+	"fmt"
+	"runtime"
 	"testing"
 	"time"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
+
+func TestError_SIGTERMDuringEnumerationDoesNotHang(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not support sending SIGTERM with os.Process.Signal")
+	}
+
+	const fileCount = 5000
+	files := make([]interface{}, fileCount)
+	for i := range files {
+		files[i] = fmt.Sprintf("file-%05d", i)
+	}
+
+	RunScenarios(
+		t,
+		eOperation.Copy(),
+		eTestFromTo.Other(common.EFromTo.LocalBlob()),
+		eValidate.Auto(),
+		anonymousAuthOnly,
+		anonymousAuthOnly,
+		params{
+			recursive:                true,
+			disableParallelTesting:   true,
+			sigtermDuringEnumeration: true,
+		},
+		nil,
+		testFiles{
+			defaultSize:    "1",
+			shouldTransfer: files,
+		},
+		EAccountType.Standard(), EAccountType.Standard(), "")
+}
 
 func TestError_CancelFromStdin(t *testing.T) {
 	RunScenarios(

--- a/e2etest/zt_error_handling_test.go
+++ b/e2etest/zt_error_handling_test.go
@@ -21,7 +21,6 @@
 package e2etest
 
 import (
-	"fmt"
 	"runtime"
 	"testing"
 	"time"
@@ -32,12 +31,6 @@ import (
 func TestError_SIGTERMDuringEnumerationDoesNotHang(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows does not support sending SIGTERM with os.Process.Signal")
-	}
-
-	const fileCount = 5000
-	files := make([]interface{}, fileCount)
-	for i := range files {
-		files[i] = fmt.Sprintf("file-%05d", i)
 	}
 
 	RunScenarios(
@@ -54,8 +47,8 @@ func TestError_SIGTERMDuringEnumerationDoesNotHang(t *testing.T) {
 		},
 		nil,
 		testFiles{
-			defaultSize:    "1",
-			shouldTransfer: files,
+			defaultSize:    "1K",
+			shouldTransfer: []interface{}{"file-1", "file-2"},
 		},
 		EAccountType.Standard(), EAccountType.Standard(), "")
 }


### PR DESCRIPTION
## Description

Fixes a cancellation hang when AzCopy receives SIGTERM while copy enumeration is still in progress.

The copy migration in #3310 moved signal handling to context cancellation. The lifecycle manager then invoked the CLI prompt after the context was already canceled. In non-interactive executions such as `timeout`, that prompt could wait indefinitely for stdin, preventing `cancelJob` from running.

#3373 repaired stdin cancellation delivery and repeated context handling, but cancellation during incomplete enumeration could still block before reaching those fixes.

This change logs the existing non-resumability warning and proceeds with cancellation without prompting. Context cancellation is irreversible, so prompting at this point cannot safely resume the operation.

## Tests

- Added a focused lifecycle test with a deliberately blocking prompt hook.
- Added a deterministic process-level E2E test that pauses immediately before enumeration, sends SIGTERM, and fails if AzCopy does not exit within 10 seconds.
- The E2E test verifies the incomplete-enumeration warning so it cannot pass after enumeration completes.
- Added output-marker coverage for normal, split-write, and `io.Copy` streaming paths.
- The signal scenario runs on Linux/macOS and skips on Windows, where `os.Process.Signal(SIGTERM)` is unsupported.

WSL validation with Go 1.25.11 and local Azurite 3.35.0:

- `go test ./azcopy -run '^TestContextCancellationDoesNotPromptDuringEnumeration$' -count=1`
- `go test ./e2etest -run '^TestOutputMarkerBufferDetectsMarker$' -count=1`
- `go test ./cmd ./common -run '^$'`
- Linux `go build -tags netgo`
- `go test -timeout=2m -tags olde2etest ./e2etest -run '^TestError_SIGTERMDuringEnumerationDoesNotHang$' -count=1 -v`