### PR TITLE
Merged two test pipeline jobs.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -241,87 +241,71 @@ jobs:
         # this runs even if the job was canceled (only if the mutex was acquired by this job)
         condition: and(always(), eq(variables['isMutexSet'], 'true'))
 
-  - job: Additional_E2E_Test_Linux
+  - job: Additional_E2E_Tests
     timeoutInMinutes: 360
     strategy:
       matrix:
         Linux:
-          AgentName: "blobfuse-ubuntu20"
+          pool_name: 'blobfuse-ubuntu-pool'
+          image_name: 'blobfuse-ubuntu20'
           build_name: 'azcopy_linux_amd64'
           container_name: 'testcontainer1'
           GOOS: 'linux'
           GOARCH: 'amd64'
           CGO_ENABLED: '0'
-    pool:
-      name: "blobfuse-ubuntu-pool"
-      demands:
-        - ImageOverride -equals $(AgentName)
-
-    steps:
-      - script: |
-          # Install Az.Accounts module using Bash script
-          sudo apt-get update
-          sudo apt-get install -y powershell
-          pwsh -Command "Install-Module -Name Az.Accounts -Scope CurrentUser -Repository PSGallery -AllowClobber -Force"
-        displayName: 'Install PowerShell Az Module'
-
-      - task: GoTool@0
-        inputs:
-          version: $(AZCOPY_GOLANG_VERSION_COVERAGE)
-      
-      # Install azcli
-      - script: |
-          curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-          az --version
-        displayName: 'Install Azure CLI'
-
-      - template: azurePipelineTemplates/run_scenarios.yml
-        parameters:
-          container_name: $(container_name)
-          storage_account_name: $(AZCOPY_E2E_ACCOUNT_NAME)
-          GOOS: $(GOOS)
-          GOARCH: $(GOARCH)
-          CGO_ENABLED: $(CGO_ENABLED)
-          build_name: $(build_name)
-          
-  - job: Additional_E2E_Test_Windows
-    timeoutInMinutes: 360
-    strategy:
-      matrix:
         Windows:
-          AgentName: 'azcopy-windows-22'
+          pool_name: 'azcopy-windows-pool'
+          image_name: 'azcopy-windows-22'
           build_name: 'azcopy_windows_amd64.exe'
           container_name: 'testcontainer2'
           GOOS: 'windows'
           GOARCH: 'amd64'
-          CGO_ENABLED: '0'
+          CGO_ENABLED: '0'        
+        #TODO: Add MacOS after creating macos pool
     pool:
-      name: "azcopy-windows-pool"
+      name: $(pool_name)
       demands:
-        - ImageOverride -equals $(AgentName)
+        - ImageOverride -equals $(image_name)
 
     steps:
+      - script: |
+          sudo apt-get update
+          sudo apt-get install -y powershell
+          pwsh -Command "Install-Module -Name Az.Accounts -Scope CurrentUser -Repository PSGallery -AllowClobber -Force"
+        displayName: 'Install PowerShell Az Module'
+        # Don't run if job is canceled
+        condition: and(succeededOrFailed(), eq(variables.GOOS, 'linux'))
+
       - task: PowerShell@2
         inputs:
           targetType: 'inline'
           script: |
-            # Install Az.Accounts module using PowerShell
             Install-Module -Name Az.Accounts -Scope CurrentUser -Repository PSGallery -AllowClobber -Force
-          displayName: 'Install PowerShell Az Module'
+        displayName: 'Install PowerShell Az Module'
+        # Don't run if job is canceled
+        condition: and(succeededOrFailed(), eq(variables.GOOS, 'windows'))
 
       - task: GoTool@0
         inputs:
           version: $(AZCOPY_GOLANG_VERSION_COVERAGE)
+
+      - script: |
+          curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+          az --version
+        displayName: 'Install Azure CLI'
+        # Don't run if job is canceled
+        condition: and(succeededOrFailed(), eq(variables.GOOS, 'linux'))
 
       - task: PowerShell@2
         displayName: 'Install Azure CLI'
         inputs:
           targetType: 'inline'
           script: |
-            # Install Azure CLI using Chocolatey
             choco install azure-cli -y
             az --version
-          
+        # Don't run if job is canceled
+        condition: and(succeededOrFailed(), eq(variables.GOOS, 'windows'))
+
       - template: azurePipelineTemplates/run_scenarios.yml
         parameters:
           container_name: $(container_name)
@@ -330,6 +314,4 @@ jobs:
           GOARCH: $(GOARCH)
           CGO_ENABLED: $(CGO_ENABLED)
           build_name: $(build_name)
-
-    #TODO: Add MacOS E2E tests after creating macos pool
           


### PR DESCRIPTION
This eliminates duplication, which reduces the chance of updating one job and forgetting to update the other. This also removes the redundant "Additional_E2E_Test_Windows Windows" and "*Linux Linux" naming from the pipeline.

## Description
This gave me something to do while I waited for feedback on other PRs.

**NOTE:**
This PR improves the names of some jobs in the test pipeline that GitHub requires to pass before this can be merged. I may need to work with a project admin or a support team to skip those checks if we can't make GitHub realize the jobs were renamed.

**Related Links**:
- https://github.com/Azure/azure-storage-azcopy/pull/3504 corrects the YAML for the jobs this PR updated so the display name of the task that runs the tests is shown in the pipeline.

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [x] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->
- https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31392&view=results
  - This pipeline run used a derivative of this branch that removed the irrelevant jobs. I'll do a full pipeline run on this branch before merging this PR.
- https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31427&view=results
  - Full pipeline run
