### PR TITLE
Block dedupe prototype for C2C stage (code review only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,11 @@ one-shot Storage Mover worker
     |-- starts embedded AzCopy with mover,smslidingwindow build tags
     v
 ProgramPedro AzCopy fork
-    |-- reads source committed blocks and CRC64/SHA256 hashes
+    |-- reads source committed blocks and CRC64 only
     |-- builds the source-grid chunk plan
-    |-- looks each block up in the job-local committed hash table
+    |-- finds CRC64+size candidates in the job-local committed table
+    |-- requests source/target SHA256 only for candidate ranges
+    |-- confirms reuse with exact SHA256
     |-- stages a miss from sourceURI
     |-- stages a hit from an already-committed targetURI
     |-- commits the new destination blob and indexes its blocks
@@ -74,9 +76,9 @@ DevFabric Blob endpoints through the test proxy
 ```
 
 For the local DevFabric E2E, the worker sends Blob requests to the host-style
-proxy endpoint. Normal Blob operations are routed to the managed frontend, and
-hash-bearing committed-block-list requests are routed to the native frontend
-that implements `GetBlockList(include=crc64,sha256)`.
+proxy endpoint. Normal Blob operations are routed to the managed frontend.
+CRC discovery and selective SHA requests are routed to the native frontend that
+implements `GetBlockList(include=crc64)` and `GetBlobHash(comp=hash)`.
 
 ### End-to-end transfer flow
 
@@ -85,26 +87,37 @@ that implements `GetBlockList(include=crc64,sha256)`.
 2. Mover resolves both SAS tokens and passes them to AzCopy as runtime-only
    authentication. The values are not serialized into an AzCopy plan file.
 3. For an eligible source block blob, AzCopy requests the committed block list
-   with `include=crc64,sha256`.
+   with `include=crc64`. This request does not calculate SHA256.
 4. AzCopy converts the ordered committed block list into a source-grid plan.
-   Each planned block contains its source offset, size, block name, CRC64, and
-   SHA256.
+   Each planned block contains its source offset, size, block name, and CRC64.
 5. The normal uniform chunk grid is replaced with one transfer chunk per source
    committed block.
-6. Before staging a chunk, AzCopy uses its `(offset, size)` to obtain the source
-   block hashes and looks those hashes up in the job's committed dedupe table.
-7. On a miss, AzCopy stages the range from the original source URI.
-8. On a hit in enforce mode, AzCopy stages the matching range from an
+6. AzCopy uses `(CRC64, size)` to find candidate occurrences in the job's
+   committed destination table. If no candidate exists, no SHA256 request is
+   issued.
+7. When candidates exist, AzCopy batches their source and destination ranges
+   into `GetBlobHash` calls using `x-ms-multi-range`. Every request carries the
+   exact ETag from discovery in `If-Match`.
+8. The returned SHA256 values are correlated by `(offset, length)`, never by
+   block ID or response position. Only exact CRC64, size, and SHA256 matches are
+   reusable.
+9. On a miss or SHA mismatch, AzCopy stages the range from the original source
+   URI.
+10. On a confirmed hit in enforce mode, AzCopy stages the matching range from an
    already-committed destination blob. The copy source is guarded with the
    recorded ETag.
-9. If target reuse fails, AzCopy falls back to the original source for that
-   block. Dedupe must not turn a reusable-block failure into a transfer failure.
-10. After `CommitBlockList` succeeds for the new blob, its hashed blocks,
+11. If hash retrieval or target reuse fails, AzCopy falls back to the original
+    source. A 412 invalidates the source discovery epoch or evicts the stale
+    target ETag epoch.
+12. SHA256 values calculated for a candidate are cached on the exact
+    blob/ETag/range occurrence for later files in the same job.
+13. After `CommitBlockList` succeeds for the new blob, its CRC-indexed blocks,
     destination ranges, and ETag are added to the committed table for later
-    blobs in the same job.
-11. When the job reaches a terminal state, AzCopy writes the final dedupe
-    summary, closes the dedicated dedupe log, clears both in-memory tables, and
-    releases their memory.
+    blobs in the same job. SHA256 is stored only for ranges that needed
+    confirmation.
+14. When the job reaches a terminal state, AzCopy writes the final dedupe
+    and hash-CPU summary, closes the dedicated dedupe log, clears both
+    in-memory tables, and releases their memory.
 
 ### Source-grid chunking
 
@@ -122,6 +135,9 @@ Derived source ranges:         [0,4), [4,8), [8,10) MiB
 Scheduled AzCopy chunks:       [0,4), [4,8), [8,10) MiB
 ```
 
+These sizes are illustrative only; committed blocks may have different and
+unequal positive lengths.
+
 `buildSourceGridPlan` uses the offset returned by XStore when it is present.
 For compatibility with legacy Azure responses that omit `Offset`, it derives
 only the missing value from the preceding block ranges. It rejects negative
@@ -130,7 +146,7 @@ enabling source-grid chunking for a transfer, the implementation also requires:
 
 - a block-blob to block-blob service-to-service transfer;
 - a committed named-block list;
-- a complete CRC64 and SHA256 pair for at least one block;
+- a valid CRC64 for at least one block;
 - a plan total equal to the reported source blob size;
 - no more than Azure's maximum number of blocks per block blob; and
 - a destination SAS in enforce mode, because a hit is read from a destination
@@ -152,29 +168,32 @@ Each `BlockEntry` stores:
 | Field | Purpose |
 | --- | --- |
 | `CRC64` | Fast first-pass bucket key. |
-| `SHA256` | Strong equality check within a CRC64 bucket; prevents CRC64 collisions from becoming false hits. |
+| `SHA256` / `HasSHA256` | Optional cached strong hash. SHA256 is populated only after a CRC64+size candidate triggers `GetBlobHash`; it prevents CRC64 collisions from becoming false hits. |
 | `TargetURI` | Authenticated location of the previously committed destination blob. It remains in memory and is sanitized before logging. |
 | `TargetOffset` / `TargetLength` | Exact source range for `StageBlockFromURL`. Block IDs cannot be reused across blobs, so reuse occurs by copying this byte range. |
 | `ETag` | Version guard supplied as `SourceIfMatch` when staging from the target URI. |
-| `RefCount` | Number of insertions of the same fingerprint. |
+| `RefCount` | Number of insertions of the same target epoch/range occurrence. |
 | `CreatedAt` / `TTL` | Optional expiry metadata. Prototype entries currently use a non-positive TTL and live until job cleanup. |
 
-The table maps CRC64 values to small collision buckets. A lookup first selects
-the CRC64 bucket and then requires an exact SHA256 match. Insert and lookup are
-protected by an RW mutex. An existing fingerprint increments its reference
-count rather than adding a duplicate entry.
+The table maps CRC64 values to collision buckets and preserves distinct target
+blob/ETag/range occurrences even when their content is identical. Candidate
+lookup also requires equal range length. SHA256 is added to an exact occurrence
+after `GetBlobHash`, and final lookup requires an exact strong-hash match.
+Insert, lookup, enrichment, and ETag-epoch eviction are protected by an RW
+mutex.
 
 The per-job state currently owns two tables:
 
-- `table` is used only by observe mode to measure would-be hits before data is
-  written. It must never be used for a real target reference.
+- `table` is retained for legacy complete-hash diagnostic helpers. CRC-only
+  observe mode does not classify candidates as hits, and this table must never
+  be used for a real target reference.
 - `committed` contains only blocks from destination blobs whose
   `CommitBlockList` operation succeeded. Enforce mode consults only this table.
 
-The first committed occurrence of a fingerprint remains the reusable target.
-The implementation rejects missing ETags, invalid ranges, differently-sized
-entries, and reuse of the blob currently being written. Consequently, only
-content in another already-committed destination blob can be reused.
+The implementation can choose any safe matching occurrence. It rejects missing
+ETags, invalid ranges, differently-sized entries, and reuse of the blob
+currently being written. Consequently, only content in another
+already-committed destination blob can be reused.
 
 The table is job-local. Separate jobs, worker restarts, and separate worker
 processes do not share candidates.
@@ -188,7 +207,7 @@ worker image selects enforce mode:
 | --- | --- |
 | `AZCOPY_DEDUPE_ACT=enforce` | Uses source-grid chunks and stages a matching block from a committed destination range. Falls back to the original source on reuse failure. |
 | `AZCOPY_DEDUPE_ACT=shadow` | Uses the source grid and reports reusable blocks, but still stages all data from the original source. |
-| `AZCOPY_DEDUPE_OBSERVE=true` | Read-only alignment and would-be-hit measurement. It does not alter transfer behavior. |
+| `AZCOPY_DEDUPE_OBSERVE=true` | Read-only alignment and CRC-discovery measurement. It does not calculate SHA256 or alter transfer behavior. |
 | Variables unset | Standard AzCopy behavior. |
 
 The Storage Mover Dockerfile currently sets
@@ -232,7 +251,8 @@ For this E2E path:
 | `ste/mgr-JobMgr.go` | Stores runtime SAS values on each `jobPartMgr` and finalizes/clears dedupe state when the job terminates. |
 | `ste/mgr-JobPartTransferMgr.go` | Exposes runtime SAS values to transfer and sender code through `SAS()`. |
 | `ste/sourceGridObserver.go` | Defines source-grid plan types and construction, alignment diagnostics, and observe-mode collection. |
-| `ste/dedupeAct.go` | Parses act mode, retrieves the extended committed block list, extracts hashes, and produces source-grid chunk specifications. |
+| `ste/dedupeAct.go` | Parses act mode, retrieves CRC-only committed block lists, preserves source ETags, and produces source-grid chunk specifications. |
+| `ste/dedupeHashResolver.go` | Filters CRC64+size candidates, batches multi-range GetBlobHash requests, correlates range results, caches target SHA256, and invalidates stale ETag epochs. |
 | `ste/dedupeRecorder.go` | Owns per-job tables and counters, records committed targets, makes the core hit decision, calculates savings, sanitizes output, and writes external per-job logs. |
 | `ste/sender-blockBlobFromURL.go` | Arms dedupe for eligible S2S transfers and chooses source staging, shadow reporting, target reuse, or fallback for each block. |
 | `ste/sender-blockBlob.go` | Captures the destination ETag after `CommitBlockList`, indexes the newly committed blocks, and emits file-level progress. |
@@ -325,6 +345,15 @@ Important events include:
 
 | Event | Meaning |
 | --- | --- |
+| `crc_only_discovery` | GetBlockList returned the source grid and CRC64 values without calculating SHA256. |
+| `crc_candidate_miss` | No committed target matched CRC64 and size; no GetBlobHash call was needed. |
+| `crc_candidate_hit` | One or more committed target occurrences matched CRC64 and size. |
+| `get_blob_hash_complete` | Selective source/target SHA256 batches completed; includes range, batch, cache, and invalidation counts. |
+| `get_blob_hash_failed` | Source SHA retrieval failed and transfer falls back to normal source staging. |
+| `sha_confirmed` | Source and target ranges matched CRC64, size, and SHA256. |
+| `sha_mismatch` | CRC64 and size matched but SHA256 did not. |
+| `epoch_invalidated_412` | A source or target ETag became stale; cached entries for the target epoch were evicted. |
+| `hash_cpu_time` | Per-response and cumulative server CRC64/SHA256 CPU microseconds. `operation` distinguishes GetBlockList from GetBlobHash and `role` distinguishes source from target. |
 | `file_start` | Source-grid dedupe was armed for a blob. |
 | `small_file_transfer_start` | A Blob-to-Blob file smaller than 4 MiB entered transfer handling. Includes its size and cumulative small-file progress. |
 | `small_file_transfer_complete` | A file smaller than 4 MiB completed successfully. |
@@ -351,11 +380,18 @@ byte counts. These fields are appended alongside the existing block-level
 dedupe and WAN-savings counters, so one log shows both small-file transfer
 progress and dedupe reuse progress.
 
+The CRC64 CPU value comes from
+`x-ms-test-dedupe-crc64-cpu-time-us` on GetBlockList. SHA256 CPU values come
+from `x-ms-test-dedupe-sha256-cpu-time-us` on each GetBlobHash batch. These are
+server CPU microseconds, not client wall-clock latency. Missing, malformed,
+negative, and duplicate-request-ID responses are tracked without failing a
+transfer.
+
 ### Current limitations
 
 - Dedupe supports block-blob to block-blob S2S transfers only.
 - A source blob created with a single `PutBlob`, or a committed block list with
-  no complete hash pairs, is not eligible.
+  no valid CRC64 values, is not eligible.
 - Candidates are shared only within one in-memory AzCopy job.
 - A worker restart loses the committed table. SAS values can be refreshed for
   resume, but the dedupe candidate index is not persisted.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,344 @@ AzCopy V10 presents easy-to-use commands that are optimized for high performance
 
 :white_check_mark: Recover from failures by restarting previous jobs.
 
+## Storage Mover block-dedupe prototype
+
+> [!IMPORTANT]
+> This section describes the block-level dedupe prototype in the
+> `ProgramPedro/azure-storage-azcopy` fork. It is not part of the supported
+> upstream AzCopy release.
+
+This fork adds job-local block deduplication for Azure block-blob to block-blob
+service-to-service transfers. Storage Mover embeds the fork as a Go dependency
+inside its Linux cloud-to-cloud worker. The worker receives a normal C2C job,
+resolves source and destination SAS credentials in memory, and invokes the
+embedded AzCopy engine. Dedupe mode is selected by the worker environment; it
+is not currently a field in the C2C queue contract.
+
+### High-level architecture
+
+```text
+C2C seeder
+    |
+    | C2CJobRequest (endpoints + SAS secret references, no literal SAS)
+    v
+jobqueue
+    |
+    v
+Storage Mover orchestrator
+    |-- validates the request
+    |-- initializes job state
+    v
+endpointqueue
+    |
+    v
+one-shot Storage Mover worker
+    |-- resolves source and destination SAS values
+    |-- creates the per-job external data directory
+    |-- starts embedded AzCopy with mover,smslidingwindow build tags
+    v
+ProgramPedro AzCopy fork
+    |-- reads source committed blocks and CRC64/SHA256 hashes
+    |-- builds the source-grid chunk plan
+    |-- looks each block up in the job-local committed hash table
+    |-- stages a miss from sourceURI
+    |-- stages a hit from an already-committed targetURI
+    |-- commits the new destination blob and indexes its blocks
+    v
+DevFabric Blob endpoints through the test proxy
+```
+
+For the local DevFabric E2E, the worker sends Blob requests to the host-style
+proxy endpoint. Normal Blob operations are routed to the managed frontend, and
+hash-bearing committed-block-list requests are routed to the native frontend
+that implements `GetBlockList(include=crc64,sha256)`.
+
+### End-to-end transfer flow
+
+1. The worker receives a Blob-to-Blob C2C job containing account, container,
+   endpoint, and SAS secret-reference metadata.
+2. Mover resolves both SAS tokens and passes them to AzCopy as runtime-only
+   authentication. The values are not serialized into an AzCopy plan file.
+3. For an eligible source block blob, AzCopy requests the committed block list
+   with `include=crc64,sha256`.
+4. AzCopy converts the ordered committed block list into a source-grid plan.
+   Each planned block contains its source offset, size, block name, CRC64, and
+   SHA256.
+5. The normal uniform chunk grid is replaced with one transfer chunk per source
+   committed block.
+6. Before staging a chunk, AzCopy uses its `(offset, size)` to obtain the source
+   block hashes and looks those hashes up in the job's committed dedupe table.
+7. On a miss, AzCopy stages the range from the original source URI.
+8. On a hit in enforce mode, AzCopy stages the matching range from an
+   already-committed destination blob. The copy source is guarded with the
+   recorded ETag.
+9. If target reuse fails, AzCopy falls back to the original source for that
+   block. Dedupe must not turn a reusable-block failure into a transfer failure.
+10. After `CommitBlockList` succeeds for the new blob, its hashed blocks,
+    destination ranges, and ETag are added to the committed table for later
+    blobs in the same job.
+11. When the job reaches a terminal state, AzCopy writes the final dedupe
+    summary, closes the dedicated dedupe log, clears both in-memory tables, and
+    releases their memory.
+
+### Source-grid chunking
+
+Normal AzCopy block-blob transfers use a uniform chunk size selected from the
+transfer settings. Uniform chunks do not necessarily align with the source
+blob's committed block boundaries, so a uniform chunk may cover part of one
+source block and part of another. Its content hash would then be different from
+the hashes returned for either committed source block.
+
+The source-grid implementation preserves the source block boundaries:
+
+```text
+Committed source block sizes:  4 MiB, 4 MiB, 2 MiB
+Derived source ranges:         [0,4), [4,8), [8,10) MiB
+Scheduled AzCopy chunks:       [0,4), [4,8), [8,10) MiB
+```
+
+`buildSourceGridPlan` derives each offset as the prefix sum of the preceding
+block sizes. It rejects non-positive block sizes. Before enabling source-grid
+chunking for a transfer, the implementation also requires:
+
+- a block-blob to block-blob service-to-service transfer;
+- a committed named-block list;
+- a complete CRC64 and SHA256 pair for at least one block;
+- a plan total equal to the reported source blob size;
+- no more than Azure's maximum number of blocks per block blob; and
+- a destination SAS in enforce mode, because a hit is read from a destination
+  blob.
+
+If any eligibility check fails, the transfer retains the standard uniform grid.
+The `sourceGridChunker` interface exposes the content-defined ranges to
+`scheduleSendChunks`, and `scheduleSourceGridChunks` schedules them through the
+existing S2S copy path.
+
+### Job-local dedupe hash tables
+
+`common.DedupeHashTable` is an in-memory, concurrency-safe table. It is scoped
+to one AzCopy job and is never serialized to a plan file, queue message, or
+database.
+
+Each `BlockEntry` stores:
+
+| Field | Purpose |
+| --- | --- |
+| `CRC64` | Fast first-pass bucket key. |
+| `SHA256` | Strong equality check within a CRC64 bucket; prevents CRC64 collisions from becoming false hits. |
+| `TargetURI` | Authenticated location of the previously committed destination blob. It remains in memory and is sanitized before logging. |
+| `TargetOffset` / `TargetLength` | Exact source range for `StageBlockFromURL`. Block IDs cannot be reused across blobs, so reuse occurs by copying this byte range. |
+| `ETag` | Version guard supplied as `SourceIfMatch` when staging from the target URI. |
+| `RefCount` | Number of insertions of the same fingerprint. |
+| `CreatedAt` / `TTL` | Optional expiry metadata. Prototype entries currently use a non-positive TTL and live until job cleanup. |
+
+The table maps CRC64 values to small collision buckets. A lookup first selects
+the CRC64 bucket and then requires an exact SHA256 match. Insert and lookup are
+protected by an RW mutex. An existing fingerprint increments its reference
+count rather than adding a duplicate entry.
+
+The per-job state currently owns two tables:
+
+- `table` is used only by observe mode to measure would-be hits before data is
+  written. It must never be used for a real target reference.
+- `committed` contains only blocks from destination blobs whose
+  `CommitBlockList` operation succeeded. Enforce mode consults only this table.
+
+The first committed occurrence of a fingerprint remains the reusable target.
+The implementation rejects missing ETags, invalid ranges, differently-sized
+entries, and reuse of the blob currently being written. Consequently, only
+content in another already-committed destination blob can be reused.
+
+The table is job-local. Separate jobs, worker restarts, and separate worker
+processes do not share candidates.
+
+### Dedupe modes
+
+The current fork retains the prototype diagnostic modes, although the Mover
+worker image selects enforce mode:
+
+| Configuration | Behavior |
+| --- | --- |
+| `AZCOPY_DEDUPE_ACT=enforce` | Uses source-grid chunks and stages a matching block from a committed destination range. Falls back to the original source on reuse failure. |
+| `AZCOPY_DEDUPE_ACT=shadow` | Uses the source grid and reports reusable blocks, but still stages all data from the original source. |
+| `AZCOPY_DEDUPE_OBSERVE=true` | Read-only alignment and would-be-hit measurement. It does not alter transfer behavior. |
+| Variables unset | Standard AzCopy behavior. |
+
+The Storage Mover Dockerfile currently sets
+`AZCOPY_DEDUPE_ACT=enforce`. Neither mode value is part of
+`C2CJobRequest`.
+
+### Runtime SAS handling
+
+The source and destination SAS values are needed after the SAS-free plan has
+been created:
+
+```text
+CopyJobPartOrderRequest
+    -> ste.AddJobPartArgs (transient SAS fields)
+    -> jobPartMgr.sourceSAS / destinationSAS
+    -> jobPartTransferMgr.SAS()
+    -> source and target StageBlockFromURL calls
+```
+
+`jobsAdmin.ExecuteNewCopyJobPartOrder` copies `SourceRoot.SAS` and
+`DestinationRoot.SAS` into transient `AddJobPartArgs` fields. `AddJobPart`
+copies them into the in-memory `jobPartMgr`. The job plan deliberately stores
+only SAS-free roots. Resume continues to obtain fresh SAS values rather than
+recovering credentials from a plan file.
+
+For this E2E path:
+
+- the source SAS requires read and list;
+- the destination SAS requires read, create, write, delete, and list; and
+- destination read is specifically required for target-to-target block reuse.
+
+### Files changed by this prototype
+
+| File | Responsibility |
+| --- | --- |
+| `common/dedupeHashTable.go` | Defines `BlockEntry` and the concurrency-safe CRC64-bucket/SHA256-confirmed hash table. |
+| `common/environment.go` | Defines the internal `AZCOPY_DEDUPE_ACT` and `AZCOPY_DEDUPE_OBSERVE` switches. |
+| `common/util.go` | Exposes the configured AzCopy log root used by the dedicated dedupe log writer. |
+| `cmd/root.go` | Publishes the initialized log folder to `common.AzcopyLogFolder`. |
+| `jobsAdmin/init.go` | Carries source and destination SAS values from the incoming order into transient `AddJobPartArgs`. |
+| `ste/mgr-JobMgr.go` | Stores runtime SAS values on each `jobPartMgr` and finalizes/clears dedupe state when the job terminates. |
+| `ste/mgr-JobPartTransferMgr.go` | Exposes runtime SAS values to transfer and sender code through `SAS()`. |
+| `ste/sourceGridObserver.go` | Defines source-grid plan types and construction, alignment diagnostics, and observe-mode collection. |
+| `ste/dedupeAct.go` | Parses act mode, retrieves the extended committed block list, extracts hashes, and produces source-grid chunk specifications. |
+| `ste/dedupeRecorder.go` | Owns per-job tables and counters, records committed targets, makes the core hit decision, calculates savings, sanitizes output, and writes external per-job logs. |
+| `ste/sender-blockBlobFromURL.go` | Arms dedupe for eligible S2S transfers and chooses source staging, shadow reporting, target reuse, or fallback for each block. |
+| `ste/sender-blockBlob.go` | Captures the destination ETag after `CommitBlockList`, indexes the newly committed blocks, and emits file-level progress. |
+| `ste/xfer-anyToRemote-file.go` | Invokes observe mode and schedules source-grid chunks through the existing S2S transfer pipeline. |
+| `ste/testJobPartTransferManager_test.go` | Extends the test transfer manager for SAS and dedupe test seams. |
+| `common/zt_dedupeHashTable_test.go` | Covers insertion, collision buckets, expiry, reference counts, removal, and concurrent access. |
+| `jobsAdmin/init_test.go` and `ste/mgr-JobPartMgr_test.go` | Verify runtime SAS reaches the transfer manager while sentinel SAS values remain absent from generated plans; preserve non-SAS and resume behavior. |
+| `ste/dedupeAct_test.go` and `ste/dedupeRecorder_test.go` | Cover mode parsing, hash extraction, committed-target recording, hit decisions, fallback counters, summaries, redaction, and external logging. |
+| `ste/sourceGridObserver_test.go` | Covers source-grid offset construction and alignment calculations. |
+
+### Building the Mover worker image
+
+Mover consumes this fork as a Go module replacement. Its `xdatamoved/go.mod`
+must require the published AzCopy pseudo-version and replace the upstream module
+with the same version from this fork. It must also retain the ProgramPedro
+`azblob` replacement that defines the extended block-list hash fields.
+
+Conceptually:
+
+```go
+require github.com/Azure/azure-storage-azcopy/v10 <azcopy-pseudo-version>
+
+replace github.com/Azure/azure-storage-azcopy/v10 => github.com/ProgramPedro/azure-storage-azcopy/v10 <azcopy-pseudo-version>
+
+replace github.com/Azure/azure-sdk-for-go/sdk/storage/azblob => github.com/ProgramPedro/azure-sdk-for-go/sdk/storage/azblob <azblob-pseudo-version>
+```
+
+From the Mover repository root, build the Linux worker with:
+
+```bash
+docker build \
+  --tag mover-worker:dedupe \
+  --file xdatamoved/cloud2cloud/worker/Dockerfile \
+  .
+```
+
+The worker Dockerfile compiles with the `mover,smslidingwindow` build tags,
+sets `FEATURE_MODE=CLOUD_TO_CLOUD`, and currently sets
+`AZCOPY_DEDUPE_ACT=enforce`. The AzCopy and azblob commits must be pushed before
+building from pseudo-versions; a local unpushed commit cannot be downloaded by
+the Docker builder.
+
+### External dedupe logs
+
+Mover creates a persistent per-job data folder below its worker file-share
+mount. Embedded AzCopy uses the `azcopy` child directory as its log root. This
+fork lazily creates a dedicated log file on the first dedupe event:
+
+```text
+/mnt/clpfileshare/
+  <jobDefinitionId>/
+    <jobRunId>/
+      azcopy/
+        dedupe-logs/
+          <AzCopyJobID>.log
+```
+
+The filename contains the AzCopy job ID. The surrounding directories identify
+the Mover job definition and run.
+
+To access the file outside the Linux container, bind-mount or otherwise
+persist `/mnt/clpfileshare`. Include this mount in the complete worker launch
+configuration:
+
+```bash
+docker run \
+  --mount type=bind,source=<host-log-root>,target=/mnt/clpfileshare \
+  mover-worker:dedupe
+```
+
+On a Windows host, the resulting file is available under:
+
+```text
+<host-log-root>\<jobDefinitionId>\<jobRunId>\azcopy\dedupe-logs\<AzCopyJobID>.log
+```
+
+The file is append-only and can be read while the transfer is active:
+
+```powershell
+$log = Get-ChildItem <host-log-root> -Recurse -Filter *.log |
+  Where-Object FullName -Match '[\\/]azcopy[\\/]dedupe-logs[\\/]' |
+  Sort-Object LastWriteTime -Descending |
+  Select-Object -First 1
+
+Get-Content $log.FullName -Wait
+```
+
+Progress events begin with `DEDUPE_PROGRESS` and use stable key/value fields.
+Important events include:
+
+| Event | Meaning |
+| --- | --- |
+| `file_start` | Source-grid dedupe was armed for a blob. |
+| `small_file_transfer_start` | A Blob-to-Blob file smaller than 4 MiB entered transfer handling. Includes its size and cumulative small-file progress. |
+| `small_file_transfer_complete` | A file smaller than 4 MiB completed successfully. |
+| `small_file_transfer_failed` | A file smaller than 4 MiB completed with a failure status. |
+| `small_file_transfer_skipped` | A file smaller than 4 MiB was skipped by transfer policy. |
+| `small_file_transfer_canceled` | A file smaller than 4 MiB was canceled. |
+| `source_block_transferred` | A block was staged from the original source URI. |
+| `target_reuse_candidate` | Shadow mode found a reusable committed target. |
+| `target_reuse` | Enforce mode successfully staged a block from a target URI. |
+| `target_reuse_fallback` | Target reuse failed and the block will be staged from the source. |
+| `file_committed` | The destination blob committed and its eligible blocks were indexed. |
+| `job_complete` | Final cumulative block, byte, fallback, and WAN-savings counters. |
+| `output_dropped` | The bounded asynchronous log queue was full; transfer work continued without blocking. |
+
+Per-block transfer goroutines enqueue events into a bounded asynchronous queue,
+so a slow host-mounted log volume does not directly block data staging. The
+terminal event waits for a bounded flush and then closes the job's writer.
+Files rotate at 500 MiB. URLs are written without query strings, and the AzCopy
+log sanitizer provides an additional backstop for SAS signatures and tokens.
+
+Small-file events use a strict `< 4 MiB` threshold. Their cumulative fields
+include started, completed, failed, skipped, canceled, and in-progress file and
+byte counts. These fields are appended alongside the existing block-level
+dedupe and WAN-savings counters, so one log shows both small-file transfer
+progress and dedupe reuse progress.
+
+### Current limitations
+
+- Dedupe supports block-blob to block-blob S2S transfers only.
+- A source blob created with a single `PutBlob`, or a committed block list with
+  no complete hash pairs, is not eligible.
+- Candidates are shared only within one in-memory AzCopy job.
+- A worker restart loses the committed table. SAS values can be refreshed for
+  resume, but the dedupe candidate index is not persisted.
+- Separate Storage Mover jobs cannot share destination candidates.
+- Only already-committed destination blobs are reusable. A concurrently written
+  or same-target blob is not a valid source.
+- Scheduling order and concurrency affect which destination blobs have
+  committed early enough to serve as candidates.
+- The custom `azblob` extension and hash-enabled DevFabric frontend are required.
+
 ## Download AzCopy
 The latest binary for AzCopy along with installation instructions may be found
 [here](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10).

--- a/README.md
+++ b/README.md
@@ -122,9 +122,11 @@ Derived source ranges:         [0,4), [4,8), [8,10) MiB
 Scheduled AzCopy chunks:       [0,4), [4,8), [8,10) MiB
 ```
 
-`buildSourceGridPlan` derives each offset as the prefix sum of the preceding
-block sizes. It rejects non-positive block sizes. Before enabling source-grid
-chunking for a transfer, the implementation also requires:
+`buildSourceGridPlan` uses the offset returned by XStore when it is present.
+For compatibility with legacy Azure responses that omit `Offset`, it derives
+only the missing value from the preceding block ranges. It rejects negative
+offsets, gaps, overlaps, integer overflow, and non-positive block sizes. Before
+enabling source-grid chunking for a transfer, the implementation also requires:
 
 - a block-blob to block-blob service-to-service transfer;
 - a committed named-block list;

--- a/common/dedupeHashTable.go
+++ b/common/dedupeHashTable.go
@@ -39,8 +39,12 @@ type BlockEntry struct {
 	// collision-free, so a match must always be confirmed with SHA256.
 	CRC64 uint64
 	// SHA256 is the strong content hash of the block. Two blocks are considered
-	// identical (a dedupe hit) only when both CRC64 and SHA256 match.
+	// identical (a dedupe hit) only when both CRC64 and SHA256 match. It is only
+	// meaningful when HasSHA256 is true.
 	SHA256 [32]byte
+	// HasSHA256 distinguishes a CRC-only entry from an entry whose valid SHA256
+	// happens to be all zeroes.
+	HasSHA256 bool
 	// TargetURI is the location of the already-stored block content that a hit
 	// can be served from / referenced against.
 	TargetURI string
@@ -61,8 +65,9 @@ type BlockEntry struct {
 	// CreatedAt is the time the entry was recorded. It is set automatically on
 	// insert when left as the zero value.
 	CreatedAt time.Time
-	// RefCount counts insertions/references to this fingerprint. Insert initializes it
-	// to one and increments it when the same fingerprint is inserted again.
+	// RefCount counts insertions/references to this target occurrence. Insert
+	// initializes it to one and increments it when the same target epoch and
+	// range are inserted again.
 	RefCount int64
 }
 
@@ -83,9 +88,9 @@ func (e *BlockEntry) IsExpired() bool {
 // migration completes so the memory is released until the next migration starts.
 //
 // Entries are bucketed by their CRC64 so that a caller can do a cheap first-pass
-// check (LookupByCRC64) using only the weak checksum, and confirm a true match
-// with the strong SHA256 hash (Lookup). Within a bucket, entries are uniquely
-// identified by their SHA256, so CRC64 collisions are handled correctly.
+// check (LookupByCRC64 or LookupByCRC64AndLength) using only the weak checksum,
+// and confirm a true match with the strong SHA256 hash (Lookup). Distinct target
+// occurrences remain separate even when they contain identical data.
 type DedupeHashTable struct {
 	mu sync.RWMutex
 	// buckets maps a CRC64 checksum to the entries sharing it. The slice is
@@ -110,12 +115,32 @@ func NewDedupeHashTable() *DedupeHashTable {
 	}
 }
 
-// findLocked returns the entry matching both crc64 and sha256 along with its
-// index inside its bucket, or (nil, -1) if not present. Callers must hold the
-// appropriate lock.
+// findLocked returns a SHA-bearing entry matching both crc64 and sha256 along
+// with its index inside its bucket, or (nil, -1) if not present. Callers must
+// hold the appropriate lock.
 func (t *DedupeHashTable) findLocked(crc64 uint64, sha256 [32]byte) (*BlockEntry, int) {
 	for i, e := range t.buckets[crc64] {
-		if e.SHA256 == sha256 {
+		if e.HasSHA256 && e.SHA256 == sha256 {
+			return e, i
+		}
+	}
+	return nil, -1
+}
+
+// findOccurrenceLocked returns the entry for an exact target epoch and range
+// within a CRC64 bucket. Callers must hold the appropriate lock.
+func (t *DedupeHashTable) findOccurrenceLocked(
+	crc64 uint64,
+	targetURI string,
+	targetOffset int64,
+	targetLength int64,
+	etag azcore.ETag,
+) (*BlockEntry, int) {
+	for i, e := range t.buckets[crc64] {
+		if e.TargetURI == targetURI &&
+			e.ETag == etag &&
+			e.TargetOffset == targetOffset &&
+			e.TargetLength == targetLength {
 			return e, i
 		}
 	}
@@ -138,17 +163,36 @@ func (t *DedupeHashTable) removeAtLocked(crc64 uint64, idx int) {
 
 // Insert records a block in the table.
 //
-// If a block with the same CRC64 and SHA256 is already present, its RefCount is
-// incremented and the existing (now updated) entry is returned with inserted set
-// to false. Otherwise the supplied entry is stored — defaulting CreatedAt to the
-// current time and RefCount to 1 when left unset — and returned with inserted set
-// to true.
+// If the same target epoch and range already exist in the CRC64 bucket, its
+// RefCount is incremented and a newly supplied SHA256 enriches a CRC-only entry.
+// The existing (now updated) entry is returned with inserted set to false.
+// Otherwise the supplied occurrence is stored — defaulting CreatedAt to the
+// current time and RefCount to 1 when left unset — and returned with inserted
+// set to true.
+//
+// For backward compatibility, a nonzero SHA256 implies HasSHA256 even when the
+// caller leaves HasSHA256 false. Callers with a valid all-zero SHA256 must set
+// HasSHA256 explicitly.
 func (t *DedupeHashTable) Insert(entry BlockEntry) (stored BlockEntry, inserted bool) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	if existing, idx := t.findLocked(entry.CRC64, entry.SHA256); existing != nil {
+	if !entry.HasSHA256 && entry.SHA256 != ([32]byte{}) {
+		entry.HasSHA256 = true
+	}
+
+	if existing, idx := t.findOccurrenceLocked(
+		entry.CRC64,
+		entry.TargetURI,
+		entry.TargetOffset,
+		entry.TargetLength,
+		entry.ETag,
+	); existing != nil {
 		if !existing.IsExpired() {
+			if entry.HasSHA256 && !existing.HasSHA256 {
+				existing.SHA256 = entry.SHA256
+				existing.HasSHA256 = true
+			}
 			existing.RefCount++
 			return *existing, false
 		}
@@ -169,17 +213,19 @@ func (t *DedupeHashTable) Insert(entry BlockEntry) (stored BlockEntry, inserted 
 }
 
 // Lookup reports whether a candidate block with the given CRC64 and SHA256 has a
-// matching, non-expired entry in the table. The returned BlockEntry is a snapshot
-// copy; use IncrementRefCount / DecrementRefCount to mutate reference counts.
+// matching, non-expired entry with HasSHA256 set in the table. The returned
+// BlockEntry is a snapshot copy; use IncrementRefCount / DecrementRefCount to
+// mutate reference counts.
 func (t *DedupeHashTable) Lookup(crc64 uint64, sha256 [32]byte) (BlockEntry, bool) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 
-	e, _ := t.findLocked(crc64, sha256)
-	if e == nil || e.IsExpired() {
-		return BlockEntry{}, false
+	for _, e := range t.buckets[crc64] {
+		if e.HasSHA256 && e.SHA256 == sha256 && !e.IsExpired() {
+			return *e, true
+		}
 	}
-	return *e, true
+	return BlockEntry{}, false
 }
 
 // LookupByCRC64 returns snapshot copies of all non-expired entries that share the
@@ -197,6 +243,133 @@ func (t *DedupeHashTable) LookupByCRC64(crc64 uint64) []BlockEntry {
 		}
 	}
 	return out
+}
+
+// LookupByCRC64AndLength returns snapshot copies of all non-expired entries
+// whose CRC64 and positive target length exactly match the supplied values.
+func (t *DedupeHashTable) LookupByCRC64AndLength(crc64 uint64, length int64) []BlockEntry {
+	if length <= 0 {
+		return nil
+	}
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	var out []BlockEntry
+	for _, e := range t.buckets[crc64] {
+		if e.TargetLength == length && !e.IsExpired() {
+			out = append(out, *e)
+		}
+	}
+	return out
+}
+
+// SetSHA256 records the strong hash for every exact, non-expired target
+// occurrence found across the CRC64 buckets. It returns false when no such
+// occurrence is present.
+func (t *DedupeHashTable) SetSHA256(
+	targetURI string,
+	targetOffset int64,
+	targetLength int64,
+	etag azcore.ETag,
+	sha256 [32]byte,
+) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	found := false
+	for _, bucket := range t.buckets {
+		for _, e := range bucket {
+			if e.TargetURI == targetURI &&
+				e.ETag == etag &&
+				e.TargetOffset == targetOffset &&
+				e.TargetLength == targetLength &&
+				!e.IsExpired() {
+				e.SHA256 = sha256
+				e.HasSHA256 = true
+				found = true
+			}
+		}
+	}
+	return found
+}
+
+// SetSHA256ForCRC64 records the strong hash for an exact, non-expired target
+// occurrence in one CRC64 bucket. It avoids scanning unrelated candidates.
+func (t *DedupeHashTable) SetSHA256ForCRC64(
+	crc64 uint64,
+	targetURI string,
+	targetOffset int64,
+	targetLength int64,
+	etag azcore.ETag,
+	sha256 [32]byte,
+) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	for _, e := range t.buckets[crc64] {
+		if e.TargetURI == targetURI &&
+			e.ETag == etag &&
+			e.TargetOffset == targetOffset &&
+			e.TargetLength == targetLength &&
+			!e.IsExpired() {
+			e.SHA256 = sha256
+			e.HasSHA256 = true
+			return true
+		}
+	}
+	return false
+}
+
+// RemoveTargetEpoch removes every occurrence recorded for the supplied target
+// URI and ETag, and returns the number removed.
+func (t *DedupeHashTable) RemoveTargetEpoch(targetURI string, etag azcore.ETag) int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	removed := 0
+	for crc64, bucket := range t.buckets {
+		kept := bucket[:0]
+		for _, e := range bucket {
+			if e.TargetURI == targetURI && e.ETag == etag {
+				removed++
+				continue
+			}
+			kept = append(kept, e)
+		}
+		if len(kept) == 0 {
+			delete(t.buckets, crc64)
+		} else {
+			t.buckets[crc64] = kept
+		}
+	}
+	t.entries -= removed
+	return removed
+}
+
+// RemoveTargetOccurrence removes one exact target epoch/range occurrence,
+// regardless of its CRC64 or SHA256, and reports whether it was present.
+func (t *DedupeHashTable) RemoveTargetOccurrence(
+	targetURI string,
+	targetOffset int64,
+	targetLength int64,
+	etag azcore.ETag,
+) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	for crc64, bucket := range t.buckets {
+		for i, entry := range bucket {
+			if entry.TargetURI == targetURI &&
+				entry.TargetOffset == targetOffset &&
+				entry.TargetLength == targetLength &&
+				entry.ETag == etag {
+				t.removeAtLocked(crc64, i)
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // StatsForCRC64 returns table growth details for logging/diagnostics.

--- a/common/dedupeHashTable.go
+++ b/common/dedupeHashTable.go
@@ -1,0 +1,303 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package common
+
+import (
+	"sync"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+// BlockEntry is a single block recorded in the dedupe hash table. Each entry
+// describes a block of content that already exists at some target location, so
+// that a later candidate block with identical content can reference it instead
+// of being transferred again.
+type BlockEntry struct {
+	// JobID identifies the migration job that recorded this block.
+	JobID JobID
+	// CRC64 is a fast, weak checksum of the block content. It is used as the
+	// first-pass bucketing key: cheap to compute for every candidate, but not
+	// collision-free, so a match must always be confirmed with SHA256.
+	CRC64 uint64
+	// SHA256 is the strong content hash of the block. Two blocks are considered
+	// identical (a dedupe hit) only when both CRC64 and SHA256 match.
+	SHA256 [32]byte
+	// TargetURI is the location of the already-stored block content that a hit
+	// can be served from / referenced against.
+	TargetURI string
+	// TargetOffset and TargetLength locate the block's content within TargetURI.
+	// Because Azure block IDs are blob-scoped, a hit cannot reuse another blob's
+	// block by ID; instead it is served by staging from this sub-range of the
+	// already-migrated target blob (Put Block From URL over
+	// [TargetOffset, TargetOffset+TargetLength)). Both are therefore required to
+	// address content inside an existing blob.
+	TargetOffset int64
+	TargetLength int64
+	// ETag is the concurrency/version token of the target, used to detect whether
+	// the referenced content has changed since it was recorded.
+	ETag azcore.ETag
+	// TTL is the lifetime of this entry relative to CreatedAt. A non-positive
+	// TTL means the entry never expires.
+	TTL time.Duration
+	// CreatedAt is the time the entry was recorded. It is set automatically on
+	// insert when left as the zero value.
+	CreatedAt time.Time
+	// RefCount counts insertions/references to this fingerprint. Insert initializes it
+	// to one and increments it when the same fingerprint is inserted again.
+	RefCount int64
+}
+
+// IsExpired reports whether the entry has outlived its TTL. A non-positive TTL
+// is treated as "never expires".
+func (e *BlockEntry) IsExpired() bool {
+	if e.TTL <= 0 {
+		return false
+	}
+	return time.Since(e.CreatedAt) > e.TTL
+}
+
+// DedupeHashTable is an in-memory, concurrency-safe table of recorded blocks
+// used for dedupe candidate lookup during a migration.
+//
+// Lifecycle: create one table per migration with NewDedupeHashTable, use it for
+// the duration of the migration, then drop the reference (or call Clear) once the
+// migration completes so the memory is released until the next migration starts.
+//
+// Entries are bucketed by their CRC64 so that a caller can do a cheap first-pass
+// check (LookupByCRC64) using only the weak checksum, and confirm a true match
+// with the strong SHA256 hash (Lookup). Within a bucket, entries are uniquely
+// identified by their SHA256, so CRC64 collisions are handled correctly.
+type DedupeHashTable struct {
+	mu sync.RWMutex
+	// buckets maps a CRC64 checksum to the entries sharing it. The slice is
+	// almost always of length one; it only grows when distinct blocks happen to
+	// share a CRC64 value.
+	buckets map[uint64][]*BlockEntry
+	entries int
+}
+
+// DedupeHashTableStats is a point-in-time view of table growth. BucketEntries
+// reports how many entries share the requested CRC64 bucket.
+type DedupeHashTableStats struct {
+	Entries       int
+	Buckets       int
+	BucketEntries int
+}
+
+// NewDedupeHashTable returns an empty hash table ready for a single migration.
+func NewDedupeHashTable() *DedupeHashTable {
+	return &DedupeHashTable{
+		buckets: make(map[uint64][]*BlockEntry),
+	}
+}
+
+// findLocked returns the entry matching both crc64 and sha256 along with its
+// index inside its bucket, or (nil, -1) if not present. Callers must hold the
+// appropriate lock.
+func (t *DedupeHashTable) findLocked(crc64 uint64, sha256 [32]byte) (*BlockEntry, int) {
+	for i, e := range t.buckets[crc64] {
+		if e.SHA256 == sha256 {
+			return e, i
+		}
+	}
+	return nil, -1
+}
+
+// removeAtLocked removes the entry at index idx from the bucket for crc64,
+// deleting the bucket entirely once it becomes empty. Callers must hold the
+// write lock.
+func (t *DedupeHashTable) removeAtLocked(crc64 uint64, idx int) {
+	bucket := t.buckets[crc64]
+	bucket = append(bucket[:idx], bucket[idx+1:]...)
+	t.entries--
+	if len(bucket) == 0 {
+		delete(t.buckets, crc64)
+	} else {
+		t.buckets[crc64] = bucket
+	}
+}
+
+// Insert records a block in the table.
+//
+// If a block with the same CRC64 and SHA256 is already present, its RefCount is
+// incremented and the existing (now updated) entry is returned with inserted set
+// to false. Otherwise the supplied entry is stored — defaulting CreatedAt to the
+// current time and RefCount to 1 when left unset — and returned with inserted set
+// to true.
+func (t *DedupeHashTable) Insert(entry BlockEntry) (stored BlockEntry, inserted bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if existing, idx := t.findLocked(entry.CRC64, entry.SHA256); existing != nil {
+		if !existing.IsExpired() {
+			existing.RefCount++
+			return *existing, false
+		}
+		t.removeAtLocked(entry.CRC64, idx)
+	}
+
+	if entry.CreatedAt.IsZero() {
+		entry.CreatedAt = time.Now()
+	}
+	if entry.RefCount < 1 {
+		entry.RefCount = 1
+	}
+
+	e := entry // store a copy so the caller cannot mutate table state by reference
+	t.buckets[entry.CRC64] = append(t.buckets[entry.CRC64], &e)
+	t.entries++
+	return e, true
+}
+
+// Lookup reports whether a candidate block with the given CRC64 and SHA256 has a
+// matching, non-expired entry in the table. The returned BlockEntry is a snapshot
+// copy; use IncrementRefCount / DecrementRefCount to mutate reference counts.
+func (t *DedupeHashTable) Lookup(crc64 uint64, sha256 [32]byte) (BlockEntry, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	e, _ := t.findLocked(crc64, sha256)
+	if e == nil || e.IsExpired() {
+		return BlockEntry{}, false
+	}
+	return *e, true
+}
+
+// LookupByCRC64 returns snapshot copies of all non-expired entries that share the
+// given CRC64. It is intended as a cheap first-pass filter: compute the weak
+// checksum for a candidate, and only compute the strong SHA256 (and call Lookup)
+// when this returns one or more potential matches.
+func (t *DedupeHashTable) LookupByCRC64(crc64 uint64) []BlockEntry {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	var out []BlockEntry
+	for _, e := range t.buckets[crc64] {
+		if !e.IsExpired() {
+			out = append(out, *e)
+		}
+	}
+	return out
+}
+
+// StatsForCRC64 returns table growth details for logging/diagnostics.
+func (t *DedupeHashTable) StatsForCRC64(crc64 uint64) DedupeHashTableStats {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	stats := DedupeHashTableStats{
+		Entries:       t.entries,
+		Buckets:       len(t.buckets),
+		BucketEntries: len(t.buckets[crc64]),
+	}
+	return stats
+}
+
+// IncrementRefCount increases the reference count of the matching entry and
+// returns the new count. The boolean is false if no matching entry exists.
+func (t *DedupeHashTable) IncrementRefCount(crc64 uint64, sha256 [32]byte) (int64, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	e, _ := t.findLocked(crc64, sha256)
+	if e == nil {
+		return 0, false
+	}
+	e.RefCount++
+	return e.RefCount, true
+}
+
+// DecrementRefCount decreases the reference count of the matching entry. When the
+// count reaches zero the entry is evicted and (0, true) is returned. The boolean
+// is false if no matching entry exists.
+func (t *DedupeHashTable) DecrementRefCount(crc64 uint64, sha256 [32]byte) (int64, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	e, idx := t.findLocked(crc64, sha256)
+	if e == nil {
+		return 0, false
+	}
+	e.RefCount--
+	if e.RefCount <= 0 {
+		t.removeAtLocked(crc64, idx)
+		return 0, true
+	}
+	return e.RefCount, true
+}
+
+// Remove deletes the matching entry regardless of its reference count. It returns
+// true if an entry was removed.
+func (t *DedupeHashTable) Remove(crc64 uint64, sha256 [32]byte) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if _, idx := t.findLocked(crc64, sha256); idx >= 0 {
+		t.removeAtLocked(crc64, idx)
+		return true
+	}
+	return false
+}
+
+// EvictExpired removes every entry whose TTL has elapsed and returns the number
+// of entries removed.
+func (t *DedupeHashTable) EvictExpired() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	removed := 0
+	for crc64, bucket := range t.buckets {
+		kept := bucket[:0]
+		for _, e := range bucket {
+			if e.IsExpired() {
+				removed++
+				continue
+			}
+			kept = append(kept, e)
+		}
+		if len(kept) == 0 {
+			delete(t.buckets, crc64)
+		} else {
+			t.buckets[crc64] = kept
+		}
+	}
+	t.entries -= removed
+	return removed
+}
+
+// Len returns the number of entries currently stored in the table.
+func (t *DedupeHashTable) Len() int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	return t.entries
+}
+
+// Clear removes all entries from the table. Call this when a migration finishes
+// to release the table's memory until the next migration begins.
+func (t *DedupeHashTable) Clear() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.buckets = make(map[uint64][]*BlockEntry)
+	t.entries = 0
+}

--- a/common/environment.go
+++ b/common/environment.go
@@ -493,3 +493,28 @@ func (EnvironmentVariable) DisableBlobTransferResume() EnvironmentVariable {
 		Description:  "An incomplete transfer to blob endpoint will be resumed from start if set to true",
 	}
 }
+
+// DedupeObserve gates a read-only prototype diagnostic. When set to "true", block-blob to
+// block-blob S2S transfers log how the source blob's committed block boundaries line up with
+// AzCopy's uniform chunk grid. It never changes transfer behavior. Intentionally not listed in
+// VisibleEnvironmentVariables because it is an internal prototype switch, not a supported feature.
+func (EnvironmentVariable) DedupeObserve() EnvironmentVariable {
+	return EnvironmentVariable{
+		Name:         "AZCOPY_DEDUPE_OBSERVE",
+		DefaultValue: "false",
+		Description:  "Prototype diagnostic: when true, logs how source block-blob committed block boundaries align with AzCopy's uniform chunk grid (read-only, no transfer behavior change).",
+	}
+}
+
+func (EnvironmentVariable) DedupeAct() EnvironmentVariable {
+	return EnvironmentVariable{
+		Name:         "AZCOPY_DEDUPE_ACT",
+		DefaultValue: "",
+		Description: "Prototype (block-blob -> block-blob S2S only): act on block-level dedupe. " +
+			"\"shadow\" chunks on the source's committed block boundaries and logs which blocks WOULD be served " +
+			"from an already-migrated destination block (no behavior change to the bytes written). " +
+			"\"enforce\" additionally stages those blocks from the destination (Put Block From URL over the recorded " +
+			"target sub-range, guarded by an If-Match ETag, with automatic fallback to the source on any failure). " +
+			"Any other value disables it. Requires the service GetHash feature so GetBlockList returns per-block crc64/sha256.",
+	}
+}

--- a/common/init.go
+++ b/common/init.go
@@ -8,6 +8,7 @@ import (
 
 var AzcopyJobPlanFolder string
 var LogPathFolder string
+var AzcopyLogFolder string
 
 func InitializeFolders() {
 	LogPathFolder = GetEnvironmentVariable(EEnvironmentVariable.LogLocation())           // user specified location for log files
@@ -24,6 +25,7 @@ func InitializeFolders() {
 	if err := os.MkdirAll(LogPathFolder, os.ModeDir|os.ModePerm); err != nil && !os.IsExist(err) {
 		log.Fatalf("Problem making .azcopy directory. Try setting AZCOPY_LOG_LOCATION env variable. %v", err)
 	}
+	AzcopyLogFolder = LogPathFolder
 
 	// the user can optionally put the plan files somewhere else
 	if AzcopyJobPlanFolder == "" {

--- a/common/zt_dedupeHashTable_test.go
+++ b/common/zt_dedupeHashTable_test.go
@@ -56,6 +56,7 @@ func TestDedupeHashTable_InsertAndLookup(t *testing.T) {
 	stored, inserted := tbl.Insert(e)
 	a.True(inserted)
 	a.Equal(int64(1), stored.RefCount)
+	a.True(stored.HasSHA256)           // inferred for backward-compatible callers
 	a.False(stored.CreatedAt.IsZero()) // defaulted on insert
 	a.Equal(1, tbl.Len())
 
@@ -115,6 +116,157 @@ func TestDedupeHashTable_CRC64Collision(t *testing.T) {
 	a.Equal(e2.TargetURI, got2.TargetURI)
 }
 
+func TestDedupeHashTable_LookupByCRC64AndLength(t *testing.T) {
+	a := assert.New(t)
+	tbl := NewDedupeHashTable()
+
+	matching := newTestEntry(100, "matching")
+	matching.SHA256 = [32]byte{}
+	matching.TargetLength = 512
+	stored, inserted := tbl.Insert(matching)
+	a.True(inserted)
+	a.False(stored.HasSHA256)
+
+	wrongLength := newTestEntry(100, "wrong-length")
+	wrongLength.SHA256 = [32]byte{}
+	wrongLength.TargetLength = 1024
+	tbl.Insert(wrongLength)
+
+	candidates := tbl.LookupByCRC64AndLength(100, 512)
+	if a.Len(candidates, 1) {
+		a.Equal(matching.TargetURI, candidates[0].TargetURI)
+		a.False(candidates[0].HasSHA256)
+	}
+	a.Empty(tbl.LookupByCRC64AndLength(100, 256))
+	a.Empty(tbl.LookupByCRC64AndLength(100, 0))
+
+	// A CRC-only entry must not look like a known all-zero SHA256.
+	_, ok := tbl.Lookup(100, [32]byte{})
+	a.False(ok)
+}
+
+func TestDedupeHashTable_DistinctTargetOccurrencesWithSameHash(t *testing.T) {
+	a := assert.New(t)
+	tbl := NewDedupeHashTable()
+
+	base := newTestEntry(100, "same-content")
+	occurrences := []BlockEntry{base}
+
+	differentURI := base
+	differentURI.TargetURI += "-other"
+	occurrences = append(occurrences, differentURI)
+
+	differentETag := base
+	differentETag.ETag = azcore.ETag("other-etag")
+	occurrences = append(occurrences, differentETag)
+
+	differentOffset := base
+	differentOffset.TargetOffset++
+	occurrences = append(occurrences, differentOffset)
+
+	differentLength := base
+	differentLength.TargetLength++
+	occurrences = append(occurrences, differentLength)
+
+	for _, entry := range occurrences {
+		_, inserted := tbl.Insert(entry)
+		a.True(inserted)
+	}
+	a.Equal(len(occurrences), tbl.Len())
+	a.Len(tbl.LookupByCRC64(base.CRC64), len(occurrences))
+
+	stored, inserted := tbl.Insert(base)
+	a.False(inserted)
+	a.Equal(int64(2), stored.RefCount)
+	a.Equal(len(occurrences), tbl.Len())
+}
+
+func TestDedupeHashTable_EnrichesExactOccurrenceSHA256(t *testing.T) {
+	a := assert.New(t)
+	tbl := NewDedupeHashTable()
+
+	entry := newTestEntry(100, "crc-only")
+	entry.SHA256 = [32]byte{}
+	tbl.Insert(entry)
+
+	a.False(tbl.SetSHA256(
+		entry.TargetURI,
+		entry.TargetOffset+1,
+		entry.TargetLength,
+		entry.ETag,
+		[32]byte{},
+	))
+
+	sameRangeOtherCRC := entry
+	sameRangeOtherCRC.CRC64++
+	tbl.Insert(sameRangeOtherCRC)
+	a.True(tbl.SetSHA256(
+		entry.TargetURI,
+		entry.TargetOffset,
+		entry.TargetLength,
+		entry.ETag,
+		[32]byte{},
+	))
+
+	got, ok := tbl.Lookup(entry.CRC64, [32]byte{})
+	a.True(ok)
+	a.True(got.HasSHA256)
+	a.Equal(entry.TargetURI, got.TargetURI)
+	got, ok = tbl.Lookup(sameRangeOtherCRC.CRC64, [32]byte{})
+	a.True(ok)
+	a.True(got.HasSHA256)
+
+	explicitZero := newTestEntry(200, "explicit-zero")
+	explicitZero.SHA256 = [32]byte{}
+	explicitZero.HasSHA256 = true
+	stored, inserted := tbl.Insert(explicitZero)
+	a.True(inserted)
+	a.True(stored.HasSHA256)
+	got, ok = tbl.Lookup(explicitZero.CRC64, [32]byte{})
+	a.True(ok)
+	a.Equal(explicitZero.TargetURI, got.TargetURI)
+
+	another := newTestEntry(300, "another-crc-only")
+	another.SHA256 = [32]byte{}
+	tbl.Insert(another)
+	enriched := another
+	enriched.SHA256 = sha256Of("now-known")
+	stored, inserted = tbl.Insert(enriched)
+	a.False(inserted)
+	a.True(stored.HasSHA256)
+	a.Equal(enriched.SHA256, stored.SHA256)
+	a.Equal(int64(2), stored.RefCount)
+}
+
+func TestDedupeHashTable_SetSHA256ForCRC64(t *testing.T) {
+	a := assert.New(t)
+	tbl := NewDedupeHashTable()
+	entry := newTestEntry(100, "crc-only-bucket")
+	entry.SHA256 = [32]byte{}
+	tbl.Insert(entry)
+
+	hash := sha256Of("known")
+	a.False(tbl.SetSHA256ForCRC64(
+		200,
+		entry.TargetURI,
+		entry.TargetOffset,
+		entry.TargetLength,
+		entry.ETag,
+		hash,
+	))
+	a.True(tbl.SetSHA256ForCRC64(
+		entry.CRC64,
+		entry.TargetURI,
+		entry.TargetOffset,
+		entry.TargetLength,
+		entry.ETag,
+		hash,
+	))
+	got, ok := tbl.Lookup(entry.CRC64, hash)
+	a.True(ok)
+	a.Equal(entry.TargetURI, got.TargetURI)
+}
+
 func TestDedupeHashTable_ConcurrentInsertAndLookup(t *testing.T) {
 	a := assert.New(t)
 	tbl := NewDedupeHashTable()
@@ -136,6 +288,62 @@ func TestDedupeHashTable_ConcurrentInsertAndLookup(t *testing.T) {
 	wg.Wait()
 
 	a.Equal(entries, tbl.Len())
+}
+
+func TestDedupeHashTable_ConcurrentCRCEnrichmentAndEpochEviction(t *testing.T) {
+	a := assert.New(t)
+	tbl := NewDedupeHashTable()
+
+	const entries = 100
+	items := make([]BlockEntry, entries)
+	var wg sync.WaitGroup
+	for i := range items {
+		items[i] = newTestEntry(uint64(i%10), fmt.Sprintf("candidate-%d", i))
+		items[i].SHA256 = [32]byte{}
+		items[i].TargetLength = int64(i + 1)
+		wg.Add(1)
+		go func(entry BlockEntry) {
+			defer wg.Done()
+			tbl.Insert(entry)
+		}(items[i])
+	}
+	wg.Wait()
+	a.Equal(entries, tbl.Len())
+
+	for i := range items {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			entry := items[i]
+			sha := sha256Of(fmt.Sprintf("candidate-%d", i))
+			a.True(tbl.SetSHA256(
+				entry.TargetURI,
+				entry.TargetOffset,
+				entry.TargetLength,
+				entry.ETag,
+				sha,
+			))
+			candidates := tbl.LookupByCRC64AndLength(entry.CRC64, entry.TargetLength)
+			if a.Len(candidates, 1) {
+				a.Equal(entry.TargetURI, candidates[0].TargetURI)
+			}
+			_, ok := tbl.Lookup(entry.CRC64, sha)
+			a.True(ok)
+		}()
+	}
+	wg.Wait()
+
+	for _, entry := range items {
+		entry := entry
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			a.Equal(1, tbl.RemoveTargetEpoch(entry.TargetURI, entry.ETag))
+		}()
+	}
+	wg.Wait()
+	a.Equal(0, tbl.Len())
 }
 
 func TestDedupeHashTable_StatsForCRC64(t *testing.T) {
@@ -207,6 +415,7 @@ func TestDedupeHashTable_Expiry(t *testing.T) {
 	_, ok := tbl.Lookup(expired.CRC64, expired.SHA256)
 	a.False(ok)
 	a.Empty(tbl.LookupByCRC64(expired.CRC64))
+	a.Empty(tbl.LookupByCRC64AndLength(expired.CRC64, expired.TargetLength))
 
 	// A non-positive TTL never expires.
 	permanent := newTestEntry(200, "beta")
@@ -227,21 +436,85 @@ func TestDedupeHashTable_InsertReplacesExpiredEntry(t *testing.T) {
 	tbl := NewDedupeHashTable()
 
 	expired := newTestEntry(100, "alpha")
-	expired.TargetURI = "expired"
+	expired.TargetURI = "target"
 	expired.TTL = time.Millisecond
 	expired.CreatedAt = time.Now().Add(-time.Hour)
 	tbl.Insert(expired)
 
 	replacement := newTestEntry(100, "alpha")
-	replacement.TargetURI = "replacement"
+	replacement.TargetURI = "target"
 	stored, inserted := tbl.Insert(replacement)
 
 	a.True(inserted)
-	a.Equal("replacement", stored.TargetURI)
+	a.Equal("target", stored.TargetURI)
 	a.Equal(1, tbl.Len())
 	got, ok := tbl.Lookup(replacement.CRC64, replacement.SHA256)
 	a.True(ok)
-	a.Equal("replacement", got.TargetURI)
+	a.Equal("target", got.TargetURI)
+}
+
+func TestDedupeHashTable_RemoveTargetEpoch(t *testing.T) {
+	a := assert.New(t)
+	tbl := NewDedupeHashTable()
+
+	targetURI := "https://acct.blob.core.windows.net/c/target"
+	etag := azcore.ETag("target-etag")
+
+	first := newTestEntry(100, "first")
+	first.SHA256 = [32]byte{}
+	first.TargetURI = targetURI
+	first.ETag = etag
+	second := newTestEntry(200, "second")
+	second.SHA256 = [32]byte{}
+	second.TargetURI = targetURI
+	second.ETag = etag
+	second.TargetOffset = 300
+
+	otherEpoch := newTestEntry(300, "other-epoch")
+	otherEpoch.TargetURI = targetURI
+	otherEpoch.ETag = azcore.ETag("new-etag")
+	otherTarget := newTestEntry(400, "other-target")
+	otherTarget.ETag = etag
+
+	for _, entry := range []BlockEntry{first, second, otherEpoch, otherTarget} {
+		tbl.Insert(entry)
+	}
+
+	a.Equal(2, tbl.RemoveTargetEpoch(targetURI, etag))
+	a.Equal(2, tbl.Len())
+	a.Equal(0, tbl.RemoveTargetEpoch(targetURI, etag))
+	_, ok := tbl.Lookup(otherEpoch.CRC64, otherEpoch.SHA256)
+	a.True(ok)
+	_, ok = tbl.Lookup(otherTarget.CRC64, otherTarget.SHA256)
+	a.True(ok)
+}
+
+func TestDedupeHashTable_RemoveTargetOccurrence(t *testing.T) {
+	a := assert.New(t)
+	tbl := NewDedupeHashTable()
+	first := newTestEntry(100, "first-occurrence")
+	second := newTestEntry(100, "second-occurrence")
+	second.SHA256 = first.SHA256
+	second.TargetLength = first.TargetLength
+	tbl.Insert(first)
+	tbl.Insert(second)
+
+	a.True(tbl.RemoveTargetOccurrence(
+		first.TargetURI,
+		first.TargetOffset,
+		first.TargetLength,
+		first.ETag,
+	))
+	a.False(tbl.RemoveTargetOccurrence(
+		first.TargetURI,
+		first.TargetOffset,
+		first.TargetLength,
+		first.ETag,
+	))
+	a.Equal(1, tbl.Len())
+	got, ok := tbl.Lookup(second.CRC64, second.SHA256)
+	a.True(ok)
+	a.Equal(second.TargetURI, got.TargetURI)
 }
 
 func TestDedupeHashTable_Clear(t *testing.T) {

--- a/common/zt_dedupeHashTable_test.go
+++ b/common/zt_dedupeHashTable_test.go
@@ -1,0 +1,262 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package common
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/stretchr/testify/assert"
+)
+
+func sha256Of(s string) [32]byte {
+	return sha256.Sum256([]byte(s))
+}
+
+func newTestEntry(crc64 uint64, content string) BlockEntry {
+	return BlockEntry{
+		JobID:        NewJobID(),
+		CRC64:        crc64,
+		SHA256:       sha256Of(content),
+		TargetURI:    "https://acct.blob.core.windows.net/c/" + content,
+		TargetOffset: 100,
+		TargetLength: 200,
+		ETag:         azcore.ETag("etag-" + content),
+		RefCount:     1,
+	}
+}
+
+func TestDedupeHashTable_InsertAndLookup(t *testing.T) {
+	a := assert.New(t)
+	tbl := NewDedupeHashTable()
+
+	e := newTestEntry(100, "alpha")
+	stored, inserted := tbl.Insert(e)
+	a.True(inserted)
+	a.Equal(int64(1), stored.RefCount)
+	a.False(stored.CreatedAt.IsZero()) // defaulted on insert
+	a.Equal(1, tbl.Len())
+
+	// Hit: both CRC64 and SHA256 match.
+	got, ok := tbl.Lookup(e.CRC64, e.SHA256)
+	a.True(ok)
+	a.Equal(e.TargetURI, got.TargetURI)
+	a.Equal(e.TargetOffset, got.TargetOffset)
+	a.Equal(e.TargetLength, got.TargetLength)
+	a.Equal(e.ETag, got.ETag)
+
+	// Miss: SHA256 differs even though CRC64 matches.
+	_, ok = tbl.Lookup(e.CRC64, sha256Of("different"))
+	a.False(ok)
+
+	// Miss: unknown CRC64.
+	_, ok = tbl.Lookup(999, e.SHA256)
+	a.False(ok)
+}
+
+func TestDedupeHashTable_InsertDuplicateIncrementsRefCount(t *testing.T) {
+	a := assert.New(t)
+	tbl := NewDedupeHashTable()
+
+	e := newTestEntry(100, "alpha")
+	_, inserted := tbl.Insert(e)
+	a.True(inserted)
+
+	stored, inserted := tbl.Insert(e)
+	a.False(inserted) // already present
+	a.Equal(int64(2), stored.RefCount)
+	a.Equal(1, tbl.Len()) // still a single entry
+}
+
+func TestDedupeHashTable_CRC64Collision(t *testing.T) {
+	a := assert.New(t)
+	tbl := NewDedupeHashTable()
+
+	// Two distinct blocks that share a CRC64 bucket but differ in SHA256.
+	e1 := newTestEntry(100, "alpha")
+	e2 := newTestEntry(100, "beta")
+	tbl.Insert(e1)
+	tbl.Insert(e2)
+	a.Equal(2, tbl.Len())
+
+	// First-pass filter returns both candidates.
+	candidates := tbl.LookupByCRC64(100)
+	a.Len(candidates, 2)
+
+	// Confirmation by SHA256 resolves to the correct entry.
+	got1, ok := tbl.Lookup(100, e1.SHA256)
+	a.True(ok)
+	a.Equal(e1.TargetURI, got1.TargetURI)
+
+	got2, ok := tbl.Lookup(100, e2.SHA256)
+	a.True(ok)
+	a.Equal(e2.TargetURI, got2.TargetURI)
+}
+
+func TestDedupeHashTable_ConcurrentInsertAndLookup(t *testing.T) {
+	a := assert.New(t)
+	tbl := NewDedupeHashTable()
+
+	const entries = 100
+	var wg sync.WaitGroup
+	for i := 0; i < entries; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			entry := newTestEntry(uint64(i%10), fmt.Sprintf("block-%d", i))
+			tbl.Insert(entry)
+			got, ok := tbl.Lookup(entry.CRC64, entry.SHA256)
+			a.True(ok)
+			a.Equal(entry.TargetURI, got.TargetURI)
+		}()
+	}
+	wg.Wait()
+
+	a.Equal(entries, tbl.Len())
+}
+
+func TestDedupeHashTable_StatsForCRC64(t *testing.T) {
+	a := assert.New(t)
+	tbl := NewDedupeHashTable()
+
+	tbl.Insert(newTestEntry(100, "alpha"))
+	tbl.Insert(newTestEntry(100, "beta"))
+	tbl.Insert(newTestEntry(200, "gamma"))
+
+	stats := tbl.StatsForCRC64(100)
+	a.Equal(3, stats.Entries)
+	a.Equal(2, stats.Buckets)
+	a.Equal(2, stats.BucketEntries)
+
+	stats = tbl.StatsForCRC64(999)
+	a.Equal(3, stats.Entries)
+	a.Equal(2, stats.Buckets)
+	a.Equal(0, stats.BucketEntries)
+}
+
+func TestDedupeHashTable_RefCounting(t *testing.T) {
+	a := assert.New(t)
+	tbl := NewDedupeHashTable()
+
+	e := newTestEntry(100, "alpha")
+	tbl.Insert(e) // RefCount = 1
+
+	count, ok := tbl.IncrementRefCount(e.CRC64, e.SHA256)
+	a.True(ok)
+	a.Equal(int64(2), count)
+
+	count, ok = tbl.DecrementRefCount(e.CRC64, e.SHA256)
+	a.True(ok)
+	a.Equal(int64(1), count)
+
+	// Final decrement drops to zero and evicts the entry.
+	count, ok = tbl.DecrementRefCount(e.CRC64, e.SHA256)
+	a.True(ok)
+	a.Equal(int64(0), count)
+	a.Equal(0, tbl.Len())
+
+	_, ok = tbl.Lookup(e.CRC64, e.SHA256)
+	a.False(ok)
+}
+
+func TestDedupeHashTable_Remove(t *testing.T) {
+	a := assert.New(t)
+	tbl := NewDedupeHashTable()
+
+	e := newTestEntry(100, "alpha")
+	tbl.Insert(e)
+
+	a.True(tbl.Remove(e.CRC64, e.SHA256))
+	a.Equal(0, tbl.Len())
+	a.False(tbl.Remove(e.CRC64, e.SHA256)) // already gone
+}
+
+func TestDedupeHashTable_Expiry(t *testing.T) {
+	a := assert.New(t)
+	tbl := NewDedupeHashTable()
+
+	expired := newTestEntry(100, "alpha")
+	expired.TTL = time.Millisecond
+	expired.CreatedAt = time.Now().Add(-time.Hour) // already past its TTL
+	tbl.Insert(expired)
+
+	// Expired entries are treated as a miss.
+	_, ok := tbl.Lookup(expired.CRC64, expired.SHA256)
+	a.False(ok)
+	a.Empty(tbl.LookupByCRC64(expired.CRC64))
+
+	// A non-positive TTL never expires.
+	permanent := newTestEntry(200, "beta")
+	permanent.TTL = 0
+	permanent.CreatedAt = time.Now().Add(-time.Hour)
+	tbl.Insert(permanent)
+	_, ok = tbl.Lookup(permanent.CRC64, permanent.SHA256)
+	a.True(ok)
+
+	// EvictExpired purges only the expired entry.
+	removed := tbl.EvictExpired()
+	a.Equal(1, removed)
+	a.Equal(1, tbl.Len())
+}
+
+func TestDedupeHashTable_InsertReplacesExpiredEntry(t *testing.T) {
+	a := assert.New(t)
+	tbl := NewDedupeHashTable()
+
+	expired := newTestEntry(100, "alpha")
+	expired.TargetURI = "expired"
+	expired.TTL = time.Millisecond
+	expired.CreatedAt = time.Now().Add(-time.Hour)
+	tbl.Insert(expired)
+
+	replacement := newTestEntry(100, "alpha")
+	replacement.TargetURI = "replacement"
+	stored, inserted := tbl.Insert(replacement)
+
+	a.True(inserted)
+	a.Equal("replacement", stored.TargetURI)
+	a.Equal(1, tbl.Len())
+	got, ok := tbl.Lookup(replacement.CRC64, replacement.SHA256)
+	a.True(ok)
+	a.Equal("replacement", got.TargetURI)
+}
+
+func TestDedupeHashTable_Clear(t *testing.T) {
+	a := assert.New(t)
+	tbl := NewDedupeHashTable()
+
+	tbl.Insert(newTestEntry(100, "alpha"))
+	tbl.Insert(newTestEntry(200, "beta"))
+	a.Equal(2, tbl.Len())
+
+	tbl.Clear()
+	a.Equal(0, tbl.Len())
+
+	// Table is reusable after clearing (e.g. for the next migration).
+	_, inserted := tbl.Insert(newTestEntry(300, "gamma"))
+	a.True(inserted)
+	a.Equal(1, tbl.Len())
+}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/Azure/azure-storage-azcopy/v10
 
 require (
 	cloud.google.com/go/storage v1.45.0
-	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.2
+	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.3-0.20260727190053-93e310a26728
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azfile v0.0.0-20250313100248-09ad70aa7647
 	github.com/JeffreyRichter/enum v0.0.0-20180725232043-2567042f9cda
@@ -119,3 +119,5 @@ require (
 replace github.com/Azure/azure-sdk-for-go/sdk/storage/azfile => github.com/Azure/azure-sdk-for-go/sdk/storage/azfile v0.0.0-20250313100248-09ad70aa7647
 
 go 1.24.4
+
+replace github.com/Azure/azure-sdk-for-go/sdk/storage/azblob => github.com/ProgramPedro/azure-sdk-for-go/sdk/storage/azblob v1.6.3-0.20260727190053-93e310a26728

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/Azure/azure-storage-azcopy/v10
 
 require (
 	cloud.google.com/go/storage v1.45.0
-	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.3-0.20260727190053-93e310a26728
+	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.3-0.20260731063207-dbae4229a0d2
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azfile v0.0.0-20250313100248-09ad70aa7647
 	github.com/JeffreyRichter/enum v0.0.0-20180725232043-2567042f9cda
@@ -120,4 +120,4 @@ replace github.com/Azure/azure-sdk-for-go/sdk/storage/azfile => github.com/Azure
 
 go 1.24.4
 
-replace github.com/Azure/azure-sdk-for-go/sdk/storage/azblob => github.com/ProgramPedro/azure-sdk-for-go/sdk/storage/azblob v1.6.3-0.20260727190053-93e310a26728
+replace github.com/Azure/azure-sdk-for-go/sdk/storage/azblob => github.com/ProgramPedro/azure-sdk-for-go/sdk/storage/azblob v1.6.3-0.20260731063207-dbae4229a0d2

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,6 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1 h1:FPKJS1T+clwv+OLGt13a8U
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1/go.mod h1:j2chePtV91HrC22tGoRX3sGY42uF13WzmmV80/OdVAA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1 h1:/Zt+cDPnpC3OVDm/JKLOs7M2DKmLRIIp3XIx9pHHiig=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1/go.mod h1:Ng3urmn6dYe8gnbCMoHHVl5APYz2txho3koEkV2o2HA=
-github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.2 h1:FwladfywkNirM+FZYLBR2kBz5C8Tg0fw5w5Y7meRXWI=
-github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.2/go.mod h1:vv5Ad0RrIoT1lJFdWBZwt4mB1+j+V8DUroixmKDTCdk=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake v1.2.0 h1:gXpwp0sGZz2FY9lVpSdM1rMpsP9PUtevHQyFhGoqHxY=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake v1.2.0/go.mod h1:K+OqH/n5xyCEvbenN5OtZMycqHRCeoHh0whMoRjWYK4=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azfile v0.0.0-20250313100248-09ad70aa7647 h1:GxVLSBaAfOLtbs4aXBjWDSED38CdisphC+CnvXm3R9w=
@@ -58,6 +56,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.48.1/go.mod h1:viRWSEhtMZqz1rhwmOVKkWl6SwmVowfL9O2YR5gI2PE=
 github.com/JeffreyRichter/enum v0.0.0-20180725232043-2567042f9cda h1:NOo6+gM9NNPJ3W56nxOKb4164LEw094U0C8zYQM8mQU=
 github.com/JeffreyRichter/enum v0.0.0-20180725232043-2567042f9cda/go.mod h1:2CaSFTh2ph9ymS6goiOKIBdfhwWUVsX4nQ5QjIYFHHs=
+github.com/ProgramPedro/azure-sdk-for-go/sdk/storage/azblob v1.6.3-0.20260727190053-93e310a26728 h1:8hcQ2DsBHpQqw3qtpFUmc4kR9wguxH421CnFjLMvzVg=
+github.com/ProgramPedro/azure-sdk-for-go/sdk/storage/azblob v1.6.3-0.20260727190053-93e310a26728/go.mod h1:vv5Ad0RrIoT1lJFdWBZwt4mB1+j+V8DUroixmKDTCdk=
 github.com/PuerkitoBio/goquery v1.7.1/go.mod h1:XY0pP4kfraEmmV1O7Uf6XyjoslwsneBbgeDjLYuN8xY=
 github.com/andybalholm/cascadia v1.2.0/go.mod h1:YCyR8vOZT9aZ1CHEd8ap0gMVm2aFgxBp0T0eFw1RUQY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.48.1/go.mod h1:viRWSEhtMZqz1rhwmOVKkWl6SwmVowfL9O2YR5gI2PE=
 github.com/JeffreyRichter/enum v0.0.0-20180725232043-2567042f9cda h1:NOo6+gM9NNPJ3W56nxOKb4164LEw094U0C8zYQM8mQU=
 github.com/JeffreyRichter/enum v0.0.0-20180725232043-2567042f9cda/go.mod h1:2CaSFTh2ph9ymS6goiOKIBdfhwWUVsX4nQ5QjIYFHHs=
-github.com/ProgramPedro/azure-sdk-for-go/sdk/storage/azblob v1.6.3-0.20260727190053-93e310a26728 h1:8hcQ2DsBHpQqw3qtpFUmc4kR9wguxH421CnFjLMvzVg=
-github.com/ProgramPedro/azure-sdk-for-go/sdk/storage/azblob v1.6.3-0.20260727190053-93e310a26728/go.mod h1:vv5Ad0RrIoT1lJFdWBZwt4mB1+j+V8DUroixmKDTCdk=
+github.com/ProgramPedro/azure-sdk-for-go/sdk/storage/azblob v1.6.3-0.20260731063207-dbae4229a0d2 h1:SG9P+0MDjj1dZOaqcb0pzdWeiRDqI+Abnb/TzEt9/y0=
+github.com/ProgramPedro/azure-sdk-for-go/sdk/storage/azblob v1.6.3-0.20260731063207-dbae4229a0d2/go.mod h1:vv5Ad0RrIoT1lJFdWBZwt4mB1+j+V8DUroixmKDTCdk=
 github.com/PuerkitoBio/goquery v1.7.1/go.mod h1:XY0pP4kfraEmmV1O7Uf6XyjoslwsneBbgeDjLYuN8xY=
 github.com/andybalholm/cascadia v1.2.0/go.mod h1:YCyR8vOZT9aZ1CHEd8ap0gMVm2aFgxBp0T0eFw1RUQY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/jobsAdmin/init.go
+++ b/jobsAdmin/init.go
@@ -114,6 +114,8 @@ func(order common.CopyJobPartOrderRequest) common.CopyJobPartOrderResponse {
 		PartNum:           order.PartNum,
 		PlanFile:          jppfn,
 		ExistingPlanMMF:   nil,
+		SourceSAS:         order.SourceRoot.SAS,
+		DestinationSAS:    order.DestinationRoot.SAS,
 		SrcClient:         order.SrcServiceClient,
 		DstClient:         order.DstServiceClient,
 		SrcIsOAuth:        order.S2SSourceCredentialType.IsAzureOAuth(),

--- a/jobsAdmin/init_test.go
+++ b/jobsAdmin/init_test.go
@@ -1,0 +1,176 @@
+// Copyright © 2017 Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package jobsAdmin
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/ste"
+)
+
+type executeJobPartOrderTestAdmin struct {
+	*jobsAdmin
+	jobMgr *executeJobPartOrderTestJobMgr
+}
+
+func (a *executeJobPartOrderTestAdmin) NewJobPartPlanFileName(
+	jobID common.JobID,
+	partNumber common.PartNumber,
+) ste.JobPartPlanFileName {
+	return ste.JobPartPlanFileName(fmt.Sprintf(
+		ste.JobPartPlanFileNameFormat,
+		jobID.String(),
+		partNumber,
+		ste.DataSchemaVersion,
+	))
+}
+
+func (a *executeJobPartOrderTestAdmin) JobMgrEnsureExists(
+	common.JobID,
+	common.LogLevel,
+	string,
+) ste.IJobMgr {
+	return a.jobMgr
+}
+
+func (*executeJobPartOrderTestAdmin) RegisterStatsMonitorIfNotDone() {}
+
+type executeJobPartOrderTestJobMgr struct {
+	ste.IJobMgr
+	totalFiles int64
+	jobPart    *executeJobPartOrderTestJobPartMgr
+}
+
+func (*executeJobPartOrderTestJobMgr) SetInMemoryTransitJobState(ste.InMemoryTransitJobState) {}
+
+func (jm *executeJobPartOrderTestJobMgr) AddTotalNumFilesProcessed(numFiles int64) {
+	jm.totalFiles += numFiles
+}
+
+func (jm *executeJobPartOrderTestJobMgr) GetTotalNumFilesProcessed() int64 {
+	return jm.totalFiles
+}
+
+func (jm *executeJobPartOrderTestJobMgr) AddJobPart(args *ste.AddJobPartArgs) ste.IJobPartMgr {
+	jm.jobPart = &executeJobPartOrderTestJobPartMgr{
+		sourceSAS:      args.SourceSAS,
+		destinationSAS: args.DestinationSAS,
+	}
+	return jm.jobPart
+}
+
+func (*executeJobPartOrderTestJobMgr) SendJobPartCreatedMsg(ste.JobPartCreatedMsg) {}
+
+type executeJobPartOrderTestJobPartMgr struct {
+	ste.IJobPartMgr
+	sourceSAS      string
+	destinationSAS string
+}
+
+func (jpm *executeJobPartOrderTestJobPartMgr) SAS() (string, string) {
+	return jpm.sourceSAS, jpm.destinationSAS
+}
+
+func TestExecuteNewCopyJobPartOrderPreservesRuntimeSASWithoutPersistingIt(t *testing.T) {
+	const (
+		sourceSAS      = "sp=rl&sig=source-runtime-sentinel"
+		destinationSAS = "sp=rcwdl&sig=destination-runtime-sentinel"
+	)
+
+	originalJobsAdmin := JobsAdmin
+	originalPlanFolder := common.AzcopyJobPlanFolder
+	common.AzcopyJobPlanFolder = t.TempDir()
+	t.Cleanup(func() {
+		JobsAdmin = originalJobsAdmin
+		common.AzcopyJobPlanFolder = originalPlanFolder
+	})
+
+	jobMgr := &executeJobPartOrderTestJobMgr{}
+	testAdmin := &executeJobPartOrderTestAdmin{jobMgr: jobMgr}
+	JobsAdmin = testAdmin
+
+	order := common.CopyJobPartOrderRequest{
+		JobID:   common.NewJobID(),
+		PartNum: 0,
+		FromTo:  common.EFromTo.BlobBlob(),
+		Fpo:     common.EFolderPropertiesOption.NoFolders(),
+		SourceRoot: common.ResourceString{
+			Value: "https://source.blob.core.windows.net/container",
+			SAS:   sourceSAS,
+		},
+		DestinationRoot: common.ResourceString{
+			Value: "https://destination.blob.core.windows.net/container",
+			SAS:   destinationSAS,
+		},
+	}
+
+	response := ExecuteNewCopyJobPartOrder(order)
+	if !response.JobStarted {
+		t.Fatal("expected job part order to start")
+	}
+	if jobMgr.jobPart == nil {
+		t.Fatal("expected AddJobPart to receive the job part")
+	}
+
+	actualSourceSAS, actualDestinationSAS := jobMgr.jobPart.SAS()
+	if actualSourceSAS != sourceSAS {
+		t.Fatalf("source SAS mismatch: got %q", actualSourceSAS)
+	}
+	if actualDestinationSAS != destinationSAS {
+		t.Fatalf("destination SAS mismatch: got %q", actualDestinationSAS)
+	}
+
+	planFile := testAdmin.NewJobPartPlanFileName(order.JobID, order.PartNum)
+	planBytes, err := os.ReadFile(filepath.Join(common.AzcopyJobPlanFolder, string(planFile)))
+	if err != nil {
+		t.Fatalf("reading generated plan file: %v", err)
+	}
+	for _, sentinel := range []string{sourceSAS, destinationSAS} {
+		if bytes.Contains(planBytes, []byte(sentinel)) {
+			t.Fatalf("generated plan file contains runtime SAS sentinel %q", sentinel)
+		}
+	}
+
+	nonSASJobMgr := &executeJobPartOrderTestJobMgr{}
+	testAdmin.jobMgr = nonSASJobMgr
+	nonSASOrder := order
+	nonSASOrder.JobID = common.NewJobID()
+	nonSASOrder.SourceRoot.SAS = ""
+	nonSASOrder.DestinationRoot.SAS = ""
+
+	response = ExecuteNewCopyJobPartOrder(nonSASOrder)
+	if !response.JobStarted {
+		t.Fatal("expected non-SAS job part order to start")
+	}
+	actualSourceSAS, actualDestinationSAS = nonSASJobMgr.jobPart.SAS()
+	if actualSourceSAS != "" || actualDestinationSAS != "" {
+		t.Fatalf(
+			"expected non-SAS job part to remain empty, got source %q destination %q",
+			actualSourceSAS,
+			actualDestinationSAS,
+		)
+	}
+}

--- a/ste/dedupeAct.go
+++ b/ste/dedupeAct.go
@@ -141,9 +141,17 @@ func dedupeActDestinationReady(mode dedupeActMode, destinationSAS string) bool {
 func rawCommittedBlocksFromResponse(resp blockblob.GetBlockListResponse) []rawCommittedBlock {
 	raw := make([]rawCommittedBlock, 0, len(resp.CommittedBlocks))
 	for _, b := range resp.CommittedBlocks {
+		if b == nil {
+			raw = append(raw, rawCommittedBlock{})
+			continue
+		}
 		rb := rawCommittedBlock{
 			Name: common.IffNotNil(b.Name, ""),
 			Size: common.IffNotNil(b.Size, 0),
+		}
+		if b.Offset != nil {
+			rb.Offset = *b.Offset
+			rb.HasOffset = true
 		}
 		if len(b.Crc64) == 8 && len(b.Sha256) == 32 {
 			rb.CRC64 = binary.LittleEndian.Uint64(b.Crc64)

--- a/ste/dedupeAct.go
+++ b/ste/dedupeAct.go
@@ -94,12 +94,33 @@ func getSourceBlockList(jptm IJobPartTransferMgr) (blockblob.GetBlockListRespons
 		return blockblob.GetBlockListResponse{}, err
 	}
 	srcClient := bsc.NewContainerClient(info.SrcContainer).NewBlockBlobClient(info.SrcFilePath)
+	srcClient, err = sourceBlockBlobClientForTransfer(srcClient, info)
+	if err != nil {
+		return blockblob.GetBlockListResponse{}, err
+	}
 	return srcClient.GetBlockList(jptm.Context(), blockblob.BlockListTypeCommitted, &blockblob.GetBlockListOptions{
 		Include: []blockblob.BlockListIncludeItem{
 			blockblob.BlockListIncludeItemCrc64,
 			blockblob.BlockListIncludeItemSha256,
 		},
 	})
+}
+
+func sourceBlockBlobClientForTransfer(srcClient *blockblob.Client, info *TransferInfo) (*blockblob.Client, error) {
+	if info.VersionID != "" {
+		return srcClient.WithVersionID(info.VersionID)
+	}
+	if info.SnapshotID != "" {
+		return srcClient.WithSnapshot(info.SnapshotID)
+	}
+	return srcClient, nil
+}
+
+func dedupeActDestinationReady(mode dedupeActMode, destinationSAS string) bool {
+	if mode != dedupeActEnforce {
+		return true
+	}
+	return strings.TrimPrefix(strings.TrimSpace(destinationSAS), "?") != ""
 }
 
 // rawCommittedBlocksFromResponse extracts the minimal per-block info (name, size, and the optional

--- a/ste/dedupeAct.go
+++ b/ste/dedupeAct.go
@@ -71,6 +71,18 @@ func dedupeActModeFromEnv() dedupeActMode {
 	return parseDedupeActMode(common.GetEnvironmentVariable(common.EEnvironmentVariable.DedupeAct()))
 }
 
+func initializeDedupeStateForTransfer(jptm IJobPartTransferMgr) {
+	mode := dedupeActModeFromEnv()
+	if mode == dedupeActOff {
+		return
+	}
+	fromTo := jptm.FromTo()
+	if fromTo.From() != common.ELocation.Blob() || fromTo.To() != common.ELocation.Blob() {
+		return
+	}
+	setDedupeActModeForJob(jptm.Info().JobID, mode)
+}
+
 // parseDedupeActMode is the pure core of dedupeActModeFromEnv, split out so it can be unit tested.
 func parseDedupeActMode(raw string) dedupeActMode {
 	switch strings.ToLower(strings.TrimSpace(raw)) {

--- a/ste/dedupeAct.go
+++ b/ste/dedupeAct.go
@@ -22,8 +22,11 @@ package ste
 
 import (
 	"encoding/binary"
+	"fmt"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
@@ -34,7 +37,7 @@ import (
 // It builds on the read-only Phase 0/1 observer+recorder. When AZCOPY_DEDUPE_ACT is set, a
 // block-blob -> block-blob S2S transfer is chunked on the source's committed block boundaries
 // (Phase 3) instead of AzCopy's uniform grid, so that every chunk lines up with a source block
-// that carries content hashes. Each such chunk is then looked up against the job's committed
+// that carries CRC64 metadata. Each such chunk is then looked up against the job's committed
 // table (Phase 2): on a hit, the block can be staged from the already-migrated destination blob
 // instead of re-read from the source.
 //
@@ -95,10 +98,9 @@ func parseDedupeActMode(raw string) dedupeActMode {
 	}
 }
 
-// getSourceBlockList fetches the source blob's committed block list, requesting the per-block
-// content hashes (include=crc64,sha256). The hashes are only populated when the service GetHash
-// feature is enabled; otherwise the fields come back empty and callers simply see zero hashes.
-// It is shared by the read-only observer and the act path.
+// getSourceBlockList fetches the source blob's committed block list, requesting only per-block
+// CRC64 metadata (include=crc64). CRC64 is populated only when the service GetHash feature is
+// enabled; otherwise it comes back empty. It is shared by the read-only observer and the act path.
 func getSourceBlockList(jptm IJobPartTransferMgr) (blockblob.GetBlockListResponse, error) {
 	info := jptm.Info()
 	bsc, err := jptm.SrcServiceClient().BlobServiceClient()
@@ -110,12 +112,15 @@ func getSourceBlockList(jptm IJobPartTransferMgr) (blockblob.GetBlockListRespons
 	if err != nil {
 		return blockblob.GetBlockListResponse{}, err
 	}
-	return srcClient.GetBlockList(jptm.Context(), blockblob.BlockListTypeCommitted, &blockblob.GetBlockListOptions{
+	return srcClient.GetBlockList(jptm.Context(), blockblob.BlockListTypeCommitted, sourceBlockListOptions())
+}
+
+func sourceBlockListOptions() *blockblob.GetBlockListOptions {
+	return &blockblob.GetBlockListOptions{
 		Include: []blockblob.BlockListIncludeItem{
 			blockblob.BlockListIncludeItemCrc64,
-			blockblob.BlockListIncludeItemSha256,
 		},
-	})
+	}
 }
 
 func sourceBlockBlobClientForTransfer(srcClient *blockblob.Client, info *TransferInfo) (*blockblob.Client, error) {
@@ -128,6 +133,28 @@ func sourceBlockBlobClientForTransfer(srcClient *blockblob.Client, info *Transfe
 	return srcClient, nil
 }
 
+func validateDedupeSourceETag(jptm IJobPartTransferMgr, etag azcore.ETag) error {
+	if etag == "" {
+		return fmt.Errorf("dedupe source ETag is missing")
+	}
+	info := jptm.Info()
+	service, err := jptm.SrcServiceClient().BlobServiceClient()
+	if err != nil {
+		return err
+	}
+	client := service.NewContainerClient(info.SrcContainer).NewBlockBlobClient(info.SrcFilePath)
+	client, err = sourceBlockBlobClientForTransfer(client, info)
+	if err != nil {
+		return err
+	}
+	_, err = client.GetProperties(jptm.Context(), &blob.GetPropertiesOptions{
+		AccessConditions: &blob.AccessConditions{
+			ModifiedAccessConditions: &blob.ModifiedAccessConditions{IfMatch: &etag},
+		},
+	})
+	return err
+}
+
 func dedupeActDestinationReady(mode dedupeActMode, destinationSAS string) bool {
 	if mode != dedupeActEnforce {
 		return true
@@ -135,9 +162,9 @@ func dedupeActDestinationReady(mode dedupeActMode, destinationSAS string) bool {
 	return strings.TrimPrefix(strings.TrimSpace(destinationSAS), "?") != ""
 }
 
-// rawCommittedBlocksFromResponse extracts the minimal per-block info (name, size, and the optional
-// content hashes) from a committed block list response. Azure Storage encodes the per-block CRC64
-// little-endian.
+// rawCommittedBlocksFromResponse extracts the minimal per-block info from a committed block list
+// response. Azure Storage encodes per-block CRC64 little-endian. SHA256 is parsed independently for
+// compatibility with synthetic and legacy responses, but source discovery requests only CRC64.
 func rawCommittedBlocksFromResponse(resp blockblob.GetBlockListResponse) []rawCommittedBlock {
 	raw := make([]rawCommittedBlock, 0, len(resp.CommittedBlocks))
 	for _, b := range resp.CommittedBlocks {
@@ -153,20 +180,24 @@ func rawCommittedBlocksFromResponse(resp blockblob.GetBlockListResponse) []rawCo
 			rb.Offset = *b.Offset
 			rb.HasOffset = true
 		}
-		if len(b.Crc64) == 8 && len(b.Sha256) == 32 {
+		if len(b.Crc64) == 8 {
 			rb.CRC64 = binary.LittleEndian.Uint64(b.Crc64)
-			copy(rb.SHA256[:], b.Sha256)
-			rb.HasHashes = true
+			rb.HasCRC64 = true
 		}
+		if len(b.Sha256) == 32 {
+			copy(rb.SHA256[:], b.Sha256)
+			rb.HasSHA256 = true
+		}
+		rb.HasHashes = rb.HasCRC64 && rb.HasSHA256
 		raw = append(raw, rb)
 	}
 	return raw
 }
 
 // fetchSourceGridPlan fetches the source committed block list and turns it into a SourceGridPlan
-// (boundaries plus any per-block hashes). It returns a nil plan with no error when the source has no
-// committed named blocks (e.g. a single-PutBlob or empty blob), which simply means the blob is not
-// eligible for source-grid chunking.
+// (boundaries plus per-block CRC64 metadata when available). It returns a nil plan with no error
+// when the source has no committed named blocks (e.g. a single-PutBlob or empty blob), which simply
+// means the blob is not eligible for source-grid chunking.
 func fetchSourceGridPlan(jptm IJobPartTransferMgr) (*SourceGridPlan, error) {
 	resp, err := getSourceBlockList(jptm)
 	if err != nil {

--- a/ste/dedupeAct.go
+++ b/ste/dedupeAct.go
@@ -1,0 +1,164 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ste
+
+import (
+	"encoding/binary"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
+
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+)
+
+// This file implements "Phase 2/3" of the block-level dedupe prototype: acting on dedupe hits.
+//
+// It builds on the read-only Phase 0/1 observer+recorder. When AZCOPY_DEDUPE_ACT is set, a
+// block-blob -> block-blob S2S transfer is chunked on the source's committed block boundaries
+// (Phase 3) instead of AzCopy's uniform grid, so that every chunk lines up with a source block
+// that carries content hashes. Each such chunk is then looked up against the job's committed
+// table (Phase 2): on a hit, the block can be staged from the already-migrated destination blob
+// instead of re-read from the source.
+//
+// Everything here is gated behind AZCOPY_DEDUPE_ACT and is a no-op when it is unset.
+
+// dedupeActMode selects how aggressively the dedupe prototype acts on a hit.
+type dedupeActMode int
+
+const (
+	// dedupeActOff is the default (zero value): no dedupe behavior at all.
+	dedupeActOff dedupeActMode = iota
+	// dedupeActShadow chunks on source boundaries and LOGS which blocks would be referenced from
+	// the destination, but still stages every block from the source (no change to the bytes written).
+	dedupeActShadow
+	// dedupeActEnforce additionally stages a referenced block from the destination sub-range, with
+	// an If-Match ETag guard and automatic fallback to the source on any failure.
+	dedupeActEnforce
+)
+
+func (m dedupeActMode) String() string {
+	switch m {
+	case dedupeActShadow:
+		return "shadow"
+	case dedupeActEnforce:
+		return "enforce"
+	default:
+		return "off"
+	}
+}
+
+// dedupeActModeFromEnv parses AZCOPY_DEDUPE_ACT. "shadow" and "enforce" select the matching mode
+// (case-insensitive); "true" is treated as enforce for convenience; anything else is off.
+func dedupeActModeFromEnv() dedupeActMode {
+	return parseDedupeActMode(common.GetEnvironmentVariable(common.EEnvironmentVariable.DedupeAct()))
+}
+
+// parseDedupeActMode is the pure core of dedupeActModeFromEnv, split out so it can be unit tested.
+func parseDedupeActMode(raw string) dedupeActMode {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "shadow":
+		return dedupeActShadow
+	case "enforce", "true":
+		return dedupeActEnforce
+	default:
+		return dedupeActOff
+	}
+}
+
+// getSourceBlockList fetches the source blob's committed block list, requesting the per-block
+// content hashes (include=crc64,sha256). The hashes are only populated when the service GetHash
+// feature is enabled; otherwise the fields come back empty and callers simply see zero hashes.
+// It is shared by the read-only observer and the act path.
+func getSourceBlockList(jptm IJobPartTransferMgr) (blockblob.GetBlockListResponse, error) {
+	info := jptm.Info()
+	bsc, err := jptm.SrcServiceClient().BlobServiceClient()
+	if err != nil {
+		return blockblob.GetBlockListResponse{}, err
+	}
+	srcClient := bsc.NewContainerClient(info.SrcContainer).NewBlockBlobClient(info.SrcFilePath)
+	return srcClient.GetBlockList(jptm.Context(), blockblob.BlockListTypeCommitted, &blockblob.GetBlockListOptions{
+		Include: []blockblob.BlockListIncludeItem{
+			blockblob.BlockListIncludeItemCrc64,
+			blockblob.BlockListIncludeItemSha256,
+		},
+	})
+}
+
+// rawCommittedBlocksFromResponse extracts the minimal per-block info (name, size, and the optional
+// content hashes) from a committed block list response. Azure Storage encodes the per-block CRC64
+// little-endian.
+func rawCommittedBlocksFromResponse(resp blockblob.GetBlockListResponse) []rawCommittedBlock {
+	raw := make([]rawCommittedBlock, 0, len(resp.CommittedBlocks))
+	for _, b := range resp.CommittedBlocks {
+		rb := rawCommittedBlock{
+			Name: common.IffNotNil(b.Name, ""),
+			Size: common.IffNotNil(b.Size, 0),
+		}
+		if len(b.Crc64) == 8 && len(b.Sha256) == 32 {
+			rb.CRC64 = binary.LittleEndian.Uint64(b.Crc64)
+			copy(rb.SHA256[:], b.Sha256)
+			rb.HasHashes = true
+		}
+		raw = append(raw, rb)
+	}
+	return raw
+}
+
+// fetchSourceGridPlan fetches the source committed block list and turns it into a SourceGridPlan
+// (boundaries plus any per-block hashes). It returns a nil plan with no error when the source has no
+// committed named blocks (e.g. a single-PutBlob or empty blob), which simply means the blob is not
+// eligible for source-grid chunking.
+func fetchSourceGridPlan(jptm IJobPartTransferMgr) (*SourceGridPlan, error) {
+	resp, err := getSourceBlockList(jptm)
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.CommittedBlocks) == 0 {
+		return nil, nil
+	}
+	return buildSourceGridPlan(rawCommittedBlocksFromResponse(resp))
+}
+
+// chunkSpec is a single source-grid chunk: a contiguous [offset, offset+size) range of the source
+// blob whose boundaries match a source committed block rather than AzCopy's uniform grid.
+type chunkSpec struct {
+	offset int64
+	size   int64
+}
+
+// sourceGridChunker is implemented by senders that can override AzCopy's uniform chunk grid with a
+// content-defined one. When dedupeChunkSpecs returns a non-empty slice, scheduleSendChunks iterates
+// those specs instead of the uniform startIndex loop.
+type sourceGridChunker interface {
+	dedupeChunkSpecs() []chunkSpec
+}
+
+// chunkSpecsFromPlan converts a SourceGridPlan into the ordered chunk specs used by the scheduler.
+func chunkSpecsFromPlan(plan *SourceGridPlan) []chunkSpec {
+	if plan == nil {
+		return nil
+	}
+	specs := make([]chunkSpec, len(plan.Blocks))
+	for i, b := range plan.Blocks {
+		specs[i] = chunkSpec{offset: b.Offset, size: b.Size}
+	}
+	return specs
+}

--- a/ste/dedupeAct_test.go
+++ b/ste/dedupeAct_test.go
@@ -215,6 +215,8 @@ func TestDedupeJobStateCounters(t *testing.T) {
 	st.addSourceStaged(30)
 	st.addSourceStaged(70)
 	st.addFallback()
+	st.addFileStarted()
+	st.addFileCommitted()
 
 	a.EqualValues(2, st.referencedBlocks)
 	a.EqualValues(150, st.referencedBytes) // source-read bytes avoided under enforce
@@ -223,6 +225,8 @@ func TestDedupeJobStateCounters(t *testing.T) {
 	a.EqualValues(2, st.sourceStagedBlocks)
 	a.EqualValues(100, st.sourceStagedBytes)
 	a.EqualValues(1, st.fallbackBlocks)
+	a.EqualValues(1, st.filesStarted)
+	a.EqualValues(1, st.filesCommitted)
 }
 
 func TestDedupeJobSummaryMessageEnforce(t *testing.T) {

--- a/ste/dedupeAct_test.go
+++ b/ste/dedupeAct_test.go
@@ -272,10 +272,17 @@ func TestFinalizeDedupeJobLogsAndClearsState(t *testing.T) {
 	setDedupeActModeForJob(jobID, dedupeActEnforce)
 
 	var messages []string
-	finalizeDedupeJob(jobID, func(level common.LogLevel, value string) {
-		a.Equal(common.LogInfo, level)
-		messages = append(messages, value)
-	})
+	finalizeDedupeJob(
+		jobID,
+		common.EJobStatus.Failed(),
+		2,
+		1,
+		1,
+		func(level common.LogLevel, value string) {
+			a.Equal(common.LogInfo, level)
+			messages = append(messages, value)
+		},
+	)
 
 	a.Contains(strings.Join(messages, "\n"), "dedupe-job-summary(enforce)")
 	logPath := filepath.Join(common.AzcopyLogFolder, dedupeLogDirectoryName, jobID.String()+".log")
@@ -283,6 +290,10 @@ func TestFinalizeDedupeJobLogsAndClearsState(t *testing.T) {
 	a.NoError(err)
 	a.Contains(string(logBytes), "event=job_complete")
 	a.Contains(string(logBytes), "jobId="+jobID.String())
+	a.Contains(string(logBytes), `status="Failed"`)
+	a.Contains(string(logBytes), "transfersCompleted=2")
+	a.Contains(string(logBytes), "transfersSkipped=1")
+	a.Contains(string(logBytes), "transfersFailed=1")
 
 	_, exists := dedupeStateForJobIfExists(jobID)
 	a.False(exists)

--- a/ste/dedupeAct_test.go
+++ b/ste/dedupeAct_test.go
@@ -1,0 +1,230 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ste
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func ptrTo[T any](v T) *T { return &v }
+
+func TestParseDedupeActMode(t *testing.T) {
+	a := assert.New(t)
+
+	a.Equal(dedupeActShadow, parseDedupeActMode("shadow"))
+	a.Equal(dedupeActShadow, parseDedupeActMode("  SHADOW ")) // trimmed + case-insensitive
+	a.Equal(dedupeActEnforce, parseDedupeActMode("enforce"))
+	a.Equal(dedupeActEnforce, parseDedupeActMode("Enforce"))
+	a.Equal(dedupeActEnforce, parseDedupeActMode("true")) // convenience alias
+
+	a.Equal(dedupeActOff, parseDedupeActMode(""))
+	a.Equal(dedupeActOff, parseDedupeActMode("false"))
+	a.Equal(dedupeActOff, parseDedupeActMode("on"))
+	a.Equal(dedupeActOff, parseDedupeActMode("1"))
+}
+
+func TestDedupeActModeString(t *testing.T) {
+	a := assert.New(t)
+
+	a.Equal("off", dedupeActOff.String())
+	a.Equal("shadow", dedupeActShadow.String())
+	a.Equal("enforce", dedupeActEnforce.String())
+}
+
+func TestChunkSpecsFromPlan(t *testing.T) {
+	a := assert.New(t)
+
+	a.Nil(chunkSpecsFromPlan(nil))
+
+	plan := &SourceGridPlan{Blocks: []PlannedBlock{
+		{Offset: 0, Size: 100},
+		{Offset: 100, Size: 250},
+		{Offset: 350, Size: 50},
+	}}
+	specs := chunkSpecsFromPlan(plan)
+
+	a.Equal([]chunkSpec{{0, 100}, {100, 250}, {350, 50}}, specs)
+}
+
+func TestDedupeChunkSpecs_OffReturnsNil(t *testing.T) {
+	a := assert.New(t)
+
+	plan := &SourceGridPlan{Blocks: []PlannedBlock{{Offset: 0, Size: 100}}}
+
+	// dedupeActOff (the zero value) must never expose a source-grid plan, even if one is set.
+	off := &blockBlobSenderBase{dedupeMode: dedupeActOff, dedupePlan: plan}
+	a.Nil(off.dedupeChunkSpecs())
+
+	shadow := &blockBlobSenderBase{dedupeMode: dedupeActShadow, dedupePlan: plan}
+	a.Equal([]chunkSpec{{0, 100}}, shadow.dedupeChunkSpecs())
+}
+
+func TestRawCommittedBlocksFromResponse(t *testing.T) {
+	a := assert.New(t)
+
+	var crc [8]byte
+	binary.LittleEndian.PutUint64(crc[:], 0x0102030405060708)
+	sha := make([]byte, 32)
+	sha[0], sha[31] = 0xAA, 0xBB
+
+	resp := blockblob.GetBlockListResponse{}
+	resp.CommittedBlocks = []*blockblob.Block{
+		{Name: ptrTo("blk-0"), Size: ptrTo(int64(100)), Crc64: crc[:], Sha256: sha},
+		{Name: ptrTo("blk-1"), Size: ptrTo(int64(200))}, // no hashes (GetHash off for this block)
+	}
+
+	raw := rawCommittedBlocksFromResponse(resp)
+
+	a.Len(raw, 2)
+	a.Equal("blk-0", raw[0].Name)
+	a.EqualValues(100, raw[0].Size)
+	a.Equal(uint64(0x0102030405060708), raw[0].CRC64) // decoded little-endian
+	a.Equal(byte(0xAA), raw[0].SHA256[0])
+	a.Equal(byte(0xBB), raw[0].SHA256[31])
+	a.True(raw[0].HasHashes)
+
+	a.Equal("blk-1", raw[1].Name)
+	a.EqualValues(200, raw[1].Size)
+	a.EqualValues(0, raw[1].CRC64)
+	a.False(raw[1].HasHashes)
+	a.Equal([32]byte{}, raw[1].SHA256)
+}
+
+func TestRecordCommittedBlocks_PopulatesCommittedTableForReference(t *testing.T) {
+	a := assert.New(t)
+
+	jobID := common.NewJobID()
+	defer clearDedupeStateForJob(jobID)
+
+	plan := &SourceGridPlan{Blocks: []PlannedBlock{
+		hashedBlock("alpha", 0, 100),
+		hashedBlock("beta", 100, 200),
+		{Offset: 300, Size: 50}, // no hashes -> must be skipped
+	}}
+	const dest = "https://acct.blob.core.windows.net/c/migrated?sig=secret"
+
+	recorded := recordCommittedBlocks(jobID, "https://acct.blob.core.windows.net/c/migrated", "?sig=secret", "etag-xyz", plan)
+	a.Equal(2, recorded) // only the two hashed blocks
+
+	committed := dedupeStateForJob(jobID).committed
+	a.Equal(2, committed.Len())
+
+	// A later identical block must now resolve to a reference against the recorded target, with the
+	// executable TargetURI (including SAS, when present) and the destination ETag preserved.
+	idx := buildSourceBlockHashIndex(plan)
+	target, reference := decideStaging(idx, committed, 0, 100, "https://acct.blob.core.windows.net/c/current")
+	a.True(reference)
+	a.Equal(dest, target.TargetURI)
+	a.EqualValues(0, target.TargetOffset)
+	a.EqualValues(100, target.TargetLength)
+	a.EqualValues("etag-xyz", target.ETag)
+}
+
+func TestRecordCommittedBlocks_NilPlanIsNoOp(t *testing.T) {
+	a := assert.New(t)
+
+	jobID := common.NewJobID()
+	defer clearDedupeStateForJob(jobID)
+
+	a.Equal(0, recordCommittedBlocks(jobID, "uri", "", "etag", nil))
+}
+
+func TestRecordCommittedBlocks_MissingETagIsNoOp(t *testing.T) {
+	a := assert.New(t)
+
+	jobID := common.NewJobID()
+	defer clearDedupeStateForJob(jobID)
+
+	plan := &SourceGridPlan{Blocks: []PlannedBlock{hashedBlock("alpha", 0, 100)}}
+	a.Equal(0, recordCommittedBlocks(jobID, "https://acct.blob.core.windows.net/c/migrated", "?sig=secret", "", plan))
+
+	_, exists := dedupeStateForJobIfExists(jobID)
+	a.False(exists)
+}
+
+func TestDedupeJobStateCounters(t *testing.T) {
+	a := assert.New(t)
+	st := &dedupeJobState{}
+
+	st.addReferenced(100)
+	st.addReferenced(50)
+	st.addWouldReference(200)
+	st.addSourceStaged(30)
+	st.addSourceStaged(70)
+	st.addFallback()
+
+	a.EqualValues(2, st.referencedBlocks)
+	a.EqualValues(150, st.referencedBytes) // source-read bytes avoided under enforce
+	a.EqualValues(1, st.wouldReferenceBlocks)
+	a.EqualValues(200, st.wouldReferenceBytes)
+	a.EqualValues(2, st.sourceStagedBlocks)
+	a.EqualValues(100, st.sourceStagedBytes)
+	a.EqualValues(1, st.fallbackBlocks)
+}
+
+func TestDedupeJobSummaryMessageEnforce(t *testing.T) {
+	a := assert.New(t)
+	st := &dedupeJobState{}
+	st.addReferenced(100)
+	st.addReferenced(50)
+	st.addSourceStaged(30)
+	st.addSourceStaged(70)
+	st.addFallback()
+
+	a.Equal(
+		"dedupe-job-summary(enforce): totalBlocks=4 targetURIBlocks=2 sourceURIBlocks=2 fallbackBlocks=1 avoidedSourceReadBytes=150 totalStagedBytes=250 wanSavingsPercent=60.0",
+		dedupeJobSummaryMessage(dedupeActEnforce, st))
+}
+
+func TestDedupeJobSummaryMessageShadow(t *testing.T) {
+	a := assert.New(t)
+	st := &dedupeJobState{}
+	st.addWouldReference(150)
+	st.addSourceStaged(100)
+	st.addSourceStaged(200)
+
+	a.Equal(
+		"dedupe-job-summary(shadow): totalBlocks=2 wouldTargetURIBlocks=1 sourceURIBlocks=2 fallbackBlocks=0 potentialAvoidedSourceReadBytes=150 totalStagedBytes=300 potentialWanSavingsPercent=50.0",
+		dedupeJobSummaryMessage(dedupeActShadow, st))
+}
+
+func TestFinalizeDedupeJobLogsAndClearsState(t *testing.T) {
+	a := assert.New(t)
+	jobID := common.NewJobID()
+	st := dedupeStateForJob(jobID)
+	st.addReferenced(100)
+	setDedupeActModeForJob(jobID, dedupeActEnforce)
+
+	var message string
+	finalizeDedupeJob(jobID, func(level common.LogLevel, value string) {
+		a.Equal(common.LogInfo, level)
+		message = value
+	})
+
+	a.Contains(message, "dedupe-job-summary(enforce)")
+	_, exists := dedupeStateForJobIfExists(jobID)
+	a.False(exists)
+}

--- a/ste/dedupeAct_test.go
+++ b/ste/dedupeAct_test.go
@@ -22,6 +22,8 @@ package ste
 
 import (
 	"encoding/binary"
+	"fmt"
+	"math"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -269,6 +271,16 @@ func TestFinalizeDedupeJobLogsAndClearsState(t *testing.T) {
 	jobID := common.NewJobID()
 	st := dedupeStateForJob(jobID)
 	st.addReferenced(100)
+	cpuResponse := blockblob.GetBlockListResponse{
+		CRC64CPUTimeUS:  ptrTo(int64(math.MaxInt64)),
+		SHA256CPUTimeUS: ptrTo(int64(1)),
+		RequestID:       ptrTo("request-final"),
+	}
+	cpuResponse.CommittedBlocks = []*blockblob.Block{
+		{Size: ptrTo(int64(64)), Crc64: make([]byte, 8), Sha256: make([]byte, 32)},
+	}
+	_, accepted := st.hashCPU.record(hashCPUResponseDelta(cpuResponse))
+	a.True(accepted)
 	setDedupeActModeForJob(jobID, dedupeActEnforce)
 
 	var messages []string
@@ -294,6 +306,25 @@ func TestFinalizeDedupeJobLogsAndClearsState(t *testing.T) {
 	a.Contains(string(logBytes), "transfersCompleted=2")
 	a.Contains(string(logBytes), "transfersSkipped=1")
 	a.Contains(string(logBytes), "transfersFailed=1")
+	a.Contains(string(logBytes), "crc64CpuTimeUs="+fmt.Sprint(math.MaxInt64))
+	a.Contains(string(logBytes), "sha256CpuTimeUs=1")
+	a.Contains(string(logBytes), "hashCpuTimeUs="+fmt.Sprint(math.MaxInt64))
+	a.Contains(string(logBytes), "hashedBlocks=1")
+	a.Contains(string(logBytes), "hashedBytes=64")
+	a.Contains(string(logBytes), "hashCpuTimeResponses=1")
+	a.Contains(string(logBytes), "crc64CpuTimeMissingResponses=0")
+	a.Contains(string(logBytes), "sha256CpuTimeMissingResponses=0")
+	a.Contains(string(logBytes), "requestIdMissingResponses=0")
+	a.Contains(string(logBytes), "crc64CpuTimeInvalidResponses=0")
+	a.Contains(string(logBytes), "sha256CpuTimeInvalidResponses=0")
+	a.Contains(string(logBytes), "crc64CpuTimeOverflowed=false")
+	a.Contains(string(logBytes), "sha256CpuTimeOverflowed=false")
+	a.Contains(string(logBytes), "hashCpuTimeOverflowed=true")
+	a.Contains(string(logBytes), "hashedBlocksOverflowed=false")
+	a.Contains(string(logBytes), "hashedBytesOverflowed=false")
+	a.Contains(string(logBytes), "hashMetricsOverflowed=true")
+	a.NotContains(string(logBytes), "Delta=")
+	a.NotContains(string(logBytes), " requestId=")
 
 	_, exists := dedupeStateForJobIfExists(jobID)
 	a.False(exists)

--- a/ste/dedupeAct_test.go
+++ b/ste/dedupeAct_test.go
@@ -22,6 +22,7 @@ package ste
 
 import (
 	"encoding/binary"
+	"net/url"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
@@ -52,6 +53,45 @@ func TestDedupeActModeString(t *testing.T) {
 	a.Equal("off", dedupeActOff.String())
 	a.Equal("shadow", dedupeActShadow.String())
 	a.Equal("enforce", dedupeActEnforce.String())
+}
+
+func TestSourceBlockBlobClientForTransferPreservesVersionOrSnapshot(t *testing.T) {
+	a := assert.New(t)
+	base, err := blockblob.NewClientWithNoCredential("https://acct.blob.core.windows.net/c/blob", nil)
+	a.NoError(err)
+
+	versioned, err := sourceBlockBlobClientForTransfer(base, &TransferInfo{
+		VersionID:  "2026-07-15T12:00:00.0000000Z",
+		SnapshotID: "ignored-when-version-is-present",
+	})
+	a.NoError(err)
+	versionedURL, err := url.Parse(versioned.URL())
+	a.NoError(err)
+	a.Equal("2026-07-15T12:00:00.0000000Z", versionedURL.Query().Get("versionid"))
+	a.Empty(versionedURL.Query().Get("snapshot"))
+
+	snapshot, err := sourceBlockBlobClientForTransfer(base, &TransferInfo{
+		SnapshotID: "2026-07-15T12:30:00.0000000Z",
+	})
+	a.NoError(err)
+	snapshotURL, err := url.Parse(snapshot.URL())
+	a.NoError(err)
+	a.Equal("2026-07-15T12:30:00.0000000Z", snapshotURL.Query().Get("snapshot"))
+	a.Empty(snapshotURL.Query().Get("versionid"))
+
+	unversioned, err := sourceBlockBlobClientForTransfer(base, &TransferInfo{})
+	a.NoError(err)
+	a.Equal(base.URL(), unversioned.URL())
+}
+
+func TestDedupeActDestinationReadyRequiresSASForEnforce(t *testing.T) {
+	a := assert.New(t)
+
+	a.True(dedupeActDestinationReady(dedupeActOff, ""))
+	a.True(dedupeActDestinationReady(dedupeActShadow, ""))
+	a.False(dedupeActDestinationReady(dedupeActEnforce, ""))
+	a.False(dedupeActDestinationReady(dedupeActEnforce, "  ?  "))
+	a.True(dedupeActDestinationReady(dedupeActEnforce, "?sv=2026&sig=secret"))
 }
 
 func TestChunkSpecsFromPlan(t *testing.T) {

--- a/ste/dedupeAct_test.go
+++ b/ste/dedupeAct_test.go
@@ -137,7 +137,7 @@ func TestRawCommittedBlocksFromResponse(t *testing.T) {
 
 	resp := blockblob.GetBlockListResponse{}
 	resp.CommittedBlocks = []*blockblob.Block{
-		{Name: ptrTo("blk-0"), Size: ptrTo(int64(100)), Crc64: crc[:], Sha256: sha},
+		{Name: ptrTo("blk-0"), Size: ptrTo(int64(100)), Offset: ptrTo(int64(42)), Crc64: crc[:], Sha256: sha},
 		{Name: ptrTo("blk-1"), Size: ptrTo(int64(200))}, // no hashes (GetHash off for this block)
 	}
 
@@ -146,6 +146,8 @@ func TestRawCommittedBlocksFromResponse(t *testing.T) {
 	a.Len(raw, 2)
 	a.Equal("blk-0", raw[0].Name)
 	a.EqualValues(100, raw[0].Size)
+	a.EqualValues(42, raw[0].Offset)
+	a.True(raw[0].HasOffset)
 	a.Equal(uint64(0x0102030405060708), raw[0].CRC64) // decoded little-endian
 	a.Equal(byte(0xAA), raw[0].SHA256[0])
 	a.Equal(byte(0xBB), raw[0].SHA256[31])
@@ -153,6 +155,7 @@ func TestRawCommittedBlocksFromResponse(t *testing.T) {
 
 	a.Equal("blk-1", raw[1].Name)
 	a.EqualValues(200, raw[1].Size)
+	a.False(raw[1].HasOffset)
 	a.EqualValues(0, raw[1].CRC64)
 	a.False(raw[1].HasHashes)
 	a.Equal([32]byte{}, raw[1].SHA256)

--- a/ste/dedupeAct_test.go
+++ b/ste/dedupeAct_test.go
@@ -23,6 +23,9 @@ package ste
 import (
 	"encoding/binary"
 	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
@@ -257,18 +260,30 @@ func TestDedupeJobSummaryMessageShadow(t *testing.T) {
 
 func TestFinalizeDedupeJobLogsAndClearsState(t *testing.T) {
 	a := assert.New(t)
+	originalLogFolder := common.AzcopyLogFolder
+	common.AzcopyLogFolder = t.TempDir()
+	t.Cleanup(func() {
+		common.AzcopyLogFolder = originalLogFolder
+	})
+
 	jobID := common.NewJobID()
 	st := dedupeStateForJob(jobID)
 	st.addReferenced(100)
 	setDedupeActModeForJob(jobID, dedupeActEnforce)
 
-	var message string
+	var messages []string
 	finalizeDedupeJob(jobID, func(level common.LogLevel, value string) {
 		a.Equal(common.LogInfo, level)
-		message = value
+		messages = append(messages, value)
 	})
 
-	a.Contains(message, "dedupe-job-summary(enforce)")
+	a.Contains(strings.Join(messages, "\n"), "dedupe-job-summary(enforce)")
+	logPath := filepath.Join(common.AzcopyLogFolder, dedupeLogDirectoryName, jobID.String()+".log")
+	logBytes, err := os.ReadFile(logPath)
+	a.NoError(err)
+	a.Contains(string(logBytes), "event=job_complete")
+	a.Contains(string(logBytes), "jobId="+jobID.String())
+
 	_, exists := dedupeStateForJobIfExists(jobID)
 	a.False(exists)
 }

--- a/ste/dedupeAct_test.go
+++ b/ste/dedupeAct_test.go
@@ -30,6 +30,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/stretchr/testify/assert"
@@ -127,9 +129,130 @@ func TestDedupeChunkSpecs_OffReturnsNil(t *testing.T) {
 	a.Equal([]chunkSpec{{0, 100}}, shadow.dedupeChunkSpecs())
 }
 
-func TestRawCommittedBlocksFromResponse(t *testing.T) {
+func TestSourceStageBlockOptionsPinsDedupeSourceETag(t *testing.T) {
+	manager := &testJobPartTransferManager{}
+	token := "token"
+	copier := &urlToBlockBlobCopier{blockBlobSenderBase: blockBlobSenderBase{
+		jptm:       manager,
+		dedupeMode: dedupeActEnforce,
+		dedupeETag: azcore.ETag(`"source-etag"`),
+	}}
+
+	options := copier.sourceStageBlockOptions(7, 13, &token)
+	assert.Equal(t, blob.HTTPRange{Offset: 7, Count: 13}, options.Range)
+	assert.Equal(t, &token, options.CopySourceAuthorization)
+	if assert.NotNil(t, options.SourceModifiedAccessConditions) &&
+		assert.NotNil(t, options.SourceModifiedAccessConditions.SourceIfMatch) {
+		assert.Equal(t, azcore.ETag(`"source-etag"`), *options.SourceModifiedAccessConditions.SourceIfMatch)
+	}
+
+	copier.dedupeMode = dedupeActOff
+	options = copier.sourceStageBlockOptions(7, 13, &token)
+	assert.Nil(t, options.SourceModifiedAccessConditions)
+}
+
+func TestStageDedupeTargetCandidatesUsesAlternative(t *testing.T) {
+	targets := []common.BlockEntry{
+		{TargetURI: "first"},
+		{TargetURI: "second"},
+		{TargetURI: "third"},
+	}
+	var called []string
+	selected, attempts, staged := stageDedupeTargetCandidates(
+		targets,
+		func(target common.BlockEntry) error {
+			called = append(called, target.TargetURI)
+			if target.TargetURI == "second" {
+				return nil
+			}
+			return fmt.Errorf("unusable")
+		},
+	)
+
+	assert.True(t, staged)
+	assert.Equal(t, "second", selected.TargetURI)
+	assert.Equal(t, []string{"first", "second"}, called)
+	if assert.Len(t, attempts, 2) {
+		assert.Error(t, attempts[0].err)
+		assert.NoError(t, attempts[1].err)
+	}
+}
+
+func TestStageDedupeTargetCandidatesAllFail(t *testing.T) {
+	targets := []common.BlockEntry{{TargetURI: "first"}, {TargetURI: "second"}}
+	selected, attempts, staged := stageDedupeTargetCandidates(
+		targets,
+		func(common.BlockEntry) error { return fmt.Errorf("unusable") },
+	)
+
+	assert.False(t, staged)
+	assert.Equal(t, common.BlockEntry{}, selected)
+	assert.Len(t, attempts, 2)
+}
+
+func TestSourceBlockListOptionsRequestsOnlyCRC64(t *testing.T) {
 	a := assert.New(t)
 
+	options := sourceBlockListOptions()
+	a.Equal(
+		[]blockblob.BlockListIncludeItem{blockblob.BlockListIncludeItemCrc64},
+		options.Include,
+	)
+	a.NotContains(options.Include, blockblob.BlockListIncludeItemSha256)
+}
+
+func TestRawCommittedBlocksFromResponse_CRC64Only(t *testing.T) {
+	a := assert.New(t)
+	var crc [8]byte
+	binary.LittleEndian.PutUint64(crc[:], 0x0102030405060708)
+
+	resp := blockblob.GetBlockListResponse{}
+	resp.CommittedBlocks = []*blockblob.Block{
+		{Name: ptrTo("crc-only"), Size: ptrTo(int64(100)), Crc64: crc[:]},
+		{Name: ptrTo("zero-crc"), Size: ptrTo(int64(200)), Crc64: make([]byte, 8)},
+	}
+
+	raw := rawCommittedBlocksFromResponse(resp)
+
+	a.Len(raw, 2)
+	a.Equal("crc-only", raw[0].Name)
+	a.EqualValues(100, raw[0].Size)
+	a.Equal(uint64(0x0102030405060708), raw[0].CRC64) // decoded little-endian
+	a.True(raw[0].HasCRC64)
+	a.False(raw[0].HasSHA256)
+	a.False(raw[0].HasHashes)
+
+	a.Equal("zero-crc", raw[1].Name)
+	a.EqualValues(0, raw[1].CRC64)
+	a.True(raw[1].HasCRC64) // an all-zero CRC64 is still present
+	a.False(raw[1].HasHashes)
+}
+
+func TestRawCommittedBlocksFromResponse_MalformedCRC64(t *testing.T) {
+	sha := make([]byte, 32)
+	sha[0], sha[31] = 0xAA, 0xBB
+
+	for _, length := range []int{7, 9} {
+		t.Run(fmt.Sprintf("%d_bytes", length), func(t *testing.T) {
+			resp := blockblob.GetBlockListResponse{}
+			resp.CommittedBlocks = []*blockblob.Block{
+				{Name: ptrTo("malformed-crc"), Size: ptrTo(int64(100)), Crc64: make([]byte, length), Sha256: sha},
+			}
+
+			raw := rawCommittedBlocksFromResponse(resp)
+
+			a := assert.New(t)
+			a.Len(raw, 1)
+			a.False(raw[0].HasCRC64)
+			a.EqualValues(0, raw[0].CRC64)
+			a.True(raw[0].HasSHA256)
+			a.False(raw[0].HasHashes)
+		})
+	}
+}
+
+func TestRawCommittedBlocksFromResponse_LegacyCRC64AndSHA256(t *testing.T) {
+	a := assert.New(t)
 	var crc [8]byte
 	binary.LittleEndian.PutUint64(crc[:], 0x0102030405060708)
 	sha := make([]byte, 32)
@@ -137,28 +260,22 @@ func TestRawCommittedBlocksFromResponse(t *testing.T) {
 
 	resp := blockblob.GetBlockListResponse{}
 	resp.CommittedBlocks = []*blockblob.Block{
-		{Name: ptrTo("blk-0"), Size: ptrTo(int64(100)), Offset: ptrTo(int64(42)), Crc64: crc[:], Sha256: sha},
-		{Name: ptrTo("blk-1"), Size: ptrTo(int64(200))}, // no hashes (GetHash off for this block)
+		{Name: ptrTo("legacy"), Size: ptrTo(int64(100)), Offset: ptrTo(int64(42)), Crc64: crc[:], Sha256: sha},
 	}
 
 	raw := rawCommittedBlocksFromResponse(resp)
 
-	a.Len(raw, 2)
-	a.Equal("blk-0", raw[0].Name)
+	a.Len(raw, 1)
+	a.Equal("legacy", raw[0].Name)
 	a.EqualValues(100, raw[0].Size)
 	a.EqualValues(42, raw[0].Offset)
 	a.True(raw[0].HasOffset)
-	a.Equal(uint64(0x0102030405060708), raw[0].CRC64) // decoded little-endian
+	a.Equal(uint64(0x0102030405060708), raw[0].CRC64)
+	a.True(raw[0].HasCRC64)
 	a.Equal(byte(0xAA), raw[0].SHA256[0])
 	a.Equal(byte(0xBB), raw[0].SHA256[31])
+	a.True(raw[0].HasSHA256)
 	a.True(raw[0].HasHashes)
-
-	a.Equal("blk-1", raw[1].Name)
-	a.EqualValues(200, raw[1].Size)
-	a.False(raw[1].HasOffset)
-	a.EqualValues(0, raw[1].CRC64)
-	a.False(raw[1].HasHashes)
-	a.Equal([32]byte{}, raw[1].SHA256)
 }
 
 func TestRecordCommittedBlocks_PopulatesCommittedTableForReference(t *testing.T) {
@@ -189,6 +306,42 @@ func TestRecordCommittedBlocks_PopulatesCommittedTableForReference(t *testing.T)
 	a.EqualValues(0, target.TargetOffset)
 	a.EqualValues(100, target.TargetLength)
 	a.EqualValues("etag-xyz", target.ETag)
+}
+
+func TestRecordCommittedBlocks_RecordsCRCOnlyCandidates(t *testing.T) {
+	a := assert.New(t)
+	jobID := common.NewJobID()
+	defer clearDedupeStateForJob(jobID)
+
+	plan := &SourceGridPlan{Blocks: []PlannedBlock{
+		{Offset: 0, Size: 37, CRC64: 10, HasCRC64: true},
+		{Offset: 37, Size: 513, CRC64: 20, HasCRC64: true},
+		{Offset: 550, Size: 19},
+	}}
+	recorded := recordCommittedBlocks(
+		jobID,
+		"https://acct.blob.core.windows.net/c/migrated",
+		"?sig=secret",
+		azcore.ETag(`"etag-crc-only"`),
+		plan,
+	)
+
+	a.Equal(2, recorded)
+	committed := dedupeStateForJob(jobID).committed
+	a.Equal(2, committed.Len())
+
+	first := committed.LookupByCRC64AndLength(10, 37)
+	if a.Len(first, 1) {
+		a.False(first[0].HasSHA256)
+		a.EqualValues(0, first[0].TargetOffset)
+		a.EqualValues(37, first[0].TargetLength)
+		a.Contains(first[0].TargetURI, "sig=secret")
+	}
+	second := committed.LookupByCRC64AndLength(20, 513)
+	if a.Len(second, 1) {
+		a.False(second[0].HasSHA256)
+		a.EqualValues(37, second[0].TargetOffset)
+	}
 }
 
 func TestRecordCommittedBlocks_NilPlanIsNoOp(t *testing.T) {
@@ -235,6 +388,21 @@ func TestDedupeJobStateCounters(t *testing.T) {
 	a.EqualValues(1, st.fallbackBlocks)
 	a.EqualValues(1, st.filesStarted)
 	a.EqualValues(1, st.filesCommitted)
+}
+
+func TestDedupeJobStateCRCDiscoveryCounters(t *testing.T) {
+	st := &dedupeJobState{}
+	blocks, bytes := st.addCRCDiscovery(&SourceGridPlan{Blocks: []PlannedBlock{
+		{Offset: 0, Size: 3, CRC64: 1, HasCRC64: true},
+		{Offset: 3, Size: 7},
+		{Offset: 10, Size: 2, CRC64: 2, HasCRC64: true},
+	}})
+
+	assert.EqualValues(t, 2, blocks)
+	assert.EqualValues(t, 5, bytes)
+	snapshot := st.progressSnapshot()
+	assert.EqualValues(t, 2, snapshot.crcDiscoveredBlocks)
+	assert.EqualValues(t, 5, snapshot.crcDiscoveredBytes)
 }
 
 func TestDedupeJobSummaryMessageEnforce(t *testing.T) {

--- a/ste/dedupeHashResolver.go
+++ b/ste/dedupeHashResolver.go
@@ -40,11 +40,22 @@ const (
 	dedupeGetBlobHashMaxRanges      = 256
 	dedupeGetBlobHashMaxHeaderBytes = 8192
 	dedupeGetBlobHashMaxBytes       = int64(4000 * 1024 * 1024)
+
+	// GetBlobHash hashes ranges sequentially on the service. The 10 GiB workload
+	// timed out with requests starting at 15 ranges, so cap requests at roughly
+	// half that failure floor while retaining protocol limits as validation.
+	dedupeGetBlobHashOperationalMaxRanges = 8
 )
 
 type dedupeRangeHasher interface {
-	HashSource(context.Context, azcore.ETag, []blockblob.BlobHashRange) (blockblob.GetBlobHashResponse, int, error)
-	HashTarget(context.Context, string, azcore.ETag, []blockblob.BlobHashRange) (blockblob.GetBlobHashResponse, int, error)
+	HashSource(context.Context, azcore.ETag, []blockblob.BlobHashRange) (dedupeRangeHashResult, error)
+	HashTarget(context.Context, string, azcore.ETag, []blockblob.BlobHashRange) (dedupeRangeHashResult, error)
+}
+
+type dedupeRangeHashResult struct {
+	response        blockblob.GetBlobHashResponse
+	attemptedRanges []blockblob.BlobHashRange
+	batches         int
 }
 
 type sdkDedupeRangeHasher struct {
@@ -78,7 +89,7 @@ func (h *sdkDedupeRangeHasher) HashSource(
 	ctx context.Context,
 	etag azcore.ETag,
 	ranges []blockblob.BlobHashRange,
-) (blockblob.GetBlobHashResponse, int, error) {
+) (dedupeRangeHashResult, error) {
 	return h.hashRanges(ctx, "source", h.source, etag, ranges, nil)
 }
 
@@ -87,10 +98,10 @@ func (h *sdkDedupeRangeHasher) HashTarget(
 	targetURI string,
 	etag azcore.ETag,
 	ranges []blockblob.BlobHashRange,
-) (blockblob.GetBlobHashResponse, int, error) {
+) (dedupeRangeHashResult, error) {
 	target, err := h.targetClient(targetURI)
 	if err != nil {
-		return blockblob.GetBlobHashResponse{}, 0, err
+		return dedupeRangeHashResult{}, err
 	}
 	return h.hashRanges(ctx, "target", target, etag, ranges, h.jptm.CpkInfo())
 }
@@ -118,16 +129,21 @@ func (h *sdkDedupeRangeHasher) hashRanges(
 	etag azcore.ETag,
 	ranges []blockblob.BlobHashRange,
 	cpkInfo *blob.CPKInfo,
-) (blockblob.GetBlobHashResponse, int, error) {
+) (dedupeRangeHashResult, error) {
 	batches, err := batchDedupeBlobHashRanges(ranges)
 	if err != nil {
-		return blockblob.GetBlobHashResponse{}, 0, err
+		return dedupeRangeHashResult{}, err
 	}
 
-	combined := blockblob.GetBlobHashResponse{
-		RangeHashes: make([]blockblob.BlobHashResult, 0, len(ranges)),
+	result := dedupeRangeHashResult{
+		response: blockblob.GetBlobHashResponse{
+			RangeHashes: make([]blockblob.BlobHashResult, 0, len(ranges)),
+		},
+		attemptedRanges: make([]blockblob.BlobHashRange, 0, len(ranges)),
 	}
-	for i, batch := range batches {
+	for _, batch := range batches {
+		result.attemptedRanges = append(result.attemptedRanges, batch...)
+		result.batches++
 		response, err := client.GetBlobHash(ctx, batch, &blockblob.GetBlobHashOptions{
 			AccessConditions: &blob.AccessConditions{
 				ModifiedAccessConditions: &blob.ModifiedAccessConditions{IfMatch: &etag},
@@ -135,21 +151,21 @@ func (h *sdkDedupeRangeHasher) hashRanges(
 			CPKInfo: cpkInfo,
 		})
 		if err != nil {
-			return blockblob.GetBlobHashResponse{}, i + 1, err
+			return result, err
 		}
 		if h.onResponse != nil {
 			h.onResponse(role, response)
 		}
-		combined.RangeHashes = append(combined.RangeHashes, response.RangeHashes...)
-		combined.ETag = response.ETag
-		combined.LastModified = response.LastModified
-		combined.BlobContentLength = response.BlobContentLength
-		combined.HashAlgorithm = response.HashAlgorithm
-		combined.RequestID = response.RequestID
-		combined.ClientRequestID = response.ClientRequestID
-		combined.Version = response.Version
+		result.response.RangeHashes = append(result.response.RangeHashes, response.RangeHashes...)
+		result.response.ETag = response.ETag
+		result.response.LastModified = response.LastModified
+		result.response.BlobContentLength = response.BlobContentLength
+		result.response.HashAlgorithm = response.HashAlgorithm
+		result.response.RequestID = response.RequestID
+		result.response.ClientRequestID = response.ClientRequestID
+		result.response.Version = response.Version
 	}
-	return combined, len(batches), nil
+	return result, nil
 }
 
 func batchDedupeBlobHashRanges(ranges []blockblob.BlobHashRange) ([][]blockblob.BlobHashRange, error) {
@@ -193,7 +209,7 @@ func batchDedupeBlobHashRanges(ranges []blockblob.BlobHashRange) ([][]blockblob.
 			serializedBytes++
 		}
 
-		if len(batch) == dedupeGetBlobHashMaxRanges ||
+		if len(batch) == dedupeGetBlobHashOperationalMaxRanges ||
 			headerBytes+serializedBytes > dedupeGetBlobHashMaxHeaderBytes ||
 			batchBytes > dedupeGetBlobHashMaxBytes-rnge.Count {
 			flush()
@@ -211,9 +227,25 @@ func batchDedupeBlobHashRanges(ranges []blockblob.BlobHashRange) ([][]blockblob.
 	return batches, nil
 }
 
+func attemptedDedupeHashRanges(
+	attempted []blockblob.BlobHashRange,
+	requested map[srcBlockKey]uint64,
+) map[srcBlockKey]uint64 {
+	matched := make(map[srcBlockKey]uint64, len(attempted))
+	for _, rnge := range attempted {
+		key := srcBlockKey{offset: rnge.Offset, size: rnge.Count}
+		if crc64, ok := requested[key]; ok {
+			matched[key] = crc64
+		}
+	}
+	return matched
+}
+
 type dedupeHashResolutionStats struct {
 	candidateBlocks          int
 	candidateOccurrences     int
+	newCandidateBlocks       int
+	newCandidateOccurrences  int
 	sourceHashRanges         int
 	sourceHashBatches        int
 	targetHashRanges         int
@@ -230,6 +262,62 @@ type dedupeTargetEpoch struct {
 	etag      azcore.ETag
 }
 
+type dedupeCandidateOccurrenceKey struct {
+	source       srcBlockKey
+	crc64        uint64
+	targetURI    string
+	targetOffset int64
+	targetLength int64
+	etag         azcore.ETag
+}
+
+func newDedupeCandidateOccurrenceKey(
+	source srcBlockKey,
+	candidate common.BlockEntry,
+) dedupeCandidateOccurrenceKey {
+	return dedupeCandidateOccurrenceKey{
+		source: source,
+		crc64:  candidate.CRC64,
+		// SAS rotation must not turn one target occurrence into multiple telemetry entries.
+		targetURI:    sanitizedDestForDedupe(candidate.TargetURI),
+		targetOffset: candidate.TargetOffset,
+		targetLength: candidate.TargetLength,
+		etag:         candidate.ETag,
+	}
+}
+
+type dedupeSourceHashCache struct {
+	hashes    map[srcBlockKey]srcBlockHashes
+	attempted map[srcBlockKey]struct{}
+	// These sets live with one source file and prevent committed-table generations from being recounted.
+	seenCandidateBlocks      map[srcBlockKey]struct{}
+	seenCandidateOccurrences map[dedupeCandidateOccurrenceKey]struct{}
+	invalid                  bool
+}
+
+func cloneDedupeSourceHashCache(cache dedupeSourceHashCache) dedupeSourceHashCache {
+	cloned := dedupeSourceHashCache{
+		hashes:                   make(map[srcBlockKey]srcBlockHashes, len(cache.hashes)),
+		attempted:                make(map[srcBlockKey]struct{}, len(cache.attempted)),
+		seenCandidateBlocks:      make(map[srcBlockKey]struct{}, len(cache.seenCandidateBlocks)),
+		seenCandidateOccurrences: make(map[dedupeCandidateOccurrenceKey]struct{}, len(cache.seenCandidateOccurrences)),
+		invalid:                  cache.invalid,
+	}
+	for key, hashes := range cache.hashes {
+		cloned.hashes[key] = hashes
+	}
+	for key := range cache.attempted {
+		cloned.attempted[key] = struct{}{}
+	}
+	for key := range cache.seenCandidateBlocks {
+		cloned.seenCandidateBlocks[key] = struct{}{}
+	}
+	for key := range cache.seenCandidateOccurrences {
+		cloned.seenCandidateOccurrences[key] = struct{}{}
+	}
+	return cloned
+}
+
 func resolveDedupeCandidateHashes(
 	ctx context.Context,
 	state *dedupeJobState,
@@ -238,14 +326,38 @@ func resolveDedupeCandidateHashes(
 	currentTargetURI string,
 	hasher dedupeRangeHasher,
 ) (map[srcBlockKey]srcBlockHashes, dedupeHashResolutionStats, error) {
-	index := make(map[srcBlockKey]srcBlockHashes)
+	cache, stats, err := resolveDedupeCandidateHashesIncremental(
+		ctx,
+		state,
+		plan,
+		sourceETag,
+		currentTargetURI,
+		hasher,
+		dedupeSourceHashCache{},
+	)
+	return cache.hashes, stats, err
+}
+
+func resolveDedupeCandidateHashesIncremental(
+	ctx context.Context,
+	state *dedupeJobState,
+	plan *SourceGridPlan,
+	sourceETag azcore.ETag,
+	currentTargetURI string,
+	hasher dedupeRangeHasher,
+	existing dedupeSourceHashCache,
+) (dedupeSourceHashCache, dedupeHashResolutionStats, error) {
+	cache := cloneDedupeSourceHashCache(existing)
 	stats := dedupeHashResolutionStats{}
 	if state == nil || plan == nil || hasher == nil {
-		return index, stats, nil
+		return cache, stats, nil
+	}
+	if cache.invalid {
+		return cache, stats, nil
 	}
 
 	candidatesBySource := make(map[srcBlockKey][]common.BlockEntry)
-	sourceCRC := make(map[srcBlockKey]uint64)
+	sourceRequested := make(map[srcBlockKey]uint64)
 	sourceRanges := make([]blockblob.BlobHashRange, 0)
 	for _, block := range plan.Blocks {
 		if !blockHasCRC64(block) {
@@ -268,47 +380,118 @@ func resolveDedupeCandidateHashes(
 		}
 		stats.candidateBlocks++
 		stats.candidateOccurrences += len(candidatesBySource[key])
-		sourceCRC[key] = block.CRC64
+		if _, seen := cache.seenCandidateBlocks[key]; !seen {
+			cache.seenCandidateBlocks[key] = struct{}{}
+			stats.newCandidateBlocks++
+		}
+		for _, candidate := range candidatesBySource[key] {
+			occurrence := newDedupeCandidateOccurrenceKey(key, candidate)
+			if _, seen := cache.seenCandidateOccurrences[occurrence]; seen {
+				continue
+			}
+			cache.seenCandidateOccurrences[occurrence] = struct{}{}
+			stats.newCandidateOccurrences++
+		}
+		if _, resolved := cache.hashes[key]; resolved {
+			continue
+		}
+		if _, attempted := cache.attempted[key]; attempted {
+			continue
+		}
+		sourceRequested[key] = block.CRC64
 		sourceRanges = append(sourceRanges, blockblob.BlobHashRange{Offset: block.Offset, Count: block.Size})
 	}
-	if len(sourceRanges) == 0 {
-		return index, stats, nil
-	}
-	if sourceETag == "" {
-		return index, stats, fmt.Errorf("source GetBlockList response did not include an ETag")
+	if len(candidatesBySource) == 0 {
+		return cache, stats, nil
 	}
 
-	sourceResponse, batches, err := hasher.HashSource(ctx, sourceETag, sourceRanges)
-	stats.sourceHashRanges = len(sourceRanges)
-	stats.sourceHashBatches = batches
-	if err != nil {
+	var resolutionErr error
+	if len(sourceRanges) > 0 {
+		if sourceETag == "" {
+			cache.hashes = make(map[srcBlockKey]srcBlockHashes)
+			cache.invalid = true
+			return cache, stats, fmt.Errorf("source GetBlockList response did not include an ETag")
+		}
+		sourceResult, err := hasher.HashSource(ctx, sourceETag, sourceRanges)
+		attemptedSourceRanges := attemptedDedupeHashRanges(
+			sourceResult.attemptedRanges,
+			sourceRequested,
+		)
+		stats.sourceHashRanges = len(attemptedSourceRanges)
+		stats.sourceHashBatches = sourceResult.batches
+		for key := range attemptedSourceRanges {
+			cache.attempted[key] = struct{}{}
+		}
 		if isDedupePreconditionFailure(err) {
 			stats.sourceEpochInvalidations++
+			cache.hashes = make(map[srcBlockKey]srcBlockHashes)
+			cache.invalid = true
+			return cache, stats, err
 		}
-		return index, stats, err
-	}
-	for _, result := range sourceResponse.RangeHashes {
-		if len(result.SHA256) != 32 {
-			return index, stats, fmt.Errorf(
-				"source GetBlobHash returned a %d-byte SHA256 for offset=%d count=%d",
-				len(result.SHA256), result.Offset, result.Count)
+		sourceResponseHashes := make(map[srcBlockKey][32]byte, len(sourceResult.response.RangeHashes))
+		invalidSourceRanges := make(map[srcBlockKey]struct{})
+		for _, result := range sourceResult.response.RangeHashes {
+			key := srcBlockKey{offset: result.Offset, size: result.Count}
+			_, requested := attemptedSourceRanges[key]
+			if !requested {
+				if resolutionErr == nil {
+					resolutionErr = fmt.Errorf(
+						"source GetBlobHash returned an unrequested range offset=%d count=%d",
+						result.Offset,
+						result.Count,
+					)
+				}
+				continue
+			}
+			if _, seen := sourceResponseHashes[key]; seen {
+				delete(sourceResponseHashes, key)
+				invalidSourceRanges[key] = struct{}{}
+				if resolutionErr == nil {
+					resolutionErr = fmt.Errorf(
+						"source GetBlobHash returned duplicate results for offset=%d count=%d",
+						result.Offset,
+						result.Count,
+					)
+				}
+				continue
+			}
+			if _, invalid := invalidSourceRanges[key]; invalid {
+				continue
+			}
+			if len(result.SHA256) != 32 {
+				invalidSourceRanges[key] = struct{}{}
+				if resolutionErr == nil {
+					resolutionErr = fmt.Errorf(
+						"source GetBlobHash returned a %d-byte SHA256 for offset=%d count=%d",
+						len(result.SHA256), result.Offset, result.Count)
+				}
+				continue
+			}
+			var sha [32]byte
+			copy(sha[:], result.SHA256)
+			sourceResponseHashes[key] = sha
 		}
-		var sha [32]byte
-		copy(sha[:], result.SHA256)
-		key := srcBlockKey{offset: result.Offset, size: result.Count}
-		crc64, requested := sourceCRC[key]
-		if !requested {
-			return index, stats, fmt.Errorf(
-				"source GetBlobHash returned an unrequested range offset=%d count=%d",
-				result.Offset,
-				result.Count,
+		resolvedThisCall := make(map[srcBlockKey]struct{}, len(sourceResponseHashes))
+		for key, sha := range sourceResponseHashes {
+			crc64 := attemptedSourceRanges[key]
+			cache.hashes[key] = srcBlockHashes{crc64: crc64, sha256: sha}
+			resolvedThisCall[key] = struct{}{}
+		}
+		if err != nil {
+			resolutionErr = err
+		} else if len(resolvedThisCall) != len(attemptedSourceRanges) && resolutionErr == nil {
+			resolutionErr = fmt.Errorf(
+				"source GetBlobHash omitted %d requested range(s)",
+				len(attemptedSourceRanges)-len(resolvedThisCall),
 			)
 		}
-		index[key] = srcBlockHashes{crc64: crc64, sha256: sha}
 	}
 
 	targetRanges := make(map[dedupeTargetEpoch]map[srcBlockKey]uint64)
-	for _, candidates := range candidatesBySource {
+	for sourceKey, candidates := range candidatesBySource {
+		if _, resolved := cache.hashes[sourceKey]; !resolved {
+			continue
+		}
 		for _, candidate := range candidates {
 			epoch := dedupeTargetEpoch{targetURI: candidate.TargetURI, etag: candidate.ETag}
 			if targetRanges[epoch] == nil {
@@ -333,8 +516,15 @@ func resolveDedupeCandidateHashes(
 	})
 
 	for _, epoch := range epochs {
+		if ctx.Err() != nil {
+			break
+		}
 		epochLock := state.targetHashEpochLock(epoch)
 		epochLock.Lock()
+		if ctx.Err() != nil {
+			epochLock.Unlock()
+			break
+		}
 
 		unknownRanges := make(map[srcBlockKey]uint64)
 		for key, crc64 := range targetRanges[epoch] {
@@ -349,6 +539,9 @@ func resolveDedupeCandidateHashes(
 			}
 			if candidate.HasSHA256 {
 				stats.targetHashCacheHits++
+				continue
+			}
+			if state.targetHashRangeFailed(epoch, key) {
 				continue
 			}
 			stats.targetHashCacheMisses++
@@ -373,49 +566,87 @@ func resolveDedupeCandidateHashes(
 		for i, key := range keys {
 			ranges[i] = blockblob.BlobHashRange{Offset: key.offset, Count: key.size}
 		}
+		if ctx.Err() != nil {
+			epochLock.Unlock()
+			break
+		}
 
-		response, batches, err := hasher.HashTarget(ctx, epoch.targetURI, epoch.etag, ranges)
-		stats.targetHashRanges += len(ranges)
-		stats.targetHashBatches += batches
-		if err != nil {
-			if isDedupePreconditionFailure(err) {
-				stats.targetEpochInvalidations++
-				state.committed.RemoveTargetEpoch(epoch.targetURI, epoch.etag)
-			} else {
-				stats.targetHashFailures++
-			}
+		targetResult, err := hasher.HashTarget(ctx, epoch.targetURI, epoch.etag, ranges)
+		attemptedTargetRanges := attemptedDedupeHashRanges(
+			targetResult.attemptedRanges,
+			unknownRanges,
+		)
+		stats.targetHashRanges += len(attemptedTargetRanges)
+		stats.targetHashBatches += targetResult.batches
+		requestAttempted := len(attemptedTargetRanges) > 0
+		if requestAttempted && isDedupePreconditionFailure(err) {
+			stats.targetEpochInvalidations++
+			state.committed.RemoveTargetEpoch(epoch.targetURI, epoch.etag)
+			state.clearTargetHashFailures(epoch)
 			epochLock.Unlock()
 			continue
 		}
 
-		for _, result := range response.RangeHashes {
-			if len(result.SHA256) != 32 {
-				stats.targetHashFailures++
-				continue
-			}
-			var sha [32]byte
-			copy(sha[:], result.SHA256)
+		targetResponseHashes := make(map[srcBlockKey][32]byte, len(targetResult.response.RangeHashes))
+		invalidTargetRanges := make(map[srcBlockKey]struct{})
+		for _, result := range targetResult.response.RangeHashes {
 			key := srcBlockKey{offset: result.Offset, size: result.Count}
-			crc64, requested := unknownRanges[key]
+			_, requested := attemptedTargetRanges[key]
 			if !requested {
 				stats.targetHashFailures++
 				continue
 			}
+			if _, seen := targetResponseHashes[key]; seen {
+				delete(targetResponseHashes, key)
+				invalidTargetRanges[key] = struct{}{}
+				continue
+			}
+			if _, invalid := invalidTargetRanges[key]; invalid {
+				continue
+			}
+			if len(result.SHA256) != 32 {
+				invalidTargetRanges[key] = struct{}{}
+				continue
+			}
+			var sha [32]byte
+			copy(sha[:], result.SHA256)
+			targetResponseHashes[key] = sha
+		}
+
+		resolvedTargetRanges := make(map[srcBlockKey]struct{}, len(targetResponseHashes))
+		for key, sha := range targetResponseHashes {
+			crc64 := attemptedTargetRanges[key]
 			if !state.committed.SetSHA256ForCRC64(
 				crc64,
 				epoch.targetURI,
-				result.Offset,
-				result.Count,
+				key.offset,
+				key.size,
 				epoch.etag,
 				sha,
 			) {
-				stats.targetHashFailures++
+				continue
 			}
+			resolvedTargetRanges[key] = struct{}{}
+		}
+
+		failedRanges := make([]srcBlockKey, 0, len(attemptedTargetRanges)-len(resolvedTargetRanges))
+		for key := range attemptedTargetRanges {
+			if _, resolved := resolvedTargetRanges[key]; !resolved {
+				failedRanges = append(failedRanges, key)
+			}
+		}
+		if requestAttempted {
+			state.markTargetHashRangesFailed(epoch, failedRanges)
+		}
+		if err != nil {
+			stats.targetHashFailures++
+		} else {
+			stats.targetHashFailures += len(failedRanges)
 		}
 		epochLock.Unlock()
 	}
 
-	return index, stats, nil
+	return cache, stats, resolutionErr
 }
 
 func exactDedupeTargetOccurrence(
@@ -442,6 +673,9 @@ func applyResolvedSourceHashes(plan *SourceGridPlan, index map[srcBlockKey]srcBl
 		key := srcBlockKey{offset: plan.Blocks[i].Offset, size: plan.Blocks[i].Size}
 		hashes, ok := index[key]
 		if !ok {
+			plan.Blocks[i].SHA256 = [32]byte{}
+			plan.Blocks[i].HasSHA256 = false
+			plan.Blocks[i].HasHashes = false
 			continue
 		}
 		plan.Blocks[i].SHA256 = hashes.sha256

--- a/ste/dedupeHashResolver.go
+++ b/ste/dedupeHashResolver.go
@@ -1,0 +1,456 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ste
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"net/http"
+	"sort"
+	"strconv"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
+
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+)
+
+const (
+	dedupeGetBlobHashMaxRanges      = 256
+	dedupeGetBlobHashMaxHeaderBytes = 8192
+	dedupeGetBlobHashMaxBytes       = int64(4000 * 1024 * 1024)
+)
+
+type dedupeRangeHasher interface {
+	HashSource(context.Context, azcore.ETag, []blockblob.BlobHashRange) (blockblob.GetBlobHashResponse, int, error)
+	HashTarget(context.Context, string, azcore.ETag, []blockblob.BlobHashRange) (blockblob.GetBlobHashResponse, int, error)
+}
+
+type sdkDedupeRangeHasher struct {
+	jptm       IJobPartTransferMgr
+	source     *blockblob.Client
+	onResponse func(string, blockblob.GetBlobHashResponse)
+}
+
+func newSDKDedupeRangeHasher(
+	jptm IJobPartTransferMgr,
+	onResponse func(string, blockblob.GetBlobHashResponse),
+) (*sdkDedupeRangeHasher, error) {
+	info := jptm.Info()
+	sourceService, err := jptm.SrcServiceClient().BlobServiceClient()
+	if err != nil {
+		return nil, err
+	}
+	source := sourceService.NewContainerClient(info.SrcContainer).NewBlockBlobClient(info.SrcFilePath)
+	source, err = sourceBlockBlobClientForTransfer(source, info)
+	if err != nil {
+		return nil, err
+	}
+	return &sdkDedupeRangeHasher{
+		jptm:       jptm,
+		source:     source,
+		onResponse: onResponse,
+	}, nil
+}
+
+func (h *sdkDedupeRangeHasher) HashSource(
+	ctx context.Context,
+	etag azcore.ETag,
+	ranges []blockblob.BlobHashRange,
+) (blockblob.GetBlobHashResponse, int, error) {
+	return h.hashRanges(ctx, "source", h.source, etag, ranges, nil)
+}
+
+func (h *sdkDedupeRangeHasher) HashTarget(
+	ctx context.Context,
+	targetURI string,
+	etag azcore.ETag,
+	ranges []blockblob.BlobHashRange,
+) (blockblob.GetBlobHashResponse, int, error) {
+	target, err := h.targetClient(targetURI)
+	if err != nil {
+		return blockblob.GetBlobHashResponse{}, 0, err
+	}
+	return h.hashRanges(ctx, "target", target, etag, ranges, h.jptm.CpkInfo())
+}
+
+func (h *sdkDedupeRangeHasher) targetClient(targetURI string) (*blockblob.Client, error) {
+	parts, err := blob.ParseURL(targetURI)
+	if err != nil {
+		return nil, fmt.Errorf("parse dedupe target URL: %w", err)
+	}
+	if parts.ContainerName == "" || parts.BlobName == "" {
+		return nil, fmt.Errorf("dedupe target URL does not identify a blob")
+	}
+
+	destinationService, err := h.jptm.DstServiceClient().BlobServiceClient()
+	if err != nil {
+		return nil, err
+	}
+	return destinationService.NewContainerClient(parts.ContainerName).NewBlockBlobClient(parts.BlobName), nil
+}
+
+func (h *sdkDedupeRangeHasher) hashRanges(
+	ctx context.Context,
+	role string,
+	client *blockblob.Client,
+	etag azcore.ETag,
+	ranges []blockblob.BlobHashRange,
+	cpkInfo *blob.CPKInfo,
+) (blockblob.GetBlobHashResponse, int, error) {
+	batches, err := batchDedupeBlobHashRanges(ranges)
+	if err != nil {
+		return blockblob.GetBlobHashResponse{}, 0, err
+	}
+
+	combined := blockblob.GetBlobHashResponse{
+		RangeHashes: make([]blockblob.BlobHashResult, 0, len(ranges)),
+	}
+	for i, batch := range batches {
+		response, err := client.GetBlobHash(ctx, batch, &blockblob.GetBlobHashOptions{
+			AccessConditions: &blob.AccessConditions{
+				ModifiedAccessConditions: &blob.ModifiedAccessConditions{IfMatch: &etag},
+			},
+			CPKInfo: cpkInfo,
+		})
+		if err != nil {
+			return blockblob.GetBlobHashResponse{}, i + 1, err
+		}
+		if h.onResponse != nil {
+			h.onResponse(role, response)
+		}
+		combined.RangeHashes = append(combined.RangeHashes, response.RangeHashes...)
+		combined.ETag = response.ETag
+		combined.LastModified = response.LastModified
+		combined.BlobContentLength = response.BlobContentLength
+		combined.HashAlgorithm = response.HashAlgorithm
+		combined.RequestID = response.RequestID
+		combined.ClientRequestID = response.ClientRequestID
+		combined.Version = response.Version
+	}
+	return combined, len(batches), nil
+}
+
+func batchDedupeBlobHashRanges(ranges []blockblob.BlobHashRange) ([][]blockblob.BlobHashRange, error) {
+	if len(ranges) == 0 {
+		return nil, nil
+	}
+
+	var batches [][]blockblob.BlobHashRange
+	var batch []blockblob.BlobHashRange
+	headerBytes := len("bytes=")
+	var batchBytes int64
+	var previousEnd int64
+
+	flush := func() {
+		if len(batch) == 0 {
+			return
+		}
+		batches = append(batches, batch)
+		batch = nil
+		headerBytes = len("bytes=")
+		batchBytes = 0
+	}
+
+	for i, rnge := range ranges {
+		if rnge.Offset < 0 || rnge.Count <= 0 ||
+			rnge.Count > dedupeGetBlobHashMaxBytes ||
+			rnge.Offset > math.MaxInt64-(rnge.Count-1) {
+			return nil, fmt.Errorf("invalid GetBlobHash range %d: offset=%d count=%d", i, rnge.Offset, rnge.Count)
+		}
+		end := rnge.Offset + rnge.Count - 1
+		if i > 0 && rnge.Offset <= previousEnd {
+			return nil, fmt.Errorf(
+				"GetBlobHash range %d is unsorted or overlaps the preceding range",
+				i,
+			)
+		}
+		serializedBytes := len(strconv.FormatInt(rnge.Offset, 10)) +
+			1 +
+			len(strconv.FormatInt(end, 10))
+		if len(batch) > 0 {
+			serializedBytes++
+		}
+
+		if len(batch) == dedupeGetBlobHashMaxRanges ||
+			headerBytes+serializedBytes > dedupeGetBlobHashMaxHeaderBytes ||
+			batchBytes > dedupeGetBlobHashMaxBytes-rnge.Count {
+			flush()
+			serializedBytes = len(strconv.FormatInt(rnge.Offset, 10)) +
+				1 +
+				len(strconv.FormatInt(end, 10))
+		}
+
+		batch = append(batch, rnge)
+		headerBytes += serializedBytes
+		batchBytes += rnge.Count
+		previousEnd = end
+	}
+	flush()
+	return batches, nil
+}
+
+type dedupeHashResolutionStats struct {
+	candidateBlocks          int
+	candidateOccurrences     int
+	sourceHashRanges         int
+	sourceHashBatches        int
+	targetHashRanges         int
+	targetHashBatches        int
+	targetHashCacheHits      int
+	targetHashCacheMisses    int
+	targetHashFailures       int
+	sourceEpochInvalidations int
+	targetEpochInvalidations int
+}
+
+type dedupeTargetEpoch struct {
+	targetURI string
+	etag      azcore.ETag
+}
+
+func resolveDedupeCandidateHashes(
+	ctx context.Context,
+	state *dedupeJobState,
+	plan *SourceGridPlan,
+	sourceETag azcore.ETag,
+	currentTargetURI string,
+	hasher dedupeRangeHasher,
+) (map[srcBlockKey]srcBlockHashes, dedupeHashResolutionStats, error) {
+	index := make(map[srcBlockKey]srcBlockHashes)
+	stats := dedupeHashResolutionStats{}
+	if state == nil || plan == nil || hasher == nil {
+		return index, stats, nil
+	}
+
+	candidatesBySource := make(map[srcBlockKey][]common.BlockEntry)
+	sourceCRC := make(map[srcBlockKey]uint64)
+	sourceRanges := make([]blockblob.BlobHashRange, 0)
+	for _, block := range plan.Blocks {
+		if !blockHasCRC64(block) {
+			continue
+		}
+
+		key := srcBlockKey{offset: block.Offset, size: block.Size}
+		for _, candidate := range state.committed.LookupByCRC64AndLength(block.CRC64, block.Size) {
+			if candidate.TargetURI == "" ||
+				candidate.TargetOffset < 0 ||
+				candidate.TargetLength != block.Size ||
+				candidate.ETag == "" ||
+				sameDedupeTarget(candidate.TargetURI, currentTargetURI) {
+				continue
+			}
+			candidatesBySource[key] = append(candidatesBySource[key], candidate)
+		}
+		if len(candidatesBySource[key]) == 0 {
+			continue
+		}
+		stats.candidateBlocks++
+		stats.candidateOccurrences += len(candidatesBySource[key])
+		sourceCRC[key] = block.CRC64
+		sourceRanges = append(sourceRanges, blockblob.BlobHashRange{Offset: block.Offset, Count: block.Size})
+	}
+	if len(sourceRanges) == 0 {
+		return index, stats, nil
+	}
+	if sourceETag == "" {
+		return index, stats, fmt.Errorf("source GetBlockList response did not include an ETag")
+	}
+
+	sourceResponse, batches, err := hasher.HashSource(ctx, sourceETag, sourceRanges)
+	stats.sourceHashRanges = len(sourceRanges)
+	stats.sourceHashBatches = batches
+	if err != nil {
+		if isDedupePreconditionFailure(err) {
+			stats.sourceEpochInvalidations++
+		}
+		return index, stats, err
+	}
+	for _, result := range sourceResponse.RangeHashes {
+		if len(result.SHA256) != 32 {
+			return index, stats, fmt.Errorf(
+				"source GetBlobHash returned a %d-byte SHA256 for offset=%d count=%d",
+				len(result.SHA256), result.Offset, result.Count)
+		}
+		var sha [32]byte
+		copy(sha[:], result.SHA256)
+		key := srcBlockKey{offset: result.Offset, size: result.Count}
+		crc64, requested := sourceCRC[key]
+		if !requested {
+			return index, stats, fmt.Errorf(
+				"source GetBlobHash returned an unrequested range offset=%d count=%d",
+				result.Offset,
+				result.Count,
+			)
+		}
+		index[key] = srcBlockHashes{crc64: crc64, sha256: sha}
+	}
+
+	targetRanges := make(map[dedupeTargetEpoch]map[srcBlockKey]uint64)
+	for _, candidates := range candidatesBySource {
+		for _, candidate := range candidates {
+			epoch := dedupeTargetEpoch{targetURI: candidate.TargetURI, etag: candidate.ETag}
+			if targetRanges[epoch] == nil {
+				targetRanges[epoch] = make(map[srcBlockKey]uint64)
+			}
+			targetRanges[epoch][srcBlockKey{
+				offset: candidate.TargetOffset,
+				size:   candidate.TargetLength,
+			}] = candidate.CRC64
+		}
+	}
+
+	epochs := make([]dedupeTargetEpoch, 0, len(targetRanges))
+	for epoch := range targetRanges {
+		epochs = append(epochs, epoch)
+	}
+	sort.Slice(epochs, func(i, j int) bool {
+		if epochs[i].targetURI == epochs[j].targetURI {
+			return epochs[i].etag < epochs[j].etag
+		}
+		return epochs[i].targetURI < epochs[j].targetURI
+	})
+
+	for _, epoch := range epochs {
+		epochLock := state.targetHashEpochLock(epoch)
+		epochLock.Lock()
+
+		unknownRanges := make(map[srcBlockKey]uint64)
+		for key, crc64 := range targetRanges[epoch] {
+			candidate, found := exactDedupeTargetOccurrence(
+				state.committed,
+				crc64,
+				epoch,
+				key,
+			)
+			if !found {
+				continue
+			}
+			if candidate.HasSHA256 {
+				stats.targetHashCacheHits++
+				continue
+			}
+			stats.targetHashCacheMisses++
+			unknownRanges[key] = crc64
+		}
+
+		keys := make([]srcBlockKey, 0, len(unknownRanges))
+		for key := range unknownRanges {
+			keys = append(keys, key)
+		}
+		if len(keys) == 0 {
+			epochLock.Unlock()
+			continue
+		}
+		sort.Slice(keys, func(i, j int) bool {
+			if keys[i].offset == keys[j].offset {
+				return keys[i].size < keys[j].size
+			}
+			return keys[i].offset < keys[j].offset
+		})
+		ranges := make([]blockblob.BlobHashRange, len(keys))
+		for i, key := range keys {
+			ranges[i] = blockblob.BlobHashRange{Offset: key.offset, Count: key.size}
+		}
+
+		response, batches, err := hasher.HashTarget(ctx, epoch.targetURI, epoch.etag, ranges)
+		stats.targetHashRanges += len(ranges)
+		stats.targetHashBatches += batches
+		if err != nil {
+			if isDedupePreconditionFailure(err) {
+				stats.targetEpochInvalidations++
+				state.committed.RemoveTargetEpoch(epoch.targetURI, epoch.etag)
+			} else {
+				stats.targetHashFailures++
+			}
+			epochLock.Unlock()
+			continue
+		}
+
+		for _, result := range response.RangeHashes {
+			if len(result.SHA256) != 32 {
+				stats.targetHashFailures++
+				continue
+			}
+			var sha [32]byte
+			copy(sha[:], result.SHA256)
+			key := srcBlockKey{offset: result.Offset, size: result.Count}
+			crc64, requested := unknownRanges[key]
+			if !requested {
+				stats.targetHashFailures++
+				continue
+			}
+			if !state.committed.SetSHA256ForCRC64(
+				crc64,
+				epoch.targetURI,
+				result.Offset,
+				result.Count,
+				epoch.etag,
+				sha,
+			) {
+				stats.targetHashFailures++
+			}
+		}
+		epochLock.Unlock()
+	}
+
+	return index, stats, nil
+}
+
+func exactDedupeTargetOccurrence(
+	table *common.DedupeHashTable,
+	crc64 uint64,
+	epoch dedupeTargetEpoch,
+	key srcBlockKey,
+) (common.BlockEntry, bool) {
+	for _, candidate := range table.LookupByCRC64AndLength(crc64, key.size) {
+		if candidate.TargetURI == epoch.targetURI &&
+			candidate.ETag == epoch.etag &&
+			candidate.TargetOffset == key.offset {
+			return candidate, true
+		}
+	}
+	return common.BlockEntry{}, false
+}
+
+func applyResolvedSourceHashes(plan *SourceGridPlan, index map[srcBlockKey]srcBlockHashes) {
+	if plan == nil {
+		return
+	}
+	for i := range plan.Blocks {
+		key := srcBlockKey{offset: plan.Blocks[i].Offset, size: plan.Blocks[i].Size}
+		hashes, ok := index[key]
+		if !ok {
+			continue
+		}
+		plan.Blocks[i].SHA256 = hashes.sha256
+		plan.Blocks[i].HasSHA256 = true
+		plan.Blocks[i].HasHashes = blockHasCRC64(plan.Blocks[i])
+	}
+}
+
+func isDedupePreconditionFailure(err error) bool {
+	var responseError *azcore.ResponseError
+	return errors.As(err, &responseError) && responseError.StatusCode == http.StatusPreconditionFailed
+}

--- a/ste/dedupeHashResolver.go
+++ b/ste/dedupeHashResolver.go
@@ -250,8 +250,8 @@ type dedupeHashResolutionStats struct {
 	sourceHashBatches        int
 	targetHashRanges         int
 	targetHashBatches        int
-	targetHashCacheHits      int
-	targetHashCacheMisses    int
+	targetSHAIndexHits       int
+	targetSHAIndexMisses     int
 	targetHashFailures       int
 	sourceEpochInvalidations int
 	targetEpochInvalidations int
@@ -286,7 +286,7 @@ func newDedupeCandidateOccurrenceKey(
 	}
 }
 
-type dedupeSourceHashCache struct {
+type dedupeSourceHashResolutionState struct {
 	hashes    map[srcBlockKey]srcBlockHashes
 	attempted map[srcBlockKey]struct{}
 	// These sets live with one source file and prevent committed-table generations from being recounted.
@@ -295,24 +295,26 @@ type dedupeSourceHashCache struct {
 	invalid                  bool
 }
 
-func cloneDedupeSourceHashCache(cache dedupeSourceHashCache) dedupeSourceHashCache {
-	cloned := dedupeSourceHashCache{
-		hashes:                   make(map[srcBlockKey]srcBlockHashes, len(cache.hashes)),
-		attempted:                make(map[srcBlockKey]struct{}, len(cache.attempted)),
-		seenCandidateBlocks:      make(map[srcBlockKey]struct{}, len(cache.seenCandidateBlocks)),
-		seenCandidateOccurrences: make(map[dedupeCandidateOccurrenceKey]struct{}, len(cache.seenCandidateOccurrences)),
-		invalid:                  cache.invalid,
+func cloneDedupeSourceHashResolutionState(
+	state dedupeSourceHashResolutionState,
+) dedupeSourceHashResolutionState {
+	cloned := dedupeSourceHashResolutionState{
+		hashes:                   make(map[srcBlockKey]srcBlockHashes, len(state.hashes)),
+		attempted:                make(map[srcBlockKey]struct{}, len(state.attempted)),
+		seenCandidateBlocks:      make(map[srcBlockKey]struct{}, len(state.seenCandidateBlocks)),
+		seenCandidateOccurrences: make(map[dedupeCandidateOccurrenceKey]struct{}, len(state.seenCandidateOccurrences)),
+		invalid:                  state.invalid,
 	}
-	for key, hashes := range cache.hashes {
+	for key, hashes := range state.hashes {
 		cloned.hashes[key] = hashes
 	}
-	for key := range cache.attempted {
+	for key := range state.attempted {
 		cloned.attempted[key] = struct{}{}
 	}
-	for key := range cache.seenCandidateBlocks {
+	for key := range state.seenCandidateBlocks {
 		cloned.seenCandidateBlocks[key] = struct{}{}
 	}
-	for key := range cache.seenCandidateOccurrences {
+	for key := range state.seenCandidateOccurrences {
 		cloned.seenCandidateOccurrences[key] = struct{}{}
 	}
 	return cloned
@@ -326,16 +328,16 @@ func resolveDedupeCandidateHashes(
 	currentTargetURI string,
 	hasher dedupeRangeHasher,
 ) (map[srcBlockKey]srcBlockHashes, dedupeHashResolutionStats, error) {
-	cache, stats, err := resolveDedupeCandidateHashesIncremental(
+	sourceState, stats, err := resolveDedupeCandidateHashesIncremental(
 		ctx,
 		state,
 		plan,
 		sourceETag,
 		currentTargetURI,
 		hasher,
-		dedupeSourceHashCache{},
+		dedupeSourceHashResolutionState{},
 	)
-	return cache.hashes, stats, err
+	return sourceState.hashes, stats, err
 }
 
 func resolveDedupeCandidateHashesIncremental(
@@ -345,15 +347,15 @@ func resolveDedupeCandidateHashesIncremental(
 	sourceETag azcore.ETag,
 	currentTargetURI string,
 	hasher dedupeRangeHasher,
-	existing dedupeSourceHashCache,
-) (dedupeSourceHashCache, dedupeHashResolutionStats, error) {
-	cache := cloneDedupeSourceHashCache(existing)
+	existing dedupeSourceHashResolutionState,
+) (dedupeSourceHashResolutionState, dedupeHashResolutionStats, error) {
+	sourceState := cloneDedupeSourceHashResolutionState(existing)
 	stats := dedupeHashResolutionStats{}
 	if state == nil || plan == nil || hasher == nil {
-		return cache, stats, nil
+		return sourceState, stats, nil
 	}
-	if cache.invalid {
-		return cache, stats, nil
+	if sourceState.invalid {
+		return sourceState, stats, nil
 	}
 
 	candidatesBySource := make(map[srcBlockKey][]common.BlockEntry)
@@ -380,37 +382,37 @@ func resolveDedupeCandidateHashesIncremental(
 		}
 		stats.candidateBlocks++
 		stats.candidateOccurrences += len(candidatesBySource[key])
-		if _, seen := cache.seenCandidateBlocks[key]; !seen {
-			cache.seenCandidateBlocks[key] = struct{}{}
+		if _, seen := sourceState.seenCandidateBlocks[key]; !seen {
+			sourceState.seenCandidateBlocks[key] = struct{}{}
 			stats.newCandidateBlocks++
 		}
 		for _, candidate := range candidatesBySource[key] {
 			occurrence := newDedupeCandidateOccurrenceKey(key, candidate)
-			if _, seen := cache.seenCandidateOccurrences[occurrence]; seen {
+			if _, seen := sourceState.seenCandidateOccurrences[occurrence]; seen {
 				continue
 			}
-			cache.seenCandidateOccurrences[occurrence] = struct{}{}
+			sourceState.seenCandidateOccurrences[occurrence] = struct{}{}
 			stats.newCandidateOccurrences++
 		}
-		if _, resolved := cache.hashes[key]; resolved {
+		if _, resolved := sourceState.hashes[key]; resolved {
 			continue
 		}
-		if _, attempted := cache.attempted[key]; attempted {
+		if _, attempted := sourceState.attempted[key]; attempted {
 			continue
 		}
 		sourceRequested[key] = block.CRC64
 		sourceRanges = append(sourceRanges, blockblob.BlobHashRange{Offset: block.Offset, Count: block.Size})
 	}
 	if len(candidatesBySource) == 0 {
-		return cache, stats, nil
+		return sourceState, stats, nil
 	}
 
 	var resolutionErr error
 	if len(sourceRanges) > 0 {
 		if sourceETag == "" {
-			cache.hashes = make(map[srcBlockKey]srcBlockHashes)
-			cache.invalid = true
-			return cache, stats, fmt.Errorf("source GetBlockList response did not include an ETag")
+			sourceState.hashes = make(map[srcBlockKey]srcBlockHashes)
+			sourceState.invalid = true
+			return sourceState, stats, fmt.Errorf("source GetBlockList response did not include an ETag")
 		}
 		sourceResult, err := hasher.HashSource(ctx, sourceETag, sourceRanges)
 		attemptedSourceRanges := attemptedDedupeHashRanges(
@@ -420,13 +422,13 @@ func resolveDedupeCandidateHashesIncremental(
 		stats.sourceHashRanges = len(attemptedSourceRanges)
 		stats.sourceHashBatches = sourceResult.batches
 		for key := range attemptedSourceRanges {
-			cache.attempted[key] = struct{}{}
+			sourceState.attempted[key] = struct{}{}
 		}
 		if isDedupePreconditionFailure(err) {
 			stats.sourceEpochInvalidations++
-			cache.hashes = make(map[srcBlockKey]srcBlockHashes)
-			cache.invalid = true
-			return cache, stats, err
+			sourceState.hashes = make(map[srcBlockKey]srcBlockHashes)
+			sourceState.invalid = true
+			return sourceState, stats, err
 		}
 		sourceResponseHashes := make(map[srcBlockKey][32]byte, len(sourceResult.response.RangeHashes))
 		invalidSourceRanges := make(map[srcBlockKey]struct{})
@@ -474,7 +476,7 @@ func resolveDedupeCandidateHashesIncremental(
 		resolvedThisCall := make(map[srcBlockKey]struct{}, len(sourceResponseHashes))
 		for key, sha := range sourceResponseHashes {
 			crc64 := attemptedSourceRanges[key]
-			cache.hashes[key] = srcBlockHashes{crc64: crc64, sha256: sha}
+			sourceState.hashes[key] = srcBlockHashes{crc64: crc64, sha256: sha}
 			resolvedThisCall[key] = struct{}{}
 		}
 		if err != nil {
@@ -489,7 +491,7 @@ func resolveDedupeCandidateHashesIncremental(
 
 	targetRanges := make(map[dedupeTargetEpoch]map[srcBlockKey]uint64)
 	for sourceKey, candidates := range candidatesBySource {
-		if _, resolved := cache.hashes[sourceKey]; !resolved {
+		if _, resolved := sourceState.hashes[sourceKey]; !resolved {
 			continue
 		}
 		for _, candidate := range candidates {
@@ -538,13 +540,13 @@ func resolveDedupeCandidateHashesIncremental(
 				continue
 			}
 			if candidate.HasSHA256 {
-				stats.targetHashCacheHits++
+				stats.targetSHAIndexHits++
 				continue
 			}
 			if state.targetHashRangeFailed(epoch, key) {
 				continue
 			}
-			stats.targetHashCacheMisses++
+			stats.targetSHAIndexMisses++
 			unknownRanges[key] = crc64
 		}
 
@@ -646,7 +648,7 @@ func resolveDedupeCandidateHashesIncremental(
 		epochLock.Unlock()
 	}
 
-	return cache, stats, resolutionErr
+	return sourceState, stats, resolutionErr
 }
 
 func exactDedupeTargetOccurrence(

--- a/ste/dedupeHashResolver_test.go
+++ b/ste/dedupeHashResolver_test.go
@@ -471,7 +471,7 @@ func crcOnlyBlock(offset, size int64, crc uint64) PlannedBlock {
 }
 
 func newDedupeBatchCancellationFixture(
-	cacheTargetSHA bool,
+	indexTargetSHA bool,
 ) (
 	*SourceGridPlan,
 	*SourceGridPlan,
@@ -490,7 +490,7 @@ func newDedupeBatchCancellationFixture(
 		hash := sha256.Sum256([]byte(fmt.Sprintf("batch-range-%d", i)))
 		sourceBlocks[i] = crcOnlyBlock(sourceOffset, 1, crc64)
 		targetBlocks[i] = crcOnlyBlock(targetOffset, 1, crc64)
-		if cacheTargetSHA {
+		if indexTargetSHA {
 			targetBlocks[i].SHA256 = hash
 			targetBlocks[i].HasSHA256 = true
 			targetBlocks[i].HasHashes = true
@@ -696,8 +696,8 @@ func TestResolveDedupeCandidateHashesMatchesByRangeNotResultOrder(t *testing.T) 
 	assert.Equal(t, 2, stats.candidateOccurrences)
 	assert.Equal(t, 2, stats.newCandidateBlocks)
 	assert.Equal(t, 2, stats.newCandidateOccurrences)
-	assert.Zero(t, stats.targetHashCacheHits)
-	assert.Equal(t, 2, stats.targetHashCacheMisses)
+	assert.Zero(t, stats.targetSHAIndexHits)
+	assert.Equal(t, 2, stats.targetSHAIndexMisses)
 	assert.Equal(t, 1, hasher.sourceCalls)
 	assert.Equal(t, 1, hasher.targetCalls)
 	assert.Equal(t, []blockblob.BlobHashRange{{Offset: 0, Count: 3}, {Offset: 3, Count: 7}}, hasher.sourceRanges)
@@ -710,8 +710,8 @@ func TestResolveDedupeCandidateHashesMatchesByRangeNotResultOrder(t *testing.T) 
 	assert.False(t, hit)
 }
 
-func TestResolveDedupeCandidateHashesReusesCachedTargetSHA(t *testing.T) {
-	hash := sha256.Sum256([]byte("cached"))
+func TestResolveDedupeCandidateHashesReusesIndexedTargetSHA(t *testing.T) {
+	hash := sha256.Sum256([]byte("indexed"))
 	targetURI := "https://acct.blob.core.windows.net/c/previous"
 	state := &dedupeJobState{committed: common.NewDedupeHashTable()}
 	state.committed.Insert(common.BlockEntry{
@@ -741,8 +741,8 @@ func TestResolveDedupeCandidateHashesReusesCachedTargetSHA(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, hasher.sourceCalls)
 	assert.Zero(t, hasher.targetCalls)
-	assert.Equal(t, 1, stats.targetHashCacheHits)
-	assert.Zero(t, stats.targetHashCacheMisses)
+	assert.Equal(t, 1, stats.targetSHAIndexHits)
+	assert.Zero(t, stats.targetSHAIndexMisses)
 	_, hit := decideStaging(index, state.committed, 0, 3, "https://acct.blob.core.windows.net/c/current")
 	assert.True(t, hit)
 }
@@ -946,33 +946,33 @@ func TestResolveDedupeCandidateHashesPreservesPartialSourceResults(t *testing.T)
 		crcOnlyBlock(3, 7, 20),
 	}}
 
-	cache, stats, err := resolveDedupeCandidateHashesIncremental(
+	sourceState, stats, err := resolveDedupeCandidateHashesIncremental(
 		context.Background(),
 		state,
 		plan,
 		azcore.ETag(`"source"`),
 		"https://acct.blob.core.windows.net/c/current",
 		hasher,
-		dedupeSourceHashCache{},
+		dedupeSourceHashResolutionState{},
 	)
 
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Len(t, cache.hashes, 1)
+	assert.Len(t, sourceState.hashes, 1)
 	assert.Equal(t, 2, stats.sourceHashRanges)
 	assert.Equal(t, []blockblob.BlobHashRange{{Offset: 100, Count: 3}}, hasher.targetRanges[targetURI])
-	_, firstHit := decideStaging(cache.hashes, state.committed, 0, 3, "https://acct.blob.core.windows.net/c/current")
-	_, secondHit := decideStaging(cache.hashes, state.committed, 3, 7, "https://acct.blob.core.windows.net/c/current")
+	_, firstHit := decideStaging(sourceState.hashes, state.committed, 0, 3, "https://acct.blob.core.windows.net/c/current")
+	_, secondHit := decideStaging(sourceState.hashes, state.committed, 3, 7, "https://acct.blob.core.windows.net/c/current")
 	assert.True(t, firstHit)
 	assert.False(t, secondHit)
 
-	cache, _, err = resolveDedupeCandidateHashesIncremental(
+	sourceState, _, err = resolveDedupeCandidateHashesIncremental(
 		context.Background(),
 		state,
 		plan,
 		azcore.ETag(`"source"`),
 		"https://acct.blob.core.windows.net/c/current",
 		hasher,
-		cache,
+		sourceState,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, hasher.sourceCalls)
@@ -1021,14 +1021,14 @@ func TestResolveDedupeCandidateHashesPreservesPartialTargetResults(t *testing.T)
 		crcOnlyBlock(3, 7, 20),
 	}}
 
-	cache, stats, err := resolveDedupeCandidateHashesIncremental(
+	sourceState, stats, err := resolveDedupeCandidateHashesIncremental(
 		context.Background(),
 		state,
 		plan,
 		azcore.ETag(`"source"`),
 		"https://acct.blob.core.windows.net/c/current",
 		hasher,
-		dedupeSourceHashCache{},
+		dedupeSourceHashResolutionState{},
 	)
 
 	assert.NoError(t, err)
@@ -1042,19 +1042,19 @@ func TestResolveDedupeCandidateHashesPreservesPartialTargetResults(t *testing.T)
 	if assert.Len(t, second, 1) {
 		assert.False(t, second[0].HasSHA256)
 	}
-	_, firstHit := decideStaging(cache.hashes, state.committed, 0, 3, "https://acct.blob.core.windows.net/c/current")
-	_, secondHit := decideStaging(cache.hashes, state.committed, 3, 7, "https://acct.blob.core.windows.net/c/current")
+	_, firstHit := decideStaging(sourceState.hashes, state.committed, 0, 3, "https://acct.blob.core.windows.net/c/current")
+	_, secondHit := decideStaging(sourceState.hashes, state.committed, 3, 7, "https://acct.blob.core.windows.net/c/current")
 	assert.True(t, firstHit)
 	assert.False(t, secondHit)
 
-	cache, _, err = resolveDedupeCandidateHashesIncremental(
+	sourceState, _, err = resolveDedupeCandidateHashesIncremental(
 		context.Background(),
 		state,
 		plan,
 		azcore.ETag(`"source"`),
 		"https://acct.blob.core.windows.net/c/current",
 		hasher,
-		cache,
+		sourceState,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, hasher.sourceCalls)

--- a/ste/dedupeHashResolver_test.go
+++ b/ste/dedupeHashResolver_test.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -219,6 +220,46 @@ func TestSDKDedupeRangeHasherWireContractAndCPUCallback(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, encryptionKey, headerValueFold(transport.request.Header, "x-ms-encryption-key"))
 	assert.Equal(t, encryptionKeySHA256, headerValueFold(transport.request.Header, "x-ms-encryption-key-sha256"))
+}
+
+func TestDedupeResolutionAllowsOneResolverWithoutBlockingSiblings(t *testing.T) {
+	copier := &urlToBlockBlobCopier{
+		blockBlobSenderBase: blockBlobSenderBase{
+			dedupeResolveDone: make(chan struct{}),
+		},
+	}
+	const workers = 32
+
+	start := make(chan struct{})
+	results := make(chan bool, workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			<-start
+			results <- copier.tryStartDedupeResolution()
+		}()
+	}
+	close(start)
+
+	owners := 0
+	for i := 0; i < workers; i++ {
+		if <-results {
+			owners++
+		}
+	}
+	assert.Equal(t, 1, owners)
+	assert.Equal(t, dedupeResolveInProgress, copier.dedupeResolutionState())
+
+	started := time.Now()
+	assert.False(t, copier.ensureDedupeHashesResolved(nil))
+	assert.Less(t, time.Since(started), 100*time.Millisecond)
+
+	copier.finishDedupeResolution()
+	assert.Equal(t, dedupeResolveComplete, copier.dedupeResolutionState())
+	select {
+	case <-copier.dedupeResolveDone:
+	default:
+		t.Fatal("resolution completion channel was not closed")
+	}
 }
 
 func TestResolveDedupeCandidateHashesNoCRCHitAvoidsSHA(t *testing.T) {

--- a/ste/dedupeHashResolver_test.go
+++ b/ste/dedupeHashResolver_test.go
@@ -121,6 +121,35 @@ func (t *dedupeHashPartialTransport) snapshotRequests() []*http.Request {
 	return append([]*http.Request(nil), t.requests...)
 }
 
+type dedupeStageWireTransport struct {
+	mu       sync.Mutex
+	requests []*http.Request
+}
+
+func (t *dedupeStageWireTransport) Do(req *http.Request) (*http.Response, error) {
+	t.mu.Lock()
+	cloned := req.Clone(req.Context())
+	cloned.Header = req.Header.Clone()
+	t.requests = append(t.requests, cloned)
+	t.mu.Unlock()
+
+	headers := http.Header{}
+	headers.Set("x-ms-request-id", "stage-request")
+	return &http.Response{
+		Request:    req,
+		StatusCode: http.StatusCreated,
+		Status:     "201 Created",
+		Header:     headers,
+		Body:       io.NopCloser(strings.NewReader("")),
+	}, nil
+}
+
+func (t *dedupeStageWireTransport) snapshotRequests() []*http.Request {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return append([]*http.Request(nil), t.requests...)
+}
+
 func headerValueFold(header http.Header, name string) string {
 	for headerName, values := range header {
 		if strings.EqualFold(headerName, name) && len(values) > 0 {
@@ -152,13 +181,17 @@ type fakeDedupeRangeHasher struct {
 
 type dedupeResolutionTestTransferManager struct {
 	*testJobPartTransferManager
-	ctx context.Context
+	ctx           context.Context
+	contextCalled chan<- struct{}
 }
 
 func (m *dedupeResolutionTestTransferManager) LogAtLevelForCurrentTransfer(common.LogLevel, string) {
 }
 
 func (m *dedupeResolutionTestTransferManager) Context() context.Context {
+	if m.contextCalled != nil {
+		m.contextCalled <- struct{}{}
+	}
 	if m.ctx != nil {
 		return m.ctx
 	}
@@ -1161,6 +1194,271 @@ func newDedupeResolutionTestCopier(
 		dedupeETag:   azcore.ETag(`"source"`),
 		dedupeHasher: hasher,
 	}}
+}
+
+type concurrentDedupeStageFixture struct {
+	state       *dedupeJobState
+	copier      *urlToBlockBlobCopier
+	hasher      *fakeDedupeRangeHasher
+	transport   *dedupeStageWireTransport
+	sourcePlan  *SourceGridPlan
+	targetURI   string
+	hashStarted chan struct{}
+	hashRelease chan struct{}
+	contextUsed chan struct{}
+}
+
+func newConcurrentDedupeStageFixture(
+	t *testing.T,
+	mode dedupeActMode,
+	blockCount int,
+) concurrentDedupeStageFixture {
+	t.Helper()
+
+	jobID := common.NewJobID()
+	t.Cleanup(func() {
+		clearDedupeStateForJob(jobID)
+	})
+
+	const blockSize = int64(3)
+	targetURI := "https://dest.blob.core.windows.net/c/target"
+	sourcePlan := &SourceGridPlan{Blocks: make([]PlannedBlock, blockCount)}
+	targetPlan := &SourceGridPlan{Blocks: make([]PlannedBlock, blockCount)}
+	sourceHashes := make(map[srcBlockKey][32]byte, blockCount)
+	targetHashes := make(map[srcBlockKey][32]byte, blockCount)
+	for i := 0; i < blockCount; i++ {
+		sourceOffset := int64(i) * blockSize
+		targetOffset := int64(1000+i) * blockSize
+		crc := uint64(100 + i)
+		hash := sha256.Sum256([]byte(fmt.Sprintf("concurrent-block-%d", i)))
+		sourcePlan.Blocks[i] = crcOnlyBlock(sourceOffset, blockSize, crc)
+		targetPlan.Blocks[i] = crcOnlyBlock(targetOffset, blockSize, crc)
+		sourceHashes[srcBlockKey{offset: sourceOffset, size: blockSize}] = hash
+		targetHashes[srcBlockKey{offset: targetOffset, size: blockSize}] = hash
+	}
+
+	hashStarted := make(chan struct{}, 1)
+	hashRelease := make(chan struct{})
+	hasher := &fakeDedupeRangeHasher{
+		sourceHashes:  sourceHashes,
+		targetHashes:  map[string]map[srcBlockKey][32]byte{targetURI: targetHashes},
+		targetErr:     make(map[string]error),
+		sourceStarted: hashStarted,
+		sourceRelease: hashRelease,
+	}
+	copier := newDedupeResolutionTestCopier(jobID, sourcePlan, hasher)
+	copier.dedupeMode = mode
+	contextUsed := make(chan struct{}, blockCount*4+4)
+	copier.jptm.(*dedupeResolutionTestTransferManager).contextCalled = contextUsed
+	transport := &dedupeStageWireTransport{}
+	client, err := blockblob.NewClientWithNoCredential(
+		"https://dest.blob.core.windows.net/c/current",
+		&blockblob.ClientOptions{ClientOptions: policy.ClientOptions{
+			Transport: transport,
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	copier.destBlockBlobClient = client
+
+	if recorded := recordCommittedBlocks(
+		jobID,
+		targetURI,
+		"",
+		azcore.ETag(`"target"`),
+		targetPlan,
+	); recorded != blockCount {
+		t.Fatalf("recorded %d committed blocks, want %d", recorded, blockCount)
+	}
+
+	return concurrentDedupeStageFixture{
+		state:       dedupeStateForJob(jobID),
+		copier:      copier,
+		hasher:      hasher,
+		transport:   transport,
+		sourcePlan:  sourcePlan,
+		targetURI:   targetURI,
+		hashStarted: hashStarted,
+		hashRelease: hashRelease,
+		contextUsed: contextUsed,
+	}
+}
+
+type dedupeStageResult struct {
+	blockIndex int
+	handled    bool
+}
+
+func startDedupeStage(
+	copier *urlToBlockBlobCopier,
+	block PlannedBlock,
+	blockIndex int,
+	results chan<- dedupeStageResult,
+) {
+	encodedBlockID := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("block-%d", blockIndex)))
+	handled := copier.tryDedupeStage(
+		common.NewChunkID("current", block.Offset, block.Size),
+		int32(blockIndex),
+		encodedBlockID,
+		block.Size,
+	)
+	results <- dedupeStageResult{blockIndex: blockIndex, handled: handled}
+}
+
+func waitForDedupeStageResults(
+	t *testing.T,
+	results <-chan dedupeStageResult,
+	count int,
+) []dedupeStageResult {
+	t.Helper()
+	collected := make([]dedupeStageResult, 0, count)
+	for len(collected) < count {
+		select {
+		case result := <-results:
+			collected = append(collected, result)
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for dedupe stage result %d/%d", len(collected), count)
+		}
+	}
+	return collected
+}
+
+func waitForDedupeContextCalls(t *testing.T, calls <-chan struct{}, count int) {
+	t.Helper()
+	for i := 0; i < count; i++ {
+		select {
+		case <-calls:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for dedupe context call %d/%d", i, count)
+		}
+	}
+}
+
+func TestTryDedupeStageEnforceWaitersReusePublishedHashes(t *testing.T) {
+	const blockCount = 17
+	fixture := newConcurrentDedupeStageFixture(t, dedupeActEnforce, blockCount)
+	results := make(chan dedupeStageResult, blockCount)
+
+	go startDedupeStage(fixture.copier, fixture.sourcePlan.Blocks[0], 0, results)
+	select {
+	case <-fixture.hashStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for hash resolution to start")
+	}
+	waitForDedupeContextCalls(t, fixture.contextUsed, 1)
+	for i := 1; i < blockCount; i++ {
+		go startDedupeStage(fixture.copier, fixture.sourcePlan.Blocks[i], i, results)
+	}
+	waitForDedupeContextCalls(t, fixture.contextUsed, blockCount-1)
+	close(fixture.hashRelease)
+
+	seen := make([]bool, blockCount)
+	for _, result := range waitForDedupeStageResults(t, results, blockCount) {
+		assert.True(t, result.handled, "block %d should reuse the published target hash", result.blockIndex)
+		seen[result.blockIndex] = true
+	}
+	assert.NotContains(t, seen, false)
+	assert.Equal(t, 1, fixture.hasher.sourceCalls)
+	assert.Equal(t, 1, fixture.hasher.targetCalls)
+	assert.Len(t, fixture.hasher.sourceRanges, blockCount)
+	assert.Len(t, fixture.hasher.targetRanges[fixture.targetURI], blockCount)
+	requests := fixture.transport.snapshotRequests()
+	assert.Len(t, requests, blockCount)
+	expectedRanges := make(map[string]int, blockCount)
+	for i := range fixture.sourcePlan.Blocks {
+		targetOffset := int64(1000+i) * fixture.sourcePlan.Blocks[i].Size
+		expectedRanges[fmt.Sprintf("bytes=%d-%d", targetOffset, targetOffset+fixture.sourcePlan.Blocks[i].Size-1)]++
+	}
+	for _, request := range requests {
+		assert.Equal(t, fixture.targetURI, headerValueFold(request.Header, "x-ms-copy-source"))
+		sourceRange := headerValueFold(request.Header, "x-ms-source-range")
+		assert.Positive(t, expectedRanges[sourceRange], "unexpected or duplicate source range %q", sourceRange)
+		expectedRanges[sourceRange]--
+	}
+	for sourceRange, remaining := range expectedRanges {
+		assert.Zero(t, remaining, "source range %q was not reused", sourceRange)
+	}
+	assert.EqualValues(t, blockCount, fixture.state.progressSnapshot().referencedBlocks)
+}
+
+func TestTryDedupeStageWaiterCancellationDoesNotDeadlock(t *testing.T) {
+	fixture := newConcurrentDedupeStageFixture(t, dedupeActEnforce, 2)
+	ctx, cancel := context.WithCancel(context.Background())
+	fixture.copier.jptm.(*dedupeResolutionTestTransferManager).ctx = ctx
+	results := make(chan dedupeStageResult, 2)
+
+	go startDedupeStage(fixture.copier, fixture.sourcePlan.Blocks[0], 0, results)
+	select {
+	case <-fixture.hashStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for hash resolution to start")
+	}
+	waitForDedupeContextCalls(t, fixture.contextUsed, 1)
+	go startDedupeStage(fixture.copier, fixture.sourcePlan.Blocks[1], 1, results)
+	waitForDedupeContextCalls(t, fixture.contextUsed, 1)
+	cancel()
+
+	select {
+	case result := <-results:
+		assert.Equal(t, 1, result.blockIndex)
+		assert.False(t, result.handled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("canceled dedupe waiter did not unblock")
+	}
+	assert.Empty(t, fixture.transport.snapshotRequests())
+
+	close(fixture.hashRelease)
+	owner := waitForDedupeStageResults(t, results, 1)[0]
+	assert.Equal(t, 0, owner.blockIndex)
+	assert.False(t, owner.handled)
+}
+
+func TestTryDedupeStageResolutionTimeoutFallsBackToSource(t *testing.T) {
+	fixture := newConcurrentDedupeStageFixture(t, dedupeActEnforce, 1)
+	fixture.hasher.sourceRelease = nil
+	fixture.hasher.sourceErr = context.DeadlineExceeded
+
+	results := make(chan dedupeStageResult, 1)
+	go startDedupeStage(fixture.copier, fixture.sourcePlan.Blocks[0], 0, results)
+	result := waitForDedupeStageResults(t, results, 1)[0]
+
+	assert.False(t, result.handled)
+	assert.Equal(t, 1, fixture.hasher.sourceCalls)
+	assert.Zero(t, fixture.hasher.targetCalls)
+	assert.Empty(t, fixture.transport.snapshotRequests())
+	_, resolveErr := fixture.copier.dedupeResolutionSnapshot()
+	assert.ErrorIs(t, resolveErr, context.DeadlineExceeded)
+}
+
+func TestTryDedupeStageShadowWaitersStillObservePublishedHashes(t *testing.T) {
+	const blockCount = 17
+	fixture := newConcurrentDedupeStageFixture(t, dedupeActShadow, blockCount)
+	results := make(chan dedupeStageResult, blockCount)
+
+	go startDedupeStage(fixture.copier, fixture.sourcePlan.Blocks[0], 0, results)
+	select {
+	case <-fixture.hashStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for hash resolution to start")
+	}
+	waitForDedupeContextCalls(t, fixture.contextUsed, 1)
+	for i := 1; i < blockCount; i++ {
+		go startDedupeStage(fixture.copier, fixture.sourcePlan.Blocks[i], i, results)
+	}
+	waitForDedupeContextCalls(t, fixture.contextUsed, blockCount-1)
+	close(fixture.hashRelease)
+
+	for _, result := range waitForDedupeStageResults(t, results, blockCount) {
+		assert.False(t, result.handled)
+	}
+	assert.Equal(t, 1, fixture.hasher.sourceCalls)
+	assert.Equal(t, 1, fixture.hasher.targetCalls)
+	assert.Empty(t, fixture.transport.snapshotRequests())
+	snapshot := fixture.state.progressSnapshot()
+	assert.EqualValues(t, blockCount, snapshot.wouldReferenceBlocks)
+	assert.Zero(t, snapshot.referencedBlocks)
 }
 
 func TestDedupeResolutionReconsidersNewCommittedCandidates(t *testing.T) {

--- a/ste/dedupeHashResolver_test.go
+++ b/ste/dedupeHashResolver_test.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
+	"fmt"
 	"io"
 	"net/http"
 	"strconv"
@@ -70,6 +71,56 @@ func (t *dedupeHashWireTransport) Do(req *http.Request) (*http.Response, error) 
 	}, nil
 }
 
+type dedupeHashPartialTransport struct {
+	mu            sync.Mutex
+	requests      []*http.Request
+	successRanges []blockblob.BlobHashRange
+}
+
+func (t *dedupeHashPartialTransport) Do(req *http.Request) (*http.Response, error) {
+	t.mu.Lock()
+	cloned := req.Clone(req.Context())
+	cloned.Header = req.Header.Clone()
+	t.requests = append(t.requests, cloned)
+	call := len(t.requests)
+	t.mu.Unlock()
+
+	if call == 2 {
+		return nil, context.DeadlineExceeded
+	}
+
+	var body strings.Builder
+	body.WriteString("<RangeHashList>")
+	for _, rnge := range t.successRanges {
+		hash := sha256.Sum256([]byte(fmt.Sprintf("%d:%d", rnge.Offset, rnge.Count)))
+		fmt.Fprintf(
+			&body,
+			"<RangeHash><Offset>%d</Offset><Length>%d</Length><Sha256>%s</Sha256></RangeHash>",
+			rnge.Offset,
+			rnge.Count,
+			base64.StdEncoding.EncodeToString(hash[:]),
+		)
+	}
+	body.WriteString("</RangeHashList>")
+
+	headers := http.Header{}
+	headers.Set("Content-Type", "application/xml")
+	headers.Set("x-ms-request-id", "partial-hash-request")
+	return &http.Response{
+		Request:    req,
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Header:     headers,
+		Body:       io.NopCloser(strings.NewReader(body.String())),
+	}, nil
+}
+
+func (t *dedupeHashPartialTransport) snapshotRequests() []*http.Request {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return append([]*http.Request(nil), t.requests...)
+}
+
 func headerValueFold(header http.Header, name string) string {
 	for headerName, values := range header {
 		if strings.EqualFold(headerName, name) && len(values) > 0 {
@@ -85,66 +136,295 @@ type fakeDedupeRangeHasher struct {
 	sourceCalls int
 	targetCalls int
 
-	sourceRanges []blockblob.BlobHashRange
-	targetRanges map[string][]blockblob.BlobHashRange
-	sourceHashes map[srcBlockKey][32]byte
-	targetHashes map[string]map[srcBlockKey][32]byte
-	sourceErr    error
-	targetErr    map[string]error
+	sourceRanges     []blockblob.BlobHashRange
+	targetRanges     map[string][]blockblob.BlobHashRange
+	targetCallCounts map[string]int
+	sourceHashes     map[srcBlockKey][32]byte
+	targetHashes     map[string]map[srcBlockKey][32]byte
+	sourceErr        error
+	targetErr        map[string]error
+
+	sourceResponse  *blockblob.GetBlobHashResponse
+	targetResponses map[string]blockblob.GetBlobHashResponse
+	sourceStarted   chan<- struct{}
+	sourceRelease   <-chan struct{}
+}
+
+type dedupeResolutionTestTransferManager struct {
+	*testJobPartTransferManager
+	ctx context.Context
+}
+
+func (m *dedupeResolutionTestTransferManager) LogAtLevelForCurrentTransfer(common.LogLevel, string) {
+}
+
+func (m *dedupeResolutionTestTransferManager) Context() context.Context {
+	if m.ctx != nil {
+		return m.ctx
+	}
+	return context.Background()
 }
 
 func (h *fakeDedupeRangeHasher) HashSource(
 	_ context.Context,
 	_ azcore.ETag,
 	ranges []blockblob.BlobHashRange,
-) (blockblob.GetBlobHashResponse, int, error) {
+) (dedupeRangeHashResult, error) {
 	h.mu.Lock()
-	defer h.mu.Unlock()
 	h.sourceCalls++
 	h.sourceRanges = append([]blockblob.BlobHashRange(nil), ranges...)
-	if h.sourceErr != nil {
-		return blockblob.GetBlobHashResponse{}, 1, h.sourceErr
+	response := h.sourceResponse
+	err := h.sourceErr
+	started := h.sourceStarted
+	release := h.sourceRelease
+	sourceHashes := h.sourceHashes
+	h.mu.Unlock()
+
+	if started != nil {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+	}
+	if release != nil {
+		<-release
+	}
+	if response != nil {
+		return dedupeRangeHashResult{
+			response:        *response,
+			attemptedRanges: append([]blockblob.BlobHashRange(nil), ranges...),
+			batches:         1,
+		}, err
+	}
+	if err != nil {
+		return dedupeRangeHashResult{
+			attemptedRanges: append([]blockblob.BlobHashRange(nil), ranges...),
+			batches:         1,
+		}, err
 	}
 	results := make([]blockblob.BlobHashResult, 0, len(ranges))
 	for i := len(ranges) - 1; i >= 0; i-- {
 		rnge := ranges[i]
-		hash := h.sourceHashes[srcBlockKey{offset: rnge.Offset, size: rnge.Count}]
+		hash := sourceHashes[srcBlockKey{offset: rnge.Offset, size: rnge.Count}]
 		results = append(results, blockblob.BlobHashResult{
 			Offset: rnge.Offset,
 			Count:  rnge.Count,
 			SHA256: append([]byte(nil), hash[:]...),
 		})
 	}
-	return blockblob.GetBlobHashResponse{RangeHashes: results}, 1, nil
+	return dedupeRangeHashResult{
+		response:        blockblob.GetBlobHashResponse{RangeHashes: results},
+		attemptedRanges: append([]blockblob.BlobHashRange(nil), ranges...),
+		batches:         1,
+	}, nil
 }
 
 func (h *fakeDedupeRangeHasher) HashTarget(
-	_ context.Context,
+	ctx context.Context,
 	targetURI string,
 	_ azcore.ETag,
 	ranges []blockblob.BlobHashRange,
-) (blockblob.GetBlobHashResponse, int, error) {
+) (dedupeRangeHashResult, error) {
+	contextErr := ctx.Err()
 	h.mu.Lock()
-	defer h.mu.Unlock()
 	h.targetCalls++
 	if h.targetRanges == nil {
 		h.targetRanges = make(map[string][]blockblob.BlobHashRange)
 	}
+	if h.targetCallCounts == nil {
+		h.targetCallCounts = make(map[string]int)
+	}
 	h.targetRanges[targetURI] = append([]blockblob.BlobHashRange(nil), ranges...)
-	if err := h.targetErr[targetURI]; err != nil {
-		return blockblob.GetBlobHashResponse{}, 1, err
+	h.targetCallCounts[targetURI]++
+	response, hasResponse := h.targetResponses[targetURI]
+	err := h.targetErr[targetURI]
+	targetHashes := h.targetHashes[targetURI]
+	h.mu.Unlock()
+
+	if contextErr != nil {
+		return dedupeRangeHashResult{}, contextErr
+	}
+	if hasResponse {
+		return dedupeRangeHashResult{
+			response:        response,
+			attemptedRanges: append([]blockblob.BlobHashRange(nil), ranges...),
+			batches:         1,
+		}, err
+	}
+	if err != nil {
+		return dedupeRangeHashResult{
+			attemptedRanges: append([]blockblob.BlobHashRange(nil), ranges...),
+			batches:         1,
+		}, err
 	}
 	results := make([]blockblob.BlobHashResult, 0, len(ranges))
 	for i := len(ranges) - 1; i >= 0; i-- {
 		rnge := ranges[i]
-		hash := h.targetHashes[targetURI][srcBlockKey{offset: rnge.Offset, size: rnge.Count}]
+		hash := targetHashes[srcBlockKey{offset: rnge.Offset, size: rnge.Count}]
 		results = append(results, blockblob.BlobHashResult{
 			Offset: rnge.Offset,
 			Count:  rnge.Count,
 			SHA256: append([]byte(nil), hash[:]...),
 		})
 	}
-	return blockblob.GetBlobHashResponse{RangeHashes: results}, 1, nil
+	return dedupeRangeHashResult{
+		response:        blockblob.GetBlobHashResponse{RangeHashes: results},
+		attemptedRanges: append([]blockblob.BlobHashRange(nil), ranges...),
+		batches:         1,
+	}, nil
+}
+
+func (h *fakeDedupeRangeHasher) targetCallCount(targetURI string) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.targetCallCounts[targetURI]
+}
+
+type cancelAfterTargetHasher struct {
+	*fakeDedupeRangeHasher
+	targetURI string
+	cancel    context.CancelFunc
+	once      sync.Once
+}
+
+func (h *cancelAfterTargetHasher) HashTarget(
+	ctx context.Context,
+	targetURI string,
+	etag azcore.ETag,
+	ranges []blockblob.BlobHashRange,
+) (dedupeRangeHashResult, error) {
+	result, err := h.fakeDedupeRangeHasher.HashTarget(ctx, targetURI, etag, ranges)
+	if targetURI == h.targetURI {
+		h.once.Do(h.cancel)
+	}
+	return result, err
+}
+
+type cancelSecondBatchDedupeRangeHasher struct {
+	mu sync.Mutex
+
+	cancelRole string
+	cancel     context.CancelFunc
+
+	sourceCalls    int
+	targetCalls    int
+	sourceRequests [][]blockblob.BlobHashRange
+	targetRequests map[string][][]blockblob.BlobHashRange
+	sourceHashes   map[srcBlockKey][32]byte
+	targetHashes   map[string]map[srcBlockKey][32]byte
+}
+
+func (h *cancelSecondBatchDedupeRangeHasher) HashSource(
+	ctx context.Context,
+	_ azcore.ETag,
+	ranges []blockblob.BlobHashRange,
+) (dedupeRangeHashResult, error) {
+	h.mu.Lock()
+	h.sourceCalls++
+	call := h.sourceCalls
+	h.sourceRequests = append(
+		h.sourceRequests,
+		append([]blockblob.BlobHashRange(nil), ranges...),
+	)
+	h.mu.Unlock()
+	return h.hash(ctx, "source", call, ranges, h.sourceHashes)
+}
+
+func (h *cancelSecondBatchDedupeRangeHasher) HashTarget(
+	ctx context.Context,
+	targetURI string,
+	_ azcore.ETag,
+	ranges []blockblob.BlobHashRange,
+) (dedupeRangeHashResult, error) {
+	h.mu.Lock()
+	h.targetCalls++
+	call := h.targetCalls
+	if h.targetRequests == nil {
+		h.targetRequests = make(map[string][][]blockblob.BlobHashRange)
+	}
+	h.targetRequests[targetURI] = append(
+		h.targetRequests[targetURI],
+		append([]blockblob.BlobHashRange(nil), ranges...),
+	)
+	hashes := h.targetHashes[targetURI]
+	h.mu.Unlock()
+	return h.hash(ctx, "target", call, ranges, hashes)
+}
+
+func (h *cancelSecondBatchDedupeRangeHasher) hash(
+	ctx context.Context,
+	role string,
+	call int,
+	ranges []blockblob.BlobHashRange,
+	hashes map[srcBlockKey][32]byte,
+) (dedupeRangeHashResult, error) {
+	batches, err := batchDedupeBlobHashRanges(ranges)
+	if err != nil {
+		return dedupeRangeHashResult{}, err
+	}
+	if role == h.cancelRole && call == 1 {
+		if len(batches) < 3 {
+			return dedupeRangeHashResult{}, fmt.Errorf(
+				"cancel-second-batch test requires at least three batches",
+			)
+		}
+		attempted := append([]blockblob.BlobHashRange(nil), batches[0]...)
+		attempted = append(attempted, batches[1]...)
+		h.cancel()
+		return dedupeRangeHashResult{
+			response:        dedupeHashResponseForRanges(batches[0], hashes),
+			attemptedRanges: attempted,
+			batches:         2,
+		}, ctx.Err()
+	}
+	return dedupeRangeHashResult{
+		response:        dedupeHashResponseForRanges(ranges, hashes),
+		attemptedRanges: append([]blockblob.BlobHashRange(nil), ranges...),
+		batches:         len(batches),
+	}, nil
+}
+
+func dedupeHashResponseForRanges(
+	ranges []blockblob.BlobHashRange,
+	hashes map[srcBlockKey][32]byte,
+) blockblob.GetBlobHashResponse {
+	results := make([]blockblob.BlobHashResult, 0, len(ranges))
+	for _, rnge := range ranges {
+		hash := hashes[srcBlockKey{offset: rnge.Offset, size: rnge.Count}]
+		results = append(results, blockblob.BlobHashResult{
+			Offset: rnge.Offset,
+			Count:  rnge.Count,
+			SHA256: append([]byte(nil), hash[:]...),
+		})
+	}
+	return blockblob.GetBlobHashResponse{RangeHashes: results}
+}
+
+func (h *cancelSecondBatchDedupeRangeHasher) sourceRequest(call int) []blockblob.BlobHashRange {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]blockblob.BlobHashRange(nil), h.sourceRequests[call]...)
+}
+
+func (h *cancelSecondBatchDedupeRangeHasher) sourceRequestCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.sourceRequests)
+}
+
+func (h *cancelSecondBatchDedupeRangeHasher) targetRequest(
+	targetURI string,
+	call int,
+) []blockblob.BlobHashRange {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]blockblob.BlobHashRange(nil), h.targetRequests[targetURI][call]...)
+}
+
+func (h *cancelSecondBatchDedupeRangeHasher) targetRequestCount(targetURI string) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.targetRequests[targetURI])
 }
 
 func crcOnlyBlock(offset, size int64, crc uint64) PlannedBlock {
@@ -155,6 +435,40 @@ func crcOnlyBlock(offset, size int64, crc uint64) PlannedBlock {
 		HasCRC64:  true,
 		HasSHA256: false,
 	}
+}
+
+func newDedupeBatchCancellationFixture(
+	cacheTargetSHA bool,
+) (
+	*SourceGridPlan,
+	*SourceGridPlan,
+	map[srcBlockKey][32]byte,
+	map[srcBlockKey][32]byte,
+) {
+	count := 2*dedupeGetBlobHashOperationalMaxRanges + 1
+	sourceBlocks := make([]PlannedBlock, count)
+	targetBlocks := make([]PlannedBlock, count)
+	sourceHashes := make(map[srcBlockKey][32]byte, count)
+	targetHashes := make(map[srcBlockKey][32]byte, count)
+	for i := 0; i < count; i++ {
+		crc64 := uint64(i + 1)
+		sourceOffset := int64(i * 2)
+		targetOffset := int64(1000 + i*2)
+		hash := sha256.Sum256([]byte(fmt.Sprintf("batch-range-%d", i)))
+		sourceBlocks[i] = crcOnlyBlock(sourceOffset, 1, crc64)
+		targetBlocks[i] = crcOnlyBlock(targetOffset, 1, crc64)
+		if cacheTargetSHA {
+			targetBlocks[i].SHA256 = hash
+			targetBlocks[i].HasSHA256 = true
+			targetBlocks[i].HasHashes = true
+		}
+		sourceHashes[srcBlockKey{offset: sourceOffset, size: 1}] = hash
+		targetHashes[srcBlockKey{offset: targetOffset, size: 1}] = hash
+	}
+	return &SourceGridPlan{Blocks: sourceBlocks},
+		&SourceGridPlan{Blocks: targetBlocks},
+		sourceHashes,
+		targetHashes
 }
 
 func TestSDKDedupeRangeHasherWireContractAndCPUCallback(t *testing.T) {
@@ -175,7 +489,7 @@ func TestSDKDedupeRangeHasherWireContractAndCPUCallback(t *testing.T) {
 		},
 	}
 	ranges := []blockblob.BlobHashRange{{Offset: 0, Count: 3}, {Offset: 10, Count: 7}}
-	response, batches, err := hasher.hashRanges(
+	result, err := hasher.hashRanges(
 		context.Background(),
 		"source",
 		client,
@@ -185,8 +499,9 @@ func TestSDKDedupeRangeHasherWireContractAndCPUCallback(t *testing.T) {
 	)
 
 	assert.NoError(t, err)
-	assert.Equal(t, 1, batches)
-	assert.Len(t, response.RangeHashes, 2)
+	assert.Equal(t, 1, result.batches)
+	assert.Equal(t, ranges, result.attemptedRanges)
+	assert.Len(t, result.response.RangeHashes, 2)
 	assert.Equal(t, "source", callbackRole)
 	assert.Equal(t, int64(17), *callbackResponse.SHA256CPUTimeUS)
 	assert.Equal(t, "hash-request", *callbackResponse.RequestID)
@@ -205,7 +520,7 @@ func TestSDKDedupeRangeHasherWireContractAndCPUCallback(t *testing.T) {
 	algorithm := blob.EncryptionAlgorithmTypeAES256
 	encryptionKey := "destination-key"
 	encryptionKeySHA256 := "destination-key-sha256"
-	_, _, err = hasher.hashRanges(
+	_, err = hasher.hashRanges(
 		context.Background(),
 		"target",
 		client,
@@ -222,43 +537,44 @@ func TestSDKDedupeRangeHasherWireContractAndCPUCallback(t *testing.T) {
 	assert.Equal(t, encryptionKeySHA256, headerValueFold(transport.request.Header, "x-ms-encryption-key-sha256"))
 }
 
-func TestDedupeResolutionAllowsOneResolverWithoutBlockingSiblings(t *testing.T) {
-	copier := &urlToBlockBlobCopier{
-		blockBlobSenderBase: blockBlobSenderBase{
-			dedupeResolveDone: make(chan struct{}),
-		},
+func TestSDKDedupeRangeHasherPreservesSuccessfulBatchesOnLaterTimeout(t *testing.T) {
+	ranges := make([]blockblob.BlobHashRange, 2*dedupeGetBlobHashOperationalMaxRanges+1)
+	for i := range ranges {
+		ranges[i] = blockblob.BlobHashRange{Offset: int64(i * 2), Count: 1}
 	}
-	const workers = 32
+	transport := &dedupeHashPartialTransport{successRanges: ranges[:dedupeGetBlobHashOperationalMaxRanges]}
+	client, err := blockblob.NewClientWithNoCredential(
+		"https://acct.blob.core.windows.net/c/source",
+		&blockblob.ClientOptions{ClientOptions: policy.ClientOptions{
+			Transport: transport,
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		}},
+	)
+	assert.NoError(t, err)
 
-	start := make(chan struct{})
-	results := make(chan bool, workers)
-	for i := 0; i < workers; i++ {
-		go func() {
-			<-start
-			results <- copier.tryStartDedupeResolution()
-		}()
-	}
-	close(start)
+	hasher := &sdkDedupeRangeHasher{}
+	result, err := hasher.hashRanges(
+		context.Background(),
+		"source",
+		client,
+		azcore.ETag(`"source-etag"`),
+		ranges,
+		nil,
+	)
 
-	owners := 0
-	for i := 0; i < workers; i++ {
-		if <-results {
-			owners++
-		}
-	}
-	assert.Equal(t, 1, owners)
-	assert.Equal(t, dedupeResolveInProgress, copier.dedupeResolutionState())
+	assert.Error(t, err)
+	assert.Equal(t, 2, result.batches)
+	assert.Equal(t, ranges[:2*dedupeGetBlobHashOperationalMaxRanges], result.attemptedRanges)
+	assert.Len(t, result.response.RangeHashes, dedupeGetBlobHashOperationalMaxRanges)
 
-	started := time.Now()
-	assert.False(t, copier.ensureDedupeHashesResolved(nil))
-	assert.Less(t, time.Since(started), 100*time.Millisecond)
-
-	copier.finishDedupeResolution()
-	assert.Equal(t, dedupeResolveComplete, copier.dedupeResolutionState())
-	select {
-	case <-copier.dedupeResolveDone:
-	default:
-		t.Fatal("resolution completion channel was not closed")
+	requests := transport.snapshotRequests()
+	if assert.Len(t, requests, 2) {
+		assert.Equal(t, `"source-etag"`, headerValueFold(requests[0].Header, "If-Match"))
+		assert.Equal(t, `"source-etag"`, headerValueFold(requests[1].Header, "If-Match"))
+		assert.Equal(t, "bytes=0-0,2-2,4-4,6-6,8-8,10-10,12-12,14-14",
+			headerValueFold(requests[0].Header, "x-ms-multi-range"))
+		assert.Equal(t, "bytes=16-16,18-18,20-20,22-22,24-24,26-26,28-28,30-30",
+			headerValueFold(requests[1].Header, "x-ms-multi-range"))
 	}
 }
 
@@ -345,6 +661,8 @@ func TestResolveDedupeCandidateHashesMatchesByRangeNotResultOrder(t *testing.T) 
 	assert.NoError(t, err)
 	assert.Equal(t, 2, stats.candidateBlocks)
 	assert.Equal(t, 2, stats.candidateOccurrences)
+	assert.Equal(t, 2, stats.newCandidateBlocks)
+	assert.Equal(t, 2, stats.newCandidateOccurrences)
 	assert.Zero(t, stats.targetHashCacheHits)
 	assert.Equal(t, 2, stats.targetHashCacheMisses)
 	assert.Equal(t, 1, hasher.sourceCalls)
@@ -470,7 +788,13 @@ func TestResolveDedupeCandidateHashesEvictsTargetEpochOn412(t *testing.T) {
 	hash := sha256.Sum256([]byte("source"))
 	hasher := &fakeDedupeRangeHasher{
 		sourceHashes: map[srcBlockKey][32]byte{{offset: 0, size: 3}: hash},
-		targetHashes: make(map[string]map[srcBlockKey][32]byte),
+		targetResponses: map[string]blockblob.GetBlobHashResponse{
+			targetURI: {RangeHashes: []blockblob.BlobHashResult{{
+				Offset: 100,
+				Count:  3,
+				SHA256: append([]byte(nil), hash[:]...),
+			}}},
+		},
 		targetErr: map[string]error{
 			targetURI: &azcore.ResponseError{StatusCode: http.StatusPreconditionFailed},
 		},
@@ -533,6 +857,175 @@ func TestResolveDedupeCandidateHashesTargetFailureFallsBackWithoutCaching(t *tes
 		3,
 		"https://acct.blob.core.windows.net/c/current",
 	))
+
+	_, _, err = resolveDedupeCandidateHashes(
+		context.Background(),
+		state,
+		&SourceGridPlan{Blocks: []PlannedBlock{crcOnlyBlock(0, 3, 10)}},
+		azcore.ETag(`"source"`),
+		"https://acct.blob.core.windows.net/c/current",
+		hasher,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, hasher.targetCalls)
+}
+
+func TestResolveDedupeCandidateHashesPreservesPartialSourceResults(t *testing.T) {
+	firstHash := sha256.Sum256([]byte("first"))
+	secondHash := sha256.Sum256([]byte("second"))
+	targetURI := "https://acct.blob.core.windows.net/c/previous"
+	state := &dedupeJobState{committed: common.NewDedupeHashTable()}
+	for _, entry := range []common.BlockEntry{
+		{
+			CRC64:        10,
+			TargetURI:    targetURI,
+			TargetOffset: 100,
+			TargetLength: 3,
+			ETag:         azcore.ETag(`"target"`),
+		},
+		{
+			CRC64:        20,
+			TargetURI:    targetURI,
+			TargetOffset: 200,
+			TargetLength: 7,
+			ETag:         azcore.ETag(`"target"`),
+		},
+	} {
+		state.committed.Insert(entry)
+	}
+	hasher := &fakeDedupeRangeHasher{
+		sourceResponse: &blockblob.GetBlobHashResponse{RangeHashes: []blockblob.BlobHashResult{{
+			Offset: 0,
+			Count:  3,
+			SHA256: append([]byte(nil), firstHash[:]...),
+		}}},
+		sourceErr: context.DeadlineExceeded,
+		targetHashes: map[string]map[srcBlockKey][32]byte{
+			targetURI: {
+				{offset: 100, size: 3}: firstHash,
+				{offset: 200, size: 7}: secondHash,
+			},
+		},
+		targetErr: make(map[string]error),
+	}
+	plan := &SourceGridPlan{Blocks: []PlannedBlock{
+		crcOnlyBlock(0, 3, 10),
+		crcOnlyBlock(3, 7, 20),
+	}}
+
+	cache, stats, err := resolveDedupeCandidateHashesIncremental(
+		context.Background(),
+		state,
+		plan,
+		azcore.ETag(`"source"`),
+		"https://acct.blob.core.windows.net/c/current",
+		hasher,
+		dedupeSourceHashCache{},
+	)
+
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Len(t, cache.hashes, 1)
+	assert.Equal(t, 2, stats.sourceHashRanges)
+	assert.Equal(t, []blockblob.BlobHashRange{{Offset: 100, Count: 3}}, hasher.targetRanges[targetURI])
+	_, firstHit := decideStaging(cache.hashes, state.committed, 0, 3, "https://acct.blob.core.windows.net/c/current")
+	_, secondHit := decideStaging(cache.hashes, state.committed, 3, 7, "https://acct.blob.core.windows.net/c/current")
+	assert.True(t, firstHit)
+	assert.False(t, secondHit)
+
+	cache, _, err = resolveDedupeCandidateHashesIncremental(
+		context.Background(),
+		state,
+		plan,
+		azcore.ETag(`"source"`),
+		"https://acct.blob.core.windows.net/c/current",
+		hasher,
+		cache,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, hasher.sourceCalls)
+	assert.Equal(t, 1, hasher.targetCalls)
+}
+
+func TestResolveDedupeCandidateHashesPreservesPartialTargetResults(t *testing.T) {
+	firstHash := sha256.Sum256([]byte("first"))
+	secondHash := sha256.Sum256([]byte("second"))
+	targetURI := "https://acct.blob.core.windows.net/c/previous"
+	state := &dedupeJobState{committed: common.NewDedupeHashTable()}
+	for _, entry := range []common.BlockEntry{
+		{
+			CRC64:        10,
+			TargetURI:    targetURI,
+			TargetOffset: 100,
+			TargetLength: 3,
+			ETag:         azcore.ETag(`"target"`),
+		},
+		{
+			CRC64:        20,
+			TargetURI:    targetURI,
+			TargetOffset: 200,
+			TargetLength: 7,
+			ETag:         azcore.ETag(`"target"`),
+		},
+	} {
+		state.committed.Insert(entry)
+	}
+	hasher := &fakeDedupeRangeHasher{
+		sourceHashes: map[srcBlockKey][32]byte{
+			{offset: 0, size: 3}: firstHash,
+			{offset: 3, size: 7}: secondHash,
+		},
+		targetResponses: map[string]blockblob.GetBlobHashResponse{
+			targetURI: {RangeHashes: []blockblob.BlobHashResult{{
+				Offset: 100,
+				Count:  3,
+				SHA256: append([]byte(nil), firstHash[:]...),
+			}}},
+		},
+		targetErr: map[string]error{targetURI: context.DeadlineExceeded},
+	}
+	plan := &SourceGridPlan{Blocks: []PlannedBlock{
+		crcOnlyBlock(0, 3, 10),
+		crcOnlyBlock(3, 7, 20),
+	}}
+
+	cache, stats, err := resolveDedupeCandidateHashesIncremental(
+		context.Background(),
+		state,
+		plan,
+		azcore.ETag(`"source"`),
+		"https://acct.blob.core.windows.net/c/current",
+		hasher,
+		dedupeSourceHashCache{},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, stats.targetHashFailures)
+	first := state.committed.LookupByCRC64AndLength(10, 3)
+	second := state.committed.LookupByCRC64AndLength(20, 7)
+	if assert.Len(t, first, 1) {
+		assert.True(t, first[0].HasSHA256)
+		assert.Equal(t, firstHash, first[0].SHA256)
+	}
+	if assert.Len(t, second, 1) {
+		assert.False(t, second[0].HasSHA256)
+	}
+	_, firstHit := decideStaging(cache.hashes, state.committed, 0, 3, "https://acct.blob.core.windows.net/c/current")
+	_, secondHit := decideStaging(cache.hashes, state.committed, 3, 7, "https://acct.blob.core.windows.net/c/current")
+	assert.True(t, firstHit)
+	assert.False(t, secondHit)
+
+	cache, _, err = resolveDedupeCandidateHashesIncremental(
+		context.Background(),
+		state,
+		plan,
+		azcore.ETag(`"source"`),
+		"https://acct.blob.core.windows.net/c/current",
+		hasher,
+		cache,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, hasher.sourceCalls)
+	assert.Equal(t, 1, hasher.targetCalls)
 }
 
 func TestResolveDedupeCandidateHashesReportsSource412(t *testing.T) {
@@ -544,7 +1037,13 @@ func TestResolveDedupeCandidateHashesReportsSource412(t *testing.T) {
 		TargetLength: 3,
 		ETag:         azcore.ETag(`"target"`),
 	})
+	hash := sha256.Sum256([]byte("source"))
 	hasher := &fakeDedupeRangeHasher{
+		sourceResponse: &blockblob.GetBlobHashResponse{RangeHashes: []blockblob.BlobHashResult{{
+			Offset: 0,
+			Count:  3,
+			SHA256: append([]byte(nil), hash[:]...),
+		}}},
 		sourceErr: &azcore.ResponseError{StatusCode: http.StatusPreconditionFailed},
 	}
 
@@ -561,19 +1060,23 @@ func TestResolveDedupeCandidateHashesReportsSource412(t *testing.T) {
 	assert.Empty(t, index)
 	assert.Equal(t, 1, stats.sourceEpochInvalidations)
 	assert.Equal(t, 1, state.committed.Len())
+	assert.Equal(t, 1, hasher.sourceCalls)
+	assert.Zero(t, hasher.targetCalls)
 }
 
 func TestBatchDedupeBlobHashRanges(t *testing.T) {
 	t.Run("range count", func(t *testing.T) {
-		ranges := make([]blockblob.BlobHashRange, 257)
+		assert.Less(t, dedupeGetBlobHashOperationalMaxRanges, dedupeGetBlobHashMaxRanges)
+		ranges := make([]blockblob.BlobHashRange, 2*dedupeGetBlobHashOperationalMaxRanges+1)
 		for i := range ranges {
 			ranges[i] = blockblob.BlobHashRange{Offset: int64(i * 2), Count: 1}
 		}
 		batches, err := batchDedupeBlobHashRanges(ranges)
 		assert.NoError(t, err)
-		assert.Len(t, batches, 2)
-		assert.Len(t, batches[0], 256)
-		assert.Len(t, batches[1], 1)
+		assert.Len(t, batches, 3)
+		assert.Len(t, batches[0], dedupeGetBlobHashOperationalMaxRanges)
+		assert.Len(t, batches[1], dedupeGetBlobHashOperationalMaxRanges)
+		assert.Len(t, batches[2], 1)
 	})
 
 	t.Run("aggregate bytes", func(t *testing.T) {
@@ -596,8 +1099,9 @@ func TestBatchDedupeBlobHashRanges(t *testing.T) {
 		}
 		batches, err := batchDedupeBlobHashRanges(ranges)
 		assert.NoError(t, err)
-		assert.Len(t, batches, 2)
+		assert.Greater(t, len(batches), 2)
 		for _, batch := range batches {
+			assert.LessOrEqual(t, len(batch), dedupeGetBlobHashOperationalMaxRanges)
 			headerBytes := len("bytes=")
 			for i, rnge := range batch {
 				if i > 0 {
@@ -614,6 +1118,12 @@ func TestBatchDedupeBlobHashRanges(t *testing.T) {
 
 	t.Run("invalid", func(t *testing.T) {
 		_, err := batchDedupeBlobHashRanges([]blockblob.BlobHashRange{{Offset: -1, Count: 1}})
+		assert.Error(t, err)
+
+		_, err = batchDedupeBlobHashRanges([]blockblob.BlobHashRange{{
+			Offset: 0,
+			Count:  dedupeGetBlobHashMaxBytes + 1,
+		}})
 		assert.Error(t, err)
 	})
 
@@ -632,12 +1142,545 @@ func TestBatchDedupeBlobHashRanges(t *testing.T) {
 	})
 }
 
+func newDedupeResolutionTestCopier(
+	jobID common.JobID,
+	plan *SourceGridPlan,
+	hasher dedupeRangeHasher,
+) *urlToBlockBlobCopier {
+	manager := &dedupeResolutionTestTransferManager{testJobPartTransferManager: &testJobPartTransferManager{info: &TransferInfo{
+		JobID:       jobID,
+		Source:      "https://source.blob.core.windows.net/c/current",
+		Destination: "https://dest.blob.core.windows.net/c/current",
+		SrcFilePath: "current",
+		DstFilePath: "current",
+	}}}
+	return &urlToBlockBlobCopier{blockBlobSenderBase: blockBlobSenderBase{
+		jptm:         manager,
+		dedupeMode:   dedupeActEnforce,
+		dedupePlan:   plan,
+		dedupeETag:   azcore.ETag(`"source"`),
+		dedupeHasher: hasher,
+	}}
+}
+
+func TestDedupeResolutionReconsidersNewCommittedCandidates(t *testing.T) {
+	jobID := common.NewJobID()
+	defer clearDedupeStateForJob(jobID)
+	state := dedupeStateForJob(jobID)
+	hash := sha256.Sum256([]byte("shared"))
+	firstTarget := "https://dest.blob.core.windows.net/c/first"
+	secondTarget := "https://dest.blob.core.windows.net/c/second"
+	hasher := &fakeDedupeRangeHasher{
+		sourceHashes: map[srcBlockKey][32]byte{{offset: 0, size: 3}: hash},
+		targetHashes: map[string]map[srcBlockKey][32]byte{
+			firstTarget:  {{offset: 100, size: 3}: hash},
+			secondTarget: {{offset: 200, size: 3}: hash},
+		},
+		targetErr: make(map[string]error),
+	}
+	plan := &SourceGridPlan{Blocks: []PlannedBlock{crcOnlyBlock(0, 3, 10)}}
+	copier := newDedupeResolutionTestCopier(jobID, plan, hasher)
+
+	copier.ensureDedupeHashesResolved(state)
+	assert.Zero(t, hasher.sourceCalls)
+	assert.Zero(t, hasher.targetCalls)
+
+	assert.Equal(t, 1, recordCommittedBlocks(
+		jobID,
+		firstTarget,
+		"",
+		azcore.ETag(`"first"`),
+		&SourceGridPlan{Blocks: []PlannedBlock{crcOnlyBlock(100, 3, 10)}},
+	))
+	copier.ensureDedupeHashesResolved(state)
+	index, err := copier.dedupeResolutionSnapshot()
+	assert.NoError(t, err)
+	_, hit := decideStaging(index, state.committed, 0, 3, "https://dest.blob.core.windows.net/c/current")
+	assert.True(t, hit)
+	assert.Equal(t, 1, hasher.sourceCalls)
+	assert.Equal(t, 1, hasher.targetCalls)
+	firstSnapshot := state.progressSnapshot()
+	assert.EqualValues(t, 1, firstSnapshot.crcCandidateBlocks)
+	assert.EqualValues(t, 1, firstSnapshot.crcCandidateOccurrences)
+
+	assert.Equal(t, 1, recordCommittedBlocks(
+		jobID,
+		secondTarget,
+		"",
+		azcore.ETag(`"second"`),
+		&SourceGridPlan{Blocks: []PlannedBlock{crcOnlyBlock(200, 3, 10)}},
+	))
+	copier.ensureDedupeHashesResolved(state)
+	assert.Equal(t, 1, hasher.sourceCalls)
+	assert.Equal(t, 2, hasher.targetCalls)
+	copier.dedupeResolveMu.Lock()
+	secondStats := copier.dedupeResolveStats
+	copier.dedupeResolveMu.Unlock()
+	assert.Equal(t, 1, secondStats.candidateBlocks)
+	assert.Equal(t, 2, secondStats.candidateOccurrences)
+	assert.Zero(t, secondStats.newCandidateBlocks)
+	assert.Equal(t, 1, secondStats.newCandidateOccurrences)
+	secondSnapshot := state.progressSnapshot()
+	assert.EqualValues(t, 1, secondSnapshot.crcCandidateBlocks)
+	assert.EqualValues(t, 2, secondSnapshot.crcCandidateOccurrences)
+}
+
+func TestDedupeResolutionCancellationLeavesLaterTargetEpochEligible(t *testing.T) {
+	jobID := common.NewJobID()
+	defer clearDedupeStateForJob(jobID)
+	state := dedupeStateForJob(jobID)
+	firstHash := sha256.Sum256([]byte("first"))
+	secondHash := sha256.Sum256([]byte("second"))
+	firstTarget := "https://dest.blob.core.windows.net/c/a"
+	secondTarget := "https://dest.blob.core.windows.net/c/b"
+	fakeHasher := &fakeDedupeRangeHasher{
+		sourceHashes: map[srcBlockKey][32]byte{
+			{offset: 0, size: 3}: firstHash,
+			{offset: 3, size: 3}: secondHash,
+		},
+		targetHashes: map[string]map[srcBlockKey][32]byte{
+			firstTarget:  {{offset: 100, size: 3}: firstHash},
+			secondTarget: {{offset: 200, size: 3}: secondHash},
+		},
+		targetErr: make(map[string]error),
+	}
+	resolutionContext, cancelResolution := context.WithCancel(context.Background())
+	defer cancelResolution()
+	hasher := &cancelAfterTargetHasher{
+		fakeDedupeRangeHasher: fakeHasher,
+		targetURI:             firstTarget,
+		cancel:                cancelResolution,
+	}
+	plan := &SourceGridPlan{Blocks: []PlannedBlock{
+		crcOnlyBlock(0, 3, 10),
+		crcOnlyBlock(3, 3, 20),
+	}}
+	copier := newDedupeResolutionTestCopier(jobID, plan, hasher)
+	manager := copier.jptm.(*dedupeResolutionTestTransferManager)
+	manager.ctx = resolutionContext
+
+	assert.Equal(t, 1, recordCommittedBlocks(
+		jobID,
+		firstTarget,
+		"",
+		azcore.ETag(`"first"`),
+		&SourceGridPlan{Blocks: []PlannedBlock{crcOnlyBlock(100, 3, 10)}},
+	))
+	assert.Equal(t, 1, recordCommittedBlocks(
+		jobID,
+		secondTarget,
+		"",
+		azcore.ETag(`"second"`),
+		&SourceGridPlan{Blocks: []PlannedBlock{crcOnlyBlock(200, 3, 20)}},
+	))
+
+	assert.True(t, copier.ensureDedupeHashesResolved(state))
+	assert.Equal(t, 1, fakeHasher.targetCallCount(firstTarget))
+	assert.Zero(t, fakeHasher.targetCallCount(secondTarget))
+	assert.False(t, state.targetHashRangeFailed(
+		dedupeTargetEpoch{targetURI: secondTarget, etag: azcore.ETag(`"second"`)},
+		srcBlockKey{offset: 200, size: 3},
+	))
+
+	index, err := copier.dedupeResolutionSnapshot()
+	assert.NoError(t, err)
+	_, firstHit := decideStaging(index, state.committed, 0, 3, "https://dest.blob.core.windows.net/c/current")
+	_, secondHit := decideStaging(index, state.committed, 3, 3, "https://dest.blob.core.windows.net/c/current")
+	assert.True(t, firstHit)
+	assert.False(t, secondHit)
+
+	manager.ctx = context.Background()
+	assert.Equal(t, 1, recordCommittedBlocks(
+		jobID,
+		"https://dest.blob.core.windows.net/c/new-generation",
+		"",
+		azcore.ETag(`"new-generation"`),
+		&SourceGridPlan{Blocks: []PlannedBlock{crcOnlyBlock(300, 3, 30)}},
+	))
+	assert.True(t, copier.ensureDedupeHashesResolved(state))
+	assert.Equal(t, 1, fakeHasher.targetCallCount(firstTarget))
+	assert.Equal(t, 1, fakeHasher.targetCallCount(secondTarget))
+
+	index, err = copier.dedupeResolutionSnapshot()
+	assert.NoError(t, err)
+	_, firstHit = decideStaging(index, state.committed, 0, 3, "https://dest.blob.core.windows.net/c/current")
+	_, secondHit = decideStaging(index, state.committed, 3, 3, "https://dest.blob.core.windows.net/c/current")
+	assert.True(t, firstHit)
+	assert.True(t, secondHit)
+}
+
+func TestDedupeResolutionCancellationLeavesUnstartedTargetBatchEligible(t *testing.T) {
+	jobID := common.NewJobID()
+	defer clearDedupeStateForJob(jobID)
+	state := dedupeStateForJob(jobID)
+	sourcePlan, targetPlan, sourceHashes, targetHashes := newDedupeBatchCancellationFixture(false)
+	targetURI := "https://dest.blob.core.windows.net/c/target"
+	resolutionContext, cancelResolution := context.WithCancel(context.Background())
+	defer cancelResolution()
+	hasher := &cancelSecondBatchDedupeRangeHasher{
+		cancelRole:   "target",
+		cancel:       cancelResolution,
+		sourceHashes: sourceHashes,
+		targetHashes: map[string]map[srcBlockKey][32]byte{targetURI: targetHashes},
+	}
+	copier := newDedupeResolutionTestCopier(jobID, sourcePlan, hasher)
+	manager := copier.jptm.(*dedupeResolutionTestTransferManager)
+	manager.ctx = resolutionContext
+
+	assert.Equal(t, len(targetPlan.Blocks), recordCommittedBlocks(
+		jobID,
+		targetURI,
+		"",
+		azcore.ETag(`"target"`),
+		targetPlan,
+	))
+	assert.True(t, copier.ensureDedupeHashesResolved(state))
+	assert.Equal(t, 1, hasher.targetRequestCount(targetURI))
+	assert.Len(t, hasher.targetRequest(targetURI, 0), len(targetPlan.Blocks))
+
+	copier.dedupeResolveMu.Lock()
+	firstStats := copier.dedupeResolveStats
+	copier.dedupeResolveMu.Unlock()
+	assert.Equal(t, 2*dedupeGetBlobHashOperationalMaxRanges, firstStats.targetHashRanges)
+	assert.Equal(t, 2, firstStats.targetHashBatches)
+	assert.Equal(t, 1, firstStats.targetHashFailures)
+
+	epoch := dedupeTargetEpoch{targetURI: targetURI, etag: azcore.ETag(`"target"`)}
+	for i, block := range targetPlan.Blocks {
+		candidates := state.committed.LookupByCRC64AndLength(block.CRC64, block.Size)
+		if assert.Len(t, candidates, 1) {
+			assert.Equal(t, i < dedupeGetBlobHashOperationalMaxRanges, candidates[0].HasSHA256)
+		}
+		key := srcBlockKey{offset: block.Offset, size: block.Size}
+		assert.Equal(
+			t,
+			i >= dedupeGetBlobHashOperationalMaxRanges &&
+				i < 2*dedupeGetBlobHashOperationalMaxRanges,
+			state.targetHashRangeFailed(epoch, key),
+		)
+	}
+
+	index, err := copier.dedupeResolutionSnapshot()
+	assert.NoError(t, err)
+	_, firstHit := decideStaging(
+		index,
+		state.committed,
+		sourcePlan.Blocks[0].Offset,
+		sourcePlan.Blocks[0].Size,
+		"https://dest.blob.core.windows.net/c/current",
+	)
+	_, lastHit := decideStaging(
+		index,
+		state.committed,
+		sourcePlan.Blocks[len(sourcePlan.Blocks)-1].Offset,
+		sourcePlan.Blocks[len(sourcePlan.Blocks)-1].Size,
+		"https://dest.blob.core.windows.net/c/current",
+	)
+	assert.True(t, firstHit)
+	assert.False(t, lastHit)
+
+	manager.ctx = context.Background()
+	assert.Equal(t, 1, recordCommittedBlocks(
+		jobID,
+		"https://dest.blob.core.windows.net/c/new-generation",
+		"",
+		azcore.ETag(`"new-generation"`),
+		&SourceGridPlan{Blocks: []PlannedBlock{crcOnlyBlock(2000, 1, 1000)}},
+	))
+	assert.True(t, copier.ensureDedupeHashesResolved(state))
+	assert.Equal(t, 2, hasher.targetRequestCount(targetURI))
+	lastTarget := targetPlan.Blocks[len(targetPlan.Blocks)-1]
+	assert.Equal(t, []blockblob.BlobHashRange{{
+		Offset: lastTarget.Offset,
+		Count:  lastTarget.Size,
+	}}, hasher.targetRequest(targetURI, 1))
+
+	index, err = copier.dedupeResolutionSnapshot()
+	assert.NoError(t, err)
+	_, lastHit = decideStaging(
+		index,
+		state.committed,
+		sourcePlan.Blocks[len(sourcePlan.Blocks)-1].Offset,
+		sourcePlan.Blocks[len(sourcePlan.Blocks)-1].Size,
+		"https://dest.blob.core.windows.net/c/current",
+	)
+	assert.True(t, lastHit)
+	for i := dedupeGetBlobHashOperationalMaxRanges; i < 2*dedupeGetBlobHashOperationalMaxRanges; i++ {
+		block := targetPlan.Blocks[i]
+		assert.True(t, state.targetHashRangeFailed(
+			epoch,
+			srcBlockKey{offset: block.Offset, size: block.Size},
+		))
+	}
+	snapshot := state.progressSnapshot()
+	assert.EqualValues(t, len(targetPlan.Blocks), snapshot.targetHashRanges)
+	assert.EqualValues(t, 3, snapshot.targetHashBatches)
+	assert.EqualValues(t, len(targetPlan.Blocks), snapshot.crcCandidateBlocks)
+	assert.EqualValues(t, len(targetPlan.Blocks), snapshot.crcCandidateOccurrences)
+}
+
+func TestDedupeResolutionCancellationLeavesUnstartedSourceBatchEligible(t *testing.T) {
+	jobID := common.NewJobID()
+	defer clearDedupeStateForJob(jobID)
+	state := dedupeStateForJob(jobID)
+	sourcePlan, targetPlan, sourceHashes, targetHashes := newDedupeBatchCancellationFixture(true)
+	targetURI := "https://dest.blob.core.windows.net/c/target"
+	resolutionContext, cancelResolution := context.WithCancel(context.Background())
+	defer cancelResolution()
+	hasher := &cancelSecondBatchDedupeRangeHasher{
+		cancelRole:   "source",
+		cancel:       cancelResolution,
+		sourceHashes: sourceHashes,
+		targetHashes: map[string]map[srcBlockKey][32]byte{targetURI: targetHashes},
+	}
+	copier := newDedupeResolutionTestCopier(jobID, sourcePlan, hasher)
+	manager := copier.jptm.(*dedupeResolutionTestTransferManager)
+	manager.ctx = resolutionContext
+
+	assert.Equal(t, len(targetPlan.Blocks), recordCommittedBlocks(
+		jobID,
+		targetURI,
+		"",
+		azcore.ETag(`"target"`),
+		targetPlan,
+	))
+	assert.True(t, copier.ensureDedupeHashesResolved(state))
+	assert.Equal(t, 1, hasher.sourceRequestCount())
+	assert.Len(t, hasher.sourceRequest(0), len(sourcePlan.Blocks))
+	assert.Zero(t, hasher.targetRequestCount(targetURI))
+
+	copier.dedupeResolveMu.Lock()
+	firstStats := copier.dedupeResolveStats
+	copier.dedupeResolveMu.Unlock()
+	assert.Equal(t, 2*dedupeGetBlobHashOperationalMaxRanges, firstStats.sourceHashRanges)
+	assert.Equal(t, 2, firstStats.sourceHashBatches)
+
+	index, err := copier.dedupeResolutionSnapshot()
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Len(t, index, dedupeGetBlobHashOperationalMaxRanges)
+	_, firstHit := decideStaging(
+		index,
+		state.committed,
+		sourcePlan.Blocks[0].Offset,
+		sourcePlan.Blocks[0].Size,
+		"https://dest.blob.core.windows.net/c/current",
+	)
+	_, lastHit := decideStaging(
+		index,
+		state.committed,
+		sourcePlan.Blocks[len(sourcePlan.Blocks)-1].Offset,
+		sourcePlan.Blocks[len(sourcePlan.Blocks)-1].Size,
+		"https://dest.blob.core.windows.net/c/current",
+	)
+	assert.True(t, firstHit)
+	assert.False(t, lastHit)
+
+	manager.ctx = context.Background()
+	assert.Equal(t, 1, recordCommittedBlocks(
+		jobID,
+		"https://dest.blob.core.windows.net/c/new-generation",
+		"",
+		azcore.ETag(`"new-generation"`),
+		&SourceGridPlan{Blocks: []PlannedBlock{crcOnlyBlock(2000, 1, 1000)}},
+	))
+	assert.True(t, copier.ensureDedupeHashesResolved(state))
+	assert.Equal(t, 2, hasher.sourceRequestCount())
+	lastSource := sourcePlan.Blocks[len(sourcePlan.Blocks)-1]
+	assert.Equal(t, []blockblob.BlobHashRange{{
+		Offset: lastSource.Offset,
+		Count:  lastSource.Size,
+	}}, hasher.sourceRequest(1))
+	assert.Zero(t, hasher.targetRequestCount(targetURI))
+
+	index, err = copier.dedupeResolutionSnapshot()
+	assert.NoError(t, err)
+	assert.Len(t, index, dedupeGetBlobHashOperationalMaxRanges+1)
+	_, lastHit = decideStaging(
+		index,
+		state.committed,
+		lastSource.Offset,
+		lastSource.Size,
+		"https://dest.blob.core.windows.net/c/current",
+	)
+	assert.True(t, lastHit)
+	middleSource := sourcePlan.Blocks[dedupeGetBlobHashOperationalMaxRanges]
+	_, middleHit := decideStaging(
+		index,
+		state.committed,
+		middleSource.Offset,
+		middleSource.Size,
+		"https://dest.blob.core.windows.net/c/current",
+	)
+	assert.False(t, middleHit)
+	snapshot := state.progressSnapshot()
+	assert.EqualValues(t, len(sourcePlan.Blocks), snapshot.sourceHashRanges)
+	assert.EqualValues(t, 3, snapshot.sourceHashBatches)
+	assert.EqualValues(t, len(sourcePlan.Blocks), snapshot.crcCandidateBlocks)
+	assert.EqualValues(t, len(sourcePlan.Blocks), snapshot.crcCandidateOccurrences)
+}
+
+func TestDedupeResolutionCountsDistinctSourceTargetOccurrences(t *testing.T) {
+	jobID := common.NewJobID()
+	defer clearDedupeStateForJob(jobID)
+	state := dedupeStateForJob(jobID)
+	hash := sha256.Sum256([]byte("shared"))
+	targetURI := "https://dest.blob.core.windows.net/c/target"
+	hasher := &fakeDedupeRangeHasher{
+		sourceHashes: map[srcBlockKey][32]byte{
+			{offset: 0, size: 3}: hash,
+			{offset: 3, size: 3}: hash,
+		},
+		targetHashes: map[string]map[srcBlockKey][32]byte{
+			targetURI: {{offset: 100, size: 3}: hash},
+		},
+		targetErr: make(map[string]error),
+	}
+	plan := &SourceGridPlan{Blocks: []PlannedBlock{
+		crcOnlyBlock(0, 3, 10),
+		crcOnlyBlock(3, 3, 10),
+	}}
+	copier := newDedupeResolutionTestCopier(jobID, plan, hasher)
+
+	assert.Equal(t, 1, recordCommittedBlocks(
+		jobID,
+		targetURI,
+		"",
+		azcore.ETag(`"target"`),
+		&SourceGridPlan{Blocks: []PlannedBlock{crcOnlyBlock(100, 3, 10)}},
+	))
+	assert.True(t, copier.ensureDedupeHashesResolved(state))
+
+	copier.dedupeResolveMu.Lock()
+	stats := copier.dedupeResolveStats
+	copier.dedupeResolveMu.Unlock()
+	assert.Equal(t, 2, stats.candidateBlocks)
+	assert.Equal(t, 2, stats.candidateOccurrences)
+	assert.Equal(t, 2, stats.newCandidateBlocks)
+	assert.Equal(t, 2, stats.newCandidateOccurrences)
+	assert.Equal(t, 1, hasher.targetCallCount(targetURI))
+	snapshot := state.progressSnapshot()
+	assert.EqualValues(t, 2, snapshot.crcCandidateBlocks)
+	assert.EqualValues(t, 2, snapshot.crcCandidateOccurrences)
+
+	assert.Equal(t, 1, recordCommittedBlocks(
+		jobID,
+		"https://dest.blob.core.windows.net/c/new-generation",
+		"",
+		azcore.ETag(`"new-generation"`),
+		&SourceGridPlan{Blocks: []PlannedBlock{crcOnlyBlock(200, 3, 20)}},
+	))
+	assert.True(t, copier.ensureDedupeHashesResolved(state))
+	copier.dedupeResolveMu.Lock()
+	stats = copier.dedupeResolveStats
+	copier.dedupeResolveMu.Unlock()
+	assert.Zero(t, stats.newCandidateBlocks)
+	assert.Zero(t, stats.newCandidateOccurrences)
+	snapshot = state.progressSnapshot()
+	assert.EqualValues(t, 2, snapshot.crcCandidateBlocks)
+	assert.EqualValues(t, 2, snapshot.crcCandidateOccurrences)
+}
+
+func TestDedupeResolutionCoalescesConcurrentReresolution(t *testing.T) {
+	jobID := common.NewJobID()
+	defer clearDedupeStateForJob(jobID)
+	state := dedupeStateForJob(jobID)
+	hash := sha256.Sum256([]byte("shared"))
+	targetURI := "https://dest.blob.core.windows.net/c/target"
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	hasher := &fakeDedupeRangeHasher{
+		sourceHashes:  map[srcBlockKey][32]byte{{offset: 0, size: 3}: hash},
+		targetHashes:  map[string]map[srcBlockKey][32]byte{targetURI: {{offset: 100, size: 3}: hash}},
+		targetErr:     make(map[string]error),
+		sourceStarted: started,
+		sourceRelease: release,
+	}
+	plan := &SourceGridPlan{Blocks: []PlannedBlock{crcOnlyBlock(0, 3, 10)}}
+	copier := newDedupeResolutionTestCopier(jobID, plan, hasher)
+	copier.ensureDedupeHashesResolved(state)
+	assert.Equal(t, 1, recordCommittedBlocks(
+		jobID,
+		targetURI,
+		"",
+		azcore.ETag(`"target"`),
+		&SourceGridPlan{Blocks: []PlannedBlock{crcOnlyBlock(100, 3, 10)}},
+	))
+
+	const workers = 16
+	var waitGroup sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			copier.ensureDedupeHashesResolved(state)
+		}()
+	}
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for source hash resolution")
+	}
+	waitStarted := time.Now()
+	assert.False(t, copier.ensureDedupeHashesResolved(state))
+	assert.Less(t, time.Since(waitStarted), 100*time.Millisecond)
+	close(release)
+
+	done := make(chan struct{})
+	go func() {
+		waitGroup.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for concurrent resolvers")
+	}
+
+	assert.Equal(t, 1, hasher.sourceCalls)
+	assert.Equal(t, 1, hasher.targetCalls)
+	index, err := copier.dedupeResolutionSnapshot()
+	assert.NoError(t, err)
+	_, hit := decideStaging(index, state.committed, 0, 3, "https://dest.blob.core.windows.net/c/current")
+	assert.True(t, hit)
+	snapshot := state.progressSnapshot()
+	assert.EqualValues(t, 1, snapshot.crcCandidateBlocks)
+	assert.EqualValues(t, 1, snapshot.crcCandidateOccurrences)
+}
+
+func TestDedupeCandidateOccurrenceKeyExcludesCredentials(t *testing.T) {
+	source := srcBlockKey{offset: 0, size: 3}
+	entry := common.BlockEntry{
+		CRC64:        10,
+		TargetURI:    "https://dest.blob.core.windows.net/c/target?sv=2026&sig=first-secret",
+		TargetOffset: 100,
+		TargetLength: 3,
+		ETag:         azcore.ETag(`"target"`),
+	}
+	sameOccurrence := entry
+	sameOccurrence.TargetURI = "https://dest.blob.core.windows.net/c/target?sv=2027&sig=second-secret"
+
+	key := newDedupeCandidateOccurrenceKey(source, entry)
+	assert.Equal(t, key, newDedupeCandidateOccurrenceKey(source, sameOccurrence))
+	assert.Equal(t, "https://dest.blob.core.windows.net/c/target", key.targetURI)
+	assert.NotContains(t, key.targetURI, "secret")
+	assert.NotEqual(t, key, newDedupeCandidateOccurrenceKey(srcBlockKey{offset: 3, size: 3}, entry))
+
+	differentEpoch := entry
+	differentEpoch.ETag = azcore.ETag(`"new-target"`)
+	assert.NotEqual(t, key, newDedupeCandidateOccurrenceKey(source, differentEpoch))
+}
+
 func TestApplyResolvedSourceHashesPersistsOnlyCalculatedSHA(t *testing.T) {
 	first := sha256.Sum256([]byte("first"))
+	stale := sha256.Sum256([]byte("stale"))
 	plan := &SourceGridPlan{Blocks: []PlannedBlock{
 		crcOnlyBlock(0, 3, 10),
 		crcOnlyBlock(3, 7, 20),
 	}}
+	plan.Blocks[1].SHA256 = stale
+	plan.Blocks[1].HasSHA256 = true
+	plan.Blocks[1].HasHashes = true
 	applyResolvedSourceHashes(plan, map[srcBlockKey]srcBlockHashes{
 		{offset: 0, size: 3}: {crc64: 10, sha256: first},
 	})
@@ -649,4 +1692,5 @@ func TestApplyResolvedSourceHashesPersistsOnlyCalculatedSHA(t *testing.T) {
 	assert.True(t, plan.Blocks[1].HasCRC64)
 	assert.False(t, plan.Blocks[1].HasSHA256)
 	assert.False(t, plan.Blocks[1].HasHashes)
+	assert.Equal(t, [32]byte{}, plan.Blocks[1].SHA256)
 }

--- a/ste/dedupeHashResolver_test.go
+++ b/ste/dedupeHashResolver_test.go
@@ -1,0 +1,611 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ste
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/stretchr/testify/assert"
+)
+
+type dedupeHashWireTransport struct {
+	request *http.Request
+}
+
+func (t *dedupeHashWireTransport) Do(req *http.Request) (*http.Response, error) {
+	t.request = req.Clone(req.Context())
+	t.request.Header = req.Header.Clone()
+	first := sha256.Sum256([]byte("first"))
+	second := sha256.Sum256([]byte("second"))
+	body := `<RangeHashList>` +
+		`<RangeHash><Offset>0</Offset><Length>3</Length><Sha256>` +
+		base64.StdEncoding.EncodeToString(first[:]) +
+		`</Sha256></RangeHash>` +
+		`<RangeHash><Offset>10</Offset><Length>7</Length><Sha256>` +
+		base64.StdEncoding.EncodeToString(second[:]) +
+		`</Sha256></RangeHash>` +
+		`</RangeHashList>`
+	headers := http.Header{}
+	headers.Set("Content-Type", "application/xml")
+	headers.Set("x-ms-request-id", "hash-request")
+	headers.Set("x-ms-test-dedupe-sha256-cpu-time-us", "17")
+	return &http.Response{
+		Request:    req,
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Header:     headers,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}, nil
+}
+
+func headerValueFold(header http.Header, name string) string {
+	for headerName, values := range header {
+		if strings.EqualFold(headerName, name) && len(values) > 0 {
+			return values[0]
+		}
+	}
+	return ""
+}
+
+type fakeDedupeRangeHasher struct {
+	mu sync.Mutex
+
+	sourceCalls int
+	targetCalls int
+
+	sourceRanges []blockblob.BlobHashRange
+	targetRanges map[string][]blockblob.BlobHashRange
+	sourceHashes map[srcBlockKey][32]byte
+	targetHashes map[string]map[srcBlockKey][32]byte
+	sourceErr    error
+	targetErr    map[string]error
+}
+
+func (h *fakeDedupeRangeHasher) HashSource(
+	_ context.Context,
+	_ azcore.ETag,
+	ranges []blockblob.BlobHashRange,
+) (blockblob.GetBlobHashResponse, int, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.sourceCalls++
+	h.sourceRanges = append([]blockblob.BlobHashRange(nil), ranges...)
+	if h.sourceErr != nil {
+		return blockblob.GetBlobHashResponse{}, 1, h.sourceErr
+	}
+	results := make([]blockblob.BlobHashResult, 0, len(ranges))
+	for i := len(ranges) - 1; i >= 0; i-- {
+		rnge := ranges[i]
+		hash := h.sourceHashes[srcBlockKey{offset: rnge.Offset, size: rnge.Count}]
+		results = append(results, blockblob.BlobHashResult{
+			Offset: rnge.Offset,
+			Count:  rnge.Count,
+			SHA256: append([]byte(nil), hash[:]...),
+		})
+	}
+	return blockblob.GetBlobHashResponse{RangeHashes: results}, 1, nil
+}
+
+func (h *fakeDedupeRangeHasher) HashTarget(
+	_ context.Context,
+	targetURI string,
+	_ azcore.ETag,
+	ranges []blockblob.BlobHashRange,
+) (blockblob.GetBlobHashResponse, int, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.targetCalls++
+	if h.targetRanges == nil {
+		h.targetRanges = make(map[string][]blockblob.BlobHashRange)
+	}
+	h.targetRanges[targetURI] = append([]blockblob.BlobHashRange(nil), ranges...)
+	if err := h.targetErr[targetURI]; err != nil {
+		return blockblob.GetBlobHashResponse{}, 1, err
+	}
+	results := make([]blockblob.BlobHashResult, 0, len(ranges))
+	for i := len(ranges) - 1; i >= 0; i-- {
+		rnge := ranges[i]
+		hash := h.targetHashes[targetURI][srcBlockKey{offset: rnge.Offset, size: rnge.Count}]
+		results = append(results, blockblob.BlobHashResult{
+			Offset: rnge.Offset,
+			Count:  rnge.Count,
+			SHA256: append([]byte(nil), hash[:]...),
+		})
+	}
+	return blockblob.GetBlobHashResponse{RangeHashes: results}, 1, nil
+}
+
+func crcOnlyBlock(offset, size int64, crc uint64) PlannedBlock {
+	return PlannedBlock{
+		Offset:    offset,
+		Size:      size,
+		CRC64:     crc,
+		HasCRC64:  true,
+		HasSHA256: false,
+	}
+}
+
+func TestSDKDedupeRangeHasherWireContractAndCPUCallback(t *testing.T) {
+	transport := &dedupeHashWireTransport{}
+	client, err := blockblob.NewClientWithNoCredential(
+		"https://acct.blob.core.windows.net/c/source?sig=secret",
+		&blockblob.ClientOptions{ClientOptions: policy.ClientOptions{Transport: transport}},
+	)
+	assert.NoError(t, err)
+
+	var callbackRole string
+	var callbackResponse blockblob.GetBlobHashResponse
+	hasher := &sdkDedupeRangeHasher{
+		jptm: &testJobPartTransferManager{},
+		onResponse: func(role string, response blockblob.GetBlobHashResponse) {
+			callbackRole = role
+			callbackResponse = response
+		},
+	}
+	ranges := []blockblob.BlobHashRange{{Offset: 0, Count: 3}, {Offset: 10, Count: 7}}
+	response, batches, err := hasher.hashRanges(
+		context.Background(),
+		"source",
+		client,
+		azcore.ETag(`"source-etag"`),
+		ranges,
+		nil,
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, batches)
+	assert.Len(t, response.RangeHashes, 2)
+	assert.Equal(t, "source", callbackRole)
+	assert.Equal(t, int64(17), *callbackResponse.SHA256CPUTimeUS)
+	assert.Equal(t, "hash-request", *callbackResponse.RequestID)
+
+	assert.NotNil(t, transport.request)
+	assert.Equal(t, http.MethodGet, transport.request.Method)
+	assert.Equal(t, "hash", transport.request.URL.Query().Get("comp"))
+	assert.Equal(t, "secret", transport.request.URL.Query().Get("sig"))
+	assert.Equal(t, "Sha256", headerValueFold(transport.request.Header, "x-ms-hash-algorithm"))
+	assert.Equal(t, "bytes=0-2,10-16", headerValueFold(transport.request.Header, "x-ms-multi-range"))
+	assert.Equal(t, `"source-etag"`, headerValueFold(transport.request.Header, "If-Match"))
+	assert.Empty(t, headerValueFold(transport.request.Header, "x-ms-encryption-key"))
+	assert.True(t, transport.request.Body == nil || transport.request.Body == http.NoBody)
+	assert.Zero(t, transport.request.ContentLength)
+
+	algorithm := blob.EncryptionAlgorithmTypeAES256
+	encryptionKey := "destination-key"
+	encryptionKeySHA256 := "destination-key-sha256"
+	_, _, err = hasher.hashRanges(
+		context.Background(),
+		"target",
+		client,
+		azcore.ETag(`"target-etag"`),
+		ranges,
+		&blob.CPKInfo{
+			EncryptionAlgorithm: &algorithm,
+			EncryptionKey:       &encryptionKey,
+			EncryptionKeySHA256: &encryptionKeySHA256,
+		},
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, encryptionKey, headerValueFold(transport.request.Header, "x-ms-encryption-key"))
+	assert.Equal(t, encryptionKeySHA256, headerValueFold(transport.request.Header, "x-ms-encryption-key-sha256"))
+}
+
+func TestResolveDedupeCandidateHashesNoCRCHitAvoidsSHA(t *testing.T) {
+	state := &dedupeJobState{committed: common.NewDedupeHashTable()}
+	state.committed.Insert(common.BlockEntry{
+		CRC64:        1,
+		TargetURI:    "https://acct.blob.core.windows.net/c/wrong-size",
+		TargetOffset: 0,
+		TargetLength: 4,
+		ETag:         azcore.ETag(`"target"`),
+	})
+	hasher := &fakeDedupeRangeHasher{}
+	plan := &SourceGridPlan{Blocks: []PlannedBlock{
+		crcOnlyBlock(0, 3, 1),
+		crcOnlyBlock(3, 7, 2),
+		crcOnlyBlock(10, 2, 3),
+	}}
+
+	index, stats, err := resolveDedupeCandidateHashes(
+		context.Background(),
+		state,
+		plan,
+		azcore.ETag(`"source"`),
+		"https://acct.blob.core.windows.net/c/current",
+		hasher,
+	)
+
+	assert.NoError(t, err)
+	assert.Empty(t, index)
+	assert.Zero(t, stats.candidateBlocks)
+	assert.Zero(t, hasher.sourceCalls)
+	assert.Zero(t, hasher.targetCalls)
+}
+
+func TestResolveDedupeCandidateHashesMatchesByRangeNotResultOrder(t *testing.T) {
+	shared := sha256.Sum256([]byte("shared"))
+	other := sha256.Sum256([]byte("other"))
+	targetURI := "https://acct.blob.core.windows.net/c/previous?sig=secret"
+	state := &dedupeJobState{committed: common.NewDedupeHashTable()}
+	state.committed.Insert(common.BlockEntry{
+		CRC64:        10,
+		TargetURI:    targetURI,
+		TargetOffset: 100,
+		TargetLength: 3,
+		ETag:         azcore.ETag(`"target"`),
+	})
+	state.committed.Insert(common.BlockEntry{
+		CRC64:        20,
+		TargetURI:    targetURI,
+		TargetOffset: 200,
+		TargetLength: 7,
+		ETag:         azcore.ETag(`"target"`),
+	})
+	plan := &SourceGridPlan{Blocks: []PlannedBlock{
+		crcOnlyBlock(0, 3, 10),
+		crcOnlyBlock(3, 7, 20),
+	}}
+	plan.Blocks[0].SrcBlockName = "duplicate-block-id"
+	plan.Blocks[1].SrcBlockName = "duplicate-block-id"
+	hasher := &fakeDedupeRangeHasher{
+		sourceHashes: map[srcBlockKey][32]byte{
+			{offset: 0, size: 3}: shared,
+			{offset: 3, size: 7}: other,
+		},
+		targetHashes: map[string]map[srcBlockKey][32]byte{
+			targetURI: {
+				{offset: 100, size: 3}: shared,
+				{offset: 200, size: 7}: sha256.Sum256([]byte("mismatch")),
+			},
+		},
+		targetErr: make(map[string]error),
+	}
+
+	index, stats, err := resolveDedupeCandidateHashes(
+		context.Background(),
+		state,
+		plan,
+		azcore.ETag(`"source"`),
+		"https://acct.blob.core.windows.net/c/current",
+		hasher,
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, stats.candidateBlocks)
+	assert.Equal(t, 2, stats.candidateOccurrences)
+	assert.Zero(t, stats.targetHashCacheHits)
+	assert.Equal(t, 2, stats.targetHashCacheMisses)
+	assert.Equal(t, 1, hasher.sourceCalls)
+	assert.Equal(t, 1, hasher.targetCalls)
+	assert.Equal(t, []blockblob.BlobHashRange{{Offset: 0, Count: 3}, {Offset: 3, Count: 7}}, hasher.sourceRanges)
+	assert.Equal(t, []blockblob.BlobHashRange{{Offset: 100, Count: 3}, {Offset: 200, Count: 7}}, hasher.targetRanges[targetURI])
+
+	target, hit := decideStaging(index, state.committed, 0, 3, "https://acct.blob.core.windows.net/c/current")
+	assert.True(t, hit)
+	assert.Equal(t, targetURI, target.TargetURI)
+	_, hit = decideStaging(index, state.committed, 3, 7, "https://acct.blob.core.windows.net/c/current")
+	assert.False(t, hit)
+}
+
+func TestResolveDedupeCandidateHashesReusesCachedTargetSHA(t *testing.T) {
+	hash := sha256.Sum256([]byte("cached"))
+	targetURI := "https://acct.blob.core.windows.net/c/previous"
+	state := &dedupeJobState{committed: common.NewDedupeHashTable()}
+	state.committed.Insert(common.BlockEntry{
+		CRC64:        10,
+		SHA256:       hash,
+		HasSHA256:    true,
+		TargetURI:    targetURI,
+		TargetOffset: 100,
+		TargetLength: 3,
+		ETag:         azcore.ETag(`"target"`),
+	})
+	hasher := &fakeDedupeRangeHasher{
+		sourceHashes: map[srcBlockKey][32]byte{{offset: 0, size: 3}: hash},
+		targetHashes: make(map[string]map[srcBlockKey][32]byte),
+		targetErr:    make(map[string]error),
+	}
+
+	index, stats, err := resolveDedupeCandidateHashes(
+		context.Background(),
+		state,
+		&SourceGridPlan{Blocks: []PlannedBlock{crcOnlyBlock(0, 3, 10)}},
+		azcore.ETag(`"source"`),
+		"https://acct.blob.core.windows.net/c/current",
+		hasher,
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, hasher.sourceCalls)
+	assert.Zero(t, hasher.targetCalls)
+	assert.Equal(t, 1, stats.targetHashCacheHits)
+	assert.Zero(t, stats.targetHashCacheMisses)
+	_, hit := decideStaging(index, state.committed, 0, 3, "https://acct.blob.core.windows.net/c/current")
+	assert.True(t, hit)
+}
+
+func TestResolveDedupeCandidateHashesCoalescesConcurrentTargetHashing(t *testing.T) {
+	hash := sha256.Sum256([]byte("shared"))
+	targetURI := "https://acct.blob.core.windows.net/c/previous"
+	state := &dedupeJobState{committed: common.NewDedupeHashTable()}
+	state.committed.Insert(common.BlockEntry{
+		CRC64:        10,
+		TargetURI:    targetURI,
+		TargetOffset: 100,
+		TargetLength: 3,
+		ETag:         azcore.ETag(`"target"`),
+	})
+	hasher := &fakeDedupeRangeHasher{
+		sourceHashes: map[srcBlockKey][32]byte{{offset: 0, size: 3}: hash},
+		targetHashes: map[string]map[srcBlockKey][32]byte{
+			targetURI: {{offset: 100, size: 3}: hash},
+		},
+		targetErr: make(map[string]error),
+	}
+	plan := &SourceGridPlan{Blocks: []PlannedBlock{crcOnlyBlock(0, 3, 10)}}
+
+	const workers = 16
+	results := make(chan map[srcBlockKey]srcBlockHashes, workers)
+	errorsCh := make(chan error, workers)
+	var waitGroup sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			index, _, err := resolveDedupeCandidateHashes(
+				context.Background(),
+				state,
+				plan,
+				azcore.ETag(`"source"`),
+				"https://acct.blob.core.windows.net/c/current",
+				hasher,
+			)
+			results <- index
+			errorsCh <- err
+		}()
+	}
+	waitGroup.Wait()
+	close(results)
+	close(errorsCh)
+
+	for err := range errorsCh {
+		assert.NoError(t, err)
+	}
+	for index := range results {
+		_, hit := decideStaging(
+			index,
+			state.committed,
+			0,
+			3,
+			"https://acct.blob.core.windows.net/c/current",
+		)
+		assert.True(t, hit)
+	}
+	assert.Equal(t, workers, hasher.sourceCalls)
+	assert.Equal(t, 1, hasher.targetCalls)
+}
+
+func TestResolveDedupeCandidateHashesEvictsTargetEpochOn412(t *testing.T) {
+	targetURI := "https://acct.blob.core.windows.net/c/previous"
+	state := &dedupeJobState{committed: common.NewDedupeHashTable()}
+	state.committed.Insert(common.BlockEntry{
+		CRC64:        10,
+		TargetURI:    targetURI,
+		TargetOffset: 100,
+		TargetLength: 3,
+		ETag:         azcore.ETag(`"target"`),
+	})
+	hash := sha256.Sum256([]byte("source"))
+	hasher := &fakeDedupeRangeHasher{
+		sourceHashes: map[srcBlockKey][32]byte{{offset: 0, size: 3}: hash},
+		targetHashes: make(map[string]map[srcBlockKey][32]byte),
+		targetErr: map[string]error{
+			targetURI: &azcore.ResponseError{StatusCode: http.StatusPreconditionFailed},
+		},
+	}
+
+	index, stats, err := resolveDedupeCandidateHashes(
+		context.Background(),
+		state,
+		&SourceGridPlan{Blocks: []PlannedBlock{crcOnlyBlock(0, 3, 10)}},
+		azcore.ETag(`"source"`),
+		"https://acct.blob.core.windows.net/c/current",
+		hasher,
+	)
+
+	assert.NoError(t, err)
+	assert.Len(t, index, 1)
+	assert.Equal(t, 1, stats.targetEpochInvalidations)
+	assert.Empty(t, state.committed.LookupByCRC64(10))
+}
+
+func TestResolveDedupeCandidateHashesTargetFailureFallsBackWithoutCaching(t *testing.T) {
+	targetURI := "https://acct.blob.core.windows.net/c/previous"
+	state := &dedupeJobState{committed: common.NewDedupeHashTable()}
+	state.committed.Insert(common.BlockEntry{
+		CRC64:        10,
+		TargetURI:    targetURI,
+		TargetOffset: 100,
+		TargetLength: 3,
+		ETag:         azcore.ETag(`"target"`),
+	})
+	hash := sha256.Sum256([]byte("source"))
+	hasher := &fakeDedupeRangeHasher{
+		sourceHashes: map[srcBlockKey][32]byte{{offset: 0, size: 3}: hash},
+		targetHashes: make(map[string]map[srcBlockKey][32]byte),
+		targetErr:    map[string]error{targetURI: context.DeadlineExceeded},
+	}
+
+	index, stats, err := resolveDedupeCandidateHashes(
+		context.Background(),
+		state,
+		&SourceGridPlan{Blocks: []PlannedBlock{crcOnlyBlock(0, 3, 10)}},
+		azcore.ETag(`"source"`),
+		"https://acct.blob.core.windows.net/c/current",
+		hasher,
+	)
+
+	assert.NoError(t, err)
+	assert.Len(t, index, 1)
+	assert.Equal(t, 1, stats.targetHashFailures)
+	candidates := state.committed.LookupByCRC64AndLength(10, 3)
+	if assert.Len(t, candidates, 1) {
+		assert.False(t, candidates[0].HasSHA256)
+	}
+	_, hit := decideStaging(index, state.committed, 0, 3, "https://acct.blob.core.windows.net/c/current")
+	assert.False(t, hit)
+	assert.False(t, hasDedupeSHAMismatch(
+		index,
+		state.committed,
+		0,
+		3,
+		"https://acct.blob.core.windows.net/c/current",
+	))
+}
+
+func TestResolveDedupeCandidateHashesReportsSource412(t *testing.T) {
+	state := &dedupeJobState{committed: common.NewDedupeHashTable()}
+	state.committed.Insert(common.BlockEntry{
+		CRC64:        10,
+		TargetURI:    "https://acct.blob.core.windows.net/c/previous",
+		TargetOffset: 100,
+		TargetLength: 3,
+		ETag:         azcore.ETag(`"target"`),
+	})
+	hasher := &fakeDedupeRangeHasher{
+		sourceErr: &azcore.ResponseError{StatusCode: http.StatusPreconditionFailed},
+	}
+
+	index, stats, err := resolveDedupeCandidateHashes(
+		context.Background(),
+		state,
+		&SourceGridPlan{Blocks: []PlannedBlock{crcOnlyBlock(0, 3, 10)}},
+		azcore.ETag(`"source"`),
+		"https://acct.blob.core.windows.net/c/current",
+		hasher,
+	)
+
+	assert.Error(t, err)
+	assert.Empty(t, index)
+	assert.Equal(t, 1, stats.sourceEpochInvalidations)
+	assert.Equal(t, 1, state.committed.Len())
+}
+
+func TestBatchDedupeBlobHashRanges(t *testing.T) {
+	t.Run("range count", func(t *testing.T) {
+		ranges := make([]blockblob.BlobHashRange, 257)
+		for i := range ranges {
+			ranges[i] = blockblob.BlobHashRange{Offset: int64(i * 2), Count: 1}
+		}
+		batches, err := batchDedupeBlobHashRanges(ranges)
+		assert.NoError(t, err)
+		assert.Len(t, batches, 2)
+		assert.Len(t, batches[0], 256)
+		assert.Len(t, batches[1], 1)
+	})
+
+	t.Run("aggregate bytes", func(t *testing.T) {
+		ranges := []blockblob.BlobHashRange{
+			{Offset: 0, Count: dedupeGetBlobHashMaxBytes},
+			{Offset: dedupeGetBlobHashMaxBytes, Count: 1},
+		}
+		batches, err := batchDedupeBlobHashRanges(ranges)
+		assert.NoError(t, err)
+		assert.Len(t, batches, 2)
+	})
+
+	t.Run("header bytes", func(t *testing.T) {
+		ranges := make([]blockblob.BlobHashRange, 205)
+		for i := range ranges {
+			ranges[i] = blockblob.BlobHashRange{
+				Offset: 1000000000000000000 + int64(i*2),
+				Count:  1,
+			}
+		}
+		batches, err := batchDedupeBlobHashRanges(ranges)
+		assert.NoError(t, err)
+		assert.Len(t, batches, 2)
+		for _, batch := range batches {
+			headerBytes := len("bytes=")
+			for i, rnge := range batch {
+				if i > 0 {
+					headerBytes++
+				}
+				end := rnge.Offset + rnge.Count - 1
+				headerBytes += len(strconv.FormatInt(rnge.Offset, 10)) +
+					1 +
+					len(strconv.FormatInt(end, 10))
+			}
+			assert.LessOrEqual(t, headerBytes, dedupeGetBlobHashMaxHeaderBytes)
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		_, err := batchDedupeBlobHashRanges([]blockblob.BlobHashRange{{Offset: -1, Count: 1}})
+		assert.Error(t, err)
+	})
+
+	t.Run("unsorted or overlapping", func(t *testing.T) {
+		_, err := batchDedupeBlobHashRanges([]blockblob.BlobHashRange{
+			{Offset: 10, Count: 2},
+			{Offset: 9, Count: 1},
+		})
+		assert.Error(t, err)
+
+		_, err = batchDedupeBlobHashRanges([]blockblob.BlobHashRange{
+			{Offset: 0, Count: 10},
+			{Offset: 9, Count: 2},
+		})
+		assert.Error(t, err)
+	})
+}
+
+func TestApplyResolvedSourceHashesPersistsOnlyCalculatedSHA(t *testing.T) {
+	first := sha256.Sum256([]byte("first"))
+	plan := &SourceGridPlan{Blocks: []PlannedBlock{
+		crcOnlyBlock(0, 3, 10),
+		crcOnlyBlock(3, 7, 20),
+	}}
+	applyResolvedSourceHashes(plan, map[srcBlockKey]srcBlockHashes{
+		{offset: 0, size: 3}: {crc64: 10, sha256: first},
+	})
+
+	assert.True(t, plan.Blocks[0].HasCRC64)
+	assert.True(t, plan.Blocks[0].HasSHA256)
+	assert.True(t, plan.Blocks[0].HasHashes)
+	assert.Equal(t, first, plan.Blocks[0].SHA256)
+	assert.True(t, plan.Blocks[1].HasCRC64)
+	assert.False(t, plan.Blocks[1].HasSHA256)
+	assert.False(t, plan.Blocks[1].HasHashes)
+}

--- a/ste/dedupeRecorder.go
+++ b/ste/dedupeRecorder.go
@@ -23,6 +23,7 @@ package ste
 import (
 	"fmt"
 	"io"
+	"math"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -32,6 +33,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
@@ -43,6 +45,7 @@ import (
 // dedupeJobState holds a single job's dedupe tables plus cumulative would-be-hit counters.
 type dedupeJobState struct {
 	smallProgressMu sync.Mutex
+	hashCPU         dedupeHashCPUState
 
 	// table is the Phase 1 measurement table: blocks are recorded pre-write purely to count the
 	// would-be-hit rate, so it must NOT be used to decide a real reference (the content may not yet
@@ -159,6 +162,289 @@ func (s *dedupeJobState) addSmallFileResultLocked(status common.TransferStatus, 
 	default:
 		return ""
 	}
+}
+
+type dedupeHashCPUState struct {
+	mu sync.Mutex
+
+	seenRequestIDs map[string]struct{}
+
+	crc64CPUTimeUS                int64
+	sha256CPUTimeUS               int64
+	hashedBlocks                  int64
+	hashedBytes                   int64
+	hashCPUTimeResponses          int64
+	crc64CPUTimeMissingResponses  int64
+	sha256CPUTimeMissingResponses int64
+	requestIDMissingResponses     int64
+	crc64CPUTimeInvalidResponses  int64
+	sha256CPUTimeInvalidResponses int64
+	crc64CPUTimeOverflowed        bool
+	sha256CPUTimeOverflowed       bool
+	hashCPUTimeOverflowed         bool
+	hashedBlocksOverflowed        bool
+	hashedBytesOverflowed         bool
+	hashMetricsOverflowed         bool
+}
+
+type dedupeHashCPUResponseDelta struct {
+	requestID string
+
+	crc64CPUTimeUS         int64
+	sha256CPUTimeUS        int64
+	hashCPUTimeUS          int64
+	hashedBlocks           int64
+	hashedBytes            int64
+	crc64CPUTimeMissing    bool
+	sha256CPUTimeMissing   bool
+	crc64CPUTimeInvalid    bool
+	sha256CPUTimeInvalid   bool
+	hashCPUTimeOverflowed  bool
+	hashedBlocksOverflowed bool
+	hashedBytesOverflowed  bool
+}
+
+type dedupeHashCPUSnapshot struct {
+	crc64CPUTimeUS                int64
+	sha256CPUTimeUS               int64
+	hashCPUTimeUS                 int64
+	hashedBlocks                  int64
+	hashedBytes                   int64
+	hashCPUTimeResponses          int64
+	crc64CPUTimeMissingResponses  int64
+	sha256CPUTimeMissingResponses int64
+	requestIDMissingResponses     int64
+	crc64CPUTimeInvalidResponses  int64
+	sha256CPUTimeInvalidResponses int64
+	crc64CPUTimeOverflowed        bool
+	sha256CPUTimeOverflowed       bool
+	hashCPUTimeOverflowed         bool
+	hashedBlocksOverflowed        bool
+	hashedBytesOverflowed         bool
+	hashMetricsOverflowed         bool
+}
+
+type dedupeHashCPUEventSnapshot struct {
+	delta      dedupeHashCPUResponseDelta
+	cumulative dedupeHashCPUSnapshot
+}
+
+func satAddNonNegative(a, b int64) (sum int64, overflow bool) {
+	if a < 0 || b < 0 {
+		return math.MaxInt64, true
+	}
+	if a > math.MaxInt64-b {
+		return math.MaxInt64, true
+	}
+	return a + b, false
+}
+
+func hashCPUTimeDelta(value *int64) (delta int64, missing bool, invalid bool) {
+	if value == nil {
+		return 0, true, false
+	}
+	if *value < 0 {
+		return 0, false, true
+	}
+	return *value, false, false
+}
+
+func hashCPUResponseDelta(resp blockblob.GetBlockListResponse) dedupeHashCPUResponseDelta {
+	delta := dedupeHashCPUResponseDelta{}
+	if resp.RequestID != nil {
+		delta.requestID = strings.TrimSpace(*resp.RequestID)
+	}
+	delta.crc64CPUTimeUS, delta.crc64CPUTimeMissing, delta.crc64CPUTimeInvalid =
+		hashCPUTimeDelta(resp.CRC64CPUTimeUS)
+	delta.sha256CPUTimeUS, delta.sha256CPUTimeMissing, delta.sha256CPUTimeInvalid =
+		hashCPUTimeDelta(resp.SHA256CPUTimeUS)
+	delta.hashCPUTimeUS, delta.hashCPUTimeOverflowed = satAddNonNegative(
+		delta.crc64CPUTimeUS,
+		delta.sha256CPUTimeUS,
+	)
+
+	for _, block := range resp.CommittedBlocks {
+		if block == nil || len(block.Crc64) != 8 || len(block.Sha256) != 32 {
+			continue
+		}
+
+		var overflow bool
+		delta.hashedBlocks, overflow = satAddNonNegative(delta.hashedBlocks, 1)
+		delta.hashedBlocksOverflowed = delta.hashedBlocksOverflowed || overflow
+		if block.Size == nil || *block.Size <= 0 {
+			continue
+		}
+		delta.hashedBytes, overflow = satAddNonNegative(delta.hashedBytes, *block.Size)
+		delta.hashedBytesOverflowed = delta.hashedBytesOverflowed || overflow
+	}
+	return delta
+}
+
+func (s *dedupeHashCPUState) record(delta dedupeHashCPUResponseDelta) (dedupeHashCPUEventSnapshot, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if delta.requestID != "" {
+		if _, duplicate := s.seenRequestIDs[delta.requestID]; duplicate {
+			return dedupeHashCPUEventSnapshot{}, false
+		}
+		if s.seenRequestIDs == nil {
+			s.seenRequestIDs = make(map[string]struct{})
+		}
+		s.seenRequestIDs[delta.requestID] = struct{}{}
+	}
+
+	metricsOverflowed := delta.hashCPUTimeOverflowed ||
+		delta.hashedBlocksOverflowed ||
+		delta.hashedBytesOverflowed
+
+	var overflow bool
+	s.crc64CPUTimeUS, overflow = satAddNonNegative(s.crc64CPUTimeUS, delta.crc64CPUTimeUS)
+	s.crc64CPUTimeOverflowed = s.crc64CPUTimeOverflowed || overflow
+	metricsOverflowed = metricsOverflowed || overflow
+
+	s.sha256CPUTimeUS, overflow = satAddNonNegative(s.sha256CPUTimeUS, delta.sha256CPUTimeUS)
+	s.sha256CPUTimeOverflowed = s.sha256CPUTimeOverflowed || overflow
+	metricsOverflowed = metricsOverflowed || overflow
+
+	s.hashedBlocks, overflow = satAddNonNegative(s.hashedBlocks, delta.hashedBlocks)
+	s.hashedBlocksOverflowed = s.hashedBlocksOverflowed || delta.hashedBlocksOverflowed || overflow
+	metricsOverflowed = metricsOverflowed || overflow
+
+	s.hashedBytes, overflow = satAddNonNegative(s.hashedBytes, delta.hashedBytes)
+	s.hashedBytesOverflowed = s.hashedBytesOverflowed || delta.hashedBytesOverflowed || overflow
+	metricsOverflowed = metricsOverflowed || overflow
+
+	s.hashCPUTimeResponses, overflow = satAddNonNegative(s.hashCPUTimeResponses, 1)
+	metricsOverflowed = metricsOverflowed || overflow
+
+	if delta.crc64CPUTimeMissing {
+		s.crc64CPUTimeMissingResponses, overflow =
+			satAddNonNegative(s.crc64CPUTimeMissingResponses, 1)
+		metricsOverflowed = metricsOverflowed || overflow
+	}
+	if delta.sha256CPUTimeMissing {
+		s.sha256CPUTimeMissingResponses, overflow =
+			satAddNonNegative(s.sha256CPUTimeMissingResponses, 1)
+		metricsOverflowed = metricsOverflowed || overflow
+	}
+	if delta.requestID == "" {
+		s.requestIDMissingResponses, overflow =
+			satAddNonNegative(s.requestIDMissingResponses, 1)
+		metricsOverflowed = metricsOverflowed || overflow
+	}
+	if delta.crc64CPUTimeInvalid {
+		s.crc64CPUTimeInvalidResponses, overflow =
+			satAddNonNegative(s.crc64CPUTimeInvalidResponses, 1)
+		metricsOverflowed = metricsOverflowed || overflow
+	}
+	if delta.sha256CPUTimeInvalid {
+		s.sha256CPUTimeInvalidResponses, overflow =
+			satAddNonNegative(s.sha256CPUTimeInvalidResponses, 1)
+		metricsOverflowed = metricsOverflowed || overflow
+	}
+
+	_, overflow = satAddNonNegative(s.crc64CPUTimeUS, s.sha256CPUTimeUS)
+	s.hashCPUTimeOverflowed = s.hashCPUTimeOverflowed ||
+		delta.hashCPUTimeOverflowed ||
+		s.crc64CPUTimeOverflowed ||
+		s.sha256CPUTimeOverflowed ||
+		overflow
+	metricsOverflowed = metricsOverflowed ||
+		s.crc64CPUTimeOverflowed ||
+		s.sha256CPUTimeOverflowed ||
+		s.hashCPUTimeOverflowed ||
+		s.hashedBlocksOverflowed ||
+		s.hashedBytesOverflowed
+	s.hashMetricsOverflowed = s.hashMetricsOverflowed || metricsOverflowed
+
+	return dedupeHashCPUEventSnapshot{
+		delta:      delta,
+		cumulative: s.snapshotLocked(),
+	}, true
+}
+
+func (s *dedupeHashCPUState) snapshot() dedupeHashCPUSnapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.snapshotLocked()
+}
+
+func (s *dedupeHashCPUState) snapshotLocked() dedupeHashCPUSnapshot {
+	hashCPUTimeUS, hashCPUTimeOverflowed :=
+		satAddNonNegative(s.crc64CPUTimeUS, s.sha256CPUTimeUS)
+	hashCPUTimeOverflowed = hashCPUTimeOverflowed ||
+		s.crc64CPUTimeOverflowed ||
+		s.sha256CPUTimeOverflowed ||
+		s.hashCPUTimeOverflowed
+
+	return dedupeHashCPUSnapshot{
+		crc64CPUTimeUS:                s.crc64CPUTimeUS,
+		sha256CPUTimeUS:               s.sha256CPUTimeUS,
+		hashCPUTimeUS:                 hashCPUTimeUS,
+		hashedBlocks:                  s.hashedBlocks,
+		hashedBytes:                   s.hashedBytes,
+		hashCPUTimeResponses:          s.hashCPUTimeResponses,
+		crc64CPUTimeMissingResponses:  s.crc64CPUTimeMissingResponses,
+		sha256CPUTimeMissingResponses: s.sha256CPUTimeMissingResponses,
+		requestIDMissingResponses:     s.requestIDMissingResponses,
+		crc64CPUTimeInvalidResponses:  s.crc64CPUTimeInvalidResponses,
+		sha256CPUTimeInvalidResponses: s.sha256CPUTimeInvalidResponses,
+		crc64CPUTimeOverflowed:        s.crc64CPUTimeOverflowed,
+		sha256CPUTimeOverflowed:       s.sha256CPUTimeOverflowed,
+		hashCPUTimeOverflowed:         hashCPUTimeOverflowed,
+		hashedBlocksOverflowed:        s.hashedBlocksOverflowed,
+		hashedBytesOverflowed:         s.hashedBytesOverflowed,
+		hashMetricsOverflowed: s.hashMetricsOverflowed ||
+			s.crc64CPUTimeOverflowed ||
+			s.sha256CPUTimeOverflowed ||
+			hashCPUTimeOverflowed ||
+			s.hashedBlocksOverflowed ||
+			s.hashedBytesOverflowed,
+	}
+}
+
+func (s dedupeHashCPUSnapshot) fields() string {
+	return fmt.Sprintf(
+		"crc64CpuTimeUs=%d sha256CpuTimeUs=%d hashCpuTimeUs=%d hashedBlocks=%d "+
+			"hashedBytes=%d hashCpuTimeResponses=%d crc64CpuTimeMissingResponses=%d "+
+			"sha256CpuTimeMissingResponses=%d requestIdMissingResponses=%d "+
+			"crc64CpuTimeInvalidResponses=%d sha256CpuTimeInvalidResponses=%d "+
+			"crc64CpuTimeOverflowed=%t sha256CpuTimeOverflowed=%t "+
+			"hashCpuTimeOverflowed=%t hashedBlocksOverflowed=%t "+
+			"hashedBytesOverflowed=%t hashMetricsOverflowed=%t",
+		s.crc64CPUTimeUS,
+		s.sha256CPUTimeUS,
+		s.hashCPUTimeUS,
+		s.hashedBlocks,
+		s.hashedBytes,
+		s.hashCPUTimeResponses,
+		s.crc64CPUTimeMissingResponses,
+		s.sha256CPUTimeMissingResponses,
+		s.requestIDMissingResponses,
+		s.crc64CPUTimeInvalidResponses,
+		s.sha256CPUTimeInvalidResponses,
+		s.crc64CPUTimeOverflowed,
+		s.sha256CPUTimeOverflowed,
+		s.hashCPUTimeOverflowed,
+		s.hashedBlocksOverflowed,
+		s.hashedBytesOverflowed,
+		s.hashMetricsOverflowed,
+	)
+}
+
+func (s dedupeHashCPUEventSnapshot) fields() string {
+	return fmt.Sprintf(
+		"requestId=%q crc64CpuTimeUsDelta=%d sha256CpuTimeUsDelta=%d "+
+			"hashCpuTimeUsDelta=%d hashedBlocksDelta=%d hashedBytesDelta=%d %s",
+		s.delta.requestID,
+		s.delta.crc64CPUTimeUS,
+		s.delta.sha256CPUTimeUS,
+		s.delta.hashCPUTimeUS,
+		s.delta.hashedBlocks,
+		s.delta.hashedBytes,
+		s.cumulative.fields(),
+	)
 }
 
 type dedupeProgressSnapshot struct {
@@ -455,6 +741,39 @@ func writeFinalDedupeProgress(jobID common.JobID, message string) error {
 func emitDedupeProgress(jptm IJobPartTransferMgr, message string) {
 	jptm.LogAtLevelForCurrentTransfer(common.LogDebug, message)
 	enqueueDedupeProgress(jptm.Info().JobID, message)
+}
+
+func dedupeHashCPUTimeMessage(
+	mode dedupeActMode,
+	info *TransferInfo,
+	snapshot dedupeHashCPUEventSnapshot,
+) string {
+	return fmt.Sprintf(
+		"%s event=hash_cpu_time mode=%s jobId=%s file=%q destination=%q %s",
+		dedupeProgressPrefix,
+		mode,
+		info.JobID.String(),
+		info.DstFilePath,
+		sanitizedDestForDedupe(info.Destination),
+		snapshot.fields(),
+	)
+}
+
+func emitHashCPUTime(
+	jptm IJobPartTransferMgr,
+	mode dedupeActMode,
+	resp blockblob.GetBlockListResponse,
+) {
+	if mode != dedupeActEnforce {
+		return
+	}
+
+	st := dedupeStateForJob(jptm.Info().JobID)
+	snapshot, accepted := st.hashCPU.record(hashCPUResponseDelta(resp))
+	if !accepted {
+		return
+	}
+	emitDedupeProgress(jptm, dedupeHashCPUTimeMessage(mode, jptm.Info(), snapshot))
 }
 
 func isSmallFileProgressTransfer(jptm IJobPartTransferMgr) bool {
@@ -809,7 +1128,7 @@ func finalizeDedupeJob(
 		log(common.LogInfo, dedupeJobSummaryMessage(mode, st))
 		message := fmt.Sprintf(
 			"%s event=job_complete mode=%s jobId=%s status=%q transfersCompleted=%d "+
-				"transfersSkipped=%d transfersFailed=%d %s",
+				"transfersSkipped=%d transfersFailed=%d %s %s",
 			dedupeProgressPrefix,
 			mode,
 			jobID.String(),
@@ -817,7 +1136,8 @@ func finalizeDedupeJob(
 			transfersCompleted,
 			transfersSkipped,
 			transfersFailed,
-			st.progressSnapshot().fields(mode))
+			st.progressSnapshot().fields(mode),
+			st.hashCPU.snapshot().fields())
 		if err := writeFinalDedupeProgress(jobID, message); err != nil {
 			log(common.LogError,
 				dedupeProgressPrefix+" event=output_error reason="+fmt.Sprintf("%q", err.Error()))

--- a/ste/dedupeRecorder.go
+++ b/ste/dedupeRecorder.go
@@ -42,6 +42,8 @@ import (
 
 // dedupeJobState holds a single job's dedupe tables plus cumulative would-be-hit counters.
 type dedupeJobState struct {
+	smallProgressMu sync.Mutex
+
 	// table is the Phase 1 measurement table: blocks are recorded pre-write purely to count the
 	// would-be-hit rate, so it must NOT be used to decide a real reference (the content may not yet
 	// exist at the destination).
@@ -60,16 +62,26 @@ type dedupeJobState struct {
 
 	// Phase 2 "act" counters (also cumulative + atomic). Together they quantify how many source
 	// reads dedupe actually avoided (enforce) or would avoid (shadow).
-	referencedBlocks      int64 // enforce: blocks staged from the destination instead of the source
-	referencedBytes       int64 // enforce: source-read bytes avoided
-	wouldReferenceBlocks  int64 // shadow: blocks that would be referenced under enforce
-	wouldReferenceBytes   int64 // shadow: source-read bytes that would be avoided under enforce
-	sourceStagedBlocks    int64 // blocks staged from the source (real source reads)
-	sourceStagedBytes     int64 // bytes staged from the source
-	fallbackBlocks        int64 // enforce: hits whose target reference failed and fell back to source
-	filesStarted          int64 // files armed for source-grid dedupe
-	filesCommitted        int64 // files whose destination block list was committed
-	progressEventsDropped uint64
+	referencedBlocks        int64 // enforce: blocks staged from the destination instead of the source
+	referencedBytes         int64 // enforce: source-read bytes avoided
+	wouldReferenceBlocks    int64 // shadow: blocks that would be referenced under enforce
+	wouldReferenceBytes     int64 // shadow: source-read bytes that would be avoided under enforce
+	sourceStagedBlocks      int64 // blocks staged from the source (real source reads)
+	sourceStagedBytes       int64 // bytes staged from the source
+	fallbackBlocks          int64 // enforce: hits whose target reference failed and fell back to source
+	filesStarted            int64 // files armed for source-grid dedupe
+	filesCommitted          int64 // files whose destination block list was committed
+	smallFilesStarted       int64 // Blob-to-Blob files smaller than 4 MiB that entered transfer handling
+	smallFilesCompleted     int64 // small files that completed successfully
+	smallFilesFailed        int64 // small files that completed with a failure status
+	smallFilesSkipped       int64 // small files skipped by transfer policy
+	smallFilesCanceled      int64 // small files canceled before completion
+	smallFileBytesStarted   int64
+	smallFileBytesCompleted int64
+	smallFileBytesFailed    int64
+	smallFileBytesSkipped   int64
+	smallFileBytesCanceled  int64
+	progressEventsDropped   uint64
 
 	actMode int32 // active dedupeActMode for this job
 }
@@ -105,29 +117,99 @@ func (s *dedupeJobState) addFileCommitted() {
 	atomic.AddInt64(&s.filesCommitted, 1)
 }
 
+func (s *dedupeJobState) addSmallFileStarted(size int64) {
+	s.smallProgressMu.Lock()
+	defer s.smallProgressMu.Unlock()
+	s.addSmallFileStartedLocked(size)
+}
+
+func (s *dedupeJobState) addSmallFileResult(status common.TransferStatus, size int64) string {
+	s.smallProgressMu.Lock()
+	defer s.smallProgressMu.Unlock()
+	return s.addSmallFileResultLocked(status, size)
+}
+
+func (s *dedupeJobState) addSmallFileStartedLocked(size int64) {
+	s.smallFilesStarted++
+	s.smallFileBytesStarted += size
+}
+
+func (s *dedupeJobState) addSmallFileResultLocked(status common.TransferStatus, size int64) string {
+	switch status {
+	case common.ETransferStatus.Success():
+		s.smallFilesCompleted++
+		s.smallFileBytesCompleted += size
+		return "small_file_transfer_complete"
+	case common.ETransferStatus.Failed(),
+		common.ETransferStatus.BlobTierFailure(),
+		common.ETransferStatus.TierAvailabilityCheckFailure():
+		s.smallFilesFailed++
+		s.smallFileBytesFailed += size
+		return "small_file_transfer_failed"
+	case common.ETransferStatus.SkippedEntityAlreadyExists(),
+		common.ETransferStatus.SkippedBlobHasSnapshots(),
+		common.ETransferStatus.SkippedArchiveNotRestored():
+		s.smallFilesSkipped++
+		s.smallFileBytesSkipped += size
+		return "small_file_transfer_skipped"
+	case common.ETransferStatus.Cancelled():
+		s.smallFilesCanceled++
+		s.smallFileBytesCanceled += size
+		return "small_file_transfer_canceled"
+	default:
+		return ""
+	}
+}
+
 type dedupeProgressSnapshot struct {
-	referencedBlocks     int64
-	referencedBytes      int64
-	wouldReferenceBlocks int64
-	wouldReferenceBytes  int64
-	sourceStagedBlocks   int64
-	sourceStagedBytes    int64
-	fallbackBlocks       int64
-	filesStarted         int64
-	filesCommitted       int64
+	referencedBlocks        int64
+	referencedBytes         int64
+	wouldReferenceBlocks    int64
+	wouldReferenceBytes     int64
+	sourceStagedBlocks      int64
+	sourceStagedBytes       int64
+	fallbackBlocks          int64
+	filesStarted            int64
+	filesCommitted          int64
+	smallFilesStarted       int64
+	smallFilesCompleted     int64
+	smallFilesFailed        int64
+	smallFilesSkipped       int64
+	smallFilesCanceled      int64
+	smallFileBytesStarted   int64
+	smallFileBytesCompleted int64
+	smallFileBytesFailed    int64
+	smallFileBytesSkipped   int64
+	smallFileBytesCanceled  int64
 }
 
 func (s *dedupeJobState) progressSnapshot() dedupeProgressSnapshot {
+	s.smallProgressMu.Lock()
+	defer s.smallProgressMu.Unlock()
+	return s.progressSnapshotLocked()
+}
+
+func (s *dedupeJobState) progressSnapshotLocked() dedupeProgressSnapshot {
 	return dedupeProgressSnapshot{
-		referencedBlocks:     atomic.LoadInt64(&s.referencedBlocks),
-		referencedBytes:      atomic.LoadInt64(&s.referencedBytes),
-		wouldReferenceBlocks: atomic.LoadInt64(&s.wouldReferenceBlocks),
-		wouldReferenceBytes:  atomic.LoadInt64(&s.wouldReferenceBytes),
-		sourceStagedBlocks:   atomic.LoadInt64(&s.sourceStagedBlocks),
-		sourceStagedBytes:    atomic.LoadInt64(&s.sourceStagedBytes),
-		fallbackBlocks:       atomic.LoadInt64(&s.fallbackBlocks),
-		filesStarted:         atomic.LoadInt64(&s.filesStarted),
-		filesCommitted:       atomic.LoadInt64(&s.filesCommitted),
+		referencedBlocks:        atomic.LoadInt64(&s.referencedBlocks),
+		referencedBytes:         atomic.LoadInt64(&s.referencedBytes),
+		wouldReferenceBlocks:    atomic.LoadInt64(&s.wouldReferenceBlocks),
+		wouldReferenceBytes:     atomic.LoadInt64(&s.wouldReferenceBytes),
+		sourceStagedBlocks:      atomic.LoadInt64(&s.sourceStagedBlocks),
+		sourceStagedBytes:       atomic.LoadInt64(&s.sourceStagedBytes),
+		fallbackBlocks:          atomic.LoadInt64(&s.fallbackBlocks),
+		filesStarted:            atomic.LoadInt64(&s.filesStarted),
+		filesCommitted:          atomic.LoadInt64(&s.filesCommitted),
+		smallFilesStarted:       s.smallFilesStarted,
+		smallFilesCompleted:     s.smallFilesCompleted,
+		smallFilesFailed:        s.smallFilesFailed,
+		smallFilesSkipped:       s.smallFilesSkipped,
+		smallFilesCanceled:      s.smallFilesCanceled,
+		smallFileBytesStarted:   s.smallFileBytesStarted,
+		smallFileBytesCompleted: s.smallFileBytesCompleted,
+		smallFileBytesFailed:    s.smallFileBytesFailed,
+		smallFileBytesSkipped:   s.smallFileBytesSkipped,
+		smallFileBytesCanceled:  s.smallFileBytesCanceled,
 	}
 }
 
@@ -142,17 +224,42 @@ func (s dedupeProgressSnapshot) fields(mode dedupeActMode) string {
 		transferredBlocks = s.sourceStagedBlocks
 		transferredBytes = s.sourceStagedBytes
 	}
+	smallFilesInProgress := s.smallFilesStarted -
+		s.smallFilesCompleted -
+		s.smallFilesFailed -
+		s.smallFilesSkipped -
+		s.smallFilesCanceled
+	if smallFilesInProgress < 0 {
+		smallFilesInProgress = 0
+	}
+	smallFileBytesInProgress := s.smallFileBytesStarted -
+		s.smallFileBytesCompleted -
+		s.smallFileBytesFailed -
+		s.smallFileBytesSkipped -
+		s.smallFileBytesCanceled
+	if smallFileBytesInProgress < 0 {
+		smallFileBytesInProgress = 0
+	}
 
 	return fmt.Sprintf(
 		"filesStarted=%d filesCommitted=%d targetURIBlocks=%d targetURIBytes=%d "+
 			"sourceURIBlocks=%d sourceURIBytes=%d fallbackBlocks=%d transferredBlocks=%d "+
-			"transferredBytes=%d wanSavingsPercent=%.1f",
+			"transferredBytes=%d wanSavingsPercent=%.1f smallFilesStarted=%d "+
+			"smallFilesCompleted=%d smallFilesFailed=%d smallFilesSkipped=%d "+
+			"smallFilesCanceled=%d smallFilesInProgress=%d smallFileBytesStarted=%d "+
+			"smallFileBytesCompleted=%d smallFileBytesFailed=%d smallFileBytesSkipped=%d "+
+			"smallFileBytesCanceled=%d smallFileBytesInProgress=%d",
 		s.filesStarted, s.filesCommitted, targetBlocks, targetBytes,
 		s.sourceStagedBlocks, s.sourceStagedBytes, s.fallbackBlocks, transferredBlocks,
-		transferredBytes, dedupePercent(targetBytes, transferredBytes))
+		transferredBytes, dedupePercent(targetBytes, transferredBytes),
+		s.smallFilesStarted, s.smallFilesCompleted, s.smallFilesFailed,
+		s.smallFilesSkipped, s.smallFilesCanceled, smallFilesInProgress,
+		s.smallFileBytesStarted, s.smallFileBytesCompleted, s.smallFileBytesFailed,
+		s.smallFileBytesSkipped, s.smallFileBytesCanceled, smallFileBytesInProgress)
 }
 
 const dedupeProgressPrefix = "DEDUPE_PROGRESS"
+const smallFileProgressThresholdBytes = int64(4 * 1024 * 1024)
 const dedupeProgressQueueCapacity = 4096
 const dedupeProgressFinalWriteTimeout = 5 * time.Second
 const dedupeLogDirectoryName = "dedupe-logs"
@@ -236,6 +343,27 @@ var (
 		return common.AzcopyLogFolder
 	})
 )
+
+type dedupeJobPartCompletionTracker map[PartNumber]struct{}
+
+func (t dedupeJobPartCompletionTracker) record(partNum *PartNumber) bool {
+	if partNum == nil {
+		return false
+	}
+	if _, exists := t[*partNum]; exists {
+		return false
+	}
+	t[*partNum] = struct{}{}
+	return true
+}
+
+func (t dedupeJobPartCompletionTracker) allKnownPartsReported(knownParts uint32) bool {
+	return knownParts > 0 && uint32(len(t)) == knownParts
+}
+
+func (t dedupeJobPartCompletionTracker) reset() {
+	clear(t)
+}
 
 func init() {
 	go drainDedupeProgress()
@@ -327,6 +455,156 @@ func writeFinalDedupeProgress(jobID common.JobID, message string) error {
 func emitDedupeProgress(jptm IJobPartTransferMgr, message string) {
 	jptm.LogAtLevelForCurrentTransfer(common.LogDebug, message)
 	enqueueDedupeProgress(jptm.Info().JobID, message)
+}
+
+func isSmallFileProgressTransfer(jptm IJobPartTransferMgr) bool {
+	if jptm == nil || jptm.Info() == nil {
+		return false
+	}
+	fromTo := jptm.FromTo()
+	info := jptm.Info()
+	sourceSize := info.SourceSize
+	return fromTo.From() == common.ELocation.Blob() &&
+		fromTo.To() == common.ELocation.Blob() &&
+		(info.EntityType == common.EEntityType.File() ||
+			info.EntityType == common.EEntityType.Hardlink()) &&
+		sourceSize >= 0 &&
+		sourceSize < smallFileProgressThresholdBytes
+}
+
+type smallFileProgressTracker interface {
+	markSmallFileProgressStarted() bool
+	smallFileProgressStarted() bool
+}
+
+func (jptm *jobPartTransferMgr) markSmallFileProgressStarted() bool {
+	return atomic.CompareAndSwapUint32(&jptm.atomicSmallFileProgressStarted, 0, 1)
+}
+
+func (jptm *jobPartTransferMgr) smallFileProgressStarted() bool {
+	return atomic.LoadUint32(&jptm.atomicSmallFileProgressStarted) == 1
+}
+
+func emitSmallFileTransferStart(jptm IJobPartTransferMgr) {
+	if !isSmallFileProgressTransfer(jptm) {
+		return
+	}
+	st, ok := dedupeStateForJobIfExists(jptm.Info().JobID)
+	if !ok {
+		return
+	}
+	mode := dedupeActMode(atomic.LoadInt32(&st.actMode))
+	if mode == dedupeActOff {
+		return
+	}
+	tracker, ok := jptm.(smallFileProgressTracker)
+	if !ok || !tracker.markSmallFileProgressStarted() {
+		return
+	}
+
+	st.smallProgressMu.Lock()
+	defer st.smallProgressMu.Unlock()
+	st.addSmallFileStartedLocked(jptm.Info().SourceSize)
+	emitDedupeProgress(jptm, dedupeProgressMessage(
+		"small_file_transfer_start",
+		mode,
+		jptm.Info(),
+		fmt.Sprintf(
+			"status=%q fileBytes=%d thresholdBytes=%d",
+			"InProgress",
+			jptm.Info().SourceSize,
+			smallFileProgressThresholdBytes,
+		),
+		st.progressSnapshotLocked()))
+}
+
+func emitSmallFileTransferResult(
+	jptm IJobPartTransferMgr,
+	status common.TransferStatus,
+) {
+	if !isSmallFileProgressTransfer(jptm) {
+		return
+	}
+	tracker, ok := jptm.(smallFileProgressTracker)
+	if !ok || !tracker.smallFileProgressStarted() {
+		return
+	}
+	st, ok := dedupeStateForJobIfExists(jptm.Info().JobID)
+	if !ok {
+		return
+	}
+	mode := dedupeActMode(atomic.LoadInt32(&st.actMode))
+	if mode == dedupeActOff {
+		return
+	}
+
+	status = normalizeSmallFileResultStatus(status, jptm.WasCanceled())
+
+	st.smallProgressMu.Lock()
+	defer st.smallProgressMu.Unlock()
+	event := st.addSmallFileResultLocked(status, jptm.Info().SourceSize)
+	if event == "" {
+		return
+	}
+	emitDedupeProgress(jptm, dedupeProgressMessage(
+		event,
+		mode,
+		jptm.Info(),
+		fmt.Sprintf(
+			"status=%q fileBytes=%d thresholdBytes=%d",
+			status.String(),
+			jptm.Info().SourceSize,
+			smallFileProgressThresholdBytes,
+		),
+		st.progressSnapshotLocked()))
+}
+
+func normalizeSmallFileResultStatus(
+	status common.TransferStatus,
+	wasCanceled bool,
+) common.TransferStatus {
+	if wasCanceled &&
+		(status == common.ETransferStatus.NotStarted() ||
+			status == common.ETransferStatus.Started() ||
+			status == common.ETransferStatus.Restarted()) {
+		return common.ETransferStatus.Cancelled()
+	}
+	return status
+}
+
+func emitDedupeTransferFailure(
+	jptm IJobPartTransferMgr,
+	event string,
+	operation string,
+	status int,
+	requestID string,
+	reason string,
+	partNumber PartNumber,
+	transferIndex uint32,
+) {
+	st, ok := dedupeStateForJobIfExists(jptm.Info().JobID)
+	if !ok {
+		return
+	}
+	mode := dedupeActMode(atomic.LoadInt32(&st.actMode))
+	if mode == dedupeActOff {
+		return
+	}
+	details := fmt.Sprintf(
+		"operation=%q httpStatus=%d requestId=%q reason=%q partNumber=%d transferIndex=%d",
+		operation,
+		status,
+		requestID,
+		reason,
+		partNumber,
+		transferIndex,
+	)
+	emitDedupeProgress(jptm, dedupeProgressMessage(
+		event,
+		mode,
+		jptm.Info(),
+		details,
+		st.progressSnapshot()))
 }
 
 func dedupeProgressMessage(event string, mode dedupeActMode, info *TransferInfo, details string, snapshot dedupeProgressSnapshot) string {
@@ -514,7 +792,14 @@ func logDedupeJobSummary(jobID common.JobID, log func(common.LogLevel, string)) 
 	log(common.LogInfo, dedupeJobSummaryMessage(mode, st))
 }
 
-func finalizeDedupeJob(jobID common.JobID, log func(common.LogLevel, string)) {
+func finalizeDedupeJob(
+	jobID common.JobID,
+	status common.JobStatus,
+	transfersCompleted int,
+	transfersSkipped int,
+	transfersFailed int,
+	log func(common.LogLevel, string),
+) {
 	st, ok := dedupeStateForJobIfExists(jobID)
 	if !ok {
 		return
@@ -523,8 +808,16 @@ func finalizeDedupeJob(jobID common.JobID, log func(common.LogLevel, string)) {
 	if mode != dedupeActOff {
 		log(common.LogInfo, dedupeJobSummaryMessage(mode, st))
 		message := fmt.Sprintf(
-			"%s event=job_complete mode=%s jobId=%s %s",
-			dedupeProgressPrefix, mode, jobID.String(), st.progressSnapshot().fields(mode))
+			"%s event=job_complete mode=%s jobId=%s status=%q transfersCompleted=%d "+
+				"transfersSkipped=%d transfersFailed=%d %s",
+			dedupeProgressPrefix,
+			mode,
+			jobID.String(),
+			status.String(),
+			transfersCompleted,
+			transfersSkipped,
+			transfersFailed,
+			st.progressSnapshot().fields(mode))
 		if err := writeFinalDedupeProgress(jobID, message); err != nil {
 			log(common.LogError,
 				dedupeProgressPrefix+" event=output_error reason="+fmt.Sprintf("%q", err.Error()))

--- a/ste/dedupeRecorder.go
+++ b/ste/dedupeRecorder.go
@@ -22,9 +22,13 @@ package ste
 
 import (
 	"fmt"
+	"io"
 	"net/url"
+	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 
@@ -62,6 +66,8 @@ type dedupeJobState struct {
 	sourceStagedBlocks   int64 // blocks staged from the source (real source reads)
 	sourceStagedBytes    int64 // bytes staged from the source
 	fallbackBlocks       int64 // enforce: hits whose target reference failed and fell back to source
+	filesStarted         int64 // files armed for source-grid dedupe
+	filesCommitted       int64 // files whose destination block list was committed
 
 	actMode int32 // active dedupeActMode for this job
 }
@@ -89,10 +95,156 @@ func (s *dedupeJobState) addFallback() {
 	atomic.AddInt64(&s.fallbackBlocks, 1)
 }
 
+func (s *dedupeJobState) addFileStarted() {
+	atomic.AddInt64(&s.filesStarted, 1)
+}
+
+func (s *dedupeJobState) addFileCommitted() {
+	atomic.AddInt64(&s.filesCommitted, 1)
+}
+
+type dedupeProgressSnapshot struct {
+	referencedBlocks     int64
+	referencedBytes      int64
+	wouldReferenceBlocks int64
+	wouldReferenceBytes  int64
+	sourceStagedBlocks   int64
+	sourceStagedBytes    int64
+	fallbackBlocks       int64
+	filesStarted         int64
+	filesCommitted       int64
+}
+
+func (s *dedupeJobState) progressSnapshot() dedupeProgressSnapshot {
+	return dedupeProgressSnapshot{
+		referencedBlocks:     atomic.LoadInt64(&s.referencedBlocks),
+		referencedBytes:      atomic.LoadInt64(&s.referencedBytes),
+		wouldReferenceBlocks: atomic.LoadInt64(&s.wouldReferenceBlocks),
+		wouldReferenceBytes:  atomic.LoadInt64(&s.wouldReferenceBytes),
+		sourceStagedBlocks:   atomic.LoadInt64(&s.sourceStagedBlocks),
+		sourceStagedBytes:    atomic.LoadInt64(&s.sourceStagedBytes),
+		fallbackBlocks:       atomic.LoadInt64(&s.fallbackBlocks),
+		filesStarted:         atomic.LoadInt64(&s.filesStarted),
+		filesCommitted:       atomic.LoadInt64(&s.filesCommitted),
+	}
+}
+
+func (s dedupeProgressSnapshot) fields(mode dedupeActMode) string {
+	targetBlocks := s.referencedBlocks
+	targetBytes := s.referencedBytes
+	transferredBlocks := s.referencedBlocks + s.sourceStagedBlocks
+	transferredBytes := s.referencedBytes + s.sourceStagedBytes
+	if mode == dedupeActShadow {
+		targetBlocks = s.wouldReferenceBlocks
+		targetBytes = s.wouldReferenceBytes
+		transferredBlocks = s.sourceStagedBlocks
+		transferredBytes = s.sourceStagedBytes
+	}
+
+	return fmt.Sprintf(
+		"filesStarted=%d filesCommitted=%d targetURIBlocks=%d targetURIBytes=%d "+
+			"sourceURIBlocks=%d sourceURIBytes=%d fallbackBlocks=%d transferredBlocks=%d "+
+			"transferredBytes=%d wanSavingsPercent=%.1f",
+		s.filesStarted, s.filesCommitted, targetBlocks, targetBytes,
+		s.sourceStagedBlocks, s.sourceStagedBytes, s.fallbackBlocks, transferredBlocks,
+		transferredBytes, dedupePercent(targetBytes, transferredBytes))
+}
+
+const dedupeProgressPrefix = "DEDUPE_PROGRESS"
+const dedupeProgressQueueCapacity = 4096
+const dedupeProgressFinalWriteTimeout = 5 * time.Second
+
+type dedupeProgressEntry struct {
+	message string
+	done    chan error
+}
+
 var (
-	dedupeJobsMu sync.Mutex
-	dedupeJobs   = make(map[common.JobID]*dedupeJobState)
+	dedupeJobsMu              sync.Mutex
+	dedupeJobs                          = make(map[common.JobID]*dedupeJobState)
+	dedupeProgressOutput      io.Writer = os.Stdout
+	dedupeProgressErrorOutput io.Writer = os.Stderr
+	dedupeProgressSanitizer             = common.NewAzCopyLogSanitizer()
+	dedupeProgressQueue                 = make(chan dedupeProgressEntry, dedupeProgressQueueCapacity)
+	dedupeProgressDropped     uint64
 )
+
+func init() {
+	go drainDedupeProgress()
+}
+
+func writeDedupeProgressTo(output io.Writer, message string) error {
+	_, err := fmt.Fprintln(output, dedupeProgressSanitizer.SanitizeLogMessage(message))
+	return err
+}
+
+func tryEnqueueDedupeProgress(queue chan<- dedupeProgressEntry, entry dedupeProgressEntry) bool {
+	select {
+	case queue <- entry:
+		return true
+	default:
+		return false
+	}
+}
+
+func enqueueDedupeProgress(message string) {
+	if !tryEnqueueDedupeProgress(dedupeProgressQueue, dedupeProgressEntry{message: message}) {
+		atomic.AddUint64(&dedupeProgressDropped, 1)
+	}
+}
+
+func drainDedupeProgress() {
+	for entry := range dedupeProgressQueue {
+		if dropped := atomic.SwapUint64(&dedupeProgressDropped, 0); dropped > 0 {
+			droppedMessage := fmt.Sprintf("%s event=output_dropped count=%d", dedupeProgressPrefix, dropped)
+			if err := writeDedupeProgressTo(dedupeProgressOutput, droppedMessage); err != nil {
+				_, _ = fmt.Fprintf(dedupeProgressErrorOutput,
+					"%s event=output_error reason=%q\n", dedupeProgressPrefix, err.Error())
+			}
+		}
+
+		err := writeDedupeProgressTo(dedupeProgressOutput, entry.message)
+		if err != nil {
+			_, _ = fmt.Fprintf(dedupeProgressErrorOutput,
+				"%s event=output_error reason=%q\n", dedupeProgressPrefix, err.Error())
+		}
+		if entry.done != nil {
+			entry.done <- err
+		}
+	}
+}
+
+func writeFinalDedupeProgress(message string) error {
+	done := make(chan error, 1)
+	entry := dedupeProgressEntry{message: message, done: done}
+	timer := time.NewTimer(dedupeProgressFinalWriteTimeout)
+	defer timer.Stop()
+
+	select {
+	case dedupeProgressQueue <- entry:
+	case <-timer.C:
+		return fmt.Errorf("timed out queueing final dedupe progress")
+	}
+
+	select {
+	case err := <-done:
+		return err
+	case <-timer.C:
+		return fmt.Errorf("timed out writing final dedupe progress")
+	}
+}
+
+func emitDedupeProgress(jptm IJobPartTransferMgr, message string) {
+	jptm.LogAtLevelForCurrentTransfer(common.LogDebug, message)
+	enqueueDedupeProgress(message)
+}
+
+func dedupeProgressMessage(event string, mode dedupeActMode, info *TransferInfo, details string, snapshot dedupeProgressSnapshot) string {
+	return fmt.Sprintf(
+		"%s event=%s mode=%s jobId=%s file=%q destination=%q %s %s",
+		dedupeProgressPrefix, event, mode, info.JobID.String(), info.DstFilePath,
+		sanitizedDestForDedupe(info.Destination), details, snapshot.fields(mode))
+}
 
 // dedupeStateForJob returns the dedupe state for a job, creating it on first use. Callers are
 // limited to the observe and act paths, so the default transfer path allocates no dedupe state.
@@ -273,7 +425,21 @@ func logDedupeJobSummary(jobID common.JobID, log func(common.LogLevel, string)) 
 }
 
 func finalizeDedupeJob(jobID common.JobID, log func(common.LogLevel, string)) {
-	logDedupeJobSummary(jobID, log)
+	st, ok := dedupeStateForJobIfExists(jobID)
+	if !ok {
+		return
+	}
+	mode := dedupeActMode(atomic.LoadInt32(&st.actMode))
+	if mode != dedupeActOff {
+		log(common.LogInfo, dedupeJobSummaryMessage(mode, st))
+		message := fmt.Sprintf(
+			"%s event=job_complete mode=%s jobId=%s %s",
+			dedupeProgressPrefix, mode, jobID.String(), st.progressSnapshot().fields(mode))
+		if err := writeFinalDedupeProgress(message); err != nil {
+			log(common.LogError,
+				dedupeProgressPrefix+" event=output_error reason="+fmt.Sprintf("%q", err.Error()))
+		}
+	}
 	clearDedupeStateForJob(jobID)
 }
 
@@ -369,9 +535,14 @@ func measureAndRecordWithObserver(table *common.DedupeHashTable, jobID common.Jo
 func sanitizedDestForDedupe(raw string) string {
 	u, err := url.Parse(raw)
 	if err != nil {
+		if index := strings.IndexAny(raw, "?#"); index >= 0 {
+			return raw[:index]
+		}
 		return raw
 	}
 	u.RawQuery = ""
+	u.ForceQuery = false
+	u.Fragment = ""
 	return u.String()
 }
 
@@ -379,6 +550,9 @@ func sanitizedDestForDedupe(raw string) string {
 func dedupePercent(hits, total int64) float64 {
 	if total == 0 {
 		return 0
+	}
+	if hits >= total {
+		return 100
 	}
 	return 100 * float64(hits) / float64(total)
 }

--- a/ste/dedupeRecorder.go
+++ b/ste/dedupeRecorder.go
@@ -1,0 +1,479 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ste
+
+import (
+	"fmt"
+	"net/url"
+	"sync"
+	"sync/atomic"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+)
+
+// This file owns the per-job state shared by the block-level dedupe prototype. Observe mode
+// records and measures potential hits without changing transfers; act mode records only committed
+// destination blocks and uses them to make safe staging decisions.
+
+// dedupeJobState holds a single job's dedupe tables plus cumulative would-be-hit counters.
+type dedupeJobState struct {
+	// table is the Phase 1 measurement table: blocks are recorded pre-write purely to count the
+	// would-be-hit rate, so it must NOT be used to decide a real reference (the content may not yet
+	// exist at the destination).
+	table *common.DedupeHashTable
+
+	// committed is the Phase 2 table: it holds only blocks confirmed committed at the destination
+	// (recorded in the sender Epilogue after a successful CommitBlockList). A reference is only ever
+	// served from an entry in this table, so the target content is guaranteed to exist.
+	committed *common.DedupeHashTable
+
+	// Counters are cumulative across every blob processed for the job, and are updated
+	// atomically because transfers (and therefore observeSourceGrid calls) run concurrently.
+	hashedBlocks   int64 // blocks that carried crc64+sha256 (i.e. were eligible for dedupe)
+	wouldBeHits    int64 // eligible blocks whose content was already recorded by an earlier block
+	dedupableBytes int64 // total size of would-be-hit blocks: bytes that need not be re-transferred
+
+	// Phase 2 "act" counters (also cumulative + atomic). Together they quantify how many source
+	// reads dedupe actually avoided (enforce) or would avoid (shadow).
+	referencedBlocks     int64 // enforce: blocks staged from the destination instead of the source
+	referencedBytes      int64 // enforce: source-read bytes avoided
+	wouldReferenceBlocks int64 // shadow: blocks that would be referenced under enforce
+	wouldReferenceBytes  int64 // shadow: source-read bytes that would be avoided under enforce
+	sourceStagedBlocks   int64 // blocks staged from the source (real source reads)
+	sourceStagedBytes    int64 // bytes staged from the source
+	fallbackBlocks       int64 // enforce: hits whose target reference failed and fell back to source
+
+	actMode int32 // active dedupeActMode for this job
+}
+
+// addReferenced records a block that enforce mode staged from the destination (a source read avoided).
+func (s *dedupeJobState) addReferenced(size int64) {
+	atomic.AddInt64(&s.referencedBlocks, 1)
+	atomic.AddInt64(&s.referencedBytes, size)
+}
+
+// addWouldReference records a block that shadow mode would have referenced under enforce.
+func (s *dedupeJobState) addWouldReference(size int64) {
+	atomic.AddInt64(&s.wouldReferenceBlocks, 1)
+	atomic.AddInt64(&s.wouldReferenceBytes, size)
+}
+
+// addSourceStaged records a block that was actually staged from the source (a real source read).
+func (s *dedupeJobState) addSourceStaged(size int64) {
+	atomic.AddInt64(&s.sourceStagedBlocks, 1)
+	atomic.AddInt64(&s.sourceStagedBytes, size)
+}
+
+// addFallback records an enforce hit whose target reference failed and fell back to the source.
+func (s *dedupeJobState) addFallback() {
+	atomic.AddInt64(&s.fallbackBlocks, 1)
+}
+
+var (
+	dedupeJobsMu sync.Mutex
+	dedupeJobs   = make(map[common.JobID]*dedupeJobState)
+)
+
+// dedupeStateForJob returns the dedupe state for a job, creating it on first use. Callers are
+// limited to the observe and act paths, so the default transfer path allocates no dedupe state.
+func dedupeStateForJob(jobID common.JobID) *dedupeJobState {
+	dedupeJobsMu.Lock()
+	defer dedupeJobsMu.Unlock()
+
+	st, ok := dedupeJobs[jobID]
+	if !ok {
+		st = &dedupeJobState{
+			table:     common.NewDedupeHashTable(),
+			committed: common.NewDedupeHashTable(),
+		}
+		dedupeJobs[jobID] = st
+	}
+	return st
+}
+
+func dedupeStateForJobIfExists(jobID common.JobID) (*dedupeJobState, bool) {
+	dedupeJobsMu.Lock()
+	defer dedupeJobsMu.Unlock()
+
+	st, ok := dedupeJobs[jobID]
+	return st, ok
+}
+
+func setDedupeActModeForJob(jobID common.JobID, mode dedupeActMode) {
+	if mode == dedupeActOff {
+		return
+	}
+	atomic.StoreInt32(&dedupeStateForJob(jobID).actMode, int32(mode))
+}
+
+// clearDedupeStateForJob drops a job's dedupe state to release its memory. It is safe to call
+// when no state exists and is invoked after a job reaches a terminal status.
+func clearDedupeStateForJob(jobID common.JobID) {
+	dedupeJobsMu.Lock()
+	defer dedupeJobsMu.Unlock()
+
+	if st, ok := dedupeJobs[jobID]; ok {
+		st.table.Clear()
+		st.committed.Clear()
+		delete(dedupeJobs, jobID)
+	}
+}
+
+// recordCommittedBlocks records a freshly-committed destination blob's hashed blocks into the job's
+// committed table, so that later blocks with identical content can be served from this blob. It is
+// called from the sender Epilogue after CommitBlockList succeeds, with the destination's real ETag.
+// Because the destination is a byte-identical copy of the source, each block lives at the same
+// offset/length in the target blob as in the source.
+func recordCommittedBlocks(jobID common.JobID, destURI, destinationSAS string, etag azcore.ETag, plan *SourceGridPlan) (recorded int) {
+	return recordCommittedBlocksWithObserver(jobID, destURI, destinationSAS, etag, plan, nil)
+}
+
+type dedupeTableRecordEvent struct {
+	Block       PlannedBlock
+	Stored      common.BlockEntry
+	Inserted    bool
+	PreHit      bool
+	TableStats  common.DedupeHashTableStats
+	RecordIndex int
+}
+
+func recordCommittedBlocksWithObserver(jobID common.JobID, destURI, destinationSAS string, etag azcore.ETag, plan *SourceGridPlan, observer func(dedupeTableRecordEvent)) (recorded int) {
+	if plan == nil || etag == "" {
+		return 0
+	}
+	st := dedupeStateForJob(jobID)
+	target := destinationWithSASForDedupe(destURI, destinationSAS)
+	for _, b := range plan.Blocks {
+		if !blockHasHashes(b) {
+			continue
+		}
+		stored, inserted := st.committed.Insert(common.BlockEntry{
+			JobID:        jobID,
+			CRC64:        b.CRC64,
+			SHA256:       b.SHA256,
+			TargetURI:    target,
+			TargetOffset: b.Offset,
+			TargetLength: b.Size,
+			ETag:         etag,
+		})
+		recorded++
+		if observer != nil {
+			observer(dedupeTableRecordEvent{
+				Block:       b,
+				Stored:      stored,
+				Inserted:    inserted,
+				TableStats:  st.committed.StatsForCRC64(b.CRC64),
+				RecordIndex: recorded,
+			})
+		}
+	}
+	return recorded
+}
+
+// destinationWithSASForDedupe returns an executable destination URL for later use as
+// x-ms-copy-source. The destination client URL commonly already contains the SAS; merge any
+// missing SAS fields without duplicating query parameters.
+func destinationWithSASForDedupe(destURI, destinationSAS string) string {
+	if destinationSAS == "" {
+		return destURI
+	}
+	u, err := url.Parse(destURI)
+	if err != nil {
+		return destURI
+	}
+	sas := destinationSAS
+	if sas[0] == '?' {
+		sas = sas[1:]
+	}
+	if sas == "" {
+		return destURI
+	}
+
+	query, err := url.ParseQuery(u.RawQuery)
+	if err != nil {
+		return destURI
+	}
+	sasQuery, err := url.ParseQuery(sas)
+	if err != nil {
+		return destURI
+	}
+
+	for key, values := range sasQuery {
+		query[key] = append([]string(nil), values...)
+	}
+	u.RawQuery = query.Encode()
+	return u.String()
+}
+
+// logDedupeActSummary logs a running view of the job's cumulative Phase 2 savings. The terminal
+// job summary is emitted separately when the job completes.
+func logDedupeActSummary(jptm IJobPartTransferMgr, mode dedupeActMode) {
+	st := dedupeStateForJob(jptm.Info().JobID)
+
+	referencedBlocks := atomic.LoadInt64(&st.referencedBlocks)
+	referencedBytes := atomic.LoadInt64(&st.referencedBytes)
+	wouldRefBlocks := atomic.LoadInt64(&st.wouldReferenceBlocks)
+	wouldRefBytes := atomic.LoadInt64(&st.wouldReferenceBytes)
+	sourceBlocks := atomic.LoadInt64(&st.sourceStagedBlocks)
+	sourceBytes := atomic.LoadInt64(&st.sourceStagedBytes)
+	fallbacks := atomic.LoadInt64(&st.fallbackBlocks)
+
+	switch mode {
+	case dedupeActEnforce:
+		// Referenced blocks were staged from the destination; source-staged blocks were read from the
+		// source. Total = referenced + source; avoided source-read bytes = referencedBytes.
+		totalStagedBytes := referencedBytes + sourceBytes
+		jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
+			"dedupe-summary(enforce): dedupe-target blocks=%d bytes=%d; sourceURI blocks=%d bytes=%d; "+
+				"WAN savings=%d bytes (%.1f%% of %d staged bytes); fallback blocks=%d",
+			referencedBlocks, referencedBytes, sourceBlocks, sourceBytes,
+			referencedBytes, dedupePercent(referencedBytes, totalStagedBytes), totalStagedBytes,
+			fallbacks))
+	case dedupeActShadow:
+		// Every block is staged from the source in shadow mode, so sourceBytes is the total; the
+		// would-reference blocks are the subset that enforce would have avoided.
+		jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
+			"dedupe-summary(shadow): would-dedupe-target blocks=%d bytes=%d; sourceURI blocks=%d bytes=%d; "+
+				"potential WAN savings=%d bytes (%.1f%% of %d staged bytes); all bytes currently staged from source",
+			wouldRefBlocks, wouldRefBytes, sourceBlocks, sourceBytes,
+			wouldRefBytes, dedupePercent(wouldRefBytes, sourceBytes), sourceBytes))
+	}
+}
+
+func logDedupeJobSummary(jobID common.JobID, log func(common.LogLevel, string)) {
+	st, ok := dedupeStateForJobIfExists(jobID)
+	if !ok {
+		return
+	}
+	mode := dedupeActMode(atomic.LoadInt32(&st.actMode))
+	if mode == dedupeActOff {
+		return
+	}
+	log(common.LogInfo, dedupeJobSummaryMessage(mode, st))
+}
+
+func finalizeDedupeJob(jobID common.JobID, log func(common.LogLevel, string)) {
+	logDedupeJobSummary(jobID, log)
+	clearDedupeStateForJob(jobID)
+}
+
+func dedupeJobSummaryMessage(mode dedupeActMode, st *dedupeJobState) string {
+	referencedBlocks := atomic.LoadInt64(&st.referencedBlocks)
+	referencedBytes := atomic.LoadInt64(&st.referencedBytes)
+	wouldRefBlocks := atomic.LoadInt64(&st.wouldReferenceBlocks)
+	wouldRefBytes := atomic.LoadInt64(&st.wouldReferenceBytes)
+	sourceBlocks := atomic.LoadInt64(&st.sourceStagedBlocks)
+	sourceBytes := atomic.LoadInt64(&st.sourceStagedBytes)
+	fallbacks := atomic.LoadInt64(&st.fallbackBlocks)
+
+	switch mode {
+	case dedupeActShadow:
+		totalStagedBytes := sourceBytes
+		return fmt.Sprintf(
+			"dedupe-job-summary(shadow): totalBlocks=%d wouldTargetURIBlocks=%d sourceURIBlocks=%d fallbackBlocks=%d potentialAvoidedSourceReadBytes=%d totalStagedBytes=%d potentialWanSavingsPercent=%.1f",
+			sourceBlocks, wouldRefBlocks, sourceBlocks, fallbacks, wouldRefBytes, totalStagedBytes,
+			dedupePercent(wouldRefBytes, totalStagedBytes))
+	case dedupeActEnforce:
+		totalStagedBytes := referencedBytes + sourceBytes
+		return fmt.Sprintf(
+			"dedupe-job-summary(enforce): totalBlocks=%d targetURIBlocks=%d sourceURIBlocks=%d fallbackBlocks=%d avoidedSourceReadBytes=%d totalStagedBytes=%d wanSavingsPercent=%.1f",
+			referencedBlocks+sourceBlocks, referencedBlocks, sourceBlocks, fallbacks, referencedBytes, totalStagedBytes,
+			dedupePercent(referencedBytes, totalStagedBytes))
+	default:
+		return "dedupe-job-summary(off): disabled"
+	}
+}
+
+// blockHasHashes reports whether a planned block carried both content hashes in the extended
+// GetBlockList response. Presence is tracked separately because an all-zero hash is valid.
+func blockHasHashes(b PlannedBlock) bool {
+	return b.HasHashes
+}
+
+// measureAndRecord performs the Phase 1 lookup-then-record over a set of planned blocks against
+// the given table. For each block that carries hashes it (1) looks the content up, counting a
+// would-be hit when identical content was already recorded, then (2) records the block keyed to
+// where it is being migrated (targetURI). It returns the number of eligible (hashed) blocks, the
+// number of would-be hits, and the total size of those hit blocks.
+//
+// It is deliberately free of any jptm/logging dependency so it can be unit tested directly.
+//
+// Note: between the Lookup and Insert of a given block another goroutine may insert identical
+// content, so concurrent identical blocks can be under-counted as misses. That is acceptable for a
+// measurement phase — the reported hit rate is conservative (never over-counted).
+func measureAndRecord(table *common.DedupeHashTable, jobID common.JobID, targetURI string, blocks []PlannedBlock) (hashed, hits, dedupableBytes int64) {
+	return measureAndRecordWithObserver(table, jobID, targetURI, blocks, nil)
+}
+
+func measureAndRecordWithObserver(table *common.DedupeHashTable, jobID common.JobID, targetURI string, blocks []PlannedBlock, observer func(dedupeTableRecordEvent)) (hashed, hits, dedupableBytes int64) {
+	for _, b := range blocks {
+		if !blockHasHashes(b) {
+			continue
+		}
+		hashed++
+
+		_, hit := table.Lookup(b.CRC64, b.SHA256)
+		if hit {
+			hits++
+			dedupableBytes += b.Size
+		}
+
+		stored, inserted := table.Insert(common.BlockEntry{
+			JobID:     jobID,
+			CRC64:     b.CRC64,
+			SHA256:    b.SHA256,
+			TargetURI: targetURI,
+			// The destination is a byte-identical copy of the source, so the block lives
+			// at the same offset/length in the target blob as in the source.
+			TargetOffset: b.Offset,
+			TargetLength: b.Size,
+			// ETag is populated in Phase 2, where recording happens after a successful
+			// destination write; Phase 1 records pre-write, for measurement only.
+		})
+		if observer != nil {
+			observer(dedupeTableRecordEvent{
+				Block:       b,
+				Stored:      stored,
+				Inserted:    inserted,
+				PreHit:      hit,
+				TableStats:  table.StatsForCRC64(b.CRC64),
+				RecordIndex: int(hashed),
+			})
+		}
+	}
+	return hashed, hits, dedupableBytes
+}
+
+// sanitizedDestForDedupe strips the query string from a destination URL before logging or
+// comparing it. The committed table intentionally retains an authenticated URL for reuse.
+func sanitizedDestForDedupe(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	u.RawQuery = ""
+	return u.String()
+}
+
+// dedupePercent returns hits/total as a percentage, treating total==0 as 0%.
+func dedupePercent(hits, total int64) float64 {
+	if total == 0 {
+		return 0
+	}
+	return 100 * float64(hits) / float64(total)
+}
+
+// recordSourceGridForDedupe implements Phase 1 for a single transfer (blob). It records the
+// source's committed blocks into the per-job table, accumulates the would-be-hit counters, and
+// logs both this blob's contribution and the running job-wide hit rate. It changes no transfer
+// behavior.
+func recordSourceGridForDedupe(jptm IJobPartTransferMgr, plan *SourceGridPlan) {
+	info := jptm.Info()
+	st := dedupeStateForJob(info.JobID)
+	targetURI := sanitizedDestForDedupe(info.Destination)
+
+	hashed, hits, dedupableBytes := measureAndRecordWithObserver(st.table, info.JobID, targetURI, plan.Blocks, func(event dedupeTableRecordEvent) {
+		jptm.LogAtLevelForCurrentTransfer(common.LogDebug, fmt.Sprintf(
+			"dedupe-table(observe): record=%d inserted=%t wouldBeHit=%t entries=%d buckets=%d bucketEntries=%d refCount=%d "+
+				"crc64=%016x sha256=%x offset=%d size=%d target=%s",
+			event.RecordIndex, event.Inserted, event.PreHit, event.TableStats.Entries, event.TableStats.Buckets,
+			event.TableStats.BucketEntries, event.Stored.RefCount, event.Block.CRC64, event.Block.SHA256,
+			event.Block.Offset, event.Block.Size, sanitizedDestForDedupe(event.Stored.TargetURI)))
+	})
+	if hashed == 0 {
+		return // nothing eligible (service GetHash feature off, or include not honored)
+	}
+
+	totalHashed := atomic.AddInt64(&st.hashedBlocks, hashed)
+	totalHits := atomic.AddInt64(&st.wouldBeHits, hits)
+	totalBytes := atomic.AddInt64(&st.dedupableBytes, dedupableBytes)
+
+	jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
+		"dedupe-phase1: blob %q would-be-hits=%d/%d blocks; job cumulative would-be-hits=%d/%d blocks (%.1f%%), dedupable bytes=%d, table entries=%d",
+		info.SrcFilePath, hits, hashed,
+		totalHits, totalHashed, dedupePercent(totalHits, totalHashed),
+		totalBytes, st.table.Len()))
+}
+
+// --- Phase 2 core: staging-time hit decision ---
+
+// srcBlockKey identifies a source committed block by its position and length. A uniform AzCopy
+// chunk can be matched to a source block (and so to its content hashes) only when the two share the
+// same offset and size — until source-grid chunking (Phase 3) makes every chunk a source block, the
+// index therefore only resolves chunks that already align with the source's committed boundaries.
+type srcBlockKey struct {
+	offset int64
+	size   int64
+}
+
+// srcBlockHashes are the content hashes of a single source committed block.
+type srcBlockHashes struct {
+	crc64  uint64
+	sha256 [32]byte
+}
+
+// buildSourceBlockHashIndex turns a source-grid plan into a lookup from a block's (offset,size) to
+// its content hashes, including only blocks that actually carry hashes. The staging path consults it
+// to discover whether the chunk it is about to send has a known hash to look up.
+func buildSourceBlockHashIndex(plan *SourceGridPlan) map[srcBlockKey]srcBlockHashes {
+	idx := make(map[srcBlockKey]srcBlockHashes, len(plan.Blocks))
+	for _, b := range plan.Blocks {
+		if !blockHasHashes(b) {
+			continue
+		}
+		idx[srcBlockKey{offset: b.Offset, size: b.Size}] = srcBlockHashes{crc64: b.CRC64, sha256: b.SHA256}
+	}
+	return idx
+}
+
+// decideStaging is the core Phase 2 "act on a hit" decision for a single block about to be staged at
+// [offset, offset+size) of the source. It returns the matching target entry with reference=true when
+// (a) the chunk exactly matches a hashed source block, and (b) that content is already recorded in the
+// destination hash index as committed destination content — meaning the block can be staged from the
+// target blob (Put Block From URL over the target's sub-range) instead of re-read from the source.
+// Otherwise it returns reference=false and the caller stages from the source as normal.
+//
+// currentTargetURI is the blob currently being written. A matching entry for that same target is not
+// a cross-blob reuse candidate and must be ignored; same-blob hits are intentionally observe-only in
+// this targetURI design because the current blob's destination ranges are not committed/readable yet.
+func decideStaging(index map[srcBlockKey]srcBlockHashes, committed *common.DedupeHashTable, offset, size int64, currentTargetURI string) (target common.BlockEntry, reference bool) {
+	h, ok := index[srcBlockKey{offset: offset, size: size}]
+	if !ok {
+		return common.BlockEntry{}, false // no known hash for this chunk (not aligned to a source block)
+	}
+	entry, hit := committed.Lookup(h.crc64, h.sha256)
+	if !hit {
+		return common.BlockEntry{}, false // identical content not yet migrated to the destination
+	}
+	if entry.TargetURI == "" || entry.TargetOffset < 0 || entry.ETag == "" || entry.TargetLength != size {
+		return common.BlockEntry{}, false // never reuse an unversioned or differently-sized target range
+	}
+	if sameDedupeTarget(entry.TargetURI, currentTargetURI) {
+		return common.BlockEntry{}, false // avoid unsafe same-blob/self reuse; wait for a committed target blob
+	}
+	return entry, true
+}
+
+func sameDedupeTarget(a, b string) bool {
+	return sanitizedDestForDedupe(a) == sanitizedDestForDedupe(b)
+}

--- a/ste/dedupeRecorder.go
+++ b/ste/dedupeRecorder.go
@@ -86,8 +86,8 @@ type dedupeJobState struct {
 	sourceHashBatches       int64
 	targetHashRanges        int64
 	targetHashBatches       int64
-	targetHashCacheHits     int64
-	targetHashCacheMisses   int64
+	targetSHAIndexHits      int64
+	targetSHAIndexMisses    int64
 	targetHashFailures      int64
 	epochInvalidations      int64
 	shaConfirmedBlocks      int64
@@ -155,8 +155,8 @@ func (s *dedupeJobState) addHashResolution(stats dedupeHashResolutionStats) {
 	atomic.AddInt64(&s.sourceHashBatches, int64(stats.sourceHashBatches))
 	atomic.AddInt64(&s.targetHashRanges, int64(stats.targetHashRanges))
 	atomic.AddInt64(&s.targetHashBatches, int64(stats.targetHashBatches))
-	atomic.AddInt64(&s.targetHashCacheHits, int64(stats.targetHashCacheHits))
-	atomic.AddInt64(&s.targetHashCacheMisses, int64(stats.targetHashCacheMisses))
+	atomic.AddInt64(&s.targetSHAIndexHits, int64(stats.targetSHAIndexHits))
+	atomic.AddInt64(&s.targetSHAIndexMisses, int64(stats.targetSHAIndexMisses))
 	atomic.AddInt64(&s.targetHashFailures, int64(stats.targetHashFailures))
 	atomic.AddInt64(
 		&s.epochInvalidations,
@@ -625,8 +625,8 @@ type dedupeProgressSnapshot struct {
 	sourceHashBatches       int64
 	targetHashRanges        int64
 	targetHashBatches       int64
-	targetHashCacheHits     int64
-	targetHashCacheMisses   int64
+	targetSHAIndexHits      int64
+	targetSHAIndexMisses    int64
 	targetHashFailures      int64
 	epochInvalidations      int64
 	shaConfirmedBlocks      int64
@@ -668,8 +668,8 @@ func (s *dedupeJobState) progressSnapshotLocked() dedupeProgressSnapshot {
 		sourceHashBatches:       atomic.LoadInt64(&s.sourceHashBatches),
 		targetHashRanges:        atomic.LoadInt64(&s.targetHashRanges),
 		targetHashBatches:       atomic.LoadInt64(&s.targetHashBatches),
-		targetHashCacheHits:     atomic.LoadInt64(&s.targetHashCacheHits),
-		targetHashCacheMisses:   atomic.LoadInt64(&s.targetHashCacheMisses),
+		targetSHAIndexHits:      atomic.LoadInt64(&s.targetSHAIndexHits),
+		targetSHAIndexMisses:    atomic.LoadInt64(&s.targetSHAIndexMisses),
 		targetHashFailures:      atomic.LoadInt64(&s.targetHashFailures),
 		epochInvalidations:      atomic.LoadInt64(&s.epochInvalidations),
 		shaConfirmedBlocks:      atomic.LoadInt64(&s.shaConfirmedBlocks),
@@ -723,7 +723,7 @@ func (s dedupeProgressSnapshot) fields(mode dedupeActMode) string {
 			"transferredBytes=%d wanSavingsPercent=%.1f crcDiscoveredBlocks=%d "+
 			"crcDiscoveredBytes=%d crcCandidateBlocks=%d crcCandidateOccurrences=%d "+
 			"sourceHashRanges=%d sourceHashBatches=%d targetHashRanges=%d "+
-			"targetHashBatches=%d targetHashCacheHits=%d targetHashCacheMisses=%d "+
+			"targetHashBatches=%d targetSHAIndexHits=%d targetSHAIndexMisses=%d "+
 			"targetHashFailures=%d epochInvalidations=%d "+
 			"shaConfirmedBlocks=%d shaMismatchBlocks=%d smallFilesStarted=%d "+
 			"smallFilesCompleted=%d smallFilesFailed=%d smallFilesSkipped=%d "+
@@ -735,8 +735,8 @@ func (s dedupeProgressSnapshot) fields(mode dedupeActMode) string {
 		transferredBytes, dedupePercent(targetBytes, transferredBytes),
 		s.crcDiscoveredBlocks, s.crcDiscoveredBytes, s.crcCandidateBlocks,
 		s.crcCandidateOccurrences, s.sourceHashRanges, s.sourceHashBatches,
-		s.targetHashRanges, s.targetHashBatches, s.targetHashCacheHits,
-		s.targetHashCacheMisses, s.targetHashFailures,
+		s.targetHashRanges, s.targetHashBatches, s.targetSHAIndexHits,
+		s.targetSHAIndexMisses, s.targetHashFailures,
 		s.epochInvalidations, s.shaConfirmedBlocks, s.shaMismatchBlocks,
 		s.smallFilesStarted, s.smallFilesCompleted, s.smallFilesFailed,
 		s.smallFilesSkipped, s.smallFilesCanceled, smallFilesInProgress,
@@ -1085,7 +1085,7 @@ func emitDedupeHashResolutionProgress(
 		jptm.Info(),
 		fmt.Sprintf(
 			"candidateBlocks=%d candidateOccurrences=%d sourceRanges=%d sourceBatches=%d "+
-				"targetRanges=%d targetBatches=%d targetCacheHits=%d targetCacheMisses=%d "+
+				"targetRanges=%d targetBatches=%d targetSHAIndexHits=%d targetSHAIndexMisses=%d "+
 				"targetFailures=%d "+
 				"sourceEpochInvalidations=%d targetEpochInvalidations=%d reason=%q",
 			stats.candidateBlocks,
@@ -1094,8 +1094,8 @@ func emitDedupeHashResolutionProgress(
 			stats.sourceHashBatches,
 			stats.targetHashRanges,
 			stats.targetHashBatches,
-			stats.targetHashCacheHits,
-			stats.targetHashCacheMisses,
+			stats.targetSHAIndexHits,
+			stats.targetSHAIndexMisses,
 			stats.targetHashFailures,
 			stats.sourceEpochInvalidations,
 			stats.targetEpochInvalidations,

--- a/ste/dedupeRecorder.go
+++ b/ste/dedupeRecorder.go
@@ -47,8 +47,11 @@ type dedupeJobState struct {
 	smallProgressMu sync.Mutex
 	hashCPU         dedupeHashCPUState
 
-	targetHashMu         sync.Mutex
-	targetHashEpochLocks map[dedupeTargetEpoch]*sync.Mutex
+	targetHashMu           sync.Mutex
+	targetHashEpochLocks   map[dedupeTargetEpoch]*sync.Mutex
+	targetHashFailedRanges map[dedupeTargetEpoch]map[srcBlockKey]struct{}
+
+	committedGeneration uint64
 
 	// table is the Phase 1 measurement table: blocks are recorded pre-write purely to count the
 	// would-be-hit rate, so it must NOT be used to decide a real reference (the content may not yet
@@ -146,8 +149,8 @@ func (s *dedupeJobState) addCRCDiscovery(plan *SourceGridPlan) (blocks, bytes in
 }
 
 func (s *dedupeJobState) addHashResolution(stats dedupeHashResolutionStats) {
-	atomic.AddInt64(&s.crcCandidateBlocks, int64(stats.candidateBlocks))
-	atomic.AddInt64(&s.crcCandidateOccurrences, int64(stats.candidateOccurrences))
+	atomic.AddInt64(&s.crcCandidateBlocks, int64(stats.newCandidateBlocks))
+	atomic.AddInt64(&s.crcCandidateOccurrences, int64(stats.newCandidateOccurrences))
 	atomic.AddInt64(&s.sourceHashRanges, int64(stats.sourceHashRanges))
 	atomic.AddInt64(&s.sourceHashBatches, int64(stats.sourceHashBatches))
 	atomic.AddInt64(&s.targetHashRanges, int64(stats.targetHashRanges))
@@ -181,6 +184,44 @@ func (s *dedupeJobState) targetHashEpochLock(epoch dedupeTargetEpoch) *sync.Mute
 		s.targetHashEpochLocks[epoch] = lock
 	}
 	return lock
+}
+
+func (s *dedupeJobState) committedGenerationValue() uint64 {
+	return atomic.LoadUint64(&s.committedGeneration)
+}
+
+func (s *dedupeJobState) markCommittedPublication() {
+	atomic.AddUint64(&s.committedGeneration, 1)
+}
+
+func (s *dedupeJobState) targetHashRangeFailed(epoch dedupeTargetEpoch, key srcBlockKey) bool {
+	s.targetHashMu.Lock()
+	defer s.targetHashMu.Unlock()
+	_, failed := s.targetHashFailedRanges[epoch][key]
+	return failed
+}
+
+func (s *dedupeJobState) markTargetHashRangesFailed(epoch dedupeTargetEpoch, keys []srcBlockKey) {
+	if len(keys) == 0 {
+		return
+	}
+	s.targetHashMu.Lock()
+	defer s.targetHashMu.Unlock()
+	if s.targetHashFailedRanges == nil {
+		s.targetHashFailedRanges = make(map[dedupeTargetEpoch]map[srcBlockKey]struct{})
+	}
+	if s.targetHashFailedRanges[epoch] == nil {
+		s.targetHashFailedRanges[epoch] = make(map[srcBlockKey]struct{})
+	}
+	for _, key := range keys {
+		s.targetHashFailedRanges[epoch][key] = struct{}{}
+	}
+}
+
+func (s *dedupeJobState) clearTargetHashFailures(epoch dedupeTargetEpoch) {
+	s.targetHashMu.Lock()
+	defer s.targetHashMu.Unlock()
+	delete(s.targetHashFailedRanges, epoch)
 }
 
 func (s *dedupeJobState) addFileStarted() {
@@ -1314,6 +1355,9 @@ func recordCommittedBlocksWithObserver(jobID common.JobID, destURI, destinationS
 				RecordIndex: recorded,
 			})
 		}
+	}
+	if recorded > 0 {
+		st.markCommittedPublication()
 	}
 	return recorded
 }

--- a/ste/dedupeRecorder.go
+++ b/ste/dedupeRecorder.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -59,15 +60,16 @@ type dedupeJobState struct {
 
 	// Phase 2 "act" counters (also cumulative + atomic). Together they quantify how many source
 	// reads dedupe actually avoided (enforce) or would avoid (shadow).
-	referencedBlocks     int64 // enforce: blocks staged from the destination instead of the source
-	referencedBytes      int64 // enforce: source-read bytes avoided
-	wouldReferenceBlocks int64 // shadow: blocks that would be referenced under enforce
-	wouldReferenceBytes  int64 // shadow: source-read bytes that would be avoided under enforce
-	sourceStagedBlocks   int64 // blocks staged from the source (real source reads)
-	sourceStagedBytes    int64 // bytes staged from the source
-	fallbackBlocks       int64 // enforce: hits whose target reference failed and fell back to source
-	filesStarted         int64 // files armed for source-grid dedupe
-	filesCommitted       int64 // files whose destination block list was committed
+	referencedBlocks      int64 // enforce: blocks staged from the destination instead of the source
+	referencedBytes       int64 // enforce: source-read bytes avoided
+	wouldReferenceBlocks  int64 // shadow: blocks that would be referenced under enforce
+	wouldReferenceBytes   int64 // shadow: source-read bytes that would be avoided under enforce
+	sourceStagedBlocks    int64 // blocks staged from the source (real source reads)
+	sourceStagedBytes     int64 // bytes staged from the source
+	fallbackBlocks        int64 // enforce: hits whose target reference failed and fell back to source
+	filesStarted          int64 // files armed for source-grid dedupe
+	filesCommitted        int64 // files whose destination block list was committed
+	progressEventsDropped uint64
 
 	actMode int32 // active dedupeActMode for this job
 }
@@ -153,20 +155,86 @@ func (s dedupeProgressSnapshot) fields(mode dedupeActMode) string {
 const dedupeProgressPrefix = "DEDUPE_PROGRESS"
 const dedupeProgressQueueCapacity = 4096
 const dedupeProgressFinalWriteTimeout = 5 * time.Second
+const dedupeLogDirectoryName = "dedupe-logs"
+const dedupeLogMaxSize = 500 * 1024 * 1024
 
 type dedupeProgressEntry struct {
-	message string
-	done    chan error
+	jobID           common.JobID
+	message         string
+	closeAfterWrite bool
+	done            chan error
+}
+
+type dedupeProgressFileSink struct {
+	rootFolder func() string
+	writers    map[common.JobID]io.WriteCloser
+}
+
+func newDedupeProgressFileSink(rootFolder func() string) *dedupeProgressFileSink {
+	return &dedupeProgressFileSink{
+		rootFolder: rootFolder,
+		writers:    make(map[common.JobID]io.WriteCloser),
+	}
+}
+
+func (s *dedupeProgressFileSink) logPath(jobID common.JobID) (string, error) {
+	if s == nil || s.rootFolder == nil {
+		return "", fmt.Errorf("dedupe log root is not configured")
+	}
+	root := s.rootFolder()
+	if root == "" {
+		return "", fmt.Errorf("AzCopy log folder is not configured")
+	}
+	return filepath.Join(root, dedupeLogDirectoryName, jobID.String()+".log"), nil
+}
+
+func (s *dedupeProgressFileSink) writer(jobID common.JobID) (io.WriteCloser, error) {
+	if writer, ok := s.writers[jobID]; ok {
+		return writer, nil
+	}
+
+	logPath, err := s.logPath(jobID)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(logPath), os.ModeDir|os.ModePerm); err != nil {
+		return nil, fmt.Errorf("create dedupe log directory: %w", err)
+	}
+
+	writer, err := common.NewRotatingWriter(logPath, dedupeLogMaxSize)
+	if err != nil {
+		return nil, fmt.Errorf("open dedupe log: %w", err)
+	}
+	s.writers[jobID] = writer
+	return writer, nil
+}
+
+func (s *dedupeProgressFileSink) write(jobID common.JobID, message string) error {
+	writer, err := s.writer(jobID)
+	if err != nil {
+		return err
+	}
+	return writeDedupeProgressTo(writer, message)
+}
+
+func (s *dedupeProgressFileSink) close(jobID common.JobID) error {
+	writer, ok := s.writers[jobID]
+	if !ok {
+		return nil
+	}
+	delete(s.writers, jobID)
+	return writer.Close()
 }
 
 var (
 	dedupeJobsMu              sync.Mutex
 	dedupeJobs                          = make(map[common.JobID]*dedupeJobState)
-	dedupeProgressOutput      io.Writer = os.Stdout
 	dedupeProgressErrorOutput io.Writer = os.Stderr
 	dedupeProgressSanitizer             = common.NewAzCopyLogSanitizer()
 	dedupeProgressQueue                 = make(chan dedupeProgressEntry, dedupeProgressQueueCapacity)
-	dedupeProgressDropped     uint64
+	dedupeProgressSink                  = newDedupeProgressFileSink(func() string {
+		return common.AzcopyLogFolder
+	})
 )
 
 func init() {
@@ -187,26 +255,43 @@ func tryEnqueueDedupeProgress(queue chan<- dedupeProgressEntry, entry dedupeProg
 	}
 }
 
-func enqueueDedupeProgress(message string) {
-	if !tryEnqueueDedupeProgress(dedupeProgressQueue, dedupeProgressEntry{message: message}) {
-		atomic.AddUint64(&dedupeProgressDropped, 1)
+func enqueueDedupeProgress(jobID common.JobID, message string) {
+	entry := dedupeProgressEntry{jobID: jobID, message: message}
+	if !tryEnqueueDedupeProgress(dedupeProgressQueue, entry) {
+		atomic.AddUint64(&dedupeStateForJob(jobID).progressEventsDropped, 1)
 	}
 }
 
 func drainDedupeProgress() {
 	for entry := range dedupeProgressQueue {
-		if dropped := atomic.SwapUint64(&dedupeProgressDropped, 0); dropped > 0 {
-			droppedMessage := fmt.Sprintf("%s event=output_dropped count=%d", dedupeProgressPrefix, dropped)
-			if err := writeDedupeProgressTo(dedupeProgressOutput, droppedMessage); err != nil {
-				_, _ = fmt.Fprintf(dedupeProgressErrorOutput,
-					"%s event=output_error reason=%q\n", dedupeProgressPrefix, err.Error())
+		if st, ok := dedupeStateForJobIfExists(entry.jobID); ok {
+			if dropped := atomic.SwapUint64(&st.progressEventsDropped, 0); dropped > 0 {
+				droppedMessage := fmt.Sprintf(
+					"%s event=output_dropped jobId=%s count=%d",
+					dedupeProgressPrefix, entry.jobID.String(), dropped)
+				if err := dedupeProgressSink.write(entry.jobID, droppedMessage); err != nil {
+					_, _ = fmt.Fprintf(dedupeProgressErrorOutput,
+						"%s event=output_error jobId=%s reason=%q\n",
+						dedupeProgressPrefix, entry.jobID.String(), err.Error())
+				}
 			}
 		}
 
-		err := writeDedupeProgressTo(dedupeProgressOutput, entry.message)
+		err := dedupeProgressSink.write(entry.jobID, entry.message)
 		if err != nil {
 			_, _ = fmt.Fprintf(dedupeProgressErrorOutput,
-				"%s event=output_error reason=%q\n", dedupeProgressPrefix, err.Error())
+				"%s event=output_error jobId=%s reason=%q\n",
+				dedupeProgressPrefix, entry.jobID.String(), err.Error())
+		}
+		if entry.closeAfterWrite {
+			if closeErr := dedupeProgressSink.close(entry.jobID); closeErr != nil {
+				_, _ = fmt.Fprintf(dedupeProgressErrorOutput,
+					"%s event=output_error jobId=%s reason=%q\n",
+					dedupeProgressPrefix, entry.jobID.String(), closeErr.Error())
+				if err == nil {
+					err = closeErr
+				}
+			}
 		}
 		if entry.done != nil {
 			entry.done <- err
@@ -214,9 +299,14 @@ func drainDedupeProgress() {
 	}
 }
 
-func writeFinalDedupeProgress(message string) error {
+func writeFinalDedupeProgress(jobID common.JobID, message string) error {
 	done := make(chan error, 1)
-	entry := dedupeProgressEntry{message: message, done: done}
+	entry := dedupeProgressEntry{
+		jobID:           jobID,
+		message:         message,
+		closeAfterWrite: true,
+		done:            done,
+	}
 	timer := time.NewTimer(dedupeProgressFinalWriteTimeout)
 	defer timer.Stop()
 
@@ -236,7 +326,7 @@ func writeFinalDedupeProgress(message string) error {
 
 func emitDedupeProgress(jptm IJobPartTransferMgr, message string) {
 	jptm.LogAtLevelForCurrentTransfer(common.LogDebug, message)
-	enqueueDedupeProgress(message)
+	enqueueDedupeProgress(jptm.Info().JobID, message)
 }
 
 func dedupeProgressMessage(event string, mode dedupeActMode, info *TransferInfo, details string, snapshot dedupeProgressSnapshot) string {
@@ -435,7 +525,7 @@ func finalizeDedupeJob(jobID common.JobID, log func(common.LogLevel, string)) {
 		message := fmt.Sprintf(
 			"%s event=job_complete mode=%s jobId=%s %s",
 			dedupeProgressPrefix, mode, jobID.String(), st.progressSnapshot().fields(mode))
-		if err := writeFinalDedupeProgress(message); err != nil {
+		if err := writeFinalDedupeProgress(jobID, message); err != nil {
 			log(common.LogError,
 				dedupeProgressPrefix+" event=output_error reason="+fmt.Sprintf("%q", err.Error()))
 		}

--- a/ste/dedupeRecorder.go
+++ b/ste/dedupeRecorder.go
@@ -47,6 +47,9 @@ type dedupeJobState struct {
 	smallProgressMu sync.Mutex
 	hashCPU         dedupeHashCPUState
 
+	targetHashMu         sync.Mutex
+	targetHashEpochLocks map[dedupeTargetEpoch]*sync.Mutex
+
 	// table is the Phase 1 measurement table: blocks are recorded pre-write purely to count the
 	// would-be-hit rate, so it must NOT be used to decide a real reference (the content may not yet
 	// exist at the destination).
@@ -72,6 +75,20 @@ type dedupeJobState struct {
 	sourceStagedBlocks      int64 // blocks staged from the source (real source reads)
 	sourceStagedBytes       int64 // bytes staged from the source
 	fallbackBlocks          int64 // enforce: hits whose target reference failed and fell back to source
+	crcDiscoveredBlocks     int64
+	crcDiscoveredBytes      int64
+	crcCandidateBlocks      int64
+	crcCandidateOccurrences int64
+	sourceHashRanges        int64
+	sourceHashBatches       int64
+	targetHashRanges        int64
+	targetHashBatches       int64
+	targetHashCacheHits     int64
+	targetHashCacheMisses   int64
+	targetHashFailures      int64
+	epochInvalidations      int64
+	shaConfirmedBlocks      int64
+	shaMismatchBlocks       int64
 	filesStarted            int64 // files armed for source-grid dedupe
 	filesCommitted          int64 // files whose destination block list was committed
 	smallFilesStarted       int64 // Blob-to-Blob files smaller than 4 MiB that entered transfer handling
@@ -110,6 +127,60 @@ func (s *dedupeJobState) addSourceStaged(size int64) {
 // addFallback records an enforce hit whose target reference failed and fell back to the source.
 func (s *dedupeJobState) addFallback() {
 	atomic.AddInt64(&s.fallbackBlocks, 1)
+}
+
+func (s *dedupeJobState) addCRCDiscovery(plan *SourceGridPlan) (blocks, bytes int64) {
+	if plan == nil {
+		return 0, 0
+	}
+	for _, block := range plan.Blocks {
+		if !blockHasCRC64(block) {
+			continue
+		}
+		blocks++
+		bytes += block.Size
+	}
+	atomic.AddInt64(&s.crcDiscoveredBlocks, blocks)
+	atomic.AddInt64(&s.crcDiscoveredBytes, bytes)
+	return blocks, bytes
+}
+
+func (s *dedupeJobState) addHashResolution(stats dedupeHashResolutionStats) {
+	atomic.AddInt64(&s.crcCandidateBlocks, int64(stats.candidateBlocks))
+	atomic.AddInt64(&s.crcCandidateOccurrences, int64(stats.candidateOccurrences))
+	atomic.AddInt64(&s.sourceHashRanges, int64(stats.sourceHashRanges))
+	atomic.AddInt64(&s.sourceHashBatches, int64(stats.sourceHashBatches))
+	atomic.AddInt64(&s.targetHashRanges, int64(stats.targetHashRanges))
+	atomic.AddInt64(&s.targetHashBatches, int64(stats.targetHashBatches))
+	atomic.AddInt64(&s.targetHashCacheHits, int64(stats.targetHashCacheHits))
+	atomic.AddInt64(&s.targetHashCacheMisses, int64(stats.targetHashCacheMisses))
+	atomic.AddInt64(&s.targetHashFailures, int64(stats.targetHashFailures))
+	atomic.AddInt64(
+		&s.epochInvalidations,
+		int64(stats.sourceEpochInvalidations+stats.targetEpochInvalidations),
+	)
+}
+
+func (s *dedupeJobState) addSHAConfirmed() {
+	atomic.AddInt64(&s.shaConfirmedBlocks, 1)
+}
+
+func (s *dedupeJobState) addSHAMismatch() {
+	atomic.AddInt64(&s.shaMismatchBlocks, 1)
+}
+
+func (s *dedupeJobState) targetHashEpochLock(epoch dedupeTargetEpoch) *sync.Mutex {
+	s.targetHashMu.Lock()
+	defer s.targetHashMu.Unlock()
+	if s.targetHashEpochLocks == nil {
+		s.targetHashEpochLocks = make(map[dedupeTargetEpoch]*sync.Mutex)
+	}
+	lock, ok := s.targetHashEpochLocks[epoch]
+	if !ok {
+		lock = &sync.Mutex{}
+		s.targetHashEpochLocks[epoch] = lock
+	}
+	return lock
 }
 
 func (s *dedupeJobState) addFileStarted() {
@@ -275,6 +346,56 @@ func hashCPUResponseDelta(resp blockblob.GetBlockListResponse) dedupeHashCPUResp
 			continue
 		}
 		delta.hashedBytes, overflow = satAddNonNegative(delta.hashedBytes, *block.Size)
+		delta.hashedBytesOverflowed = delta.hashedBytesOverflowed || overflow
+	}
+	return delta
+}
+
+func getBlockListCRCResponseDelta(resp blockblob.GetBlockListResponse) dedupeHashCPUResponseDelta {
+	delta := dedupeHashCPUResponseDelta{}
+	if resp.RequestID != nil {
+		delta.requestID = strings.TrimSpace(*resp.RequestID)
+	}
+	delta.crc64CPUTimeUS, delta.crc64CPUTimeMissing, delta.crc64CPUTimeInvalid =
+		hashCPUTimeDelta(resp.CRC64CPUTimeUS)
+	delta.hashCPUTimeUS = delta.crc64CPUTimeUS
+
+	for _, block := range resp.CommittedBlocks {
+		if block == nil || len(block.Crc64) != 8 {
+			continue
+		}
+		var overflow bool
+		delta.hashedBlocks, overflow = satAddNonNegative(delta.hashedBlocks, 1)
+		delta.hashedBlocksOverflowed = delta.hashedBlocksOverflowed || overflow
+		if block.Size == nil || *block.Size <= 0 {
+			continue
+		}
+		delta.hashedBytes, overflow = satAddNonNegative(delta.hashedBytes, *block.Size)
+		delta.hashedBytesOverflowed = delta.hashedBytesOverflowed || overflow
+	}
+	return delta
+}
+
+func getBlobHashSHAResponseDelta(resp blockblob.GetBlobHashResponse) dedupeHashCPUResponseDelta {
+	delta := dedupeHashCPUResponseDelta{}
+	if resp.RequestID != nil {
+		delta.requestID = strings.TrimSpace(*resp.RequestID)
+	}
+	delta.sha256CPUTimeUS, delta.sha256CPUTimeMissing, delta.sha256CPUTimeInvalid =
+		hashCPUTimeDelta(resp.SHA256CPUTimeUS)
+	delta.hashCPUTimeUS = delta.sha256CPUTimeUS
+
+	for _, result := range resp.RangeHashes {
+		if len(result.SHA256) != 32 {
+			continue
+		}
+		var overflow bool
+		delta.hashedBlocks, overflow = satAddNonNegative(delta.hashedBlocks, 1)
+		delta.hashedBlocksOverflowed = delta.hashedBlocksOverflowed || overflow
+		if result.Count <= 0 {
+			continue
+		}
+		delta.hashedBytes, overflow = satAddNonNegative(delta.hashedBytes, result.Count)
 		delta.hashedBytesOverflowed = delta.hashedBytesOverflowed || overflow
 	}
 	return delta
@@ -455,6 +576,20 @@ type dedupeProgressSnapshot struct {
 	sourceStagedBlocks      int64
 	sourceStagedBytes       int64
 	fallbackBlocks          int64
+	crcDiscoveredBlocks     int64
+	crcDiscoveredBytes      int64
+	crcCandidateBlocks      int64
+	crcCandidateOccurrences int64
+	sourceHashRanges        int64
+	sourceHashBatches       int64
+	targetHashRanges        int64
+	targetHashBatches       int64
+	targetHashCacheHits     int64
+	targetHashCacheMisses   int64
+	targetHashFailures      int64
+	epochInvalidations      int64
+	shaConfirmedBlocks      int64
+	shaMismatchBlocks       int64
 	filesStarted            int64
 	filesCommitted          int64
 	smallFilesStarted       int64
@@ -484,6 +619,20 @@ func (s *dedupeJobState) progressSnapshotLocked() dedupeProgressSnapshot {
 		sourceStagedBlocks:      atomic.LoadInt64(&s.sourceStagedBlocks),
 		sourceStagedBytes:       atomic.LoadInt64(&s.sourceStagedBytes),
 		fallbackBlocks:          atomic.LoadInt64(&s.fallbackBlocks),
+		crcDiscoveredBlocks:     atomic.LoadInt64(&s.crcDiscoveredBlocks),
+		crcDiscoveredBytes:      atomic.LoadInt64(&s.crcDiscoveredBytes),
+		crcCandidateBlocks:      atomic.LoadInt64(&s.crcCandidateBlocks),
+		crcCandidateOccurrences: atomic.LoadInt64(&s.crcCandidateOccurrences),
+		sourceHashRanges:        atomic.LoadInt64(&s.sourceHashRanges),
+		sourceHashBatches:       atomic.LoadInt64(&s.sourceHashBatches),
+		targetHashRanges:        atomic.LoadInt64(&s.targetHashRanges),
+		targetHashBatches:       atomic.LoadInt64(&s.targetHashBatches),
+		targetHashCacheHits:     atomic.LoadInt64(&s.targetHashCacheHits),
+		targetHashCacheMisses:   atomic.LoadInt64(&s.targetHashCacheMisses),
+		targetHashFailures:      atomic.LoadInt64(&s.targetHashFailures),
+		epochInvalidations:      atomic.LoadInt64(&s.epochInvalidations),
+		shaConfirmedBlocks:      atomic.LoadInt64(&s.shaConfirmedBlocks),
+		shaMismatchBlocks:       atomic.LoadInt64(&s.shaMismatchBlocks),
 		filesStarted:            atomic.LoadInt64(&s.filesStarted),
 		filesCommitted:          atomic.LoadInt64(&s.filesCommitted),
 		smallFilesStarted:       s.smallFilesStarted,
@@ -530,7 +679,12 @@ func (s dedupeProgressSnapshot) fields(mode dedupeActMode) string {
 	return fmt.Sprintf(
 		"filesStarted=%d filesCommitted=%d targetURIBlocks=%d targetURIBytes=%d "+
 			"sourceURIBlocks=%d sourceURIBytes=%d fallbackBlocks=%d transferredBlocks=%d "+
-			"transferredBytes=%d wanSavingsPercent=%.1f smallFilesStarted=%d "+
+			"transferredBytes=%d wanSavingsPercent=%.1f crcDiscoveredBlocks=%d "+
+			"crcDiscoveredBytes=%d crcCandidateBlocks=%d crcCandidateOccurrences=%d "+
+			"sourceHashRanges=%d sourceHashBatches=%d targetHashRanges=%d "+
+			"targetHashBatches=%d targetHashCacheHits=%d targetHashCacheMisses=%d "+
+			"targetHashFailures=%d epochInvalidations=%d "+
+			"shaConfirmedBlocks=%d shaMismatchBlocks=%d smallFilesStarted=%d "+
 			"smallFilesCompleted=%d smallFilesFailed=%d smallFilesSkipped=%d "+
 			"smallFilesCanceled=%d smallFilesInProgress=%d smallFileBytesStarted=%d "+
 			"smallFileBytesCompleted=%d smallFileBytesFailed=%d smallFileBytesSkipped=%d "+
@@ -538,6 +692,11 @@ func (s dedupeProgressSnapshot) fields(mode dedupeActMode) string {
 		s.filesStarted, s.filesCommitted, targetBlocks, targetBytes,
 		s.sourceStagedBlocks, s.sourceStagedBytes, s.fallbackBlocks, transferredBlocks,
 		transferredBytes, dedupePercent(targetBytes, transferredBytes),
+		s.crcDiscoveredBlocks, s.crcDiscoveredBytes, s.crcCandidateBlocks,
+		s.crcCandidateOccurrences, s.sourceHashRanges, s.sourceHashBatches,
+		s.targetHashRanges, s.targetHashBatches, s.targetHashCacheHits,
+		s.targetHashCacheMisses, s.targetHashFailures,
+		s.epochInvalidations, s.shaConfirmedBlocks, s.shaMismatchBlocks,
 		s.smallFilesStarted, s.smallFilesCompleted, s.smallFilesFailed,
 		s.smallFilesSkipped, s.smallFilesCanceled, smallFilesInProgress,
 		s.smallFileBytesStarted, s.smallFileBytesCompleted, s.smallFileBytesFailed,
@@ -759,6 +918,26 @@ func dedupeHashCPUTimeMessage(
 	)
 }
 
+func dedupeHashCPUTimeMessageForOperation(
+	mode dedupeActMode,
+	info *TransferInfo,
+	operation string,
+	role string,
+	snapshot dedupeHashCPUEventSnapshot,
+) string {
+	return fmt.Sprintf(
+		"%s event=hash_cpu_time mode=%s jobId=%s file=%q destination=%q operation=%q role=%q %s",
+		dedupeProgressPrefix,
+		mode,
+		info.JobID.String(),
+		info.DstFilePath,
+		sanitizedDestForDedupe(info.Destination),
+		operation,
+		role,
+		snapshot.fields(),
+	)
+}
+
 func emitHashCPUTime(
 	jptm IJobPartTransferMgr,
 	mode dedupeActMode,
@@ -769,11 +948,120 @@ func emitHashCPUTime(
 	}
 
 	st := dedupeStateForJob(jptm.Info().JobID)
-	snapshot, accepted := st.hashCPU.record(hashCPUResponseDelta(resp))
+	snapshot, accepted := st.hashCPU.record(getBlockListCRCResponseDelta(resp))
 	if !accepted {
 		return
 	}
-	emitDedupeProgress(jptm, dedupeHashCPUTimeMessage(mode, jptm.Info(), snapshot))
+	emitDedupeProgress(jptm, dedupeHashCPUTimeMessageForOperation(
+		mode,
+		jptm.Info(),
+		"get_block_list",
+		"source",
+		snapshot,
+	))
+}
+
+func emitGetBlobHashCPUTime(
+	jptm IJobPartTransferMgr,
+	mode dedupeActMode,
+	role string,
+	resp blockblob.GetBlobHashResponse,
+) {
+	if mode != dedupeActEnforce {
+		return
+	}
+
+	st := dedupeStateForJob(jptm.Info().JobID)
+	snapshot, accepted := st.hashCPU.record(getBlobHashSHAResponseDelta(resp))
+	if !accepted {
+		return
+	}
+	emitDedupeProgress(jptm, dedupeHashCPUTimeMessageForOperation(
+		mode,
+		jptm.Info(),
+		"get_blob_hash",
+		role,
+		snapshot,
+	))
+}
+
+func emitDedupeHashResolutionProgress(
+	jptm IJobPartTransferMgr,
+	mode dedupeActMode,
+	stats dedupeHashResolutionStats,
+	err error,
+) {
+	st := dedupeStateForJob(jptm.Info().JobID)
+	st.addHashResolution(stats)
+	if stats.candidateBlocks == 0 {
+		emitDedupeProgress(jptm, dedupeProgressMessage(
+			"crc_candidate_miss",
+			mode,
+			jptm.Info(),
+			"candidateBlocks=0 candidateOccurrences=0",
+			st.progressSnapshot(),
+		))
+		return
+	}
+	emitDedupeProgress(jptm, dedupeProgressMessage(
+		"crc_candidate_hit",
+		mode,
+		jptm.Info(),
+		fmt.Sprintf(
+			"candidateBlocks=%d candidateOccurrences=%d",
+			stats.candidateBlocks,
+			stats.candidateOccurrences,
+		),
+		st.progressSnapshot(),
+	))
+	if stats.sourceEpochInvalidations > 0 {
+		emitDedupeProgress(jptm, dedupeProgressMessage(
+			"epoch_invalidated_412",
+			mode,
+			jptm.Info(),
+			fmt.Sprintf("role=%q count=%d", "source_hash", stats.sourceEpochInvalidations),
+			st.progressSnapshot(),
+		))
+	}
+	if stats.targetEpochInvalidations > 0 {
+		emitDedupeProgress(jptm, dedupeProgressMessage(
+			"epoch_invalidated_412",
+			mode,
+			jptm.Info(),
+			fmt.Sprintf("role=%q count=%d", "target_hash", stats.targetEpochInvalidations),
+			st.progressSnapshot(),
+		))
+	}
+	event := "get_blob_hash_complete"
+	reason := ""
+	if err != nil {
+		event = "get_blob_hash_failed"
+		reason = err.Error()
+	}
+	emitDedupeProgress(jptm, dedupeProgressMessage(
+		event,
+		mode,
+		jptm.Info(),
+		fmt.Sprintf(
+			"candidateBlocks=%d candidateOccurrences=%d sourceRanges=%d sourceBatches=%d "+
+				"targetRanges=%d targetBatches=%d targetCacheHits=%d targetCacheMisses=%d "+
+				"targetFailures=%d "+
+				"sourceEpochInvalidations=%d targetEpochInvalidations=%d reason=%q",
+			stats.candidateBlocks,
+			stats.candidateOccurrences,
+			stats.sourceHashRanges,
+			stats.sourceHashBatches,
+			stats.targetHashRanges,
+			stats.targetHashBatches,
+			stats.targetHashCacheHits,
+			stats.targetHashCacheMisses,
+			stats.targetHashFailures,
+			stats.sourceEpochInvalidations,
+			stats.targetEpochInvalidations,
+			reason,
+		),
+		st.progressSnapshot(),
+	))
 }
 
 func isSmallFileProgressTransfer(jptm IJobPartTransferMgr) bool {
@@ -978,7 +1266,7 @@ func clearDedupeStateForJob(jobID common.JobID) {
 	}
 }
 
-// recordCommittedBlocks records a freshly-committed destination blob's hashed blocks into the job's
+// recordCommittedBlocks records a freshly-committed destination blob's CRC-indexed blocks into the job's
 // committed table, so that later blocks with identical content can be served from this blob. It is
 // called from the sender Epilogue after CommitBlockList succeeds, with the destination's real ETag.
 // Because the destination is a byte-identical copy of the source, each block lives at the same
@@ -1003,13 +1291,14 @@ func recordCommittedBlocksWithObserver(jobID common.JobID, destURI, destinationS
 	st := dedupeStateForJob(jobID)
 	target := destinationWithSASForDedupe(destURI, destinationSAS)
 	for _, b := range plan.Blocks {
-		if !blockHasHashes(b) {
+		if !blockHasCRC64(b) {
 			continue
 		}
 		stored, inserted := st.committed.Insert(common.BlockEntry{
 			JobID:        jobID,
 			CRC64:        b.CRC64,
 			SHA256:       b.SHA256,
+			HasSHA256:    blockHasHashes(b),
 			TargetURI:    target,
 			TargetOffset: b.Offset,
 			TargetLength: b.Size,
@@ -1176,7 +1465,11 @@ func dedupeJobSummaryMessage(mode dedupeActMode, st *dedupeJobState) string {
 // blockHasHashes reports whether a planned block carried both content hashes in the extended
 // GetBlockList response. Presence is tracked separately because an all-zero hash is valid.
 func blockHasHashes(b PlannedBlock) bool {
-	return b.HasHashes
+	return b.HasSHA256 || b.HasHashes
+}
+
+func blockHasCRC64(b PlannedBlock) bool {
+	return b.HasCRC64 || b.HasHashes
 }
 
 // measureAndRecord performs the Phase 1 lookup-then-record over a set of planned blocks against
@@ -1334,21 +1627,64 @@ func buildSourceBlockHashIndex(plan *SourceGridPlan) map[srcBlockKey]srcBlockHas
 // a cross-blob reuse candidate and must be ignored; same-blob hits are intentionally observe-only in
 // this targetURI design because the current blob's destination ranges are not committed/readable yet.
 func decideStaging(index map[srcBlockKey]srcBlockHashes, committed *common.DedupeHashTable, offset, size int64, currentTargetURI string) (target common.BlockEntry, reference bool) {
+	targets := matchingDedupeTargets(index, committed, offset, size, currentTargetURI)
+	if len(targets) == 0 {
+		return common.BlockEntry{}, false
+	}
+	return targets[0], true
+}
+
+func matchingDedupeTargets(
+	index map[srcBlockKey]srcBlockHashes,
+	committed *common.DedupeHashTable,
+	offset int64,
+	size int64,
+	currentTargetURI string,
+) []common.BlockEntry {
 	h, ok := index[srcBlockKey{offset: offset, size: size}]
 	if !ok {
-		return common.BlockEntry{}, false // no known hash for this chunk (not aligned to a source block)
+		return nil
 	}
-	entry, hit := committed.Lookup(h.crc64, h.sha256)
-	if !hit {
-		return common.BlockEntry{}, false // identical content not yet migrated to the destination
+	var targets []common.BlockEntry
+	for _, entry := range committed.LookupByCRC64AndLength(h.crc64, size) {
+		if !entry.HasSHA256 || entry.SHA256 != h.sha256 {
+			continue
+		}
+		if entry.TargetURI == "" || entry.TargetOffset < 0 || entry.ETag == "" {
+			continue // never reuse an unversioned target range
+		}
+		if sameDedupeTarget(entry.TargetURI, currentTargetURI) {
+			continue // avoid unsafe same-blob/self reuse; another occurrence can still be used
+		}
+		targets = append(targets, entry)
 	}
-	if entry.TargetURI == "" || entry.TargetOffset < 0 || entry.ETag == "" || entry.TargetLength != size {
-		return common.BlockEntry{}, false // never reuse an unversioned or differently-sized target range
+	return targets
+}
+
+func hasDedupeSHAMismatch(
+	index map[srcBlockKey]srcBlockHashes,
+	committed *common.DedupeHashTable,
+	offset int64,
+	size int64,
+	currentTargetURI string,
+) bool {
+	h, ok := index[srcBlockKey{offset: offset, size: size}]
+	if !ok {
+		return false
 	}
-	if sameDedupeTarget(entry.TargetURI, currentTargetURI) {
-		return common.BlockEntry{}, false // avoid unsafe same-blob/self reuse; wait for a committed target blob
+	for _, entry := range committed.LookupByCRC64AndLength(h.crc64, size) {
+		if !entry.HasSHA256 ||
+			entry.TargetURI == "" ||
+			entry.TargetOffset < 0 ||
+			entry.ETag == "" ||
+			sameDedupeTarget(entry.TargetURI, currentTargetURI) {
+			continue
+		}
+		if entry.SHA256 != h.sha256 {
+			return true
+		}
 	}
-	return entry, true
+	return false
 }
 
 func sameDedupeTarget(a, b string) bool {

--- a/ste/dedupeRecorder_test.go
+++ b/ste/dedupeRecorder_test.go
@@ -51,7 +51,9 @@ func hashedBlock(content string, offset, size int64) PlannedBlock {
 		Size:         size,
 		SrcBlockName: content,
 		CRC64:        crc,
+		HasCRC64:     true,
 		SHA256:       sum,
+		HasSHA256:    true,
 		HasHashes:    true,
 	}
 }
@@ -182,6 +184,39 @@ func TestHashCPUResponseDeltaCPUValues(t *testing.T) {
 			assert.False(t, delta.hashCPUTimeOverflowed)
 		})
 	}
+}
+
+func TestGetBlockListCRCResponseDeltaIgnoresSHA(t *testing.T) {
+	response := blockblob.GetBlockListResponse{
+		CRC64CPUTimeUS:  ptrTo(int64(7)),
+		SHA256CPUTimeUS: ptrTo(int64(999)),
+		RequestID:       ptrTo("crc-only-request"),
+		BlockList: blockblob.BlockList{CommittedBlocks: []*blockblob.Block{
+			{Size: ptrTo(int64(37)), Crc64: make([]byte, 8), Sha256: make([]byte, 32)},
+		}},
+	}
+
+	delta := getBlockListCRCResponseDelta(response)
+
+	assert.EqualValues(t, 7, delta.crc64CPUTimeUS)
+	assert.Zero(t, delta.sha256CPUTimeUS)
+	assert.EqualValues(t, 7, delta.hashCPUTimeUS)
+	assert.False(t, delta.sha256CPUTimeMissing)
+	assert.EqualValues(t, 1, delta.hashedBlocks)
+	assert.EqualValues(t, 37, delta.hashedBytes)
+}
+
+func TestGetBlobHashSHAResponseDeltaDiagnostics(t *testing.T) {
+	missing := getBlobHashSHAResponseDelta(blockblob.GetBlobHashResponse{})
+	assert.True(t, missing.sha256CPUTimeMissing)
+	assert.False(t, missing.crc64CPUTimeMissing)
+
+	invalid := getBlobHashSHAResponseDelta(blockblob.GetBlobHashResponse{
+		SHA256CPUTimeUS: ptrTo(int64(-1)),
+	})
+	assert.True(t, invalid.sha256CPUTimeInvalid)
+	assert.False(t, invalid.sha256CPUTimeMissing)
+	assert.Zero(t, invalid.sha256CPUTimeUS)
 }
 
 func TestHashCPUResponseDeltaCountsOnlyCompleteHashes(t *testing.T) {
@@ -552,8 +587,8 @@ func TestHashCPUEmitterScopesModesAndAcceptedResponses(t *testing.T) {
 	emitHashCPUTime(manager, dedupeActEnforce, response)
 	snapshot := state.hashCPU.snapshot()
 	assert.EqualValues(t, 7, snapshot.crc64CPUTimeUS)
-	assert.EqualValues(t, 11, snapshot.sha256CPUTimeUS)
-	assert.EqualValues(t, 18, snapshot.hashCPUTimeUS)
+	assert.Zero(t, snapshot.sha256CPUTimeUS)
+	assert.EqualValues(t, 7, snapshot.hashCPUTimeUS)
 	assert.Zero(t, snapshot.hashedBlocks)
 	assert.Zero(t, snapshot.hashedBytes)
 	assert.EqualValues(t, 1, snapshot.hashCPUTimeResponses)
@@ -561,6 +596,7 @@ func TestHashCPUEmitterScopesModesAndAcceptedResponses(t *testing.T) {
 	assert.Len(t, manager.logMessages(), 1)
 	first := <-queue
 	assert.Contains(t, first.message, "event=hash_cpu_time")
+	assert.Contains(t, first.message, `operation="get_block_list" role="source"`)
 	assert.Contains(t, first.message, `requestId="request-empty-list"`)
 
 	emitHashCPUTime(manager, dedupeActEnforce, response)
@@ -574,6 +610,148 @@ func TestHashCPUEmitterScopesModesAndAcceptedResponses(t *testing.T) {
 	assert.Len(t, queue, 1)
 	assert.Len(t, manager.logMessages(), 2)
 	assert.EqualValues(t, 2, state.hashCPU.snapshot().hashCPUTimeResponses)
+}
+
+func TestGetBlobHashCPUEmitterRecordsSHAOnly(t *testing.T) {
+	oldQueue := dedupeProgressQueue
+	queue := make(chan dedupeProgressEntry, 2)
+	dedupeProgressQueue = queue
+	t.Cleanup(func() {
+		dedupeProgressQueue = oldQueue
+	})
+
+	jobID := common.NewJobID()
+	t.Cleanup(func() {
+		clearDedupeStateForJob(jobID)
+	})
+	manager := &hashCPUTestTransferManager{
+		testJobPartTransferManager: &testJobPartTransferManager{
+			info: &TransferInfo{
+				JobID:       jobID,
+				DstFilePath: "candidate.bin",
+				Destination: "https://acct.blob.core.windows.net/c/candidate.bin",
+			},
+		},
+	}
+	response := blockblob.GetBlobHashResponse{
+		SHA256CPUTimeUS: ptrTo(int64(23)),
+		RequestID:       ptrTo("request-get-blob-hash"),
+		RangeHashes: []blockblob.BlobHashResult{
+			{Offset: 0, Count: 3, SHA256: make([]byte, 32)},
+			{Offset: 10, Count: 7, SHA256: make([]byte, 32)},
+		},
+	}
+
+	emitGetBlobHashCPUTime(manager, dedupeActEnforce, "target", response)
+
+	snapshot := dedupeStateForJob(jobID).hashCPU.snapshot()
+	assert.Zero(t, snapshot.crc64CPUTimeUS)
+	assert.EqualValues(t, 23, snapshot.sha256CPUTimeUS)
+	assert.EqualValues(t, 23, snapshot.hashCPUTimeUS)
+	assert.EqualValues(t, 2, snapshot.hashedBlocks)
+	assert.EqualValues(t, 10, snapshot.hashedBytes)
+	assert.Zero(t, snapshot.crc64CPUTimeMissingResponses)
+	assert.Zero(t, snapshot.sha256CPUTimeMissingResponses)
+	assert.Len(t, queue, 1)
+	assert.Len(t, manager.logMessages(), 1)
+	message := (<-queue).message
+	assert.Contains(t, message, `operation="get_blob_hash" role="target"`)
+	assert.Contains(t, message, `sha256CpuTimeUsDelta=23`)
+	assert.Contains(t, message, `hashedBlocksDelta=2`)
+	assert.Contains(t, message, `hashedBytesDelta=10`)
+}
+
+func TestDedupeHashResolutionProgressCounters(t *testing.T) {
+	oldQueue := dedupeProgressQueue
+	queue := make(chan dedupeProgressEntry, 4)
+	dedupeProgressQueue = queue
+	t.Cleanup(func() {
+		dedupeProgressQueue = oldQueue
+	})
+
+	jobID := common.NewJobID()
+	t.Cleanup(func() {
+		clearDedupeStateForJob(jobID)
+	})
+	manager := &hashCPUTestTransferManager{
+		testJobPartTransferManager: &testJobPartTransferManager{
+			info: &TransferInfo{
+				JobID:       jobID,
+				DstFilePath: "candidate.bin",
+				Destination: "https://acct.blob.core.windows.net/c/candidate.bin?sig=secret",
+			},
+		},
+	}
+	stats := dedupeHashResolutionStats{
+		candidateBlocks:          2,
+		candidateOccurrences:     3,
+		sourceHashRanges:         2,
+		sourceHashBatches:        1,
+		targetHashRanges:         3,
+		targetHashBatches:        2,
+		targetHashCacheHits:      4,
+		targetHashCacheMisses:    3,
+		targetHashFailures:       1,
+		sourceEpochInvalidations: 1,
+		targetEpochInvalidations: 2,
+	}
+
+	emitDedupeHashResolutionProgress(manager, dedupeActEnforce, stats, nil)
+
+	snapshot := dedupeStateForJob(jobID).progressSnapshot()
+	assert.EqualValues(t, 2, snapshot.crcCandidateBlocks)
+	assert.EqualValues(t, 3, snapshot.crcCandidateOccurrences)
+	assert.EqualValues(t, 2, snapshot.sourceHashRanges)
+	assert.EqualValues(t, 1, snapshot.sourceHashBatches)
+	assert.EqualValues(t, 3, snapshot.targetHashRanges)
+	assert.EqualValues(t, 2, snapshot.targetHashBatches)
+	assert.EqualValues(t, 4, snapshot.targetHashCacheHits)
+	assert.EqualValues(t, 3, snapshot.targetHashCacheMisses)
+	assert.EqualValues(t, 1, snapshot.targetHashFailures)
+	assert.EqualValues(t, 3, snapshot.epochInvalidations)
+
+	assert.Len(t, queue, 4)
+	messages := []string{(<-queue).message, (<-queue).message, (<-queue).message, (<-queue).message}
+	combined := strings.Join(messages, "\n")
+	assert.Contains(t, combined, "event=crc_candidate_hit")
+	assert.Contains(t, combined, `event=epoch_invalidated_412`)
+	assert.Contains(t, combined, `role="source_hash"`)
+	assert.Contains(t, combined, `role="target_hash"`)
+	assert.Contains(t, combined, "event=get_blob_hash_complete")
+	assert.NotContains(t, combined, "sig=secret")
+}
+
+func TestDedupeHashResolutionProgressNoCandidate(t *testing.T) {
+	oldQueue := dedupeProgressQueue
+	queue := make(chan dedupeProgressEntry, 1)
+	dedupeProgressQueue = queue
+	t.Cleanup(func() {
+		dedupeProgressQueue = oldQueue
+	})
+
+	jobID := common.NewJobID()
+	t.Cleanup(func() {
+		clearDedupeStateForJob(jobID)
+	})
+	manager := &hashCPUTestTransferManager{
+		testJobPartTransferManager: &testJobPartTransferManager{
+			info: &TransferInfo{
+				JobID:       jobID,
+				DstFilePath: "miss.bin",
+				Destination: "https://acct.blob.core.windows.net/c/miss.bin",
+			},
+		},
+	}
+
+	emitDedupeHashResolutionProgress(
+		manager,
+		dedupeActEnforce,
+		dedupeHashResolutionStats{},
+		nil,
+	)
+
+	assert.Len(t, queue, 1)
+	assert.Contains(t, (<-queue).message, "event=crc_candidate_miss")
 }
 
 func TestHashCPUFieldsAreIsolatedFromGenericProgressEvents(t *testing.T) {
@@ -618,7 +796,12 @@ func TestDedupeProgressSnapshotEnforce(t *testing.T) {
 	a.Equal(
 		"filesStarted=2 filesCommitted=1 targetURIBlocks=2 targetURIBytes=150 "+
 			"sourceURIBlocks=1 sourceURIBytes=100 fallbackBlocks=1 transferredBlocks=3 "+
-			"transferredBytes=250 wanSavingsPercent=60.0 smallFilesStarted=1 "+
+			"transferredBytes=250 wanSavingsPercent=60.0 crcDiscoveredBlocks=0 "+
+			"crcDiscoveredBytes=0 crcCandidateBlocks=0 crcCandidateOccurrences=0 "+
+			"sourceHashRanges=0 sourceHashBatches=0 targetHashRanges=0 "+
+			"targetHashBatches=0 targetHashCacheHits=0 targetHashCacheMisses=0 "+
+			"targetHashFailures=0 epochInvalidations=0 "+
+			"shaConfirmedBlocks=0 shaMismatchBlocks=0 smallFilesStarted=1 "+
 			"smallFilesCompleted=1 smallFilesFailed=0 smallFilesSkipped=0 "+
 			"smallFilesCanceled=0 smallFilesInProgress=0 smallFileBytesStarted=1024 "+
 			"smallFileBytesCompleted=1024 smallFileBytesFailed=0 smallFileBytesSkipped=0 "+
@@ -867,7 +1050,7 @@ func TestMeasureAndRecord_IntraBlobDuplicate(t *testing.T) {
 	a.EqualValues(3, hashed)
 	a.EqualValues(1, hits)
 	a.EqualValues(10, bytes)
-	a.Equal(2, tbl.Len()) // only two distinct contents stored
+	a.Equal(3, tbl.Len()) // every target occurrence is preserved, including the duplicate range
 }
 
 func TestMeasureAndRecord_CrossBlobAccumulation(t *testing.T) {
@@ -893,7 +1076,7 @@ func TestMeasureAndRecord_CrossBlobAccumulation(t *testing.T) {
 	a.EqualValues(1, hit2)
 	a.EqualValues(50, b2)
 
-	a.Equal(3, tbl.Len()) // shared + unique1 + unique2
+	a.Equal(4, tbl.Len()) // shared is preserved at both target occurrences
 }
 
 func TestMeasureAndRecord_PopulatesTargetRange(t *testing.T) {
@@ -1099,4 +1282,90 @@ func TestDecideStaging_SameTargetIsNotReusable(t *testing.T) {
 
 	_, reference := decideStaging(idx, committed, 0, 100, "https://acct.blob.core.windows.net/c/current?sig=secret")
 	a.False(reference)
+}
+
+func TestDecideStaging_SkipsSameTargetAndUsesAnotherOccurrence(t *testing.T) {
+	a := assert.New(t)
+
+	b := hashedBlock("a", 0, 100)
+	idx := buildSourceBlockHashIndex(&SourceGridPlan{Blocks: []PlannedBlock{b}})
+	committed := common.NewDedupeHashTable()
+	committed.Insert(common.BlockEntry{
+		CRC64:        b.CRC64,
+		SHA256:       b.SHA256,
+		HasSHA256:    true,
+		TargetURI:    "https://acct.blob.core.windows.net/c/current",
+		TargetOffset: 0,
+		TargetLength: 100,
+		ETag:         azcore.ETag("etag-current"),
+	})
+	committed.Insert(common.BlockEntry{
+		CRC64:        b.CRC64,
+		SHA256:       b.SHA256,
+		HasSHA256:    true,
+		TargetURI:    "https://acct.blob.core.windows.net/c/previous",
+		TargetOffset: 200,
+		TargetLength: 100,
+		ETag:         azcore.ETag("etag-previous"),
+	})
+
+	target, reference := decideStaging(
+		idx,
+		committed,
+		0,
+		100,
+		"https://acct.blob.core.windows.net/c/current?sig=secret",
+	)
+	a.True(reference)
+	a.Equal("https://acct.blob.core.windows.net/c/previous", target.TargetURI)
+	a.EqualValues(200, target.TargetOffset)
+}
+
+func TestHasDedupeSHAMismatchRequiresComparableTargetSHA(t *testing.T) {
+	source := hashedBlock("source", 0, 100)
+	idx := buildSourceBlockHashIndex(&SourceGridPlan{Blocks: []PlannedBlock{source}})
+	committed := common.NewDedupeHashTable()
+	targetURI := "https://acct.blob.core.windows.net/c/previous"
+	entry := common.BlockEntry{
+		CRC64:        source.CRC64,
+		TargetURI:    targetURI,
+		TargetOffset: 0,
+		TargetLength: 100,
+		ETag:         azcore.ETag("etag"),
+	}
+	committed.Insert(entry)
+
+	assert.False(t, hasDedupeSHAMismatch(
+		idx,
+		committed,
+		0,
+		100,
+		"https://acct.blob.core.windows.net/c/current",
+	))
+
+	mismatch := sha256.Sum256([]byte("different"))
+	assert.True(t, committed.SetSHA256ForCRC64(
+		source.CRC64,
+		targetURI,
+		0,
+		100,
+		azcore.ETag("etag"),
+		mismatch,
+	))
+	assert.True(t, hasDedupeSHAMismatch(
+		idx,
+		committed,
+		0,
+		100,
+		"https://acct.blob.core.windows.net/c/current",
+	))
+
+	committed.RemoveTargetEpoch(targetURI, azcore.ETag("etag"))
+	assert.False(t, hasDedupeSHAMismatch(
+		idx,
+		committed,
+		0,
+		100,
+		"https://acct.blob.core.windows.net/c/current",
+	))
 }

--- a/ste/dedupeRecorder_test.go
+++ b/ste/dedupeRecorder_test.go
@@ -691,8 +691,8 @@ func TestDedupeHashResolutionProgressCounters(t *testing.T) {
 		sourceHashBatches:        1,
 		targetHashRanges:         3,
 		targetHashBatches:        2,
-		targetHashCacheHits:      4,
-		targetHashCacheMisses:    3,
+		targetSHAIndexHits:       4,
+		targetSHAIndexMisses:     3,
 		targetHashFailures:       1,
 		sourceEpochInvalidations: 1,
 		targetEpochInvalidations: 2,
@@ -707,8 +707,8 @@ func TestDedupeHashResolutionProgressCounters(t *testing.T) {
 	assert.EqualValues(t, 1, snapshot.sourceHashBatches)
 	assert.EqualValues(t, 3, snapshot.targetHashRanges)
 	assert.EqualValues(t, 2, snapshot.targetHashBatches)
-	assert.EqualValues(t, 4, snapshot.targetHashCacheHits)
-	assert.EqualValues(t, 3, snapshot.targetHashCacheMisses)
+	assert.EqualValues(t, 4, snapshot.targetSHAIndexHits)
+	assert.EqualValues(t, 3, snapshot.targetSHAIndexMisses)
 	assert.EqualValues(t, 1, snapshot.targetHashFailures)
 	assert.EqualValues(t, 3, snapshot.epochInvalidations)
 
@@ -801,7 +801,7 @@ func TestDedupeProgressSnapshotEnforce(t *testing.T) {
 			"transferredBytes=250 wanSavingsPercent=60.0 crcDiscoveredBlocks=0 "+
 			"crcDiscoveredBytes=0 crcCandidateBlocks=0 crcCandidateOccurrences=0 "+
 			"sourceHashRanges=0 sourceHashBatches=0 targetHashRanges=0 "+
-			"targetHashBatches=0 targetHashCacheHits=0 targetHashCacheMisses=0 "+
+			"targetHashBatches=0 targetSHAIndexHits=0 targetSHAIndexMisses=0 "+
 			"targetHashFailures=0 epochInvalidations=0 "+
 			"shaConfirmedBlocks=0 shaMismatchBlocks=0 smallFilesStarted=1 "+
 			"smallFilesCompleted=1 smallFilesFailed=0 smallFilesSkipped=0 "+

--- a/ste/dedupeRecorder_test.go
+++ b/ste/dedupeRecorder_test.go
@@ -23,13 +23,16 @@ package ste
 import (
 	"crypto/sha256"
 	"fmt"
+	"math"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/stretchr/testify/assert"
 )
@@ -50,6 +53,552 @@ func hashedBlock(content string, offset, size int64) PlannedBlock {
 		CRC64:        crc,
 		SHA256:       sum,
 		HasHashes:    true,
+	}
+}
+
+func hashCPUBlock(size *int64, crc64Length, sha256Length int) *blockblob.Block {
+	return &blockblob.Block{
+		Size:   size,
+		Crc64:  make([]byte, crc64Length),
+		Sha256: make([]byte, sha256Length),
+	}
+}
+
+type hashCPUTestTransferManager struct {
+	*testJobPartTransferManager
+
+	logsMu sync.Mutex
+	logs   []string
+}
+
+func (m *hashCPUTestTransferManager) LogAtLevelForCurrentTransfer(_ common.LogLevel, message string) {
+	m.logsMu.Lock()
+	defer m.logsMu.Unlock()
+	m.logs = append(m.logs, message)
+}
+
+func (m *hashCPUTestTransferManager) logMessages() []string {
+	m.logsMu.Lock()
+	defer m.logsMu.Unlock()
+	return append([]string(nil), m.logs...)
+}
+
+func assertNoHashCPUMetricFields(t *testing.T, message string) {
+	t.Helper()
+	for _, field := range []string{
+		"crc64CpuTimeUs",
+		"sha256CpuTimeUs",
+		"hashCpuTimeUs",
+		"hashedBlocks",
+		"hashedBytes",
+		"hashCpuTimeResponses",
+		"crc64CpuTimeMissingResponses",
+		"sha256CpuTimeMissingResponses",
+		"requestIdMissingResponses",
+		"crc64CpuTimeInvalidResponses",
+		"sha256CpuTimeInvalidResponses",
+		"crc64CpuTimeOverflowed",
+		"sha256CpuTimeOverflowed",
+		"hashCpuTimeOverflowed",
+		"hashedBlocksOverflowed",
+		"hashedBytesOverflowed",
+		"hashMetricsOverflowed",
+	} {
+		assert.NotContains(t, message, field)
+	}
+}
+
+func TestHashCPUResponseDeltaCPUValues(t *testing.T) {
+	requestID := "  request-42  "
+	tests := []struct {
+		name               string
+		crc64              *int64
+		sha256             *int64
+		requestID          *string
+		wantCRC64          int64
+		wantSHA256         int64
+		wantCRC64Missing   bool
+		wantSHA256Missing  bool
+		wantCRC64Invalid   bool
+		wantSHA256Invalid  bool
+		wantTrimmedRequest string
+	}{
+		{
+			name:               "positive values and trimmed request ID",
+			crc64:              ptrTo(int64(7)),
+			sha256:             ptrTo(int64(11)),
+			requestID:          &requestID,
+			wantCRC64:          7,
+			wantSHA256:         11,
+			wantTrimmedRequest: "request-42",
+		},
+		{
+			name:   "explicit zero",
+			crc64:  ptrTo(int64(0)),
+			sha256: ptrTo(int64(0)),
+		},
+		{
+			name:             "crc64 nil",
+			sha256:           ptrTo(int64(5)),
+			wantSHA256:       5,
+			wantCRC64Missing: true,
+		},
+		{
+			name:              "sha256 nil",
+			crc64:             ptrTo(int64(3)),
+			wantCRC64:         3,
+			wantSHA256Missing: true,
+		},
+		{
+			name:              "both nil",
+			wantCRC64Missing:  true,
+			wantSHA256Missing: true,
+		},
+		{
+			name:              "synthetic negative pointers",
+			crc64:             ptrTo(int64(-1)),
+			sha256:            ptrTo(int64(-2)),
+			wantCRC64Invalid:  true,
+			wantSHA256Invalid: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			delta := hashCPUResponseDelta(blockblob.GetBlockListResponse{
+				CRC64CPUTimeUS:  test.crc64,
+				SHA256CPUTimeUS: test.sha256,
+				RequestID:       test.requestID,
+			})
+
+			assert.Equal(t, test.wantTrimmedRequest, delta.requestID)
+			assert.Equal(t, test.wantCRC64, delta.crc64CPUTimeUS)
+			assert.Equal(t, test.wantSHA256, delta.sha256CPUTimeUS)
+			assert.Equal(t, test.wantCRC64+test.wantSHA256, delta.hashCPUTimeUS)
+			assert.Equal(t, test.wantCRC64Missing, delta.crc64CPUTimeMissing)
+			assert.Equal(t, test.wantSHA256Missing, delta.sha256CPUTimeMissing)
+			assert.Equal(t, test.wantCRC64Invalid, delta.crc64CPUTimeInvalid)
+			assert.Equal(t, test.wantSHA256Invalid, delta.sha256CPUTimeInvalid)
+			assert.False(t, delta.hashCPUTimeOverflowed)
+		})
+	}
+}
+
+func TestHashCPUResponseDeltaCountsOnlyCompleteHashes(t *testing.T) {
+	response := blockblob.GetBlockListResponse{}
+	response.CommittedBlocks = []*blockblob.Block{
+		hashCPUBlock(ptrTo(int64(10)), 8, 32),
+		hashCPUBlock(ptrTo(int64(20)), 8, 32),
+		hashCPUBlock(nil, 8, 32),
+		hashCPUBlock(ptrTo(int64(0)), 8, 32),
+		hashCPUBlock(ptrTo(int64(-5)), 8, 32),
+		hashCPUBlock(ptrTo(int64(100)), 7, 32),
+		hashCPUBlock(ptrTo(int64(100)), 8, 31),
+		hashCPUBlock(ptrTo(int64(100)), 9, 32),
+		hashCPUBlock(ptrTo(int64(100)), 8, 33),
+		nil,
+	}
+
+	delta := hashCPUResponseDelta(response)
+
+	assert.EqualValues(t, 5, delta.hashedBlocks)
+	assert.EqualValues(t, 30, delta.hashedBytes)
+	assert.False(t, delta.hashedBlocksOverflowed)
+	assert.False(t, delta.hashedBytesOverflowed)
+}
+
+func TestHashCPUResponseDeltaSaturatesCombinedCPUAndHashedBytes(t *testing.T) {
+	response := blockblob.GetBlockListResponse{
+		CRC64CPUTimeUS:  ptrTo(int64(math.MaxInt64)),
+		SHA256CPUTimeUS: ptrTo(int64(1)),
+	}
+	response.CommittedBlocks = []*blockblob.Block{
+		hashCPUBlock(ptrTo(int64(math.MaxInt64)), 8, 32),
+		hashCPUBlock(ptrTo(int64(1)), 8, 32),
+	}
+
+	delta := hashCPUResponseDelta(response)
+
+	assert.EqualValues(t, math.MaxInt64, delta.hashCPUTimeUS)
+	assert.True(t, delta.hashCPUTimeOverflowed)
+	assert.EqualValues(t, 2, delta.hashedBlocks)
+	assert.EqualValues(t, math.MaxInt64, delta.hashedBytes)
+	assert.True(t, delta.hashedBytesOverflowed)
+}
+
+func TestHashCPURecordAccumulatesTotalsAndDiagnostics(t *testing.T) {
+	state := &dedupeHashCPUState{}
+	responses := []blockblob.GetBlockListResponse{
+		{
+			CRC64CPUTimeUS: ptrTo(int64(10)),
+			RequestID:      ptrTo("request-1"),
+			BlockList: blockblob.BlockList{CommittedBlocks: []*blockblob.Block{
+				hashCPUBlock(ptrTo(int64(100)), 8, 32),
+			}},
+		},
+		{
+			SHA256CPUTimeUS: ptrTo(int64(20)),
+			RequestID:       ptrTo("request-2"),
+			BlockList: blockblob.BlockList{CommittedBlocks: []*blockblob.Block{
+				hashCPUBlock(ptrTo(int64(50)), 8, 32),
+			}},
+		},
+		{
+			CRC64CPUTimeUS:  ptrTo(int64(-1)),
+			SHA256CPUTimeUS: ptrTo(int64(-2)),
+			RequestID:       ptrTo("   "),
+		},
+	}
+
+	for _, response := range responses {
+		_, accepted := state.record(hashCPUResponseDelta(response))
+		assert.True(t, accepted)
+	}
+
+	assert.Equal(t, dedupeHashCPUSnapshot{
+		crc64CPUTimeUS:                10,
+		sha256CPUTimeUS:               20,
+		hashCPUTimeUS:                 30,
+		hashedBlocks:                  2,
+		hashedBytes:                   150,
+		hashCPUTimeResponses:          3,
+		crc64CPUTimeMissingResponses:  1,
+		sha256CPUTimeMissingResponses: 1,
+		requestIDMissingResponses:     1,
+		crc64CPUTimeInvalidResponses:  1,
+		sha256CPUTimeInvalidResponses: 1,
+	}, state.snapshot())
+}
+
+func TestHashCPURecordRejectsDuplicateRequestID(t *testing.T) {
+	state := &dedupeHashCPUState{}
+	delta := dedupeHashCPUResponseDelta{
+		requestID:       "request-duplicate",
+		crc64CPUTimeUS:  2,
+		sha256CPUTimeUS: 3,
+		hashCPUTimeUS:   5,
+		hashedBlocks:    1,
+		hashedBytes:     64,
+	}
+
+	first, accepted := state.record(delta)
+	assert.True(t, accepted)
+	assert.EqualValues(t, 1, first.cumulative.hashCPUTimeResponses)
+
+	duplicate, accepted := state.record(delta)
+	assert.False(t, accepted)
+	assert.Equal(t, dedupeHashCPUEventSnapshot{}, duplicate)
+
+	snapshot := state.snapshot()
+	assert.EqualValues(t, 2, snapshot.crc64CPUTimeUS)
+	assert.EqualValues(t, 3, snapshot.sha256CPUTimeUS)
+	assert.EqualValues(t, 1, snapshot.hashedBlocks)
+	assert.EqualValues(t, 64, snapshot.hashedBytes)
+	assert.EqualValues(t, 1, snapshot.hashCPUTimeResponses)
+}
+
+func TestHashCPURecordConcurrentDuplicateRequestID(t *testing.T) {
+	const workers = 64
+	state := &dedupeHashCPUState{}
+	delta := dedupeHashCPUResponseDelta{
+		requestID:       "request-concurrent",
+		crc64CPUTimeUS:  13,
+		sha256CPUTimeUS: 17,
+		hashCPUTimeUS:   30,
+		hashedBlocks:    1,
+		hashedBytes:     128,
+	}
+	start := make(chan struct{})
+	results := make(chan bool, workers)
+	var waitGroup sync.WaitGroup
+
+	for i := 0; i < workers; i++ {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			<-start
+			_, accepted := state.record(delta)
+			results <- accepted
+		}()
+	}
+	close(start)
+	waitGroup.Wait()
+	close(results)
+
+	accepted := 0
+	for result := range results {
+		if result {
+			accepted++
+		}
+	}
+	assert.Equal(t, 1, accepted)
+	assert.Equal(t, dedupeHashCPUSnapshot{
+		crc64CPUTimeUS:       13,
+		sha256CPUTimeUS:      17,
+		hashCPUTimeUS:        30,
+		hashedBlocks:         1,
+		hashedBytes:          128,
+		hashCPUTimeResponses: 1,
+	}, state.snapshot())
+}
+
+func TestHashCPURecordAcceptsEveryMissingRequestID(t *testing.T) {
+	state := &dedupeHashCPUState{}
+	requestIDs := []*string{nil, ptrTo(""), ptrTo(" \t ")}
+
+	for _, requestID := range requestIDs {
+		_, accepted := state.record(hashCPUResponseDelta(blockblob.GetBlockListResponse{
+			CRC64CPUTimeUS:  ptrTo(int64(0)),
+			SHA256CPUTimeUS: ptrTo(int64(0)),
+			RequestID:       requestID,
+		}))
+		assert.True(t, accepted)
+	}
+
+	snapshot := state.snapshot()
+	assert.EqualValues(t, 3, snapshot.hashCPUTimeResponses)
+	assert.EqualValues(t, 3, snapshot.requestIDMissingResponses)
+	assert.Zero(t, snapshot.crc64CPUTimeMissingResponses)
+	assert.Zero(t, snapshot.sha256CPUTimeMissingResponses)
+}
+
+func TestHashCPURecordSaturationAndStickyOverflow(t *testing.T) {
+	t.Run("components", func(t *testing.T) {
+		state := &dedupeHashCPUState{
+			crc64CPUTimeUS:  math.MaxInt64,
+			sha256CPUTimeUS: math.MaxInt64,
+		}
+		_, accepted := state.record(dedupeHashCPUResponseDelta{
+			requestID:       "component-overflow",
+			crc64CPUTimeUS:  1,
+			sha256CPUTimeUS: 1,
+			hashCPUTimeUS:   2,
+		})
+		assert.True(t, accepted)
+
+		snapshot := state.snapshot()
+		assert.EqualValues(t, math.MaxInt64, snapshot.crc64CPUTimeUS)
+		assert.EqualValues(t, math.MaxInt64, snapshot.sha256CPUTimeUS)
+		assert.EqualValues(t, math.MaxInt64, snapshot.hashCPUTimeUS)
+		assert.True(t, snapshot.crc64CPUTimeOverflowed)
+		assert.True(t, snapshot.sha256CPUTimeOverflowed)
+		assert.True(t, snapshot.hashCPUTimeOverflowed)
+		assert.True(t, snapshot.hashMetricsOverflowed)
+
+		_, accepted = state.record(dedupeHashCPUResponseDelta{requestID: "after-component-overflow"})
+		assert.True(t, accepted)
+		snapshot = state.snapshot()
+		assert.True(t, snapshot.crc64CPUTimeOverflowed)
+		assert.True(t, snapshot.sha256CPUTimeOverflowed)
+		assert.True(t, snapshot.hashCPUTimeOverflowed)
+		assert.True(t, snapshot.hashMetricsOverflowed)
+	})
+
+	t.Run("combined", func(t *testing.T) {
+		state := &dedupeHashCPUState{
+			crc64CPUTimeUS:  math.MaxInt64 - 1,
+			sha256CPUTimeUS: 1,
+		}
+		_, accepted := state.record(dedupeHashCPUResponseDelta{
+			requestID:       "combined-overflow",
+			sha256CPUTimeUS: 1,
+			hashCPUTimeUS:   1,
+		})
+		assert.True(t, accepted)
+
+		snapshot := state.snapshot()
+		assert.False(t, snapshot.crc64CPUTimeOverflowed)
+		assert.False(t, snapshot.sha256CPUTimeOverflowed)
+		assert.True(t, snapshot.hashCPUTimeOverflowed)
+		assert.EqualValues(t, math.MaxInt64, snapshot.hashCPUTimeUS)
+		assert.True(t, snapshot.hashMetricsOverflowed)
+	})
+
+	t.Run("block and byte totals", func(t *testing.T) {
+		state := &dedupeHashCPUState{
+			hashedBlocks: math.MaxInt64,
+			hashedBytes:  math.MaxInt64,
+		}
+		_, accepted := state.record(dedupeHashCPUResponseDelta{
+			requestID:    "hash-total-overflow",
+			hashedBlocks: 1,
+			hashedBytes:  1,
+		})
+		assert.True(t, accepted)
+
+		snapshot := state.snapshot()
+		assert.EqualValues(t, math.MaxInt64, snapshot.hashedBlocks)
+		assert.EqualValues(t, math.MaxInt64, snapshot.hashedBytes)
+		assert.True(t, snapshot.hashedBlocksOverflowed)
+		assert.True(t, snapshot.hashedBytesOverflowed)
+		assert.True(t, snapshot.hashMetricsOverflowed)
+
+		_, accepted = state.record(dedupeHashCPUResponseDelta{requestID: "after-hash-total-overflow"})
+		assert.True(t, accepted)
+		snapshot = state.snapshot()
+		assert.True(t, snapshot.hashedBlocksOverflowed)
+		assert.True(t, snapshot.hashedBytesOverflowed)
+		assert.True(t, snapshot.hashMetricsOverflowed)
+	})
+
+	t.Run("diagnostic counters", func(t *testing.T) {
+		state := &dedupeHashCPUState{
+			hashCPUTimeResponses:          math.MaxInt64,
+			crc64CPUTimeMissingResponses:  math.MaxInt64,
+			sha256CPUTimeMissingResponses: math.MaxInt64,
+			requestIDMissingResponses:     math.MaxInt64,
+			crc64CPUTimeInvalidResponses:  math.MaxInt64,
+			sha256CPUTimeInvalidResponses: math.MaxInt64,
+		}
+		_, accepted := state.record(dedupeHashCPUResponseDelta{
+			crc64CPUTimeMissing:  true,
+			sha256CPUTimeMissing: true,
+			crc64CPUTimeInvalid:  true,
+			sha256CPUTimeInvalid: true,
+		})
+		assert.True(t, accepted)
+
+		snapshot := state.snapshot()
+		assert.EqualValues(t, math.MaxInt64, snapshot.hashCPUTimeResponses)
+		assert.EqualValues(t, math.MaxInt64, snapshot.crc64CPUTimeMissingResponses)
+		assert.EqualValues(t, math.MaxInt64, snapshot.sha256CPUTimeMissingResponses)
+		assert.EqualValues(t, math.MaxInt64, snapshot.requestIDMissingResponses)
+		assert.EqualValues(t, math.MaxInt64, snapshot.crc64CPUTimeInvalidResponses)
+		assert.EqualValues(t, math.MaxInt64, snapshot.sha256CPUTimeInvalidResponses)
+		assert.True(t, snapshot.hashMetricsOverflowed)
+
+		_, accepted = state.record(dedupeHashCPUResponseDelta{requestID: "after-diagnostic-overflow"})
+		assert.True(t, accepted)
+		assert.True(t, state.snapshot().hashMetricsOverflowed)
+	})
+}
+
+func TestHashCPUTimeMessageContainsExactDeltaAndCumulativeFields(t *testing.T) {
+	response := blockblob.GetBlockListResponse{
+		CRC64CPUTimeUS:  ptrTo(int64(4)),
+		SHA256CPUTimeUS: ptrTo(int64(6)),
+		RequestID:       ptrTo("  request-event  "),
+		BlockList: blockblob.BlockList{CommittedBlocks: []*blockblob.Block{
+			hashCPUBlock(ptrTo(int64(9)), 8, 32),
+			hashCPUBlock(nil, 8, 32),
+		}},
+	}
+	state := &dedupeHashCPUState{}
+	snapshot, accepted := state.record(hashCPUResponseDelta(response))
+	assert.True(t, accepted)
+
+	jobID := common.NewJobID()
+	info := &TransferInfo{
+		JobID:       jobID,
+		DstFilePath: "dir/file.bin",
+		Destination: "https://acct.blob.core.windows.net/c/file.bin?sig=secret",
+	}
+	expectedFields := "requestId=\"request-event\" crc64CpuTimeUsDelta=4 " +
+		"sha256CpuTimeUsDelta=6 hashCpuTimeUsDelta=10 hashedBlocksDelta=2 " +
+		"hashedBytesDelta=9 crc64CpuTimeUs=4 sha256CpuTimeUs=6 hashCpuTimeUs=10 " +
+		"hashedBlocks=2 hashedBytes=9 hashCpuTimeResponses=1 " +
+		"crc64CpuTimeMissingResponses=0 sha256CpuTimeMissingResponses=0 " +
+		"requestIdMissingResponses=0 crc64CpuTimeInvalidResponses=0 " +
+		"sha256CpuTimeInvalidResponses=0 crc64CpuTimeOverflowed=false " +
+		"sha256CpuTimeOverflowed=false hashCpuTimeOverflowed=false " +
+		"hashedBlocksOverflowed=false hashedBytesOverflowed=false hashMetricsOverflowed=false"
+	expected := fmt.Sprintf(
+		"%s event=hash_cpu_time mode=enforce jobId=%s file=%q destination=%q %s",
+		dedupeProgressPrefix,
+		jobID.String(),
+		info.DstFilePath,
+		"https://acct.blob.core.windows.net/c/file.bin",
+		expectedFields,
+	)
+
+	assert.Equal(t, expectedFields, snapshot.fields())
+	assert.Equal(t, expected, dedupeHashCPUTimeMessage(dedupeActEnforce, info, snapshot))
+}
+
+func TestHashCPUEmitterScopesModesAndAcceptedResponses(t *testing.T) {
+	oldQueue := dedupeProgressQueue
+	queue := make(chan dedupeProgressEntry, 8)
+	dedupeProgressQueue = queue
+	t.Cleanup(func() {
+		dedupeProgressQueue = oldQueue
+	})
+
+	jobID := common.NewJobID()
+	t.Cleanup(func() {
+		clearDedupeStateForJob(jobID)
+	})
+	manager := &hashCPUTestTransferManager{
+		testJobPartTransferManager: &testJobPartTransferManager{
+			info: &TransferInfo{
+				JobID:       jobID,
+				DstFilePath: "empty-block-list.bin",
+				Destination: "https://acct.blob.core.windows.net/c/empty-block-list.bin",
+			},
+		},
+	}
+	state := dedupeStateForJob(jobID)
+	response := blockblob.GetBlockListResponse{
+		CRC64CPUTimeUS:  ptrTo(int64(7)),
+		SHA256CPUTimeUS: ptrTo(int64(11)),
+		RequestID:       ptrTo("request-empty-list"),
+	}
+
+	emitHashCPUTime(manager, dedupeActOff, response)
+	emitHashCPUTime(manager, dedupeActShadow, response)
+	assert.Equal(t, dedupeHashCPUSnapshot{}, state.hashCPU.snapshot())
+	assert.Empty(t, queue)
+	assert.Empty(t, manager.logMessages())
+
+	emitHashCPUTime(manager, dedupeActEnforce, response)
+	snapshot := state.hashCPU.snapshot()
+	assert.EqualValues(t, 7, snapshot.crc64CPUTimeUS)
+	assert.EqualValues(t, 11, snapshot.sha256CPUTimeUS)
+	assert.EqualValues(t, 18, snapshot.hashCPUTimeUS)
+	assert.Zero(t, snapshot.hashedBlocks)
+	assert.Zero(t, snapshot.hashedBytes)
+	assert.EqualValues(t, 1, snapshot.hashCPUTimeResponses)
+	assert.Len(t, queue, 1)
+	assert.Len(t, manager.logMessages(), 1)
+	first := <-queue
+	assert.Contains(t, first.message, "event=hash_cpu_time")
+	assert.Contains(t, first.message, `requestId="request-empty-list"`)
+
+	emitHashCPUTime(manager, dedupeActEnforce, response)
+	assert.Empty(t, queue)
+	assert.Len(t, manager.logMessages(), 1)
+	assert.EqualValues(t, 1, state.hashCPU.snapshot().hashCPUTimeResponses)
+
+	secondResponse := response
+	secondResponse.RequestID = ptrTo("request-empty-list-2")
+	emitHashCPUTime(manager, dedupeActEnforce, secondResponse)
+	assert.Len(t, queue, 1)
+	assert.Len(t, manager.logMessages(), 2)
+	assert.EqualValues(t, 2, state.hashCPU.snapshot().hashCPUTimeResponses)
+}
+
+func TestHashCPUFieldsAreIsolatedFromGenericProgressEvents(t *testing.T) {
+	info := &TransferInfo{
+		JobID:       common.NewJobID(),
+		DstFilePath: "file.bin",
+		Destination: "https://acct.blob.core.windows.net/c/file.bin",
+	}
+	snapshot := dedupeProgressSnapshot{
+		referencedBlocks:   1,
+		referencedBytes:    64,
+		sourceStagedBlocks: 2,
+		sourceStagedBytes:  128,
+	}
+
+	for _, event := range []string{"target_reuse", "small_file_transfer_complete"} {
+		message := dedupeProgressMessage(
+			event,
+			dedupeActEnforce,
+			info,
+			`operation="unrelated" requestId="service-request"`,
+			snapshot,
+		)
+		assert.Contains(t, message, "event="+event)
+		assertNoHashCPUMetricFields(t, message)
 	}
 }
 

--- a/ste/dedupeRecorder_test.go
+++ b/ste/dedupeRecorder_test.go
@@ -685,6 +685,8 @@ func TestDedupeHashResolutionProgressCounters(t *testing.T) {
 	stats := dedupeHashResolutionStats{
 		candidateBlocks:          2,
 		candidateOccurrences:     3,
+		newCandidateBlocks:       2,
+		newCandidateOccurrences:  3,
 		sourceHashRanges:         2,
 		sourceHashBatches:        1,
 		targetHashRanges:         3,

--- a/ste/dedupeRecorder_test.go
+++ b/ste/dedupeRecorder_test.go
@@ -21,10 +21,11 @@
 package ste
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"fmt"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -103,20 +104,27 @@ func TestDedupeProgressMessageSanitizesSASAndIsExtractable(t *testing.T) {
 	a.NotContains(message, "TARGET_SECRET")
 	a.NotContains(message, "sig=")
 
-	var output bytes.Buffer
-	a.NoError(writeDedupeProgressTo(&output, message))
-	a.Equal(message+"\n", output.String())
+	root := t.TempDir()
+	sink := newDedupeProgressFileSink(func() string { return root })
+	a.NoError(sink.write(jobID, message))
 
-	output.Reset()
-	a.NoError(writeDedupeProgressTo(
-		&output,
-		dedupeProgressPrefix+" event=test sig=SHOULD_NOT_LEAK"))
-	a.NotContains(output.String(), "SHOULD_NOT_LEAK")
-	a.Contains(output.String(), "sig=-REDACTED-")
+	logPath, err := sink.logPath(jobID)
+	a.NoError(err)
+	a.Equal(filepath.Join(root, dedupeLogDirectoryName, jobID.String()+".log"), logPath)
+	logBytes, err := os.ReadFile(logPath)
+	a.NoError(err)
+	a.Equal(message+"\n", string(logBytes))
+
+	a.NoError(sink.write(jobID, dedupeProgressPrefix+" event=test sig=SHOULD_NOT_LEAK"))
+	logBytes, err = os.ReadFile(logPath)
+	a.NoError(err)
+	a.NotContains(string(logBytes), "SHOULD_NOT_LEAK")
+	a.Contains(string(logBytes), "sig=-REDACTED-")
+	a.NoError(sink.close(jobID))
 
 	queue := make(chan dedupeProgressEntry, 1)
-	a.True(tryEnqueueDedupeProgress(queue, dedupeProgressEntry{message: "first"}))
-	a.False(tryEnqueueDedupeProgress(queue, dedupeProgressEntry{message: "second"}))
+	a.True(tryEnqueueDedupeProgress(queue, dedupeProgressEntry{jobID: jobID, message: "first"}))
+	a.False(tryEnqueueDedupeProgress(queue, dedupeProgressEntry{jobID: jobID, message: "second"}))
 }
 
 func TestBlockHasHashes(t *testing.T) {

--- a/ste/dedupeRecorder_test.go
+++ b/ste/dedupeRecorder_test.go
@@ -21,8 +21,11 @@
 package ste
 
 import (
+	"bytes"
 	"crypto/sha256"
+	"fmt"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -47,6 +50,73 @@ func hashedBlock(content string, offset, size int64) PlannedBlock {
 		SHA256:       sum,
 		HasHashes:    true,
 	}
+}
+
+func TestDedupeProgressSnapshotEnforce(t *testing.T) {
+	a := assert.New(t)
+	st := &dedupeJobState{}
+	st.addFileStarted()
+	st.addFileStarted()
+	st.addFileCommitted()
+	st.addReferenced(100)
+	st.addReferenced(50)
+	st.addSourceStaged(100)
+	st.addFallback()
+
+	a.Equal(
+		"filesStarted=2 filesCommitted=1 targetURIBlocks=2 targetURIBytes=150 "+
+			"sourceURIBlocks=1 sourceURIBytes=100 fallbackBlocks=1 transferredBlocks=3 "+
+			"transferredBytes=250 wanSavingsPercent=60.0",
+		st.progressSnapshot().fields(dedupeActEnforce))
+}
+
+func TestDedupeProgressMessageSanitizesSASAndIsExtractable(t *testing.T) {
+	a := assert.New(t)
+	jobID := common.NewJobID()
+	info := &TransferInfo{
+		JobID:       jobID,
+		DstFilePath: "folder/file.bin",
+		Destination: "https://acct.blob.core.windows.net/c/file.bin?sv=2026&sig=CURRENT_SECRET",
+	}
+	targetURI := sanitizedDestForDedupe(
+		"https://acct.blob.core.windows.net/c/previous.bin?sv=2026&sig=TARGET_SECRET")
+	message := dedupeProgressMessage(
+		"target_reuse",
+		dedupeActEnforce,
+		info,
+		"blockIndex=3 sourceOffset=4096 blockBytes=1024 targetURI="+fmt.Sprintf("%q", targetURI)+
+			" targetOffset=8192 targetLength=1024",
+		dedupeProgressSnapshot{
+			referencedBlocks:   1,
+			referencedBytes:    1024,
+			sourceStagedBlocks: 1,
+			sourceStagedBytes:  1024,
+			filesStarted:       2,
+			filesCommitted:     1,
+		})
+
+	a.True(strings.HasPrefix(message, dedupeProgressPrefix+" "))
+	a.Contains(message, "event=target_reuse")
+	a.Contains(message, "targetURI=\"https://acct.blob.core.windows.net/c/previous.bin\"")
+	a.Contains(message, "wanSavingsPercent=50.0")
+	a.NotContains(message, "CURRENT_SECRET")
+	a.NotContains(message, "TARGET_SECRET")
+	a.NotContains(message, "sig=")
+
+	var output bytes.Buffer
+	a.NoError(writeDedupeProgressTo(&output, message))
+	a.Equal(message+"\n", output.String())
+
+	output.Reset()
+	a.NoError(writeDedupeProgressTo(
+		&output,
+		dedupeProgressPrefix+" event=test sig=SHOULD_NOT_LEAK"))
+	a.NotContains(output.String(), "SHOULD_NOT_LEAK")
+	a.Contains(output.String(), "sig=-REDACTED-")
+
+	queue := make(chan dedupeProgressEntry, 1)
+	a.True(tryEnqueueDedupeProgress(queue, dedupeProgressEntry{message: "first"}))
+	a.False(tryEnqueueDedupeProgress(queue, dedupeProgressEntry{message: "second"}))
 }
 
 func TestBlockHasHashes(t *testing.T) {
@@ -194,6 +264,9 @@ func TestSanitizedDestForDedupe_StripsSAS(t *testing.T) {
 	// No query string is left unchanged.
 	plain := "https://acct.blob.core.windows.net/c/b.bin"
 	a.Equal(plain, sanitizedDestForDedupe(plain))
+
+	// Even malformed URLs must not leak their query or fragment to progress output.
+	a.Equal("://malformed", sanitizedDestForDedupe("://malformed?sig=SECRET#fragment"))
 }
 
 func TestDedupePercent(t *testing.T) {
@@ -203,6 +276,7 @@ func TestDedupePercent(t *testing.T) {
 	a.EqualValues(0, dedupePercent(0, 10))
 	a.EqualValues(50, dedupePercent(5, 10))
 	a.EqualValues(100, dedupePercent(10, 10))
+	a.EqualValues(100, dedupePercent(15, 10))
 }
 
 func TestDedupeStateForJob_IsolatesAndClears(t *testing.T) {

--- a/ste/dedupeRecorder_test.go
+++ b/ste/dedupeRecorder_test.go
@@ -63,12 +63,145 @@ func TestDedupeProgressSnapshotEnforce(t *testing.T) {
 	st.addReferenced(50)
 	st.addSourceStaged(100)
 	st.addFallback()
+	st.addSmallFileStarted(1024)
+	st.addSmallFileResult(common.ETransferStatus.Success(), 1024)
 
 	a.Equal(
 		"filesStarted=2 filesCommitted=1 targetURIBlocks=2 targetURIBytes=150 "+
 			"sourceURIBlocks=1 sourceURIBytes=100 fallbackBlocks=1 transferredBlocks=3 "+
-			"transferredBytes=250 wanSavingsPercent=60.0",
+			"transferredBytes=250 wanSavingsPercent=60.0 smallFilesStarted=1 "+
+			"smallFilesCompleted=1 smallFilesFailed=0 smallFilesSkipped=0 "+
+			"smallFilesCanceled=0 smallFilesInProgress=0 smallFileBytesStarted=1024 "+
+			"smallFileBytesCompleted=1024 smallFileBytesFailed=0 smallFileBytesSkipped=0 "+
+			"smallFileBytesCanceled=0 smallFileBytesInProgress=0",
 		st.progressSnapshot().fields(dedupeActEnforce))
+}
+
+func TestDedupeProgressSmallFileThreshold(t *testing.T) {
+	jptm := &testJobPartTransferManager{
+		info: &TransferInfo{
+			SourceSize: smallFileProgressThresholdBytes - 1,
+			EntityType: common.EEntityType.File(),
+		},
+		fromTo: common.EFromTo.BlobBlob(),
+	}
+	assert.True(t, isSmallFileProgressTransfer(jptm))
+
+	jptm.info.SourceSize = 0
+	assert.True(t, isSmallFileProgressTransfer(jptm))
+
+	jptm.info.SourceSize = smallFileProgressThresholdBytes
+	assert.False(t, isSmallFileProgressTransfer(jptm))
+
+	jptm.info.SourceSize = smallFileProgressThresholdBytes - 1
+	jptm.fromTo = common.EFromTo.LocalBlob()
+	assert.False(t, isSmallFileProgressTransfer(jptm))
+
+	jptm.fromTo = common.EFromTo.BlobBlob()
+	jptm.info.EntityType = common.EEntityType.Folder()
+	assert.False(t, isSmallFileProgressTransfer(jptm))
+}
+
+func TestDedupeProgressSmallFileResultCounters(t *testing.T) {
+	st := &dedupeJobState{}
+	st.addSmallFileStarted(100)
+	st.addSmallFileStarted(200)
+	st.addSmallFileStarted(300)
+	st.addSmallFileStarted(400)
+	st.addSmallFileStarted(500)
+
+	assert.Equal(
+		t,
+		"small_file_transfer_complete",
+		st.addSmallFileResult(common.ETransferStatus.Success(), 100),
+	)
+	assert.Equal(
+		t,
+		"small_file_transfer_failed",
+		st.addSmallFileResult(common.ETransferStatus.Failed(), 200),
+	)
+	assert.Equal(
+		t,
+		"small_file_transfer_skipped",
+		st.addSmallFileResult(common.ETransferStatus.SkippedEntityAlreadyExists(), 300),
+	)
+	assert.Equal(
+		t,
+		"small_file_transfer_canceled",
+		st.addSmallFileResult(common.ETransferStatus.Cancelled(), 400),
+	)
+
+	snapshot := st.progressSnapshot()
+	assert.EqualValues(t, 5, snapshot.smallFilesStarted)
+	assert.EqualValues(t, 1, snapshot.smallFilesCompleted)
+	assert.EqualValues(t, 1, snapshot.smallFilesFailed)
+	assert.EqualValues(t, 1, snapshot.smallFilesSkipped)
+	assert.EqualValues(t, 1, snapshot.smallFilesCanceled)
+	assert.EqualValues(t, 1500, snapshot.smallFileBytesStarted)
+	assert.EqualValues(t, 100, snapshot.smallFileBytesCompleted)
+	assert.EqualValues(t, 200, snapshot.smallFileBytesFailed)
+	assert.EqualValues(t, 300, snapshot.smallFileBytesSkipped)
+	assert.EqualValues(t, 400, snapshot.smallFileBytesCanceled)
+	assert.Contains(t, snapshot.fields(dedupeActEnforce), "smallFilesInProgress=1")
+	assert.Contains(t, snapshot.fields(dedupeActEnforce), "smallFileBytesInProgress=500")
+}
+
+func TestDedupeProgressSmallFileStartMarkerIsExactlyOnce(t *testing.T) {
+	jptm := &jobPartTransferMgr{}
+
+	assert.False(t, jptm.smallFileProgressStarted())
+	assert.True(t, jptm.markSmallFileProgressStarted())
+	assert.True(t, jptm.smallFileProgressStarted())
+	assert.False(t, jptm.markSmallFileProgressStarted())
+}
+
+func TestDedupeProgressSmallFileCancellationNormalizesStatus(t *testing.T) {
+	assert.Equal(
+		t,
+		common.ETransferStatus.Cancelled(),
+		normalizeSmallFileResultStatus(common.ETransferStatus.Started(), true),
+	)
+	assert.Equal(
+		t,
+		common.ETransferStatus.Started(),
+		normalizeSmallFileResultStatus(common.ETransferStatus.Started(), false),
+	)
+	assert.Equal(
+		t,
+		common.ETransferStatus.Success(),
+		normalizeSmallFileResultStatus(common.ETransferStatus.Success(), true),
+	)
+}
+
+func TestDedupeJobPartCompletionTracker(t *testing.T) {
+	tracker := make(dedupeJobPartCompletionTracker)
+	part0 := PartNumber(0)
+	part1 := PartNumber(1)
+
+	assert.False(t, tracker.record(nil))
+	assert.True(t, tracker.record(&part0))
+	assert.False(t, tracker.record(&part0))
+	assert.False(t, tracker.allKnownPartsReported(2))
+	assert.True(t, tracker.record(&part1))
+	assert.True(t, tracker.allKnownPartsReported(2))
+
+	tracker.reset()
+	assert.False(t, tracker.allKnownPartsReported(2))
+}
+
+func TestDedupePausedRunResetsOnlyAfterAllPartsReport(t *testing.T) {
+	assert.True(
+		t,
+		shouldResetDedupeRunProgress(common.EJobStatus.Paused(), true),
+	)
+	assert.False(
+		t,
+		shouldResetDedupeRunProgress(common.EJobStatus.Paused(), false),
+	)
+	assert.False(
+		t,
+		shouldResetDedupeRunProgress(common.EJobStatus.Completed(), true),
+	)
 }
 
 func TestDedupeProgressMessageSanitizesSASAndIsExtractable(t *testing.T) {

--- a/ste/dedupeRecorder_test.go
+++ b/ste/dedupeRecorder_test.go
@@ -1,0 +1,338 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ste
+
+import (
+	"crypto/sha256"
+	"net/url"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/stretchr/testify/assert"
+)
+
+// hashedBlock builds a PlannedBlock whose hashes are derived from content, so identical content
+// produces identical CRC64+SHA256 (and therefore a dedupe hit).
+func hashedBlock(content string, offset, size int64) PlannedBlock {
+	sum := sha256.Sum256([]byte(content))
+	// Derive a stable, content-dependent CRC64 surrogate from the first 8 bytes of the SHA256.
+	var crc uint64
+	for i := 0; i < 8; i++ {
+		crc = crc<<8 | uint64(sum[i])
+	}
+	return PlannedBlock{
+		Offset:       offset,
+		Size:         size,
+		SrcBlockName: content,
+		CRC64:        crc,
+		SHA256:       sum,
+		HasHashes:    true,
+	}
+}
+
+func TestBlockHasHashes(t *testing.T) {
+	a := assert.New(t)
+
+	a.True(blockHasHashes(hashedBlock("alpha", 0, 10)))
+	a.True(blockHasHashes(PlannedBlock{HasHashes: true})) // valid hashes may contain all zero bytes
+	a.False(blockHasHashes(PlannedBlock{CRC64: 1}))
+	a.False(blockHasHashes(PlannedBlock{SHA256: [32]byte{0: 1}}))
+	a.False(blockHasHashes(PlannedBlock{Offset: 0, Size: 100})) // no hashes -> not eligible
+}
+
+func TestMeasureAndRecord_SkipsBlocksWithoutHashes(t *testing.T) {
+	a := assert.New(t)
+	tbl := common.NewDedupeHashTable()
+
+	blocks := []PlannedBlock{
+		{Offset: 0, Size: 100},   // no hashes
+		{Offset: 100, Size: 200}, // no hashes
+	}
+	hashed, hits, bytes := measureAndRecord(tbl, common.NewJobID(), "https://acct.blob.core.windows.net/c/b", blocks)
+
+	a.EqualValues(0, hashed)
+	a.EqualValues(0, hits)
+	a.EqualValues(0, bytes)
+	a.Equal(0, tbl.Len())
+}
+
+func TestMeasureAndRecord_DistinctBlocksProduceNoHits(t *testing.T) {
+	a := assert.New(t)
+	tbl := common.NewDedupeHashTable()
+
+	blocks := []PlannedBlock{
+		hashedBlock("a", 0, 10),
+		hashedBlock("b", 10, 20),
+		hashedBlock("c", 30, 30),
+	}
+	hashed, hits, bytes := measureAndRecord(tbl, common.NewJobID(), "uri", blocks)
+
+	a.EqualValues(3, hashed)
+	a.EqualValues(0, hits)
+	a.EqualValues(0, bytes)
+	a.Equal(3, tbl.Len())
+}
+
+func TestMeasureAndRecord_IntraBlobDuplicate(t *testing.T) {
+	a := assert.New(t)
+	tbl := common.NewDedupeHashTable()
+
+	// The third block repeats the content of the first -> one would-be hit of size 10.
+	blocks := []PlannedBlock{
+		hashedBlock("dup", 0, 10),
+		hashedBlock("other", 10, 20),
+		hashedBlock("dup", 30, 10),
+	}
+	hashed, hits, bytes := measureAndRecord(tbl, common.NewJobID(), "uri", blocks)
+
+	a.EqualValues(3, hashed)
+	a.EqualValues(1, hits)
+	a.EqualValues(10, bytes)
+	a.Equal(2, tbl.Len()) // only two distinct contents stored
+}
+
+func TestMeasureAndRecord_CrossBlobAccumulation(t *testing.T) {
+	a := assert.New(t)
+	tbl := common.NewDedupeHashTable()
+	job := common.NewJobID()
+
+	// First blob: two distinct blocks, no hits.
+	h1, hit1, b1 := measureAndRecord(tbl, job, "uri-blob1", []PlannedBlock{
+		hashedBlock("shared", 0, 50),
+		hashedBlock("unique1", 50, 25),
+	})
+	a.EqualValues(2, h1)
+	a.EqualValues(0, hit1)
+	a.EqualValues(0, b1)
+
+	// Second blob: re-uses "shared" content from the first blob -> one cross-blob would-be hit.
+	h2, hit2, b2 := measureAndRecord(tbl, job, "uri-blob2", []PlannedBlock{
+		hashedBlock("shared", 0, 50),
+		hashedBlock("unique2", 50, 25),
+	})
+	a.EqualValues(2, h2)
+	a.EqualValues(1, hit2)
+	a.EqualValues(50, b2)
+
+	a.Equal(3, tbl.Len()) // shared + unique1 + unique2
+}
+
+func TestMeasureAndRecord_PopulatesTargetRange(t *testing.T) {
+	a := assert.New(t)
+	tbl := common.NewDedupeHashTable()
+
+	// A recorded block must carry the target sub-range so Phase 2 can later stage it
+	// from [TargetOffset, TargetOffset+TargetLength) of the already-migrated dest blob.
+	b := hashedBlock("x", 4096, 1000)
+	measureAndRecord(tbl, common.NewJobID(), "https://acct.blob.core.windows.net/c/b", []PlannedBlock{b})
+
+	got, ok := tbl.Lookup(b.CRC64, b.SHA256)
+	a.True(ok)
+	a.Equal("https://acct.blob.core.windows.net/c/b", got.TargetURI)
+	a.EqualValues(4096, got.TargetOffset)
+	a.EqualValues(1000, got.TargetLength)
+}
+
+func TestDestinationWithSASForDedupe_MergesDestinationSAS(t *testing.T) {
+	a := assert.New(t)
+
+	got := destinationWithSASForDedupe("https://acct.blob.core.windows.net/c/b.bin", "?sv=2021&sig=SECRET")
+	u, err := url.Parse(got)
+	a.NoError(err)
+	a.Equal("2021", u.Query().Get("sv"))
+	a.Equal("SECRET", u.Query().Get("sig"))
+
+	got = destinationWithSASForDedupe("https://acct.blob.core.windows.net/c/b.bin?existing=true", "sv=2021&sig=SECRET")
+	u, err = url.Parse(got)
+	a.NoError(err)
+	a.Equal("true", u.Query().Get("existing"))
+	a.Equal("2021", u.Query().Get("sv"))
+	a.Equal("SECRET", u.Query().Get("sig"))
+
+	alreadyAuthenticated := "https://acct.blob.core.windows.net/c/b.bin?sv=2021&sig=SECRET"
+	u, err = url.Parse(destinationWithSASForDedupe(alreadyAuthenticated, "sv=2021&sig=SECRET"))
+	a.NoError(err)
+	a.Len(u.Query()["sig"], 1)
+
+	u, err = url.Parse(destinationWithSASForDedupe(
+		"https://acct.blob.core.windows.net/c/b.bin?sv=old&sig=OLD",
+		"sv=2021&sig=NEW"))
+	a.NoError(err)
+	a.Equal("2021", u.Query().Get("sv"))
+	a.Equal("NEW", u.Query().Get("sig"))
+	a.Len(u.Query()["sig"], 1)
+
+	plain := "https://acct.blob.core.windows.net/c/b.bin"
+	a.Equal(plain, destinationWithSASForDedupe(plain, ""))
+}
+
+func TestSanitizedDestForDedupe_StripsSAS(t *testing.T) {
+	a := assert.New(t)
+
+	got := sanitizedDestForDedupe("https://acct.blob.core.windows.net/c/b.bin?sv=2021&sig=SECRET")
+	a.Equal("https://acct.blob.core.windows.net/c/b.bin", got)
+
+	// No query string is left unchanged.
+	plain := "https://acct.blob.core.windows.net/c/b.bin"
+	a.Equal(plain, sanitizedDestForDedupe(plain))
+}
+
+func TestDedupePercent(t *testing.T) {
+	a := assert.New(t)
+
+	a.EqualValues(0, dedupePercent(0, 0))
+	a.EqualValues(0, dedupePercent(0, 10))
+	a.EqualValues(50, dedupePercent(5, 10))
+	a.EqualValues(100, dedupePercent(10, 10))
+}
+
+func TestDedupeStateForJob_IsolatesAndClears(t *testing.T) {
+	a := assert.New(t)
+
+	jobA := common.NewJobID()
+	jobB := common.NewJobID()
+
+	stA := dedupeStateForJob(jobA)
+	stB := dedupeStateForJob(jobB)
+	a.NotSame(stA, stB)                  // distinct jobs get distinct tables
+	a.Same(stA, dedupeStateForJob(jobA)) // same job returns the same state
+
+	measureAndRecord(stA.table, jobA, "uri", []PlannedBlock{hashedBlock("x", 0, 10)})
+	a.Equal(1, stA.table.Len())
+
+	clearDedupeStateForJob(jobA)
+	clearDedupeStateForJob(jobB)
+
+	// A fresh state is created after clearing, with an empty table.
+	a.Equal(0, dedupeStateForJob(jobA).table.Len())
+	clearDedupeStateForJob(jobA)
+}
+
+func TestBuildSourceBlockHashIndex(t *testing.T) {
+	a := assert.New(t)
+
+	plan := &SourceGridPlan{Blocks: []PlannedBlock{
+		hashedBlock("a", 0, 100),
+		hashedBlock("b", 100, 200),
+		{Offset: 300, Size: 50}, // no hashes -> excluded from the index
+	}}
+	idx := buildSourceBlockHashIndex(plan)
+
+	a.Len(idx, 2)
+	_, ok := idx[srcBlockKey{offset: 0, size: 100}]
+	a.True(ok)
+	_, ok = idx[srcBlockKey{offset: 100, size: 200}]
+	a.True(ok)
+	_, ok = idx[srcBlockKey{offset: 300, size: 50}]
+	a.False(ok)
+}
+
+func TestDecideStaging_NoHashForChunk(t *testing.T) {
+	a := assert.New(t)
+
+	idx := buildSourceBlockHashIndex(&SourceGridPlan{Blocks: []PlannedBlock{hashedBlock("a", 0, 100)}})
+	committed := common.NewDedupeHashTable()
+
+	// A chunk whose (offset,size) matches no source block has no known hash -> stage from source.
+	_, reference := decideStaging(idx, committed, 0, 64, "https://acct.blob.core.windows.net/c/current")
+	a.False(reference)
+}
+
+func TestDecideStaging_HashButNotYetCommitted(t *testing.T) {
+	a := assert.New(t)
+
+	b := hashedBlock("a", 0, 100)
+	idx := buildSourceBlockHashIndex(&SourceGridPlan{Blocks: []PlannedBlock{b}})
+	committed := common.NewDedupeHashTable() // nothing migrated yet
+
+	_, reference := decideStaging(idx, committed, 0, 100, "https://acct.blob.core.windows.net/c/current")
+	a.False(reference) // hash known, but content not present at the destination -> stage from source
+}
+
+func TestDecideStaging_Hit(t *testing.T) {
+	a := assert.New(t)
+
+	b := hashedBlock("a", 0, 100)
+	idx := buildSourceBlockHashIndex(&SourceGridPlan{Blocks: []PlannedBlock{b}})
+
+	committed := common.NewDedupeHashTable()
+	committed.Insert(common.BlockEntry{
+		CRC64:        b.CRC64,
+		SHA256:       b.SHA256,
+		TargetURI:    "https://acct.blob.core.windows.net/c/already-migrated",
+		TargetOffset: 0,
+		TargetLength: 100,
+		ETag:         azcore.ETag("etag-1"),
+	})
+
+	target, reference := decideStaging(idx, committed, 0, 100, "https://acct.blob.core.windows.net/c/current")
+	a.True(reference)
+	a.Equal("https://acct.blob.core.windows.net/c/already-migrated", target.TargetURI)
+	a.EqualValues(0, target.TargetOffset)
+	a.EqualValues(100, target.TargetLength)
+	a.Equal(azcore.ETag("etag-1"), target.ETag)
+}
+
+func TestDecideStaging_RejectsUnsafeTarget(t *testing.T) {
+	a := assert.New(t)
+
+	b := hashedBlock("a", 0, 100)
+	idx := buildSourceBlockHashIndex(&SourceGridPlan{Blocks: []PlannedBlock{b}})
+
+	for _, entry := range []common.BlockEntry{
+		{
+			CRC64: b.CRC64, SHA256: b.SHA256,
+			TargetURI:    "https://acct.blob.core.windows.net/c/missing-etag",
+			TargetLength: 100,
+		},
+		{
+			CRC64: b.CRC64, SHA256: b.SHA256,
+			TargetURI:    "https://acct.blob.core.windows.net/c/wrong-size",
+			TargetLength: 50, ETag: azcore.ETag("etag-1"),
+		},
+	} {
+		committed := common.NewDedupeHashTable()
+		committed.Insert(entry)
+		_, reference := decideStaging(idx, committed, 0, 100, "https://acct.blob.core.windows.net/c/current")
+		a.False(reference)
+	}
+}
+
+func TestDecideStaging_SameTargetIsNotReusable(t *testing.T) {
+	a := assert.New(t)
+
+	b := hashedBlock("a", 0, 100)
+	idx := buildSourceBlockHashIndex(&SourceGridPlan{Blocks: []PlannedBlock{b}})
+
+	committed := common.NewDedupeHashTable()
+	committed.Insert(common.BlockEntry{
+		CRC64:        b.CRC64,
+		SHA256:       b.SHA256,
+		TargetURI:    "https://acct.blob.core.windows.net/c/current",
+		TargetOffset: 0,
+		TargetLength: 100,
+		ETag:         azcore.ETag("etag-1"),
+	})
+
+	_, reference := decideStaging(idx, committed, 0, 100, "https://acct.blob.core.windows.net/c/current?sig=secret")
+	a.False(reference)
+}

--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -529,6 +529,10 @@ type AddJobPartArgs struct {
 	PlanFile        JobPartPlanFileName
 	ExistingPlanMMF *JobPartPlanMMF
 
+	// SAS values are runtime-only and must never be persisted in the plan file.
+	SourceSAS      string
+	DestinationSAS string
+
 	// this is required in S2S transfers authenticating to src
 	// via oAuth
 	SourceTokenCred *string
@@ -550,6 +554,8 @@ func (jm *jobMgr) AddJobPart(args *AddJobPartArgs) IJobPartMgr {
 	jpm := &jobPartMgr{
 		jobMgr:            jm,
 		filename:          args.PlanFile,
+		sourceSAS:         args.SourceSAS,
+		destinationSAS:    args.DestinationSAS,
 		srcServiceClient:  args.SrcClient,
 		dstServiceClient:  args.DstClient,
 		pacer:             jm.pacer,

--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -794,117 +794,211 @@ func (jm *jobMgr) ReportJobPartDone(progressInfo jobPartProgressInfo) {
 	jm.jobPartProgress <- progressInfo
 }
 
+// jobPartDoneState holds the loop-local accumulators for reportJobPartDoneHandler. The state is
+// owned exclusively by that single goroutine, so its fields need no synchronization.
+type jobPartDoneState struct {
+	jobProgress          jobPartProgressInfo
+	dedupeProgress       jobPartProgressInfo
+	dedupeCompletedParts dedupeJobPartCompletionTracker
+	shouldLog            bool
+}
+
+// accumulate folds one part's reported progress into the running job-wide totals, and into the
+// dedupe totals the first time each part is seen.
+func (s *jobPartDoneState) accumulate(partProgressInfo jobPartProgressInfo) {
+	if s.dedupeCompletedParts.record(partProgressInfo.partNum) {
+		s.dedupeProgress.transfersCompleted += partProgressInfo.transfersCompleted
+		s.dedupeProgress.transfersSkipped += partProgressInfo.transfersSkipped
+		s.dedupeProgress.transfersFailed += partProgressInfo.transfersFailed
+	}
+	s.jobProgress.transfersCompleted += partProgressInfo.transfersCompleted
+	s.jobProgress.transfersSkipped += partProgressInfo.transfersSkipped
+	s.jobProgress.transfersFailed += partProgressInfo.transfersFailed
+}
+
 func (jm *jobMgr) reportJobPartDoneHandler() {
-	var haveFinalPart bool
-	var jobProgressInfo jobPartProgressInfo
-	shouldLog := jm.ShouldLog(common.LogInfo)
+	state := &jobPartDoneState{
+		dedupeCompletedParts: make(dedupeJobPartCompletionTracker),
+		shouldLog:            jm.ShouldLog(common.LogInfo),
+	}
 
 	for {
 		select {
 		case <-jm.reportCancelCh:
-			jobPart0Mgr, ok := jm.jobPartMgrs.Get(0)
-			if ok {
-				part0plan := jobPart0Mgr.Plan()
-				if part0plan.JobStatus() == common.EJobStatus.InProgress() ||
-					part0plan.JobStatus() == common.EJobStatus.Cancelling() {
-					jm.Panic(fmt.Errorf("reportCancelCh received cancel event while job still not completed, Job(%s) in state: %s",
-						jm.jobID.String(), part0plan.JobStatus()))
-				}
-			} else {
-				jm.Log(common.LogError, "part0Plan of job invalid")
-			}
+			jm.assertJobFinishedOnCancel()
 			jm.Log(common.LogInfo, "reportJobPartDoneHandler done called")
 			return
 
 		case partProgressInfo := <-jm.jobPartProgress:
-			jobPart0Mgr, ok := jm.jobPartMgrs.Get(0)
-			if !ok {
-				jm.Panic(fmt.Errorf("Failed to find Job %v, Part #0", jm.jobID))
-			}
-			part0Plan := jobPart0Mgr.Plan()
-			jobStatus := part0Plan.JobStatus() // status of part 0 is status of job as a whole
-			partsDone := atomic.AddUint32(&jm.partsDone, 1)
-			jobProgressInfo.transfersCompleted += partProgressInfo.transfersCompleted
-			jobProgressInfo.transfersSkipped += partProgressInfo.transfersSkipped
-			jobProgressInfo.transfersFailed += partProgressInfo.transfersFailed
-
-			if buildmode.IsMover {
-				// PROGRESSIVE CLEANUP: Unmap completed job part plan files immediately to free memory
-				// Uses selective unmapping: Part 0 is preserved, Parts 1+ are unmapped
-				if partProgressInfo.partNum != nil {
-					partNum := *partProgressInfo.partNum
-					if completedPartMgr, exists := jm.jobPartMgrs.Get(partNum); exists {
-						completedPartMgr.UnmapPlanFile()
-					} else {
-						fmt.Printf("DEBUG: Could not find part manager for part %d\n", partNum)
-					}
-				} else {
-					fmt.Println("DEBUG: Skipping unmap - partNum is nil")
-				}
-			}
-
-			if partProgressInfo.completionChan != nil {
-				close(partProgressInfo.completionChan)
-			}
-
-			// If the last part is still awaited or other parts all still not complete,
-			// JobPart 0 status is not changed (unless we are cancelling)
-			haveFinalPart = atomic.LoadInt32(&jm.atomicFinalPartOrderedIndicator) == 1
-			allKnownPartsDone := partsDone == jm.jobPartMgrs.Count()
-			isCancelling := jobStatus == common.EJobStatus.Cancelling()
-			shouldComplete := (haveFinalPart && allKnownPartsDone) || // If we have all of the parts, they should all exit cleanly, so the job can be resumed properly.
-				(isCancelling && !haveFinalPart) // If we're cancelling, it's OK to try to exit early; the user already accepted this job cannot be resumed. Outgoing requests will fail anyway, so nothing can properly clean up.
-			if shouldComplete {
-				// Inform StatusManager that all parts are done.
-				if jm.jstm.xferDone != nil {
-					close(jm.jstm.xferDone)
-				}
-
-				// Wait  for all XferDone messages to be processed by statusManager. Front end
-				// depends on JobStatus to determine if we've to quit job. Setting it here without
-				// draining XferDone will make it report incorrect statistics.
-				jm.waitToDrainXferDone()
-				partDescription := "all parts of entire Job"
-				if !haveFinalPart {
-					if allKnownPartsDone {
-						partDescription = "known parts of incomplete Job"
-					} else {
-						partDescription = "incomplete Job"
-					}
-				}
-				if shouldLog {
-					jm.Log(common.LogInfo, fmt.Sprintf("%s %s successfully completed, cancelled or paused", partDescription, jm.jobID.String()))
-				}
-
-				switch part0Plan.JobStatus() {
-				case common.EJobStatus.Cancelling():
-					part0Plan.SetJobStatus(common.EJobStatus.Cancelled())
-					if shouldLog {
-						jm.Log(common.LogInfo, fmt.Sprintf("%s %v successfully cancelled", partDescription, jm.jobID))
-					}
-				case common.EJobStatus.InProgress():
-					part0Plan.SetJobStatus((common.EJobStatus).EnhanceJobStatusInfo(jobProgressInfo.transfersSkipped > 0,
-						jobProgressInfo.transfersFailed > 0,
-						jobProgressInfo.transfersCompleted > 0))
-				}
-				status := part0Plan.JobStatus()
-				if status.IsJobDone() {
-					finalizeDedupeJob(jm.jobID, jm.Log)
-				}
-
-				// reset counters
-				atomic.StoreUint32(&jm.partsDone, 0)
-				jobProgressInfo = jobPartProgressInfo{}
-
-				// flush logs
-				jm.chunkStatusLogger.FlushLog() // TODO: remove once we sort out what will be calling CloseLog (currently nothing)
-			} //Else log and wait for next part to complete
-
-			if shouldLog {
-				jm.Log(common.LogInfo, fmt.Sprintf("is part of Job which %d total number of parts done ", partsDone))
-			}
+			jm.handlePartProgress(partProgressInfo, state)
 		}
 	}
+}
+
+// assertJobFinishedOnCancel validates, when a cancel is reported, that part 0 is no longer
+// running. A cancel event for a job still InProgress/Cancelling indicates a coordination bug.
+func (jm *jobMgr) assertJobFinishedOnCancel() {
+	jobPart0Mgr, ok := jm.jobPartMgrs.Get(0)
+	if !ok {
+		jm.Log(common.LogError, "part0Plan of job invalid")
+		return
+	}
+	part0plan := jobPart0Mgr.Plan()
+	if part0plan.JobStatus() == common.EJobStatus.InProgress() ||
+		part0plan.JobStatus() == common.EJobStatus.Cancelling() {
+		jm.Panic(fmt.Errorf("reportCancelCh received cancel event while job still not completed, Job(%s) in state: %s",
+			jm.jobID.String(), part0plan.JobStatus()))
+	}
+}
+
+// handlePartProgress processes one job-part progress report: it accumulates counters, runs the
+// per-part side effects, transitions the job to a terminal state once all parts are done, and
+// finalizes dedupe reporting.
+func (jm *jobMgr) handlePartProgress(partProgressInfo jobPartProgressInfo, state *jobPartDoneState) {
+	state.accumulate(partProgressInfo)
+
+	jobPart0Mgr, ok := jm.jobPartMgrs.Get(0)
+	if !ok {
+		jm.Panic(fmt.Errorf("Failed to find Job %v, Part #0", jm.jobID))
+	}
+	part0Plan := jobPart0Mgr.Plan()
+	jobStatus := part0Plan.JobStatus() // status of part 0 is status of job as a whole
+	partsDone := atomic.AddUint32(&jm.partsDone, 1)
+
+	jm.unmapCompletedPartIfMover(partProgressInfo)
+	signalPartCompletion(partProgressInfo)
+
+	if description, shouldComplete := jm.evaluateJobCompletion(partsDone, jobStatus); shouldComplete {
+		jm.finalizeJobCompletion(part0Plan, description, state)
+	}
+
+	jm.finalizeDedupe(part0Plan, state)
+
+	if state.shouldLog {
+		jm.Log(common.LogInfo, fmt.Sprintf("is part of Job which %d total number of parts done ", partsDone))
+	}
+}
+
+// unmapCompletedPartIfMover releases a completed part's memory-mapped plan file when running in
+// Mover build mode, to bound memory use across very large jobs.
+func (jm *jobMgr) unmapCompletedPartIfMover(partProgressInfo jobPartProgressInfo) {
+	if !buildmode.IsMover {
+		return
+	}
+	// PROGRESSIVE CLEANUP: Unmap completed job part plan files immediately to free memory
+	// Uses selective unmapping: Part 0 is preserved, Parts 1+ are unmapped
+	if partProgressInfo.partNum == nil {
+		fmt.Println("DEBUG: Skipping unmap - partNum is nil")
+		return
+	}
+	partNum := *partProgressInfo.partNum
+	if completedPartMgr, exists := jm.jobPartMgrs.Get(partNum); exists {
+		completedPartMgr.UnmapPlanFile()
+	} else {
+		fmt.Printf("DEBUG: Could not find part manager for part %d\n", partNum)
+	}
+}
+
+// signalPartCompletion unblocks anything waiting on this part's completion channel.
+func signalPartCompletion(partProgressInfo jobPartProgressInfo) {
+	if partProgressInfo.completionChan != nil {
+		close(partProgressInfo.completionChan)
+	}
+}
+
+// evaluateJobCompletion decides whether the job should now be finalized, based on the number of
+// parts done and the job status captured before any completion mutation. When it returns true it
+// also returns a human-readable description of what is completing, for logging.
+func (jm *jobMgr) evaluateJobCompletion(partsDone uint32, jobStatus common.JobStatus) (description string, shouldComplete bool) {
+	// If the last part is still awaited or other parts all still not complete,
+	// JobPart 0 status is not changed (unless we are cancelling)
+	haveFinalPart := atomic.LoadInt32(&jm.atomicFinalPartOrderedIndicator) == 1
+	allKnownPartsDone := partsDone == jm.jobPartMgrs.Count()
+	isCancelling := jobStatus == common.EJobStatus.Cancelling()
+	shouldComplete = (haveFinalPart && allKnownPartsDone) || // If we have all of the parts, they should all exit cleanly, so the job can be resumed properly.
+		(isCancelling && !haveFinalPart) // If we're cancelling, it's OK to try to exit early; the user already accepted this job cannot be resumed. Outgoing requests will fail anyway, so nothing can properly clean up.
+	if !shouldComplete {
+		return "", false
+	}
+
+	description = "all parts of entire Job"
+	if !haveFinalPart {
+		if allKnownPartsDone {
+			description = "known parts of incomplete Job"
+		} else {
+			description = "incomplete Job"
+		}
+	}
+	return description, true
+}
+
+// finalizeJobCompletion drains outstanding status messages, sets the terminal status on part 0,
+// and resets the per-job progress counters. It must be called only when evaluateJobCompletion
+// reported that the job should complete.
+func (jm *jobMgr) finalizeJobCompletion(part0Plan *JobPartPlanHeader, description string, state *jobPartDoneState) {
+	// Inform StatusManager that all parts are done.
+	if jm.jstm.xferDone != nil {
+		close(jm.jstm.xferDone)
+	}
+
+	// Wait for all XferDone messages to be processed by statusManager. Front end
+	// depends on JobStatus to determine if we've to quit job. Setting it here without
+	// draining XferDone will make it report incorrect statistics.
+	jm.waitToDrainXferDone()
+
+	if state.shouldLog {
+		jm.Log(common.LogInfo, fmt.Sprintf("%s %s successfully completed, cancelled or paused", description, jm.jobID.String()))
+	}
+
+	switch part0Plan.JobStatus() {
+	case common.EJobStatus.Cancelling():
+		part0Plan.SetJobStatus(common.EJobStatus.Cancelled())
+		if state.shouldLog {
+			jm.Log(common.LogInfo, fmt.Sprintf("%s %v successfully cancelled", description, jm.jobID))
+		}
+	case common.EJobStatus.InProgress():
+		part0Plan.SetJobStatus((common.EJobStatus).EnhanceJobStatusInfo(state.jobProgress.transfersSkipped > 0,
+			state.jobProgress.transfersFailed > 0,
+			state.jobProgress.transfersCompleted > 0))
+	}
+
+	// reset counters
+	atomic.StoreUint32(&jm.partsDone, 0)
+	state.jobProgress = jobPartProgressInfo{}
+
+	// flush logs
+	jm.chunkStatusLogger.FlushLog() // TODO: remove once we sort out what will be calling CloseLog (currently nothing)
+}
+
+// finalizeDedupe emits the dedupe job summary and clears dedupe state once the job is done and
+// every known part has reported. It reads the (possibly just-updated) terminal status.
+func (jm *jobMgr) finalizeDedupe(part0Plan *JobPartPlanHeader, state *jobPartDoneState) {
+	currentStatus := part0Plan.JobStatus()
+	allKnownPartsReported := state.dedupeCompletedParts.allKnownPartsReported(jm.jobPartMgrs.Count())
+	if shouldResetDedupeRunProgress(currentStatus, allKnownPartsReported) {
+		// Resume reports the same part numbers again. Reset per-run completion accounting
+		// while retaining the job-local dedupe tables and cumulative progress counters.
+		state.dedupeCompletedParts.reset()
+		state.dedupeProgress = jobPartProgressInfo{}
+		return
+	}
+	if !currentStatus.IsJobDone() || !allKnownPartsReported {
+		return
+	}
+	finalizeDedupeJob(
+		jm.jobID,
+		currentStatus,
+		state.dedupeProgress.transfersCompleted,
+		state.dedupeProgress.transfersSkipped,
+		state.dedupeProgress.transfersFailed,
+		jm.Log,
+	)
+	state.dedupeCompletedParts.reset()
+	state.dedupeProgress = jobPartProgressInfo{}
+}
+
+func shouldResetDedupeRunProgress(status common.JobStatus, allKnownPartsReported bool) bool {
+	return status == common.EJobStatus.Paused() && allKnownPartsReported
 }
 
 func (jm *jobMgr) getInMemoryTransitJobState() InMemoryTransitJobState {

--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -881,6 +881,10 @@ func (jm *jobMgr) reportJobPartDoneHandler() {
 						jobProgressInfo.transfersFailed > 0,
 						jobProgressInfo.transfersCompleted > 0))
 				}
+				status := part0Plan.JobStatus()
+				if status.IsJobDone() {
+					finalizeDedupeJob(jm.jobID, jm.Log)
+				}
 
 				// reset counters
 				atomic.StoreUint32(&jm.partsDone, 0)

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -630,7 +630,9 @@ func (jpm *jobPartMgr) updateJobPartProgress(status common.TransferStatus) {
 	switch status {
 	case common.ETransferStatus.Success():
 		atomic.AddUint32(&jpm.atomicTransfersCompleted, 1)
-	case common.ETransferStatus.Failed(), common.ETransferStatus.BlobTierFailure():
+	case common.ETransferStatus.Failed(),
+		common.ETransferStatus.BlobTierFailure(),
+		common.ETransferStatus.TierAvailabilityCheckFailure():
 		atomic.AddUint32(&jpm.atomicTransfersFailed, 1)
 	case common.ETransferStatus.SkippedEntityAlreadyExists(), common.ETransferStatus.SkippedBlobHasSnapshots():
 		atomic.AddUint32(&jpm.atomicTransfersSkipped, 1)

--- a/ste/mgr-JobPartMgr_test.go
+++ b/ste/mgr-JobPartMgr_test.go
@@ -21,9 +21,14 @@
 package ste
 
 import (
-	"github.com/stretchr/testify/assert"
+	"context"
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
+
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInferContentType(t *testing.T) {
@@ -52,5 +57,90 @@ func TestInferContentType(t *testing.T) {
 		// make sure the inferred type is correct
 		// we use Contains to check because charset is also in contentType
 		a.True(strings.Contains(contentType, expectedType))
+	}
+}
+
+func TestAddJobPartRuntimeSAS(t *testing.T) {
+	const (
+		sourceSAS      = "sp=rl&sig=source-runtime-sentinel"
+		destinationSAS = "sp=rcwdl&sig=destination-runtime-sentinel"
+	)
+
+	originalPlanFolder := common.AzcopyJobPlanFolder
+	common.AzcopyJobPlanFolder = t.TempDir()
+	t.Cleanup(func() {
+		common.AzcopyJobPlanFolder = originalPlanFolder
+	})
+
+	tests := []struct {
+		name              string
+		existingPlan      bool
+		sourceSAS         string
+		destinationSAS    string
+		expectedSourceSAS string
+		expectedDestSAS   string
+	}{
+		{
+			name:              "new part with runtime SAS",
+			sourceSAS:         sourceSAS,
+			destinationSAS:    destinationSAS,
+			expectedSourceSAS: sourceSAS,
+			expectedDestSAS:   destinationSAS,
+		},
+		{
+			name: "new non-SAS part",
+		},
+		{
+			name:         "resumed part without runtime SAS",
+			existingPlan: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			order := common.CopyJobPartOrderRequest{
+				JobID:           common.NewJobID(),
+				PartNum:         0,
+				FromTo:          common.EFromTo.LocalBlob(),
+				Fpo:             common.EFolderPropertiesOption.NoFolders(),
+				SourceRoot:      common.ResourceString{Value: "source"},
+				DestinationRoot: common.ResourceString{Value: "https://account.blob.core.windows.net/container"},
+			}
+			planFile := JobPartPlanFileName(fmt.Sprintf(
+				JobPartPlanFileNameFormat,
+				order.JobID.String(),
+				order.PartNum,
+				DataSchemaVersion,
+			))
+			planFile.Create(order)
+
+			var existingPlanMMF *JobPartPlanMMF
+			if test.existingPlan {
+				existingPlanMMF = planFile.Map()
+			}
+
+			jm := &jobMgr{
+				ctx:         context.Background(),
+				jobPartMgrs: newJobPartToJobPartMgr(),
+				initMu:      &sync.Mutex{},
+			}
+			jpm := jm.AddJobPart(&AddJobPartArgs{
+				PartNum:         order.PartNum,
+				PlanFile:        planFile,
+				ExistingPlanMMF: existingPlanMMF,
+				SourceSAS:       test.sourceSAS,
+				DestinationSAS:  test.destinationSAS,
+			})
+			t.Cleanup(jpm.Close)
+
+			actualSourceSAS, actualDestinationSAS := jpm.SAS()
+			assert.Equal(t, test.expectedSourceSAS, actualSourceSAS)
+			assert.Equal(t, test.expectedDestSAS, actualDestinationSAS)
+
+			jptm := &jobPartTransferMgr{jobPartMgr: jpm}
+			actualSourceSAS, actualDestinationSAS = jptm.SAS()
+			assert.Equal(t, test.expectedSourceSAS, actualSourceSAS)
+			assert.Equal(t, test.expectedDestSAS, actualDestinationSAS)
+		})
 	}
 }

--- a/ste/mgr-JobPartMgr_test.go
+++ b/ste/mgr-JobPartMgr_test.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
@@ -58,6 +59,14 @@ func TestInferContentType(t *testing.T) {
 		// we use Contains to check because charset is also in contentType
 		a.True(strings.Contains(contentType, expectedType))
 	}
+}
+
+func TestUpdateJobPartProgressCountsTierAvailabilityAsFailure(t *testing.T) {
+	jpm := &jobPartMgr{}
+
+	jpm.updateJobPartProgress(common.ETransferStatus.TierAvailabilityCheckFailure())
+
+	assert.EqualValues(t, 1, atomic.LoadUint32(&jpm.atomicTransfersFailed))
 }
 
 func TestAddJobPartRuntimeSAS(t *testing.T) {

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -24,6 +24,7 @@ import (
 type IJobPartTransferMgr interface {
 	FromTo() common.FromTo
 	Info() *TransferInfo
+	SAS() (sourceSAS, destinationSAS string)
 	ResourceDstData(dataFileToXfer []byte) (headers common.ResourceHTTPHeaders, metadata common.Metadata, blobTags common.BlobTags, cpkOptions common.CpkOptions)
 	LastModifiedTime() time.Time
 	PreserveLastModifiedTime() (time.Time, bool)
@@ -448,6 +449,10 @@ func (jptm *jobPartTransferMgr) Info() *TransferInfo {
 		VersionID:         versionID,
 		SnapshotID:        snapshotID,
 	}
+}
+
+func (jptm *jobPartTransferMgr) SAS() (sourceSAS, destinationSAS string) {
+	return jptm.jobPartMgr.SAS()
 }
 
 func (jptm *jobPartTransferMgr) Context() context.Context {

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -213,6 +214,18 @@ type jobPartTransferMgr struct {
 
 	// used defensively to protect against accidental double counting
 	atomicCompletionIndicator uint32
+
+	// prevents concurrent failing chunks from emitting duplicate structured failures
+	atomicDedupeFailureLogged uint32
+
+	// pairs small-file result events with an emitted start for this transfer
+	atomicSmallFileProgressStarted uint32
+
+	dedupeFailureMu        sync.Mutex
+	dedupeFailureOperation string
+	dedupeFailureReason    string
+	dedupeFailureStatus    int
+	dedupeFailureRequestID string
 
 	// used to show whether we have started doing things that may affect the destination
 	atomicDestModifiedIndicator uint32
@@ -875,6 +888,25 @@ func (jptm *jobPartTransferMgr) failActiveTransfer(typ transferErrorCode, descri
 
 		requestID := ErrorEx{err}.MSRequestID()
 		fullMsg := fmt.Sprintf("%s. When %s. X-Ms-Request-Id: %s\n", msg, descriptionOfWhereErrorOccurred, requestID) // trailing \n to separate it better from any later, unrelated, log lines
+		partNumber := jptm.jobPartMgr.Plan().PartNum
+		jptm.recordDedupeFailureDetails(
+			descriptionOfWhereErrorOccurred,
+			status,
+			requestID,
+			msg,
+		)
+		if atomic.CompareAndSwapUint32(&jptm.atomicDedupeFailureLogged, 0, 1) {
+			emitDedupeTransferFailure(
+				jptm,
+				"transfer_failed",
+				descriptionOfWhereErrorOccurred,
+				status,
+				requestID,
+				msg,
+				partNumber,
+				jptm.transferIndex,
+			)
+		}
 		jptm.logTransferError(typ, jptm.Info().Source, jptm.Info().Destination, fullMsg, status)
 		jptm.SetStatus(failureStatus)
 		jptm.SetErrorCode(int32(status)) // TODO: what are the rules about when this needs to be set, and doesn't need to be (e.g. for earlier failures)?
@@ -954,7 +986,48 @@ func (jptm *jobPartTransferMgr) logTransferError(errorCode transferErrorCode, so
 	info := jptm.Info() // TODO we are getting a lot of Info calls and its (presumably) not well-optimized.  Profile that?
 	msg := fmt.Sprintf("%v: %v", errorCode, info.entityTypeLogIndicator()) + common.URLStringExtension(source).RedactSecretQueryParamForLogging() +
 		fmt.Sprintf(" : %03d : %s\n   Dst: ", status, errorMsg) + common.URLStringExtension(destination).RedactSecretQueryParamForLogging()
+	jptm.recordDedupeFailureDetailsIfEmpty(string(errorCode), status, "", errorMsg)
 	jptm.Log(common.LogError, msg)
+}
+
+func (jptm *jobPartTransferMgr) recordDedupeFailureDetails(
+	operation string,
+	status int,
+	requestID string,
+	reason string,
+) {
+	jptm.dedupeFailureMu.Lock()
+	defer jptm.dedupeFailureMu.Unlock()
+	jptm.dedupeFailureOperation = operation
+	jptm.dedupeFailureStatus = status
+	jptm.dedupeFailureRequestID = requestID
+	jptm.dedupeFailureReason = reason
+}
+
+func (jptm *jobPartTransferMgr) dedupeFailureDetails() (string, int, string, string) {
+	jptm.dedupeFailureMu.Lock()
+	defer jptm.dedupeFailureMu.Unlock()
+	return jptm.dedupeFailureOperation,
+		jptm.dedupeFailureStatus,
+		jptm.dedupeFailureRequestID,
+		jptm.dedupeFailureReason
+}
+
+func (jptm *jobPartTransferMgr) recordDedupeFailureDetailsIfEmpty(
+	operation string,
+	status int,
+	requestID string,
+	reason string,
+) {
+	jptm.dedupeFailureMu.Lock()
+	defer jptm.dedupeFailureMu.Unlock()
+	if jptm.dedupeFailureReason != "" {
+		return
+	}
+	jptm.dedupeFailureOperation = operation
+	jptm.dedupeFailureStatus = status
+	jptm.dedupeFailureRequestID = requestID
+	jptm.dedupeFailureReason = reason
 }
 
 func (jptm *jobPartTransferMgr) LogUploadError(source, destination, errorMsg string, status int) {
@@ -1024,17 +1097,42 @@ func (jptm *jobPartTransferMgr) ReportTransferDone() uint32 {
 		panic("cannot report the same transfer done twice")
 	}
 
+	transferStatus := jptm.jobPartPlanTransfer.TransferStatus()
+	emitSmallFileTransferResult(jptm, transferStatus)
+	switch transferStatus {
+	case common.ETransferStatus.Failed(),
+		common.ETransferStatus.BlobTierFailure(),
+		common.ETransferStatus.TierAvailabilityCheckFailure():
+		operation, status, requestID, reason := jptm.dedupeFailureDetails()
+		if operation == "" {
+			operation = "transfer_completion"
+		}
+		if reason == "" {
+			reason = "transfer completed with status " + transferStatus.String()
+		}
+		emitDedupeTransferFailure(
+			jptm,
+			"file_failed",
+			operation,
+			status,
+			requestID,
+			reason,
+			jptm.jobPartMgr.Plan().PartNum,
+			jptm.transferIndex,
+		)
+	}
+
 	// Update Status Manager
 	jptm.jobPartMgr.SendXferDoneMsg(xferDoneMsg{Src: jptm.Info().Source,
 		Dst:                jptm.Info().Destination,
 		IsFolderProperties: jptm.Info().IsFolderPropertiesTransfer(),
-		TransferStatus:     jptm.jobPartPlanTransfer.TransferStatus(),
+		TransferStatus:     transferStatus,
 		TransferSize:       uint64(jptm.Info().SourceSize),
 		ErrorCode:          jptm.ErrorCode(),
 		ErrorMessage:       jptm.ErrorMessage(),
 	})
 
-	return jptm.jobPartMgr.ReportTransferDone(jptm.jobPartPlanTransfer.TransferStatus())
+	return jptm.jobPartMgr.ReportTransferDone(transferStatus)
 }
 
 func (jptm *jobPartTransferMgr) GetS2SSourceTokenCredential(ctx context.Context) (*string, error) {

--- a/ste/sender-blockBlob.go
+++ b/ste/sender-blockBlob.go
@@ -72,6 +72,11 @@ type blockBlobSenderBase struct {
 	dedupeMode  dedupeActMode
 	dedupePlan  *SourceGridPlan
 	dedupeIndex map[srcBlockKey]srcBlockHashes
+	dedupeETag  azcore.ETag
+
+	dedupeResolveOnce  sync.Once
+	dedupeResolveErr   error
+	dedupeResolveStats dedupeHashResolutionStats
 }
 
 func getVerifiedChunkParams(transferInfo *TransferInfo, memLimit int64, strictMemLimit int64) (chunkSize int64, numChunks uint32, err error) {
@@ -266,6 +271,13 @@ func (s *blockBlobSenderBase) Epilogue() {
 
 	// commit block list if necessary
 	if jptm.IsLive() && shouldPutBlockList == putListNeeded {
+		if s.dedupeMode != dedupeActOff && s.dedupeETag != "" {
+			if err := validateDedupeSourceETag(jptm, s.dedupeETag); err != nil {
+				jptm.FailActiveSend("Validating dedupe source ETag before commit", err)
+				return
+			}
+		}
+
 		// commit the blocks.
 		if !ValidateTier(jptm, s.destBlobTier, s.destBlockBlobClient.BlobClient(), s.jptm.Context(), false) {
 			s.destBlobTier = nil
@@ -367,9 +379,9 @@ func (s *blockBlobSenderBase) Epilogue() {
 				recorded = recordCommittedBlocksWithObserver(jptm.Info().JobID, s.destBlockBlobClient.URL(), destinationSAS, etag, s.dedupePlan, func(event dedupeTableRecordEvent) {
 					jptm.LogAtLevelForCurrentTransfer(common.LogDebug, fmt.Sprintf(
 						"dedupe-table(committed): record=%d inserted=%t entries=%d buckets=%d bucketEntries=%d refCount=%d "+
-							"crc64=%016x sha256=%x target=%s offset=%d size=%d etag=%q",
+							"crc64=%016x hasSha256=%t target=%s offset=%d size=%d etag=%q",
 						event.RecordIndex, event.Inserted, event.TableStats.Entries, event.TableStats.Buckets,
-						event.TableStats.BucketEntries, event.Stored.RefCount, event.Block.CRC64, event.Block.SHA256,
+						event.TableStats.BucketEntries, event.Stored.RefCount, event.Block.CRC64, event.Block.HasSHA256,
 						sanitizedDestForDedupe(event.Stored.TargetURI), event.Stored.TargetOffset, event.Stored.TargetLength, event.Stored.ETag))
 				})
 				jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(

--- a/ste/sender-blockBlob.go
+++ b/ste/sender-blockBlob.go
@@ -74,9 +74,31 @@ type blockBlobSenderBase struct {
 	dedupeIndex map[srcBlockKey]srcBlockHashes
 	dedupeETag  azcore.ETag
 
-	dedupeResolveOnce  sync.Once
+	dedupeResolveState int32
+	dedupeResolveDone  chan struct{}
 	dedupeResolveErr   error
 	dedupeResolveStats dedupeHashResolutionStats
+}
+
+const (
+	dedupeResolveIdle int32 = iota
+	dedupeResolveInProgress
+	dedupeResolveComplete
+)
+
+func (s *blockBlobSenderBase) tryStartDedupeResolution() bool {
+	return atomic.CompareAndSwapInt32(&s.dedupeResolveState, dedupeResolveIdle, dedupeResolveInProgress)
+}
+
+func (s *blockBlobSenderBase) finishDedupeResolution() {
+	atomic.StoreInt32(&s.dedupeResolveState, dedupeResolveComplete)
+	if s.dedupeResolveDone != nil {
+		close(s.dedupeResolveDone)
+	}
+}
+
+func (s *blockBlobSenderBase) dedupeResolutionState() int32 {
+	return atomic.LoadInt32(&s.dedupeResolveState)
 }
 
 func getVerifiedChunkParams(transferInfo *TransferInfo, memLimit int64, strictMemLimit int64) (chunkSize int64, numChunks uint32, err error) {

--- a/ste/sender-blockBlob.go
+++ b/ste/sender-blockBlob.go
@@ -354,6 +354,7 @@ func (s *blockBlobSenderBase) Epilogue() {
 		// blocks into the job's committed table so that later identical blocks can be served from it.
 		// This only populates an in-memory lookup table and does not touch the bytes just written.
 		if s.dedupeMode != dedupeActOff && s.dedupePlan != nil {
+			recorded := 0
 			var etag azcore.ETag
 			if resp.ETag != nil {
 				etag = *resp.ETag
@@ -363,7 +364,7 @@ func (s *blockBlobSenderBase) Epilogue() {
 					"dedupe-act: committed destination response had no ETag; this blob will not be used as a dedupe target")
 			} else {
 				_, destinationSAS := jptm.SAS()
-				recorded := recordCommittedBlocksWithObserver(jptm.Info().JobID, s.destBlockBlobClient.URL(), destinationSAS, etag, s.dedupePlan, func(event dedupeTableRecordEvent) {
+				recorded = recordCommittedBlocksWithObserver(jptm.Info().JobID, s.destBlockBlobClient.URL(), destinationSAS, etag, s.dedupePlan, func(event dedupeTableRecordEvent) {
 					jptm.LogAtLevelForCurrentTransfer(common.LogDebug, fmt.Sprintf(
 						"dedupe-table(committed): record=%d inserted=%t entries=%d buckets=%d bucketEntries=%d refCount=%d "+
 							"crc64=%016x sha256=%x target=%s offset=%d size=%d etag=%q",
@@ -375,6 +376,14 @@ func (s *blockBlobSenderBase) Epilogue() {
 					"dedupe-act(%s): recorded %d committed block(s) for %q into the job dedupe table",
 					s.dedupeMode, recorded, jptm.Info().DstFilePath))
 			}
+			st := dedupeStateForJob(jptm.Info().JobID)
+			st.addFileCommitted()
+			emitDedupeProgress(jptm, dedupeProgressMessage(
+				"file_committed",
+				s.dedupeMode,
+				jptm.Info(),
+				fmt.Sprintf("fileBytes=%d committedIndexBlocks=%d", s.dedupePlan.TotalSize, recorded),
+				st.progressSnapshot()))
 			logDedupeActSummary(jptm, s.dedupeMode)
 		}
 

--- a/ste/sender-blockBlob.go
+++ b/ste/sender-blockBlob.go
@@ -78,7 +78,7 @@ type blockBlobSenderBase struct {
 	dedupeResolveDone        chan struct{}
 	dedupeResolveAttempted   bool
 	dedupeResolvedGeneration uint64
-	dedupeSourceCache        dedupeSourceHashCache
+	dedupeSourceHashState    dedupeSourceHashResolutionState
 	dedupeResolveErr         error
 	dedupeResolveStats       dedupeHashResolutionStats
 	dedupeHasher             dedupeRangeHasher

--- a/ste/sender-blockBlob.go
+++ b/ste/sender-blockBlob.go
@@ -69,36 +69,19 @@ type blockBlobSenderBase struct {
 	// Block-level dedupe prototype (AZCOPY_DEDUPE_ACT). These are only populated for an eligible
 	// block-blob -> block-blob S2S copy; they stay at their zero values (dedupeMode == dedupeActOff)
 	// for every other transfer, so the default code path is unaffected.
-	dedupeMode  dedupeActMode
-	dedupePlan  *SourceGridPlan
-	dedupeIndex map[srcBlockKey]srcBlockHashes
-	dedupeETag  azcore.ETag
+	dedupeMode dedupeActMode
+	dedupePlan *SourceGridPlan
+	dedupeETag azcore.ETag
 
-	dedupeResolveState int32
-	dedupeResolveDone  chan struct{}
-	dedupeResolveErr   error
-	dedupeResolveStats dedupeHashResolutionStats
-}
-
-const (
-	dedupeResolveIdle int32 = iota
-	dedupeResolveInProgress
-	dedupeResolveComplete
-)
-
-func (s *blockBlobSenderBase) tryStartDedupeResolution() bool {
-	return atomic.CompareAndSwapInt32(&s.dedupeResolveState, dedupeResolveIdle, dedupeResolveInProgress)
-}
-
-func (s *blockBlobSenderBase) finishDedupeResolution() {
-	atomic.StoreInt32(&s.dedupeResolveState, dedupeResolveComplete)
-	if s.dedupeResolveDone != nil {
-		close(s.dedupeResolveDone)
-	}
-}
-
-func (s *blockBlobSenderBase) dedupeResolutionState() int32 {
-	return atomic.LoadInt32(&s.dedupeResolveState)
+	dedupeResolveMu          sync.Mutex
+	dedupeResolveInProgress  bool
+	dedupeResolveDone        chan struct{}
+	dedupeResolveAttempted   bool
+	dedupeResolvedGeneration uint64
+	dedupeSourceCache        dedupeSourceHashCache
+	dedupeResolveErr         error
+	dedupeResolveStats       dedupeHashResolutionStats
+	dedupeHasher             dedupeRangeHasher
 }
 
 func getVerifiedChunkParams(transferInfo *TransferInfo, memLimit int64, strictMemLimit int64) (chunkSize int64, numChunks uint32, err error) {

--- a/ste/sender-blockBlob.go
+++ b/ste/sender-blockBlob.go
@@ -25,7 +25,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 	"strconv"
 	"strings"
 	"sync"
@@ -33,7 +32,9 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/file"
 
@@ -64,6 +65,13 @@ type blockBlobSenderBase struct {
 	muBlockIDs             *sync.Mutex
 	blockNamePrefix        string
 	completedBlockList     map[int]string
+
+	// Block-level dedupe prototype (AZCOPY_DEDUPE_ACT). These are only populated for an eligible
+	// block-blob -> block-blob S2S copy; they stay at their zero values (dedupeMode == dedupeActOff)
+	// for every other transfer, so the default code path is unaffected.
+	dedupeMode  dedupeActMode
+	dedupePlan  *SourceGridPlan
+	dedupeIndex map[srcBlockKey]srcBlockHashes
 }
 
 func getVerifiedChunkParams(transferInfo *TransferInfo, memLimit int64, strictMemLimit int64) (chunkSize int64, numChunks uint32, err error) {
@@ -215,6 +223,15 @@ func (s *blockBlobSenderBase) NumChunks() uint32 {
 	return s.numChunks
 }
 
+// dedupeChunkSpecs implements sourceGridChunker. It returns the source-grid chunk boundaries when the
+// dedupe prototype is active for this transfer, and nil otherwise (so the uniform chunk grid is used).
+func (s *blockBlobSenderBase) dedupeChunkSpecs() []chunkSpec {
+	if s.dedupeMode == dedupeActOff {
+		return nil
+	}
+	return chunkSpecsFromPlan(s.dedupePlan)
+}
+
 func (s *blockBlobSenderBase) RemoteFileExists() (bool, time.Time, error) {
 	properties, err := s.destBlockBlobClient.GetProperties(s.jptm.Context(), &blob.GetPropertiesOptions{CPKInfo: s.jptm.CpkInfo()})
 	return remoteObjectExists(blobPropertiesResponseAdapter{properties}, err)
@@ -266,7 +283,7 @@ func (s *blockBlobSenderBase) Epilogue() {
 			destBlobTier = nil
 		}
 
-		_, err := s.destBlockBlobClient.CommitBlockList(jptm.Context(), blockIDs,
+		resp, err := s.destBlockBlobClient.CommitBlockList(jptm.Context(), blockIDs,
 			&blockblob.CommitBlockListOptions{
 				HTTPHeaders:  &s.headersToApply,
 				Metadata:     s.metadataToApply,
@@ -331,6 +348,34 @@ func (s *blockBlobSenderBase) Epilogue() {
 			}
 
 			return
+		}
+
+		// Block-level dedupe prototype (AZCOPY_DEDUPE_ACT): record this freshly-committed blob's hashed
+		// blocks into the job's committed table so that later identical blocks can be served from it.
+		// This only populates an in-memory lookup table and does not touch the bytes just written.
+		if s.dedupeMode != dedupeActOff && s.dedupePlan != nil {
+			var etag azcore.ETag
+			if resp.ETag != nil {
+				etag = *resp.ETag
+			}
+			if etag == "" {
+				jptm.LogAtLevelForCurrentTransfer(common.LogWarning,
+					"dedupe-act: committed destination response had no ETag; this blob will not be used as a dedupe target")
+			} else {
+				_, destinationSAS := jptm.SAS()
+				recorded := recordCommittedBlocksWithObserver(jptm.Info().JobID, s.destBlockBlobClient.URL(), destinationSAS, etag, s.dedupePlan, func(event dedupeTableRecordEvent) {
+					jptm.LogAtLevelForCurrentTransfer(common.LogDebug, fmt.Sprintf(
+						"dedupe-table(committed): record=%d inserted=%t entries=%d buckets=%d bucketEntries=%d refCount=%d "+
+							"crc64=%016x sha256=%x target=%s offset=%d size=%d etag=%q",
+						event.RecordIndex, event.Inserted, event.TableStats.Entries, event.TableStats.Buckets,
+						event.TableStats.BucketEntries, event.Stored.RefCount, event.Block.CRC64, event.Block.SHA256,
+						sanitizedDestForDedupe(event.Stored.TargetURI), event.Stored.TargetOffset, event.Stored.TargetLength, event.Stored.ETag))
+				})
+				jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
+					"dedupe-act(%s): recorded %d committed block(s) for %q into the job dedupe table",
+					s.dedupeMode, recorded, jptm.Info().DstFilePath))
+			}
+			logDedupeActSummary(jptm, s.dedupeMode)
 		}
 
 		if setTags {

--- a/ste/sender-blockBlobFromURL.go
+++ b/ste/sender-blockBlobFromURL.go
@@ -22,10 +22,11 @@ package ste
 
 import (
 	"fmt"
+	"sync/atomic"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/file"
-	"sync/atomic"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
@@ -64,10 +65,70 @@ func newURLToBlockBlobCopier(jptm IJobPartTransferMgr, pacer pacer, srcInfoProvi
 		sUrl, _ := file.ParseURL(srcURL)
 		intentBool = sUrl.SAS.Signature() == "" // No SAS means using OAuth
 	}
-	return &urlToBlockBlobCopier{
+	copier := &urlToBlockBlobCopier{
 		blockBlobSenderBase:  *senderBase,
-		srcURL:               srcURL,
-		addFileRequestIntent: intentBool}, nil
+		srcURL:              srcURL,
+		addFileRequestIntent: intentBool,
+	}
+
+	// Block-level dedupe prototype (AZCOPY_DEDUPE_ACT): for an eligible block-blob -> block-blob S2S
+	// copy, chunk on the source's committed block boundaries and arm the per-block hit decision used in
+	// generatePutBlockFromURL. A no-op (uniform grid) when the flag is unset or the source is not an
+	// eligible block blob.
+	configureBlockBlobDedupe(jptm, copier, srcInfoProvider)
+
+	return copier, nil
+}
+
+// configureBlockBlobDedupe arms source-grid chunking + the dedupe hit decision on a block-blob S2S
+// copier when AZCOPY_DEDUPE_ACT is set and the source is a block blob with a committed block list. It
+// overrides the sender's chunk count so every chunk lines up with a source block. Any problem
+// leaves dedupe off and the copy proceeds on the uniform grid, so it can never break a transfer.
+func configureBlockBlobDedupe(jptm IJobPartTransferMgr, c *urlToBlockBlobCopier, srcInfoProvider IRemoteSourceInfoProvider) {
+	mode := dedupeActModeFromEnv()
+	if mode == dedupeActOff {
+		return
+	}
+	blobSrc, ok := srcInfoProvider.(IBlobSourceInfoProvider)
+	if !ok || blobSrc.BlobType() != blob.BlobTypeBlockBlob {
+		return
+	}
+
+	plan, err := fetchSourceGridPlan(jptm)
+	if err != nil {
+		jptm.LogAtLevelForCurrentTransfer(common.LogDebug, "dedupe-act: GetBlockList failed, using uniform grid: "+err.Error())
+		return
+	}
+	if plan == nil || len(plan.Blocks) == 0 {
+		return // single-PutBlob or empty source: no committed blocks to align to
+	}
+	if plan.TotalSize != jptm.Info().SourceSize {
+		jptm.LogAtLevelForCurrentTransfer(common.LogDebug, fmt.Sprintf(
+			"dedupe-act: source-grid total %d != source size %d, using uniform grid", plan.TotalSize, jptm.Info().SourceSize))
+		return
+	}
+	if len(plan.Blocks) > common.MaxNumberOfBlocksPerBlob {
+		return
+	}
+
+	dedupeIndex := buildSourceBlockHashIndex(plan)
+	if len(dedupeIndex) == 0 {
+		jptm.LogAtLevelForCurrentTransfer(common.LogDebug,
+			"dedupe-act: source block list contained no complete hashes, using uniform grid")
+		return
+	}
+
+	// One chunk per source committed block.
+	c.numChunks = uint32(len(plan.Blocks))
+	c.blockIDs = make([]string, c.numChunks)
+	c.dedupeMode = mode
+	c.dedupePlan = plan
+	c.dedupeIndex = dedupeIndex
+	setDedupeActModeForJob(jptm.Info().JobID, mode)
+
+	jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
+		"dedupe-act(%s): source-grid chunking armed: %d block(s), %d with hashes, totalSize=%d",
+		mode, len(plan.Blocks), len(c.dedupeIndex), plan.TotalSize))
 }
 
 // Returns a chunk-func for blob copies
@@ -82,7 +143,7 @@ func (c *urlToBlockBlobCopier) GenerateCopyFunc(id common.ChunkID, blockIndex in
 	 * for blobs of all sizes.
 	 */
 	// Small blobs from all sources will be copied over to destination using PutBlobFromUrl
-	if c.NumChunks() == 1 && adjustedChunkSize <= int64(common.MaxPutBlobSize) {
+	if c.dedupeMode == dedupeActOff && c.NumChunks() == 1 && adjustedChunkSize <= int64(common.MaxPutBlobSize) {
 		/*
 		 * siminsavani: FYI: For GCP, if the blob is the entirety of the file, GCP still returns
 		 * invalid error from service due to PutBlockFromUrl.
@@ -104,7 +165,9 @@ func (c *urlToBlockBlobCopier) generatePutBlockFromURL(id common.ChunkID, blockI
 		// step 2: save the block ID into the list of block IDs
 		c.setBlockID(blockIndex, encodedBlockID)
 
-		if c.ChunkAlreadyTransferred(blockIndex) {
+		// In dedupe mode the chunk grid is content-defined, so the resume "already transferred" map
+		// (keyed by the uniform-grid block names) does not apply; always (re)stage the block.
+		if c.dedupeMode == dedupeActOff && c.ChunkAlreadyTransferred(blockIndex) {
 			c.jptm.LogAtLevelForCurrentTransfer(common.LogDebug, fmt.Sprintf("Skipping chunk %d as it was already transferred.", blockIndex))
 			atomic.AddInt32(&c.atomicChunksWritten, 1)
 			return
@@ -116,11 +179,19 @@ func (c *urlToBlockBlobCopier) generatePutBlockFromURL(id common.ChunkID, blockI
 		if err := c.pacer.RequestTrafficAllocation(c.jptm.Context(), adjustedChunkSize); err != nil {
 			c.jptm.FailActiveUpload("Pacing block", err)
 		}
+		// Block-level dedupe prototype: if this chunk's content already exists at the destination, either
+		// log it (shadow) or stage it from there instead of the source (enforce, with fallback to source).
+		if c.dedupeMode != dedupeActOff && c.tryDedupeStage(id, encodedBlockID, adjustedChunkSize) {
+			atomic.AddInt32(&c.atomicChunksWritten, 1)
+			return
+		}
+
 		token, err := c.jptm.GetS2SSourceTokenCredential(c.jptm.Context())
 		if err != nil {
 			c.jptm.FailActiveS2SCopy("Getting source token credential", err)
 			return
 		}
+
 		options := &blockblob.StageBlockFromURLOptions{
 			Range:                   blob.HTTPRange{Offset: id.OffsetInFile(), Count: adjustedChunkSize},
 			CPKInfo:                 c.jptm.CpkInfo(),
@@ -141,8 +212,78 @@ func (c *urlToBlockBlobCopier) generatePutBlockFromURL(id common.ChunkID, blockI
 			return
 		}
 
+		if c.dedupeMode != dedupeActOff {
+			dedupeStateForJob(c.jptm.Info().JobID).addSourceStaged(adjustedChunkSize)
+		}
+
 		atomic.AddInt32(&c.atomicChunksWritten, 1)
 	})
+}
+
+// tryDedupeStage applies the block-level dedupe decision for one chunk. It returns true only when the
+// block was fully handled by staging it from an already-migrated destination block (enforce mode on a
+// successful reference). In shadow mode, or on any miss/failure, it returns false so the caller stages
+// the block from the source as usual.
+func (c *urlToBlockBlobCopier) tryDedupeStage(id common.ChunkID, encodedBlockID string, size int64) (handled bool) {
+	st := dedupeStateForJob(c.jptm.Info().JobID)
+	target, reference := decideStaging(c.dedupeIndex, st.committed, id.OffsetInFile(), size, c.jptm.Info().Destination)
+	if !reference {
+		c.jptm.LogAtLevelForCurrentTransfer(common.LogDebug, fmt.Sprintf(
+			"dedupe-act(%s): no committed destination hash hit for offset=%d size=%d; staging from sourceURI",
+			c.dedupeMode, id.OffsetInFile(), size))
+		return false
+	}
+
+	if c.dedupeMode == dedupeActShadow {
+		st.addWouldReference(size)
+		c.jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
+			"dedupe-act(shadow): block at offset=%d size=%d WOULD be referenced from %s [%d,%d) (staging from source instead)",
+			id.OffsetInFile(), size, sanitizedDestForDedupe(target.TargetURI), target.TargetOffset, target.TargetLength))
+		return false
+	}
+
+	// enforce: stage the block from the destination sub-range, guarded by the recorded ETag.
+	c.jptm.LogAtLevelForCurrentTransfer(common.LogDebug, fmt.Sprintf(
+		"dedupe-act(enforce): committed destination hash hit for offset=%d size=%d; staging from targetURI=%s [%d,%d)",
+		id.OffsetInFile(), size, sanitizedDestForDedupe(target.TargetURI), target.TargetOffset, target.TargetOffset+target.TargetLength))
+	if err := c.stageBlockFromTarget(encodedBlockID, target); err != nil {
+		st.addFallback()
+		c.jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
+			"dedupe-act(enforce): reference to %s failed (%v); falling back to staging from source", sanitizedDestForDedupe(target.TargetURI), err))
+		return false
+	}
+	st.addReferenced(size)
+	c.jptm.LogAtLevelForCurrentTransfer(common.LogDebug, fmt.Sprintf(
+		"dedupe-act(enforce): block at offset=%d size=%d staged from %s [%d,%d)",
+		id.OffsetInFile(), size, sanitizedDestForDedupe(target.TargetURI), target.TargetOffset, target.TargetLength))
+	return true
+}
+
+// stageBlockFromTarget stages a block by copying a sub-range of an already-migrated destination blob
+// (Put Block From URL) instead of re-reading the bytes from the source. The recorded ETag is sent as an
+// If-Match on the copy source so a changed/replaced target fails fast (and the caller falls back to the
+// source). The chunk has already been paced by the caller, so it is not re-paced here.
+func (c *urlToBlockBlobCopier) stageBlockFromTarget(encodedBlockID string, target common.BlockEntry) error {
+	if target.ETag == "" {
+		return fmt.Errorf("dedupe target is missing an ETag")
+	}
+	if target.TargetLength <= 0 {
+		return fmt.Errorf("dedupe target has invalid length %d", target.TargetLength)
+	}
+	if target.TargetOffset < 0 {
+		return fmt.Errorf("dedupe target has invalid offset %d", target.TargetOffset)
+	}
+	etag := target.ETag
+	options := &blockblob.StageBlockFromURLOptions{
+		Range:        blob.HTTPRange{Offset: target.TargetOffset, Count: target.TargetLength},
+		CPKInfo:      c.jptm.CpkInfo(),
+		CPKScopeInfo: c.jptm.CpkScopeInfo(),
+		SourceModifiedAccessConditions: &blob.SourceModifiedAccessConditions{
+			SourceIfMatch: &etag,
+		},
+	}
+	_, err := c.destBlockBlobClient.StageBlockFromURL(c.jptm.Context(), encodedBlockID, target.TargetURI, options)
+	return err
 }
 
 func (c *urlToBlockBlobCopier) generateStartPutBlobFromURL(id common.ChunkID, blockIndex int32, adjustedChunkSize int64) chunkFunc {

--- a/ste/sender-blockBlobFromURL.go
+++ b/ste/sender-blockBlobFromURL.go
@@ -209,9 +209,8 @@ func configureBlockBlobDedupe(jptm IJobPartTransferMgr, c *urlToBlockBlobCopier,
 	c.blockIDs = make([]string, c.numChunks)
 	c.dedupeMode = mode
 	c.dedupePlan = plan
-	c.dedupeIndex = make(map[srcBlockKey]srcBlockHashes)
+	c.dedupeSourceCache = cloneDedupeSourceHashCache(dedupeSourceHashCache{})
 	c.dedupeETag = *resp.ETag
-	c.dedupeResolveDone = make(chan struct{})
 	st.addFileStarted()
 
 	jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
@@ -361,36 +360,39 @@ func (c *urlToBlockBlobCopier) sourceStageBlockOptions(
 // the block from the source as usual.
 func (c *urlToBlockBlobCopier) tryDedupeStage(id common.ChunkID, blockIndex int32, encodedBlockID string, size int64) (handled bool) {
 	st := dedupeStateForJob(c.jptm.Info().JobID)
-	if !c.ensureDedupeHashesResolved(st) {
-		if c.dedupeMode == dedupeActShadow {
+	resolutionReady := c.ensureDedupeHashesResolved(st)
+	if !resolutionReady && c.dedupeMode == dedupeActShadow {
+		done := c.dedupeResolutionDone()
+		if done != nil {
 			select {
-			case <-c.dedupeResolveDone:
+			case <-done:
+				resolutionReady = true
 			case <-c.jptm.Context().Done():
 				return false
 			}
-		} else {
+		}
+	}
+	index, resolveErr := c.dedupeResolutionSnapshot()
+	if _, resolved := index[srcBlockKey{offset: id.OffsetInFile(), size: size}]; !resolved {
+		if !resolutionReady {
 			c.jptm.LogAtLevelForCurrentTransfer(common.LogDebug,
 				"dedupe-act: GetBlobHash resolution is in progress; staging this block from source")
 			return false
 		}
-	}
-	if c.dedupeResolutionState() != dedupeResolveComplete {
-		c.jptm.LogAtLevelForCurrentTransfer(common.LogDebug,
-			"dedupe-act: GetBlobHash resolution did not complete; staging this block from source")
-		return false
-	}
-	if c.dedupeResolveErr != nil {
-		if isDedupePreconditionFailure(c.dedupeResolveErr) {
+		if resolveErr == nil {
+			return false
+		}
+		if isDedupePreconditionFailure(resolveErr) {
 			c.jptm.LogAtLevelForCurrentTransfer(common.LogInfo,
 				"dedupe-act: source changed before GetBlobHash; staging from source")
 		} else {
 			c.jptm.LogAtLevelForCurrentTransfer(common.LogDebug,
-				"dedupe-act: GetBlobHash failed; staging from source: "+c.dedupeResolveErr.Error())
+				"dedupe-act: GetBlobHash did not resolve this source range; staging from source: "+resolveErr.Error())
 		}
 		return false
 	}
 	targets := matchingDedupeTargets(
-		c.dedupeIndex,
+		index,
 		st.committed,
 		id.OffsetInFile(),
 		size,
@@ -398,7 +400,7 @@ func (c *urlToBlockBlobCopier) tryDedupeStage(id common.ChunkID, blockIndex int3
 	)
 	if len(targets) == 0 {
 		if hasDedupeSHAMismatch(
-			c.dedupeIndex,
+			index,
 			st.committed,
 			id.OffsetInFile(),
 			size,
@@ -536,46 +538,79 @@ func (c *urlToBlockBlobCopier) tryDedupeStage(id common.ChunkID, blockIndex int3
 }
 
 func (c *urlToBlockBlobCopier) ensureDedupeHashesResolved(st *dedupeJobState) bool {
-	switch c.dedupeResolutionState() {
-	case dedupeResolveComplete:
+	if st == nil {
 		return true
-	case dedupeResolveInProgress:
+	}
+
+	generation := st.committedGenerationValue()
+	c.dedupeResolveMu.Lock()
+	if c.dedupeResolveInProgress {
+		c.dedupeResolveMu.Unlock()
 		return false
 	}
-
-	if !c.tryStartDedupeResolution() {
-		return c.dedupeResolutionState() == dedupeResolveComplete
+	if c.dedupeResolveAttempted && c.dedupeResolvedGeneration >= generation {
+		c.dedupeResolveMu.Unlock()
+		return true
 	}
-	defer c.finishDedupeResolution()
-
-	hasher, err := newSDKDedupeRangeHasher(c.jptm, func(role string, response blockblob.GetBlobHashResponse) {
-		emitGetBlobHashCPUTime(c.jptm, c.dedupeMode, role, response)
-	})
-	if err != nil {
-		c.dedupeResolveErr = err
+	if c.dedupeSourceCache.invalid {
+		c.dedupeResolveAttempted = true
+		c.dedupeResolvedGeneration = generation
+		c.dedupeResolveMu.Unlock()
 		return true
 	}
 
-	ctx, cancel := context.WithTimeout(c.jptm.Context(), dedupeHashResolutionTimeout)
-	defer cancel()
-	c.dedupeIndex, c.dedupeResolveStats, c.dedupeResolveErr = resolveDedupeCandidateHashes(
-		ctx,
-		st,
-		c.dedupePlan,
-		c.dedupeETag,
-		c.jptm.Info().Destination,
-		hasher,
-	)
-	if c.dedupeResolveErr == nil {
-		applyResolvedSourceHashes(c.dedupePlan, c.dedupeIndex)
+	c.dedupeResolveInProgress = true
+	c.dedupeResolveDone = make(chan struct{})
+	cache := cloneDedupeSourceHashCache(c.dedupeSourceCache)
+	hasher := c.dedupeHasher
+	c.dedupeResolveMu.Unlock()
+
+	var stats dedupeHashResolutionStats
+	var err error
+	if hasher == nil {
+		hasher, err = newSDKDedupeRangeHasher(c.jptm, func(role string, response blockblob.GetBlobHashResponse) {
+			emitGetBlobHashCPUTime(c.jptm, c.dedupeMode, role, response)
+		})
 	}
-	emitDedupeHashResolutionProgress(
-		c.jptm,
-		c.dedupeMode,
-		c.dedupeResolveStats,
-		c.dedupeResolveErr,
-	)
+	if err == nil {
+		ctx, cancel := context.WithTimeout(c.jptm.Context(), dedupeHashResolutionTimeout)
+		cache, stats, err = resolveDedupeCandidateHashesIncremental(
+			ctx,
+			st,
+			c.dedupePlan,
+			c.dedupeETag,
+			c.jptm.Info().Destination,
+			hasher,
+			cache,
+		)
+		cancel()
+		applyResolvedSourceHashes(c.dedupePlan, cache.hashes)
+	}
+
+	c.dedupeResolveMu.Lock()
+	c.dedupeSourceCache = cache
+	c.dedupeResolveStats = stats
+	c.dedupeResolveErr = err
+	c.dedupeResolveAttempted = true
+	c.dedupeResolvedGeneration = generation
+	c.dedupeResolveInProgress = false
+	close(c.dedupeResolveDone)
+	c.dedupeResolveMu.Unlock()
+
+	emitDedupeHashResolutionProgress(c.jptm, c.dedupeMode, stats, err)
 	return true
+}
+
+func (c *urlToBlockBlobCopier) dedupeResolutionSnapshot() (map[srcBlockKey]srcBlockHashes, error) {
+	c.dedupeResolveMu.Lock()
+	defer c.dedupeResolveMu.Unlock()
+	return c.dedupeSourceCache.hashes, c.dedupeResolveErr
+}
+
+func (c *urlToBlockBlobCopier) dedupeResolutionDone() <-chan struct{} {
+	c.dedupeResolveMu.Lock()
+	defer c.dedupeResolveMu.Unlock()
+	return c.dedupeResolveDone
 }
 
 type dedupeTargetStageAttempt struct {

--- a/ste/sender-blockBlobFromURL.go
+++ b/ste/sender-blockBlobFromURL.go
@@ -138,6 +138,10 @@ func configureBlockBlobDedupe(jptm IJobPartTransferMgr, c *urlToBlockBlobCopier,
 		preflightFailed("source_block_list", "source has no committed named blocks")
 		return // single-PutBlob or empty source: no committed blocks to align to
 	}
+	if resp.ETag == nil || *resp.ETag == "" {
+		preflightFailed("source_block_list", "source block list response has no ETag")
+		return
+	}
 	plan, err := buildSourceGridPlan(rawCommittedBlocksFromResponse(resp))
 	if err != nil {
 		preflightFailed("source_block_list", err.Error())
@@ -161,21 +165,35 @@ func configureBlockBlobDedupe(jptm IJobPartTransferMgr, c *urlToBlockBlobCopier,
 		return
 	}
 
-	dedupeIndex := buildSourceBlockHashIndex(plan)
-	if len(dedupeIndex) == 0 {
-		preflightFailed("source_hashes", "source block list contains no complete CRC64 and SHA256 pairs")
+	crcBlocks := countSourceGridCRCBlocks(plan)
+	if crcBlocks == 0 {
+		preflightFailed("source_hashes", "source block list contains no valid CRC64 values")
 		jptm.LogAtLevelForCurrentTransfer(common.LogDebug,
-			"dedupe-act: source block list contained no complete hashes, using uniform grid")
+			"dedupe-act: source block list contained no valid CRC64 values, using uniform grid")
 		return
 	}
+	discoveredBlocks, discoveredBytes := st.addCRCDiscovery(plan)
+	emitDedupeProgress(jptm, dedupeProgressMessage(
+		"crc_only_discovery",
+		mode,
+		info,
+		fmt.Sprintf(
+			"sourceBlocks=%d crcBlocks=%d crcBytes=%d sourceETag=%q",
+			len(plan.Blocks),
+			discoveredBlocks,
+			discoveredBytes,
+			*resp.ETag,
+		),
+		st.progressSnapshot(),
+	))
 	emitDedupeProgress(jptm, dedupeProgressMessage(
 		"chunk_plan_validated",
 		mode,
 		info,
 		fmt.Sprintf(
-			"sourceBlocks=%d hashedBlocks=%d plannedChunks=%d plannedBytes=%d sourceBytes=%d",
+			"sourceBlocks=%d crcBlocks=%d plannedChunks=%d plannedBytes=%d sourceBytes=%d",
 			len(plan.Blocks),
-			len(dedupeIndex),
+			crcBlocks,
 			len(plan.Blocks),
 			plan.TotalSize,
 			info.SourceSize,
@@ -187,19 +205,33 @@ func configureBlockBlobDedupe(jptm IJobPartTransferMgr, c *urlToBlockBlobCopier,
 	c.blockIDs = make([]string, c.numChunks)
 	c.dedupeMode = mode
 	c.dedupePlan = plan
-	c.dedupeIndex = dedupeIndex
+	c.dedupeIndex = make(map[srcBlockKey]srcBlockHashes)
+	c.dedupeETag = *resp.ETag
 	st.addFileStarted()
 
 	jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
-		"dedupe-act(%s): source-grid chunking armed: %d block(s), %d with hashes, totalSize=%d",
-		mode, len(plan.Blocks), len(c.dedupeIndex), plan.TotalSize))
+		"dedupe-act(%s): source-grid chunking armed: %d block(s), %d with CRC64, totalSize=%d",
+		mode, len(plan.Blocks), crcBlocks, plan.TotalSize))
 	emitDedupeProgress(jptm, dedupeProgressMessage(
 		"file_start",
 		mode,
 		jptm.Info(),
-		fmt.Sprintf("source=%q sourceBlocks=%d hashedBlocks=%d fileBytes=%d",
-			sanitizedDestForDedupe(jptm.Info().Source), len(plan.Blocks), len(c.dedupeIndex), plan.TotalSize),
+		fmt.Sprintf("source=%q sourceBlocks=%d crcBlocks=%d fileBytes=%d",
+			sanitizedDestForDedupe(jptm.Info().Source), len(plan.Blocks), crcBlocks, plan.TotalSize),
 		st.progressSnapshot()))
+}
+
+func countSourceGridCRCBlocks(plan *SourceGridPlan) int {
+	if plan == nil {
+		return 0
+	}
+	count := 0
+	for _, block := range plan.Blocks {
+		if blockHasCRC64(block) {
+			count++
+		}
+	}
+	return count
 }
 
 // Returns a chunk-func for blob copies
@@ -263,12 +295,11 @@ func (c *urlToBlockBlobCopier) generatePutBlockFromURL(id common.ChunkID, blockI
 			return
 		}
 
-		options := &blockblob.StageBlockFromURLOptions{
-			Range:                   blob.HTTPRange{Offset: id.OffsetInFile(), Count: adjustedChunkSize},
-			CPKInfo:                 c.jptm.CpkInfo(),
-			CPKScopeInfo:            c.jptm.CpkScopeInfo(),
-			CopySourceAuthorization: token,
-		}
+		options := c.sourceStageBlockOptions(
+			id.OffsetInFile(),
+			adjustedChunkSize,
+			token,
+		)
 
 		// Informs SDK to add xms-file-request-intent header
 		if c.addFileRequestIntent {
@@ -299,19 +330,115 @@ func (c *urlToBlockBlobCopier) generatePutBlockFromURL(id common.ChunkID, blockI
 	})
 }
 
+func (c *urlToBlockBlobCopier) sourceStageBlockOptions(
+	offset int64,
+	count int64,
+	token *string,
+) *blockblob.StageBlockFromURLOptions {
+	options := &blockblob.StageBlockFromURLOptions{
+		Range:                   blob.HTTPRange{Offset: offset, Count: count},
+		CPKInfo:                 c.jptm.CpkInfo(),
+		CPKScopeInfo:            c.jptm.CpkScopeInfo(),
+		CopySourceAuthorization: token,
+	}
+	if c.dedupeMode != dedupeActOff && c.dedupeETag != "" {
+		etag := c.dedupeETag
+		options.SourceModifiedAccessConditions = &blob.SourceModifiedAccessConditions{
+			SourceIfMatch: &etag,
+		}
+	}
+	return options
+}
+
 // tryDedupeStage applies the block-level dedupe decision for one chunk. It returns true only when the
 // block was fully handled by staging it from an already-migrated destination block (enforce mode on a
 // successful reference). In shadow mode, or on any miss/failure, it returns false so the caller stages
 // the block from the source as usual.
 func (c *urlToBlockBlobCopier) tryDedupeStage(id common.ChunkID, blockIndex int32, encodedBlockID string, size int64) (handled bool) {
 	st := dedupeStateForJob(c.jptm.Info().JobID)
-	target, reference := decideStaging(c.dedupeIndex, st.committed, id.OffsetInFile(), size, c.jptm.Info().Destination)
-	if !reference {
+	c.dedupeResolveOnce.Do(func() {
+		hasher, err := newSDKDedupeRangeHasher(c.jptm, func(role string, response blockblob.GetBlobHashResponse) {
+			emitGetBlobHashCPUTime(c.jptm, c.dedupeMode, role, response)
+		})
+		if err != nil {
+			c.dedupeResolveErr = err
+			return
+		}
+		c.dedupeIndex, c.dedupeResolveStats, c.dedupeResolveErr = resolveDedupeCandidateHashes(
+			c.jptm.Context(),
+			st,
+			c.dedupePlan,
+			c.dedupeETag,
+			c.jptm.Info().Destination,
+			hasher,
+		)
+		if c.dedupeResolveErr == nil {
+			applyResolvedSourceHashes(c.dedupePlan, c.dedupeIndex)
+		}
+		emitDedupeHashResolutionProgress(
+			c.jptm,
+			c.dedupeMode,
+			c.dedupeResolveStats,
+			c.dedupeResolveErr,
+		)
+	})
+	if c.dedupeResolveErr != nil {
+		if isDedupePreconditionFailure(c.dedupeResolveErr) {
+			c.jptm.LogAtLevelForCurrentTransfer(common.LogInfo,
+				"dedupe-act: source changed before GetBlobHash; staging from source")
+		} else {
+			c.jptm.LogAtLevelForCurrentTransfer(common.LogDebug,
+				"dedupe-act: GetBlobHash failed; staging from source: "+c.dedupeResolveErr.Error())
+		}
+		return false
+	}
+	targets := matchingDedupeTargets(
+		c.dedupeIndex,
+		st.committed,
+		id.OffsetInFile(),
+		size,
+		c.jptm.Info().Destination,
+	)
+	if len(targets) == 0 {
+		if hasDedupeSHAMismatch(
+			c.dedupeIndex,
+			st.committed,
+			id.OffsetInFile(),
+			size,
+			c.jptm.Info().Destination,
+		) {
+			st.addSHAMismatch()
+			emitDedupeProgress(c.jptm, dedupeProgressMessage(
+				"sha_mismatch",
+				c.dedupeMode,
+				c.jptm.Info(),
+				fmt.Sprintf("blockIndex=%d sourceOffset=%d blockBytes=%d",
+					blockIndex, id.OffsetInFile(), size),
+				st.progressSnapshot(),
+			))
+		}
 		c.jptm.LogAtLevelForCurrentTransfer(common.LogDebug, fmt.Sprintf(
 			"dedupe-act(%s): no committed destination hash hit for offset=%d size=%d; staging from sourceURI",
 			c.dedupeMode, id.OffsetInFile(), size))
 		return false
 	}
+	target := targets[0]
+	st.addSHAConfirmed()
+	emitDedupeProgress(c.jptm, dedupeProgressMessage(
+		"sha_confirmed",
+		c.dedupeMode,
+		c.jptm.Info(),
+		fmt.Sprintf(
+			"blockIndex=%d sourceOffset=%d blockBytes=%d targetURI=%q targetOffset=%d targetLength=%d",
+			blockIndex,
+			id.OffsetInFile(),
+			size,
+			sanitizedDestForDedupe(target.TargetURI),
+			target.TargetOffset,
+			target.TargetLength,
+		),
+		st.progressSnapshot(),
+	))
 
 	if c.dedupeMode == dedupeActShadow {
 		st.addWouldReference(size)
@@ -327,37 +454,107 @@ func (c *urlToBlockBlobCopier) tryDedupeStage(id common.ChunkID, blockIndex int3
 		return false
 	}
 
-	// enforce: stage the block from the destination sub-range, guarded by the recorded ETag.
-	c.jptm.LogAtLevelForCurrentTransfer(common.LogDebug, fmt.Sprintf(
-		"dedupe-act(enforce): committed destination hash hit for offset=%d size=%d; staging from targetURI=%s [%d,%d)",
-		id.OffsetInFile(), size, sanitizedDestForDedupe(target.TargetURI), target.TargetOffset, target.TargetOffset+target.TargetLength))
-	if err := c.stageBlockFromTarget(encodedBlockID, target); err != nil {
-		st.addFallback()
-		c.jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
-			"dedupe-act(enforce): reference to %s failed (%v); falling back to staging from source", sanitizedDestForDedupe(target.TargetURI), err))
+	// Enforce: try every safe matching occurrence before falling back to the source.
+	selected, attempts, staged := stageDedupeTargetCandidates(
+		targets,
+		func(candidate common.BlockEntry) error {
+			c.jptm.LogAtLevelForCurrentTransfer(common.LogDebug, fmt.Sprintf(
+				"dedupe-act(enforce): committed destination hash hit for offset=%d size=%d; staging from targetURI=%s [%d,%d)",
+				id.OffsetInFile(), size, sanitizedDestForDedupe(candidate.TargetURI),
+				candidate.TargetOffset, candidate.TargetOffset+candidate.TargetLength))
+			return c.stageBlockFromTarget(encodedBlockID, candidate)
+		},
+	)
+	for targetIndex, attempt := range attempts {
+		candidate := attempt.target
+		if attempt.err != nil {
+			st.committed.RemoveTargetOccurrence(
+				candidate.TargetURI,
+				candidate.TargetOffset,
+				candidate.TargetLength,
+				candidate.ETag,
+			)
+			c.jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
+				"dedupe-act(enforce): reference attempt %d/%d to %s failed (%v)",
+				targetIndex+1, len(targets), sanitizedDestForDedupe(candidate.TargetURI), attempt.err))
+			emitDedupeProgress(c.jptm, dedupeProgressMessage(
+				"target_reuse_attempt_failed",
+				c.dedupeMode,
+				c.jptm.Info(),
+				fmt.Sprintf(
+					"blockIndex=%d sourceOffset=%d blockBytes=%d targetIndex=%d targetCount=%d "+
+						"targetURI=%q targetOffset=%d targetLength=%d",
+					blockIndex, id.OffsetInFile(), size, targetIndex, len(targets),
+					sanitizedDestForDedupe(candidate.TargetURI),
+					candidate.TargetOffset, candidate.TargetLength),
+				st.progressSnapshot(),
+			))
+			if isDedupePreconditionFailure(attempt.err) {
+				removed := st.committed.RemoveTargetEpoch(candidate.TargetURI, candidate.ETag)
+				st.addHashResolution(dedupeHashResolutionStats{targetEpochInvalidations: 1})
+				emitDedupeProgress(c.jptm, dedupeProgressMessage(
+					"epoch_invalidated_412",
+					c.dedupeMode,
+					c.jptm.Info(),
+					fmt.Sprintf(
+						"role=%q targetURI=%q removedEntries=%d",
+						"target_stage",
+						sanitizedDestForDedupe(candidate.TargetURI),
+						removed,
+					),
+					st.progressSnapshot(),
+				))
+			}
+		}
+	}
+	if staged {
+		st.addReferenced(size)
+		c.jptm.LogAtLevelForCurrentTransfer(common.LogDebug, fmt.Sprintf(
+			"dedupe-act(enforce): block at offset=%d size=%d staged from %s [%d,%d)",
+			id.OffsetInFile(), size, sanitizedDestForDedupe(selected.TargetURI),
+			selected.TargetOffset, selected.TargetLength))
 		emitDedupeProgress(c.jptm, dedupeProgressMessage(
-			"target_reuse_fallback",
+			"target_reuse",
 			c.dedupeMode,
 			c.jptm.Info(),
 			fmt.Sprintf("blockIndex=%d sourceOffset=%d blockBytes=%d targetURI=%q targetOffset=%d targetLength=%d",
-				blockIndex, id.OffsetInFile(), size, sanitizedDestForDedupe(target.TargetURI),
-				target.TargetOffset, target.TargetLength),
+				blockIndex, id.OffsetInFile(), size, sanitizedDestForDedupe(selected.TargetURI),
+				selected.TargetOffset, selected.TargetLength),
 			st.progressSnapshot()))
-		return false
+		return true
 	}
-	st.addReferenced(size)
-	c.jptm.LogAtLevelForCurrentTransfer(common.LogDebug, fmt.Sprintf(
-		"dedupe-act(enforce): block at offset=%d size=%d staged from %s [%d,%d)",
-		id.OffsetInFile(), size, sanitizedDestForDedupe(target.TargetURI), target.TargetOffset, target.TargetLength))
+
+	st.addFallback()
+	c.jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
+		"dedupe-act(enforce): all %d target reference attempts failed; falling back to staging from source",
+		len(targets)))
 	emitDedupeProgress(c.jptm, dedupeProgressMessage(
-		"target_reuse",
+		"target_reuse_fallback",
 		c.dedupeMode,
 		c.jptm.Info(),
-		fmt.Sprintf("blockIndex=%d sourceOffset=%d blockBytes=%d targetURI=%q targetOffset=%d targetLength=%d",
-			blockIndex, id.OffsetInFile(), size, sanitizedDestForDedupe(target.TargetURI),
-			target.TargetOffset, target.TargetLength),
+		fmt.Sprintf("blockIndex=%d sourceOffset=%d blockBytes=%d attemptedTargets=%d",
+			blockIndex, id.OffsetInFile(), size, len(targets)),
 		st.progressSnapshot()))
-	return true
+	return false
+}
+
+type dedupeTargetStageAttempt struct {
+	target common.BlockEntry
+	err    error
+}
+
+func stageDedupeTargetCandidates(
+	targets []common.BlockEntry,
+	stage func(common.BlockEntry) error,
+) (selected common.BlockEntry, attempts []dedupeTargetStageAttempt, staged bool) {
+	for _, target := range targets {
+		err := stage(target)
+		attempts = append(attempts, dedupeTargetStageAttempt{target: target, err: err})
+		if err == nil {
+			return target, attempts, true
+		}
+	}
+	return common.BlockEntry{}, attempts, false
 }
 
 // stageBlockFromTarget stages a block by copying a sub-range of an already-migrated destination blob

--- a/ste/sender-blockBlobFromURL.go
+++ b/ste/sender-blockBlobFromURL.go
@@ -89,12 +89,38 @@ func configureBlockBlobDedupe(jptm IJobPartTransferMgr, c *urlToBlockBlobCopier,
 	if mode == dedupeActOff {
 		return
 	}
+	info := jptm.Info()
+	setDedupeActModeForJob(info.JobID, mode)
+	st := dedupeStateForJob(info.JobID)
+	emitDedupeProgress(jptm, dedupeProgressMessage(
+		"preflight_start",
+		mode,
+		info,
+		"stage=\"source_grid\"",
+		st.progressSnapshot()))
+
+	preflightFailed := func(stage, reason string) {
+		emitDedupeProgress(jptm, dedupeProgressMessage(
+			"preflight_failed",
+			mode,
+			info,
+			fmt.Sprintf(
+				"stage=%q reason=%q action=%q",
+				stage,
+				reason,
+				"uniform_grid",
+			),
+			st.progressSnapshot()))
+	}
+
 	blobSrc, ok := srcInfoProvider.(IBlobSourceInfoProvider)
 	if !ok || blobSrc.BlobType() != blob.BlobTypeBlockBlob {
+		preflightFailed("source_type", "source is not a block blob")
 		return
 	}
 	_, destinationSAS := jptm.SAS()
 	if !dedupeActDestinationReady(mode, destinationSAS) {
+		preflightFailed("destination_auth", "destination SAS is unavailable")
 		jptm.LogAtLevelForCurrentTransfer(common.LogDebug,
 			"dedupe-act(enforce): destination SAS is unavailable, using uniform grid")
 		return
@@ -102,27 +128,51 @@ func configureBlockBlobDedupe(jptm IJobPartTransferMgr, c *urlToBlockBlobCopier,
 
 	plan, err := fetchSourceGridPlan(jptm)
 	if err != nil {
+		preflightFailed("source_block_list", err.Error())
 		jptm.LogAtLevelForCurrentTransfer(common.LogDebug, "dedupe-act: GetBlockList failed, using uniform grid: "+err.Error())
 		return
 	}
 	if plan == nil || len(plan.Blocks) == 0 {
+		preflightFailed("source_block_list", "source has no committed named blocks")
 		return // single-PutBlob or empty source: no committed blocks to align to
 	}
-	if plan.TotalSize != jptm.Info().SourceSize {
+	if plan.TotalSize != info.SourceSize {
+		preflightFailed(
+			"source_grid",
+			fmt.Sprintf("planned bytes %d do not match source bytes %d", plan.TotalSize, info.SourceSize),
+		)
 		jptm.LogAtLevelForCurrentTransfer(common.LogDebug, fmt.Sprintf(
-			"dedupe-act: source-grid total %d != source size %d, using uniform grid", plan.TotalSize, jptm.Info().SourceSize))
+			"dedupe-act: source-grid total %d != source size %d, using uniform grid", plan.TotalSize, info.SourceSize))
 		return
 	}
 	if len(plan.Blocks) > common.MaxNumberOfBlocksPerBlob {
+		preflightFailed(
+			"source_grid",
+			fmt.Sprintf("source block count %d exceeds maximum %d", len(plan.Blocks), common.MaxNumberOfBlocksPerBlob),
+		)
 		return
 	}
 
 	dedupeIndex := buildSourceBlockHashIndex(plan)
 	if len(dedupeIndex) == 0 {
+		preflightFailed("source_hashes", "source block list contains no complete CRC64 and SHA256 pairs")
 		jptm.LogAtLevelForCurrentTransfer(common.LogDebug,
 			"dedupe-act: source block list contained no complete hashes, using uniform grid")
 		return
 	}
+	emitDedupeProgress(jptm, dedupeProgressMessage(
+		"chunk_plan_validated",
+		mode,
+		info,
+		fmt.Sprintf(
+			"sourceBlocks=%d hashedBlocks=%d plannedChunks=%d plannedBytes=%d sourceBytes=%d",
+			len(plan.Blocks),
+			len(dedupeIndex),
+			len(plan.Blocks),
+			plan.TotalSize,
+			info.SourceSize,
+		),
+		st.progressSnapshot()))
 
 	// One chunk per source committed block.
 	c.numChunks = uint32(len(plan.Blocks))
@@ -130,8 +180,6 @@ func configureBlockBlobDedupe(jptm IJobPartTransferMgr, c *urlToBlockBlobCopier,
 	c.dedupeMode = mode
 	c.dedupePlan = plan
 	c.dedupeIndex = dedupeIndex
-	setDedupeActModeForJob(jptm.Info().JobID, mode)
-	st := dedupeStateForJob(jptm.Info().JobID)
 	st.addFileStarted()
 
 	jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(

--- a/ste/sender-blockBlobFromURL.go
+++ b/ste/sender-blockBlobFromURL.go
@@ -361,7 +361,7 @@ func (c *urlToBlockBlobCopier) sourceStageBlockOptions(
 func (c *urlToBlockBlobCopier) tryDedupeStage(id common.ChunkID, blockIndex int32, encodedBlockID string, size int64) (handled bool) {
 	st := dedupeStateForJob(c.jptm.Info().JobID)
 	resolutionReady := c.ensureDedupeHashesResolved(st)
-	if !resolutionReady && c.dedupeMode == dedupeActShadow {
+	if !resolutionReady {
 		done := c.dedupeResolutionDone()
 		if done != nil {
 			select {

--- a/ste/sender-blockBlobFromURL.go
+++ b/ste/sender-blockBlobFromURL.go
@@ -126,15 +126,23 @@ func configureBlockBlobDedupe(jptm IJobPartTransferMgr, c *urlToBlockBlobCopier,
 		return
 	}
 
-	plan, err := fetchSourceGridPlan(jptm)
+	resp, err := getSourceBlockList(jptm)
 	if err != nil {
 		preflightFailed("source_block_list", err.Error())
 		jptm.LogAtLevelForCurrentTransfer(common.LogDebug, "dedupe-act: GetBlockList failed, using uniform grid: "+err.Error())
 		return
 	}
-	if plan == nil || len(plan.Blocks) == 0 {
+	emitHashCPUTime(jptm, mode, resp)
+
+	if len(resp.CommittedBlocks) == 0 {
 		preflightFailed("source_block_list", "source has no committed named blocks")
 		return // single-PutBlob or empty source: no committed blocks to align to
+	}
+	plan, err := buildSourceGridPlan(rawCommittedBlocksFromResponse(resp))
+	if err != nil {
+		preflightFailed("source_block_list", err.Error())
+		jptm.LogAtLevelForCurrentTransfer(common.LogDebug, "dedupe-act: GetBlockList failed, using uniform grid: "+err.Error())
+		return
 	}
 	if plan.TotalSize != info.SourceSize {
 		preflightFailed(

--- a/ste/sender-blockBlobFromURL.go
+++ b/ste/sender-blockBlobFromURL.go
@@ -131,10 +131,19 @@ func configureBlockBlobDedupe(jptm IJobPartTransferMgr, c *urlToBlockBlobCopier,
 	c.dedupePlan = plan
 	c.dedupeIndex = dedupeIndex
 	setDedupeActModeForJob(jptm.Info().JobID, mode)
+	st := dedupeStateForJob(jptm.Info().JobID)
+	st.addFileStarted()
 
 	jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
 		"dedupe-act(%s): source-grid chunking armed: %d block(s), %d with hashes, totalSize=%d",
 		mode, len(plan.Blocks), len(c.dedupeIndex), plan.TotalSize))
+	emitDedupeProgress(jptm, dedupeProgressMessage(
+		"file_start",
+		mode,
+		jptm.Info(),
+		fmt.Sprintf("source=%q sourceBlocks=%d hashedBlocks=%d fileBytes=%d",
+			sanitizedDestForDedupe(jptm.Info().Source), len(plan.Blocks), len(c.dedupeIndex), plan.TotalSize),
+		st.progressSnapshot()))
 }
 
 // Returns a chunk-func for blob copies
@@ -187,7 +196,7 @@ func (c *urlToBlockBlobCopier) generatePutBlockFromURL(id common.ChunkID, blockI
 		}
 		// Block-level dedupe prototype: if this chunk's content already exists at the destination, either
 		// log it (shadow) or stage it from there instead of the source (enforce, with fallback to source).
-		if c.dedupeMode != dedupeActOff && c.tryDedupeStage(id, encodedBlockID, adjustedChunkSize) {
+		if c.dedupeMode != dedupeActOff && c.tryDedupeStage(id, blockIndex, encodedBlockID, adjustedChunkSize) {
 			atomic.AddInt32(&c.atomicChunksWritten, 1)
 			return
 		}
@@ -219,7 +228,15 @@ func (c *urlToBlockBlobCopier) generatePutBlockFromURL(id common.ChunkID, blockI
 		}
 
 		if c.dedupeMode != dedupeActOff {
-			dedupeStateForJob(c.jptm.Info().JobID).addSourceStaged(adjustedChunkSize)
+			st := dedupeStateForJob(c.jptm.Info().JobID)
+			st.addSourceStaged(adjustedChunkSize)
+			emitDedupeProgress(c.jptm, dedupeProgressMessage(
+				"source_block_transferred",
+				c.dedupeMode,
+				c.jptm.Info(),
+				fmt.Sprintf("blockIndex=%d sourceOffset=%d blockBytes=%d",
+					blockIndex, id.OffsetInFile(), adjustedChunkSize),
+				st.progressSnapshot()))
 		}
 
 		atomic.AddInt32(&c.atomicChunksWritten, 1)
@@ -230,7 +247,7 @@ func (c *urlToBlockBlobCopier) generatePutBlockFromURL(id common.ChunkID, blockI
 // block was fully handled by staging it from an already-migrated destination block (enforce mode on a
 // successful reference). In shadow mode, or on any miss/failure, it returns false so the caller stages
 // the block from the source as usual.
-func (c *urlToBlockBlobCopier) tryDedupeStage(id common.ChunkID, encodedBlockID string, size int64) (handled bool) {
+func (c *urlToBlockBlobCopier) tryDedupeStage(id common.ChunkID, blockIndex int32, encodedBlockID string, size int64) (handled bool) {
 	st := dedupeStateForJob(c.jptm.Info().JobID)
 	target, reference := decideStaging(c.dedupeIndex, st.committed, id.OffsetInFile(), size, c.jptm.Info().Destination)
 	if !reference {
@@ -245,6 +262,12 @@ func (c *urlToBlockBlobCopier) tryDedupeStage(id common.ChunkID, encodedBlockID 
 		c.jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
 			"dedupe-act(shadow): block at offset=%d size=%d WOULD be referenced from %s [%d,%d) (staging from source instead)",
 			id.OffsetInFile(), size, sanitizedDestForDedupe(target.TargetURI), target.TargetOffset, target.TargetLength))
+		emitDedupeProgress(c.jptm, fmt.Sprintf(
+			"%s event=target_reuse_candidate mode=%s jobId=%s file=%q destination=%q "+
+				"blockIndex=%d sourceOffset=%d blockBytes=%d targetURI=%q targetOffset=%d targetLength=%d",
+			dedupeProgressPrefix, c.dedupeMode, c.jptm.Info().JobID.String(), c.jptm.Info().DstFilePath,
+			sanitizedDestForDedupe(c.jptm.Info().Destination), blockIndex, id.OffsetInFile(), size,
+			sanitizedDestForDedupe(target.TargetURI), target.TargetOffset, target.TargetLength))
 		return false
 	}
 
@@ -256,12 +279,28 @@ func (c *urlToBlockBlobCopier) tryDedupeStage(id common.ChunkID, encodedBlockID 
 		st.addFallback()
 		c.jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
 			"dedupe-act(enforce): reference to %s failed (%v); falling back to staging from source", sanitizedDestForDedupe(target.TargetURI), err))
+		emitDedupeProgress(c.jptm, dedupeProgressMessage(
+			"target_reuse_fallback",
+			c.dedupeMode,
+			c.jptm.Info(),
+			fmt.Sprintf("blockIndex=%d sourceOffset=%d blockBytes=%d targetURI=%q targetOffset=%d targetLength=%d",
+				blockIndex, id.OffsetInFile(), size, sanitizedDestForDedupe(target.TargetURI),
+				target.TargetOffset, target.TargetLength),
+			st.progressSnapshot()))
 		return false
 	}
 	st.addReferenced(size)
 	c.jptm.LogAtLevelForCurrentTransfer(common.LogDebug, fmt.Sprintf(
 		"dedupe-act(enforce): block at offset=%d size=%d staged from %s [%d,%d)",
 		id.OffsetInFile(), size, sanitizedDestForDedupe(target.TargetURI), target.TargetOffset, target.TargetLength))
+	emitDedupeProgress(c.jptm, dedupeProgressMessage(
+		"target_reuse",
+		c.dedupeMode,
+		c.jptm.Info(),
+		fmt.Sprintf("blockIndex=%d sourceOffset=%d blockBytes=%d targetURI=%q targetOffset=%d targetLength=%d",
+			blockIndex, id.OffsetInFile(), size, sanitizedDestForDedupe(target.TargetURI),
+			target.TargetOffset, target.TargetLength),
+		st.progressSnapshot()))
 	return true
 }
 

--- a/ste/sender-blockBlobFromURL.go
+++ b/ste/sender-blockBlobFromURL.go
@@ -71,7 +71,7 @@ func newURLToBlockBlobCopier(jptm IJobPartTransferMgr, pacer pacer, srcInfoProvi
 	}
 	copier := &urlToBlockBlobCopier{
 		blockBlobSenderBase:  *senderBase,
-		srcURL:              srcURL,
+		srcURL:               srcURL,
 		addFileRequestIntent: intentBool,
 	}
 
@@ -209,7 +209,9 @@ func configureBlockBlobDedupe(jptm IJobPartTransferMgr, c *urlToBlockBlobCopier,
 	c.blockIDs = make([]string, c.numChunks)
 	c.dedupeMode = mode
 	c.dedupePlan = plan
-	c.dedupeSourceCache = cloneDedupeSourceHashCache(dedupeSourceHashCache{})
+	c.dedupeSourceHashState = cloneDedupeSourceHashResolutionState(
+		dedupeSourceHashResolutionState{},
+	)
 	c.dedupeETag = *resp.ETag
 	st.addFileStarted()
 
@@ -552,7 +554,7 @@ func (c *urlToBlockBlobCopier) ensureDedupeHashesResolved(st *dedupeJobState) bo
 		c.dedupeResolveMu.Unlock()
 		return true
 	}
-	if c.dedupeSourceCache.invalid {
+	if c.dedupeSourceHashState.invalid {
 		c.dedupeResolveAttempted = true
 		c.dedupeResolvedGeneration = generation
 		c.dedupeResolveMu.Unlock()
@@ -561,7 +563,7 @@ func (c *urlToBlockBlobCopier) ensureDedupeHashesResolved(st *dedupeJobState) bo
 
 	c.dedupeResolveInProgress = true
 	c.dedupeResolveDone = make(chan struct{})
-	cache := cloneDedupeSourceHashCache(c.dedupeSourceCache)
+	sourceState := cloneDedupeSourceHashResolutionState(c.dedupeSourceHashState)
 	hasher := c.dedupeHasher
 	c.dedupeResolveMu.Unlock()
 
@@ -574,21 +576,21 @@ func (c *urlToBlockBlobCopier) ensureDedupeHashesResolved(st *dedupeJobState) bo
 	}
 	if err == nil {
 		ctx, cancel := context.WithTimeout(c.jptm.Context(), dedupeHashResolutionTimeout)
-		cache, stats, err = resolveDedupeCandidateHashesIncremental(
+		sourceState, stats, err = resolveDedupeCandidateHashesIncremental(
 			ctx,
 			st,
 			c.dedupePlan,
 			c.dedupeETag,
 			c.jptm.Info().Destination,
 			hasher,
-			cache,
+			sourceState,
 		)
 		cancel()
-		applyResolvedSourceHashes(c.dedupePlan, cache.hashes)
+		applyResolvedSourceHashes(c.dedupePlan, sourceState.hashes)
 	}
 
 	c.dedupeResolveMu.Lock()
-	c.dedupeSourceCache = cache
+	c.dedupeSourceHashState = sourceState
 	c.dedupeResolveStats = stats
 	c.dedupeResolveErr = err
 	c.dedupeResolveAttempted = true
@@ -604,7 +606,7 @@ func (c *urlToBlockBlobCopier) ensureDedupeHashesResolved(st *dedupeJobState) bo
 func (c *urlToBlockBlobCopier) dedupeResolutionSnapshot() (map[srcBlockKey]srcBlockHashes, error) {
 	c.dedupeResolveMu.Lock()
 	defer c.dedupeResolveMu.Unlock()
-	return c.dedupeSourceCache.hashes, c.dedupeResolveErr
+	return c.dedupeSourceHashState.hashes, c.dedupeResolveErr
 }
 
 func (c *urlToBlockBlobCopier) dedupeResolutionDone() <-chan struct{} {

--- a/ste/sender-blockBlobFromURL.go
+++ b/ste/sender-blockBlobFromURL.go
@@ -93,6 +93,12 @@ func configureBlockBlobDedupe(jptm IJobPartTransferMgr, c *urlToBlockBlobCopier,
 	if !ok || blobSrc.BlobType() != blob.BlobTypeBlockBlob {
 		return
 	}
+	_, destinationSAS := jptm.SAS()
+	if !dedupeActDestinationReady(mode, destinationSAS) {
+		jptm.LogAtLevelForCurrentTransfer(common.LogDebug,
+			"dedupe-act(enforce): destination SAS is unavailable, using uniform grid")
+		return
+	}
 
 	plan, err := fetchSourceGridPlan(jptm)
 	if err != nil {

--- a/ste/sender-blockBlobFromURL.go
+++ b/ste/sender-blockBlobFromURL.go
@@ -21,8 +21,10 @@
 package ste
 
 import (
+	"context"
 	"fmt"
 	"sync/atomic"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
@@ -30,6 +32,8 @@ import (
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
+
+const dedupeHashResolutionTimeout = 30 * time.Second
 
 // urlToBlockBlobCopier extends blockBlobSenderBase parent to include URL-specific functionality
 type urlToBlockBlobCopier struct {
@@ -207,6 +211,7 @@ func configureBlockBlobDedupe(jptm IJobPartTransferMgr, c *urlToBlockBlobCopier,
 	c.dedupePlan = plan
 	c.dedupeIndex = make(map[srcBlockKey]srcBlockHashes)
 	c.dedupeETag = *resp.ETag
+	c.dedupeResolveDone = make(chan struct{})
 	st.addFileStarted()
 
 	jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
@@ -356,32 +361,24 @@ func (c *urlToBlockBlobCopier) sourceStageBlockOptions(
 // the block from the source as usual.
 func (c *urlToBlockBlobCopier) tryDedupeStage(id common.ChunkID, blockIndex int32, encodedBlockID string, size int64) (handled bool) {
 	st := dedupeStateForJob(c.jptm.Info().JobID)
-	c.dedupeResolveOnce.Do(func() {
-		hasher, err := newSDKDedupeRangeHasher(c.jptm, func(role string, response blockblob.GetBlobHashResponse) {
-			emitGetBlobHashCPUTime(c.jptm, c.dedupeMode, role, response)
-		})
-		if err != nil {
-			c.dedupeResolveErr = err
-			return
+	if !c.ensureDedupeHashesResolved(st) {
+		if c.dedupeMode == dedupeActShadow {
+			select {
+			case <-c.dedupeResolveDone:
+			case <-c.jptm.Context().Done():
+				return false
+			}
+		} else {
+			c.jptm.LogAtLevelForCurrentTransfer(common.LogDebug,
+				"dedupe-act: GetBlobHash resolution is in progress; staging this block from source")
+			return false
 		}
-		c.dedupeIndex, c.dedupeResolveStats, c.dedupeResolveErr = resolveDedupeCandidateHashes(
-			c.jptm.Context(),
-			st,
-			c.dedupePlan,
-			c.dedupeETag,
-			c.jptm.Info().Destination,
-			hasher,
-		)
-		if c.dedupeResolveErr == nil {
-			applyResolvedSourceHashes(c.dedupePlan, c.dedupeIndex)
-		}
-		emitDedupeHashResolutionProgress(
-			c.jptm,
-			c.dedupeMode,
-			c.dedupeResolveStats,
-			c.dedupeResolveErr,
-		)
-	})
+	}
+	if c.dedupeResolutionState() != dedupeResolveComplete {
+		c.jptm.LogAtLevelForCurrentTransfer(common.LogDebug,
+			"dedupe-act: GetBlobHash resolution did not complete; staging this block from source")
+		return false
+	}
 	if c.dedupeResolveErr != nil {
 		if isDedupePreconditionFailure(c.dedupeResolveErr) {
 			c.jptm.LogAtLevelForCurrentTransfer(common.LogInfo,
@@ -536,6 +533,49 @@ func (c *urlToBlockBlobCopier) tryDedupeStage(id common.ChunkID, blockIndex int3
 			blockIndex, id.OffsetInFile(), size, len(targets)),
 		st.progressSnapshot()))
 	return false
+}
+
+func (c *urlToBlockBlobCopier) ensureDedupeHashesResolved(st *dedupeJobState) bool {
+	switch c.dedupeResolutionState() {
+	case dedupeResolveComplete:
+		return true
+	case dedupeResolveInProgress:
+		return false
+	}
+
+	if !c.tryStartDedupeResolution() {
+		return c.dedupeResolutionState() == dedupeResolveComplete
+	}
+	defer c.finishDedupeResolution()
+
+	hasher, err := newSDKDedupeRangeHasher(c.jptm, func(role string, response blockblob.GetBlobHashResponse) {
+		emitGetBlobHashCPUTime(c.jptm, c.dedupeMode, role, response)
+	})
+	if err != nil {
+		c.dedupeResolveErr = err
+		return true
+	}
+
+	ctx, cancel := context.WithTimeout(c.jptm.Context(), dedupeHashResolutionTimeout)
+	defer cancel()
+	c.dedupeIndex, c.dedupeResolveStats, c.dedupeResolveErr = resolveDedupeCandidateHashes(
+		ctx,
+		st,
+		c.dedupePlan,
+		c.dedupeETag,
+		c.jptm.Info().Destination,
+		hasher,
+	)
+	if c.dedupeResolveErr == nil {
+		applyResolvedSourceHashes(c.dedupePlan, c.dedupeIndex)
+	}
+	emitDedupeHashResolutionProgress(
+		c.jptm,
+		c.dedupeMode,
+		c.dedupeResolveStats,
+		c.dedupeResolveErr,
+	)
+	return true
 }
 
 type dedupeTargetStageAttempt struct {

--- a/ste/sourceGridObserver.go
+++ b/ste/sourceGridObserver.go
@@ -1,0 +1,232 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ste
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+)
+
+// This file implements "Phase 0" of the block-level dedupe prototype: a read-only,
+// opt-in diagnostic (AZCOPY_DEDUPE_OBSERVE=true) that, for block-blob -> block-blob S2S
+// transfers, builds a "source-grid" chunk plan from the source's committed block list and
+// logs how those content-defined boundaries compare to AzCopy's uniform chunk grid.
+//
+// It never changes transfer behavior. Its purpose is to gather real alignment and would-be
+// dedupe-hit measurements independently of act mode.
+
+// PlannedBlock describes one block of a source-grid chunk plan: a contiguous range of the
+// source blob whose boundaries match the source's committed block list rather than AzCopy's
+// uniform chunk grid.
+type PlannedBlock struct {
+	Offset       int64
+	Size         int64
+	SrcBlockName string
+
+	// CRC64 and SHA256 are intended to be populated from the extended GetBlockList response
+	// (include=crc64,sha256). HasHashes is true only when both hashes were present and valid.
+	CRC64     uint64
+	SHA256    [32]byte
+	HasHashes bool
+}
+
+// SourceGridPlan is an ordered, contiguous set of blocks covering [0, TotalSize) of a source
+// blob, derived from its committed block list.
+type SourceGridPlan struct {
+	Blocks    []PlannedBlock
+	TotalSize int64
+}
+
+// rawCommittedBlock is the minimal block info needed to build a plan: the committed block name
+// and its size, plus the optional per-block content hashes returned when the service supports the
+// include=crc64,sha256 extension. Offsets are derived (committed block lists are returned in order).
+type rawCommittedBlock struct {
+	Name      string
+	Size      int64
+	CRC64     uint64
+	SHA256    [32]byte
+	HasHashes bool
+}
+
+// buildSourceGridPlan converts an ordered committed block list into a SourceGridPlan, assigning
+// each block a contiguous offset equal to the prefix sum of the preceding block sizes. Non-positive
+// block sizes are rejected because they cannot be scheduled as HTTP ranges.
+func buildSourceGridPlan(blocks []rawCommittedBlock) (*SourceGridPlan, error) {
+	plan := &SourceGridPlan{Blocks: make([]PlannedBlock, 0, len(blocks))}
+	var offset int64
+	for i, b := range blocks {
+		if b.Size <= 0 {
+			return nil, fmt.Errorf("committed block %d (%q) has non-positive size %d", i, b.Name, b.Size)
+		}
+		plan.Blocks = append(plan.Blocks, PlannedBlock{
+			Offset:       offset,
+			Size:         b.Size,
+			SrcBlockName: b.Name,
+			CRC64:        b.CRC64,
+			SHA256:       b.SHA256,
+			HasHashes:    b.HasHashes,
+		})
+		offset += b.Size
+	}
+	plan.TotalSize = offset
+	return plan, nil
+}
+
+// GridAlignmentStats summarizes how a SourceGridPlan's content-defined boundaries compare to a
+// uniform chunk grid of a given size.
+type GridAlignmentStats struct {
+	SourceBlockCount  int
+	UniformChunkSize  int64
+	UniformChunkCount int64
+	TotalSize         int64
+
+	// AlignedStarts is the number of source blocks whose Offset is a multiple of UniformChunkSize.
+	AlignedStarts int
+
+	// ExactChunkMatches is the key metric: the number of source blocks whose [Offset, Offset+Size)
+	// range exactly equals a uniform-grid chunk. These are the blocks a uniform-grid hashing scheme
+	// could dedupe identically; everything else needs source-grid chunking to ever produce a hit.
+	ExactChunkMatches int
+}
+
+// AlignmentToUniformGrid reports how the plan lines up with AzCopy's uniform chunk grid of the
+// given size. It is a pure function (no I/O), which keeps it easy to unit test.
+func (p *SourceGridPlan) AlignmentToUniformGrid(uniformChunkSize int64) GridAlignmentStats {
+	stats := GridAlignmentStats{
+		SourceBlockCount: len(p.Blocks),
+		UniformChunkSize: uniformChunkSize,
+		TotalSize:        p.TotalSize,
+	}
+	if uniformChunkSize <= 0 {
+		return stats
+	}
+	if p.TotalSize > 0 {
+		stats.UniformChunkCount = (p.TotalSize + uniformChunkSize - 1) / uniformChunkSize
+	}
+	for _, b := range p.Blocks {
+		if b.Offset%uniformChunkSize != 0 {
+			continue
+		}
+		stats.AlignedStarts++
+
+		// The uniform chunk that starts at b.Offset ends at min(b.Offset+chunk, TotalSize).
+		uniformEnd := b.Offset + uniformChunkSize
+		if uniformEnd > p.TotalSize {
+			uniformEnd = p.TotalSize
+		}
+		if b.Offset+b.Size == uniformEnd {
+			stats.ExactChunkMatches++
+		}
+	}
+	return stats
+}
+
+// String renders the stats as a single log line, including the percentage of source blocks that
+// would dedupe on AzCopy's current uniform grid.
+func (s GridAlignmentStats) String() string {
+	pct := 0.0
+	if s.SourceBlockCount > 0 {
+		pct = 100 * float64(s.ExactChunkMatches) / float64(s.SourceBlockCount)
+	}
+	return fmt.Sprintf(
+		"dedupe-observe: sourceBlocks=%d uniformChunkSize=%d uniformChunks=%d totalSize=%d alignedStarts=%d exactChunkMatches=%d (%.1f%% of source blocks would dedupe on AzCopy's uniform grid)",
+		s.SourceBlockCount, s.UniformChunkSize, s.UniformChunkCount, s.TotalSize,
+		s.AlignedStarts, s.ExactChunkMatches, pct)
+}
+
+// dedupeObserveEnabled reports whether the read-only source-grid diagnostic is turned on.
+func dedupeObserveEnabled() bool {
+	return common.GetEnvironmentVariable(common.EEnvironmentVariable.DedupeObserve()) == "true"
+}
+
+// observeSourceGrid is the Phase 0 diagnostic hook. For block-blob -> block-blob S2S transfers
+// (and only when AZCOPY_DEDUPE_OBSERVE=true) it fetches the source committed block list, builds a
+// SourceGridPlan, and logs how the source boundaries align with AzCopy's uniform chunk grid.
+//
+// It is intentionally defensive: it never returns an error and swallows every failure (logging at
+// debug level), so it cannot affect transfer correctness and is safe to call unconditionally.
+func observeSourceGrid(jptm IJobPartTransferMgr) {
+	if !dedupeObserveEnabled() {
+		return
+	}
+
+	info := jptm.Info()
+
+	// Scope to block-blob -> block-blob S2S only.
+	ft := jptm.FromTo()
+	if ft.From() != common.ELocation.Blob() || ft.To() != common.ELocation.Blob() {
+		return
+	}
+	if info.SrcBlobType != blob.BlobTypeBlockBlob {
+		return
+	}
+
+	// Fetch the source committed block list, requesting the per-block content hashes
+	// (include=crc64,sha256). The service only returns them when the GetHash feature is enabled;
+	// otherwise the fields are nil and we simply observe zero hashes.
+	resp, err := getSourceBlockList(jptm)
+	if err != nil {
+		jptm.LogAtLevelForCurrentTransfer(common.LogDebug, "dedupe-observe: GetBlockList(committed, include=crc64,sha256) failed: "+err.Error())
+		return
+	}
+
+	if len(resp.CommittedBlocks) == 0 {
+		jptm.LogAtLevelForCurrentTransfer(common.LogInfo,
+			"dedupe-observe: source has no committed named blocks (e.g. single-PutBlob or empty blob); not eligible for source-grid chunking")
+		return
+	}
+
+	raw := rawCommittedBlocksFromResponse(resp)
+	hashedBlocks := 0
+	for i, b := range resp.CommittedBlocks {
+		rb := raw[i]
+		if rb.HasHashes {
+			hashedBlocks++
+		}
+
+		// Phase 0 read-only log of the extended per-block fields exactly as returned by the service.
+		jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
+			"dedupe-observe: block[%d] name=%s offset=%d size=%d hasCompleteHashes=%t crc64=%016x sha256=%x crc64LE=%s",
+			i, rb.Name, common.IffNotNil(b.Offset, -1), rb.Size,
+			rb.HasHashes, rb.CRC64, rb.SHA256, hex.EncodeToString(b.Crc64)))
+	}
+
+	jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
+		"dedupe-observe: %d/%d committed blocks carried crc64+sha256 hashes (0 means the service GetHash feature is off or include was not honored)",
+		hashedBlocks, len(resp.CommittedBlocks)))
+
+	plan, err := buildSourceGridPlan(raw)
+	if err != nil {
+		jptm.LogAtLevelForCurrentTransfer(common.LogDebug, "dedupe-observe: "+err.Error())
+		return
+	}
+
+	stats := plan.AlignmentToUniformGrid(info.BlockSize)
+	jptm.LogAtLevelForCurrentTransfer(common.LogInfo, stats.String())
+
+	// Phase 1: record these committed blocks into the per-job dedupe table and log the running
+	// would-be-hit rate. This is still read-only with respect to the transfer (no bytes skipped).
+	recordSourceGridForDedupe(jptm, plan)
+}

--- a/ste/sourceGridObserver.go
+++ b/ste/sourceGridObserver.go
@@ -23,6 +23,7 @@ package ste
 import (
 	"encoding/hex"
 	"fmt"
+	"math"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 
@@ -59,38 +60,66 @@ type SourceGridPlan struct {
 	TotalSize int64
 }
 
-// rawCommittedBlock is the minimal block info needed to build a plan: the committed block name
-// and its size, plus the optional per-block content hashes returned when the service supports the
-// include=crc64,sha256 extension. Offsets are derived (committed block lists are returned in order).
+// rawCommittedBlock is the minimal block info needed to build a plan: the committed block name,
+// size, optional service-provided offset, and optional per-block content hashes.
 type rawCommittedBlock struct {
 	Name      string
 	Size      int64
+	Offset    int64
+	HasOffset bool
 	CRC64     uint64
 	SHA256    [32]byte
 	HasHashes bool
 }
 
-// buildSourceGridPlan converts an ordered committed block list into a SourceGridPlan, assigning
-// each block a contiguous offset equal to the prefix sum of the preceding block sizes. Non-positive
-// block sizes are rejected because they cannot be scheduled as HTTP ranges.
+// buildSourceGridPlan converts an ordered committed block list into a SourceGridPlan. It uses
+// service-provided offsets when present and derives only missing offsets for legacy responses.
+// Every resulting range must be ordered and contiguous.
 func buildSourceGridPlan(blocks []rawCommittedBlock) (*SourceGridPlan, error) {
 	plan := &SourceGridPlan{Blocks: make([]PlannedBlock, 0, len(blocks))}
-	var offset int64
+	var expectedOffset int64
 	for i, b := range blocks {
 		if b.Size <= 0 {
 			return nil, fmt.Errorf("committed block %d (%q) has non-positive size %d", i, b.Name, b.Size)
 		}
+
+		blockOffset := expectedOffset
+		if b.HasOffset {
+			blockOffset = b.Offset
+			if blockOffset < 0 {
+				return nil, fmt.Errorf("committed block %d (%q) has negative offset %d", i, b.Name, blockOffset)
+			}
+			if blockOffset != expectedOffset {
+				return nil, fmt.Errorf(
+					"committed block %d (%q) has non-contiguous offset %d; expected %d",
+					i,
+					b.Name,
+					blockOffset,
+					expectedOffset,
+				)
+			}
+		}
+		if b.Size > math.MaxInt64-blockOffset {
+			return nil, fmt.Errorf(
+				"committed block %d (%q) range overflows int64: offset %d size %d",
+				i,
+				b.Name,
+				blockOffset,
+				b.Size,
+			)
+		}
+
 		plan.Blocks = append(plan.Blocks, PlannedBlock{
-			Offset:       offset,
+			Offset:       blockOffset,
 			Size:         b.Size,
 			SrcBlockName: b.Name,
 			CRC64:        b.CRC64,
 			SHA256:       b.SHA256,
 			HasHashes:    b.HasHashes,
 		})
-		offset += b.Size
+		expectedOffset = blockOffset + b.Size
 	}
-	plan.TotalSize = offset
+	plan.TotalSize = expectedOffset
 	return plan, nil
 }
 

--- a/ste/sourceGridObserver.go
+++ b/ste/sourceGridObserver.go
@@ -35,8 +35,8 @@ import (
 // transfers, builds a "source-grid" chunk plan from the source's committed block list and
 // logs how those content-defined boundaries compare to AzCopy's uniform chunk grid.
 //
-// It never changes transfer behavior. Its purpose is to gather real alignment and would-be
-// dedupe-hit measurements independently of act mode.
+// It never changes transfer behavior. Its purpose is to gather real alignment and CRC discovery
+// measurements independently of act mode without treating CRC collisions as dedupe hits.
 
 // PlannedBlock describes one block of a source-grid chunk plan: a contiguous range of the
 // source blob whose boundaries match the source's committed block list rather than AzCopy's
@@ -46,10 +46,14 @@ type PlannedBlock struct {
 	Size         int64
 	SrcBlockName string
 
-	// CRC64 and SHA256 are intended to be populated from the extended GetBlockList response
-	// (include=crc64,sha256). HasHashes is true only when both hashes were present and valid.
+	// Source discovery requests CRC64 only. SHA256 remains for compatibility with synthetic and
+	// legacy responses. Presence is explicit because an all-zero hash is valid.
 	CRC64     uint64
+	HasCRC64  bool
 	SHA256    [32]byte
+	HasSHA256 bool
+
+	// HasHashes is retained for compatibility and is true only when both hashes are present.
 	HasHashes bool
 }
 
@@ -61,14 +65,16 @@ type SourceGridPlan struct {
 }
 
 // rawCommittedBlock is the minimal block info needed to build a plan: the committed block name,
-// size, optional service-provided offset, and optional per-block content hashes.
+// size, optional service-provided offset, requested CRC64, and any legacy SHA256 fixture data.
 type rawCommittedBlock struct {
 	Name      string
 	Size      int64
 	Offset    int64
 	HasOffset bool
 	CRC64     uint64
+	HasCRC64  bool
 	SHA256    [32]byte
+	HasSHA256 bool
 	HasHashes bool
 }
 
@@ -114,8 +120,10 @@ func buildSourceGridPlan(blocks []rawCommittedBlock) (*SourceGridPlan, error) {
 			Size:         b.Size,
 			SrcBlockName: b.Name,
 			CRC64:        b.CRC64,
+			HasCRC64:     b.HasCRC64,
 			SHA256:       b.SHA256,
-			HasHashes:    b.HasHashes,
+			HasSHA256:    b.HasSHA256,
+			HasHashes:    b.HasCRC64 && b.HasSHA256,
 		})
 		expectedOffset = blockOffset + b.Size
 	}
@@ -212,12 +220,11 @@ func observeSourceGrid(jptm IJobPartTransferMgr) {
 		return
 	}
 
-	// Fetch the source committed block list, requesting the per-block content hashes
-	// (include=crc64,sha256). The service only returns them when the GetHash feature is enabled;
-	// otherwise the fields are nil and we simply observe zero hashes.
+	// Fetch the source committed block list, requesting only per-block CRC64 (include=crc64). The
+	// service returns it only when the GetHash feature is enabled; otherwise the field is nil.
 	resp, err := getSourceBlockList(jptm)
 	if err != nil {
-		jptm.LogAtLevelForCurrentTransfer(common.LogDebug, "dedupe-observe: GetBlockList(committed, include=crc64,sha256) failed: "+err.Error())
+		jptm.LogAtLevelForCurrentTransfer(common.LogDebug, "dedupe-observe: GetBlockList(committed, include=crc64) failed: "+err.Error())
 		return
 	}
 
@@ -228,23 +235,23 @@ func observeSourceGrid(jptm IJobPartTransferMgr) {
 	}
 
 	raw := rawCommittedBlocksFromResponse(resp)
-	hashedBlocks := 0
+	crc64Blocks := 0
 	for i, b := range resp.CommittedBlocks {
 		rb := raw[i]
-		if rb.HasHashes {
-			hashedBlocks++
+		if rb.HasCRC64 {
+			crc64Blocks++
 		}
 
-		// Phase 0 read-only log of the extended per-block fields exactly as returned by the service.
+		// Phase 0 read-only log of the requested per-block CRC64 field.
 		jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
-			"dedupe-observe: block[%d] name=%s offset=%d size=%d hasCompleteHashes=%t crc64=%016x sha256=%x crc64LE=%s",
+			"dedupe-observe: block[%d] name=%s offset=%d size=%d hasCRC64=%t crc64=%016x crc64LE=%s",
 			i, rb.Name, common.IffNotNil(b.Offset, -1), rb.Size,
-			rb.HasHashes, rb.CRC64, rb.SHA256, hex.EncodeToString(b.Crc64)))
+			rb.HasCRC64, rb.CRC64, hex.EncodeToString(b.Crc64)))
 	}
 
 	jptm.LogAtLevelForCurrentTransfer(common.LogInfo, fmt.Sprintf(
-		"dedupe-observe: %d/%d committed blocks carried crc64+sha256 hashes (0 means the service GetHash feature is off or include was not honored)",
-		hashedBlocks, len(resp.CommittedBlocks)))
+		"dedupe-observe: %d/%d committed blocks carried CRC64 (0 means the service GetHash feature is off or include=crc64 was not honored)",
+		crc64Blocks, len(resp.CommittedBlocks)))
 
 	plan, err := buildSourceGridPlan(raw)
 	if err != nil {
@@ -255,7 +262,9 @@ func observeSourceGrid(jptm IJobPartTransferMgr) {
 	stats := plan.AlignmentToUniformGrid(info.BlockSize)
 	jptm.LogAtLevelForCurrentTransfer(common.LogInfo, stats.String())
 
-	// Phase 1: record these committed blocks into the per-job dedupe table and log the running
-	// would-be-hit rate. This is still read-only with respect to the transfer (no bytes skipped).
-	recordSourceGridForDedupe(jptm, plan)
+	// CRC64 is only a candidate filter. Strong-match measurement now happens in the act path after
+	// a CRC64+size candidate triggers GetBlobHash; observe mode does not report CRC collisions as
+	// dedupe hits.
+	jptm.LogAtLevelForCurrentTransfer(common.LogInfo,
+		"dedupe-observe: CRC-only discovery complete; SHA256 is deferred until an act-mode CRC candidate hit")
 }

--- a/ste/sourceGridObserver_test.go
+++ b/ste/sourceGridObserver_test.go
@@ -21,6 +21,7 @@
 package ste
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,6 +48,70 @@ func TestBuildSourceGridPlan_AssignsContiguousOffsets(t *testing.T) {
 
 	a.EqualValues(350, plan.Blocks[2].Offset)
 	a.EqualValues(50, plan.Blocks[2].Size)
+}
+
+func TestBuildSourceGridPlan_UsesServiceOffsetsAndDerivesMissingOffsets(t *testing.T) {
+	a := assert.New(t)
+
+	plan, err := buildSourceGridPlan([]rawCommittedBlock{
+		{Name: "b0", Size: 100, Offset: 0, HasOffset: true},
+		{Name: "b1", Size: 250},
+		{Name: "b2", Size: 50, Offset: 350, HasOffset: true},
+	})
+	a.NoError(err)
+	a.EqualValues(400, plan.TotalSize)
+	a.EqualValues(0, plan.Blocks[0].Offset)
+	a.EqualValues(100, plan.Blocks[1].Offset)
+	a.EqualValues(350, plan.Blocks[2].Offset)
+}
+
+func TestBuildSourceGridPlan_RejectsInvalidServiceOffsets(t *testing.T) {
+	tests := []struct {
+		name   string
+		blocks []rawCommittedBlock
+	}{
+		{
+			name: "negative",
+			blocks: []rawCommittedBlock{
+				{Name: "b0", Size: 100, Offset: -1, HasOffset: true},
+			},
+		},
+		{
+			name: "nonzero first offset",
+			blocks: []rawCommittedBlock{
+				{Name: "b0", Size: 100, Offset: 1, HasOffset: true},
+			},
+		},
+		{
+			name: "gap",
+			blocks: []rawCommittedBlock{
+				{Name: "b0", Size: 100, Offset: 0, HasOffset: true},
+				{Name: "b1", Size: 100, Offset: 101, HasOffset: true},
+			},
+		},
+		{
+			name: "overlap",
+			blocks: []rawCommittedBlock{
+				{Name: "b0", Size: 100, Offset: 0, HasOffset: true},
+				{Name: "b1", Size: 100, Offset: 99, HasOffset: true},
+			},
+		},
+		{
+			name: "range overflow",
+			blocks: []rawCommittedBlock{
+				{Name: "b0", Size: math.MaxInt64},
+				{Name: "b1", Size: 1},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := buildSourceGridPlan(test.blocks)
+			a := assert.New(t)
+			a.Error(err)
+		})
+	}
 }
 
 func TestBuildSourceGridPlan_Empty(t *testing.T) {

--- a/ste/sourceGridObserver_test.go
+++ b/ste/sourceGridObserver_test.go
@@ -65,6 +65,49 @@ func TestBuildSourceGridPlan_UsesServiceOffsetsAndDerivesMissingOffsets(t *testi
 	a.EqualValues(350, plan.Blocks[2].Offset)
 }
 
+func TestBuildSourceGridPlan_PreservesHashPresenceForIrregularBlocks(t *testing.T) {
+	a := assert.New(t)
+	sha := [32]byte{0: 0xAA, 31: 0xBB}
+
+	plan, err := buildSourceGridPlan([]rawCommittedBlock{
+		{Name: "crc-only", Size: 37, Offset: 0, HasOffset: true, CRC64: 0x0102030405060708, HasCRC64: true},
+		{Name: "sha-only", Size: 513, SHA256: sha, HasSHA256: true},
+		{
+			Name:      "legacy-both",
+			Size:      19,
+			Offset:    550,
+			HasOffset: true,
+			CRC64:     0x1112131415161718,
+			HasCRC64:  true,
+			SHA256:    sha,
+			HasSHA256: true,
+			HasHashes: true,
+		},
+	})
+
+	a.NoError(err)
+	a.EqualValues(569, plan.TotalSize)
+	a.Equal([]int64{0, 37, 550}, []int64{
+		plan.Blocks[0].Offset,
+		plan.Blocks[1].Offset,
+		plan.Blocks[2].Offset,
+	})
+
+	a.Equal(uint64(0x0102030405060708), plan.Blocks[0].CRC64)
+	a.True(plan.Blocks[0].HasCRC64)
+	a.False(plan.Blocks[0].HasSHA256)
+	a.False(plan.Blocks[0].HasHashes)
+
+	a.Equal(sha, plan.Blocks[1].SHA256)
+	a.False(plan.Blocks[1].HasCRC64)
+	a.True(plan.Blocks[1].HasSHA256)
+	a.False(plan.Blocks[1].HasHashes)
+
+	a.True(plan.Blocks[2].HasCRC64)
+	a.True(plan.Blocks[2].HasSHA256)
+	a.True(plan.Blocks[2].HasHashes)
+}
+
 func TestBuildSourceGridPlan_RejectsInvalidServiceOffsets(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/ste/sourceGridObserver_test.go
+++ b/ste/sourceGridObserver_test.go
@@ -1,0 +1,178 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ste
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildSourceGridPlan_AssignsContiguousOffsets(t *testing.T) {
+	a := assert.New(t)
+
+	plan, err := buildSourceGridPlan([]rawCommittedBlock{
+		{Name: "b0", Size: 100},
+		{Name: "b1", Size: 250},
+		{Name: "b2", Size: 50},
+	})
+	a.NoError(err)
+	a.EqualValues(400, plan.TotalSize)
+	a.Len(plan.Blocks, 3)
+
+	a.EqualValues(0, plan.Blocks[0].Offset)
+	a.EqualValues(100, plan.Blocks[0].Size)
+	a.Equal("b0", plan.Blocks[0].SrcBlockName)
+
+	a.EqualValues(100, plan.Blocks[1].Offset)
+	a.EqualValues(250, plan.Blocks[1].Size)
+
+	a.EqualValues(350, plan.Blocks[2].Offset)
+	a.EqualValues(50, plan.Blocks[2].Size)
+}
+
+func TestBuildSourceGridPlan_Empty(t *testing.T) {
+	a := assert.New(t)
+
+	plan, err := buildSourceGridPlan(nil)
+	a.NoError(err)
+	a.EqualValues(0, plan.TotalSize)
+	a.Empty(plan.Blocks)
+}
+
+func TestBuildSourceGridPlan_NonPositiveSizeIsError(t *testing.T) {
+	a := assert.New(t)
+
+	_, err := buildSourceGridPlan([]rawCommittedBlock{
+		{Name: "ok", Size: 10},
+		{Name: "bad", Size: -1},
+	})
+	a.Error(err)
+
+	_, err = buildSourceGridPlan([]rawCommittedBlock{
+		{Name: "empty", Size: 0},
+	})
+	a.Error(err)
+}
+
+func TestAlignment_UniformBlocksAllMatch(t *testing.T) {
+	a := assert.New(t)
+
+	// Four blocks of exactly the uniform chunk size -> every block matches a uniform chunk.
+	plan, err := buildSourceGridPlan([]rawCommittedBlock{
+		{Name: "b0", Size: 1024},
+		{Name: "b1", Size: 1024},
+		{Name: "b2", Size: 1024},
+		{Name: "b3", Size: 1024},
+	})
+	a.NoError(err)
+
+	stats := plan.AlignmentToUniformGrid(1024)
+	a.Equal(4, stats.SourceBlockCount)
+	a.EqualValues(4, stats.UniformChunkCount)
+	a.Equal(4, stats.AlignedStarts)
+	a.Equal(4, stats.ExactChunkMatches)
+}
+
+func TestAlignment_FinalShortBlockMatches(t *testing.T) {
+	a := assert.New(t)
+
+	// Two full chunks plus a short final block that exactly equals the final (short) uniform chunk.
+	plan, err := buildSourceGridPlan([]rawCommittedBlock{
+		{Name: "b0", Size: 1024},
+		{Name: "b1", Size: 1024},
+		{Name: "b2", Size: 300},
+	})
+	a.NoError(err)
+
+	stats := plan.AlignmentToUniformGrid(1024)
+	a.EqualValues(2348, stats.TotalSize)
+	a.EqualValues(3, stats.UniformChunkCount) // ceil(2348/1024)
+	a.Equal(3, stats.AlignedStarts)
+	a.Equal(3, stats.ExactChunkMatches) // final 300-byte block == final 300-byte uniform chunk
+}
+
+func TestAlignment_MisalignedBlocksDoNotMatch(t *testing.T) {
+	a := assert.New(t)
+
+	// Blocks half the uniform size: starts alternate aligned/unaligned, and none span a whole chunk.
+	plan, err := buildSourceGridPlan([]rawCommittedBlock{
+		{Name: "b0", Size: 512},
+		{Name: "b1", Size: 512},
+		{Name: "b2", Size: 512},
+		{Name: "b3", Size: 512},
+	})
+	a.NoError(err)
+
+	stats := plan.AlignmentToUniformGrid(1024)
+	a.Equal(4, stats.SourceBlockCount)
+	// b0@0 and b2@1024 start on a 1024 boundary; b1@512 and b3@1536 do not.
+	a.Equal(2, stats.AlignedStarts)
+	// No block is a full 1024 chunk (and the file ends exactly on a boundary, so no short final chunk).
+	a.Equal(0, stats.ExactChunkMatches)
+}
+
+func TestAlignment_SingleBlockWholeFile(t *testing.T) {
+	a := assert.New(t)
+
+	// One committed block holding the whole blob, smaller than the chunk size -> it equals the single
+	// (short) uniform chunk that spans the whole file.
+	plan, err := buildSourceGridPlan([]rawCommittedBlock{
+		{Name: "only", Size: 4000},
+	})
+	a.NoError(err)
+
+	stats := plan.AlignmentToUniformGrid(8 * 1024 * 1024)
+	a.Equal(1, stats.SourceBlockCount)
+	a.EqualValues(1, stats.UniformChunkCount)
+	a.Equal(1, stats.AlignedStarts)
+	a.Equal(1, stats.ExactChunkMatches)
+}
+
+func TestAlignment_NonPositiveChunkSizeIsSafe(t *testing.T) {
+	a := assert.New(t)
+
+	plan, err := buildSourceGridPlan([]rawCommittedBlock{
+		{Name: "b0", Size: 100},
+		{Name: "b1", Size: 100},
+	})
+	a.NoError(err)
+
+	stats := plan.AlignmentToUniformGrid(0)
+	a.Equal(2, stats.SourceBlockCount)
+	a.EqualValues(0, stats.UniformChunkCount)
+	a.Equal(0, stats.AlignedStarts)
+	a.Equal(0, stats.ExactChunkMatches)
+}
+
+func TestGridAlignmentStats_StringMentionsPercentage(t *testing.T) {
+	a := assert.New(t)
+
+	plan, err := buildSourceGridPlan([]rawCommittedBlock{
+		{Name: "b0", Size: 1024},
+		{Name: "b1", Size: 512},
+	})
+	a.NoError(err)
+
+	s := plan.AlignmentToUniformGrid(1024).String()
+	a.Contains(s, "dedupe-observe:")
+	a.Contains(s, "exactChunkMatches=")
+}

--- a/ste/testJobPartTransferManager_test.go
+++ b/ste/testJobPartTransferManager_test.go
@@ -49,6 +49,10 @@ func (t *testJobPartTransferManager) Info() *TransferInfo {
 	return t.info
 }
 
+func (t *testJobPartTransferManager) SAS() (sourceSAS, destinationSAS string) {
+	return t.jobPartMgr.SAS()
+}
+
 func (t *testJobPartTransferManager) SrcServiceClient() *common.ServiceClient {
 	options := t.S2SSourceClientOptions()
 	var azureFileSpecificOptions any

--- a/ste/xfer-anyToRemote-file.go
+++ b/ste/xfer-anyToRemote-file.go
@@ -440,6 +440,10 @@ func anyToRemote_file(jptm IJobPartTransferMgr, info *TransferInfo, pacer pacer,
 	// stop tracking pseudo id (since real chunk id's will be tracked from here on)
 	jptm.LogChunkStatus(pseudoId, common.EWaitReason.ChunkDone())
 
+	// Read-only dedupe prototype diagnostic (opt-in via AZCOPY_DEDUPE_OBSERVE). No-op when
+	// disabled; never alters the transfer.
+	observeSourceGrid(jptm)
+
 	// Step 6: Go through the file and schedule chunk messages to send each chunk
 	scheduleSendChunks(jptm, info.Source, srcFile, srcSize, s, sourceFileFactory, srcInfoProvider)
 }
@@ -458,6 +462,15 @@ func scheduleSendChunks(jptm IJobPartTransferMgr, srcPath string, srcFile common
 	// For generic send
 	chunkSize := s.ChunkSize()
 	numChunks := s.NumChunks()
+
+	// Block-level dedupe prototype: when the sender provides a content-defined (source-grid) chunk
+	// plan, schedule those chunks instead of the uniform grid. S2S only (no local prefetch path).
+	if cg, ok := s.(sourceGridChunker); ok {
+		if specs := cg.dedupeChunkSpecs(); len(specs) > 0 {
+			scheduleSourceGridChunks(jptm, srcPath, s, specs)
+			return
+		}
+	}
 
 	// For upload
 	var md5Channel chan<- []byte
@@ -591,6 +604,32 @@ func createS3ChunkReader(
 		jptm.CacheLimiter(),
 	)
 	return s3ChunkReader
+}
+
+// scheduleSourceGridChunks schedules one send per source-grid chunk spec, used by the block-level
+// dedupe prototype. It mirrors the S2S branch of scheduleSendChunks (no local prefetch / md5) but
+// drives the chunk boundaries from the sender's content-defined plan instead of the uniform grid.
+func scheduleSourceGridChunks(jptm IJobPartTransferMgr, srcPath string, s sender, specs []chunkSpec) {
+	// Run the prologue before the first chunk (mirrors scheduleSendChunks). S2S has no leading bytes,
+	// so an empty prologue state is correct here.
+	if modified := s.Prologue(common.PrologueState{}); modified {
+		jptm.SetDestinationIsModified()
+	}
+
+	s2s, ok := s.(s2sCopier)
+	if !ok {
+		// Defensive: source-grid chunking is only armed for S2S copiers; fail loudly if misused.
+		jptm.FailActiveSend("source-grid chunking", errors.New("sender is not an s2sCopier"))
+		return
+	}
+
+	isWholeFile := len(specs) == 1
+	for i, sp := range specs {
+		id := common.NewChunkID(srcPath, sp.offset, sp.size)
+		jptm.LogChunkStatus(id, common.EWaitReason.WorkerGR())
+		cf := s2s.GenerateCopyFunc(id, int32(i), sp.size, isWholeFile)
+		jptm.ScheduleChunks(cf)
+	}
 }
 
 // Make reader for this chunk.

--- a/ste/xfer-anyToRemote-file.go
+++ b/ste/xfer-anyToRemote-file.go
@@ -199,6 +199,13 @@ func anyToRemote(jptm IJobPartTransferMgr, pacer pacer, senderFactory senderFact
 	info := jptm.Info()
 	fromTo := jptm.FromTo()
 
+	if (info.EntityType == common.EEntityType.File() ||
+		info.EntityType == common.EEntityType.Hardlink()) &&
+		jptm.GetOverwriteOption() != common.EOverwriteOption.PosixProperties() {
+		initializeDedupeStateForTransfer(jptm)
+		emitSmallFileTransferStart(jptm)
+	}
+
 	// Ensure that the transfer isn't the same item, and fail it if it is.
 	// This scenario can only happen with S2S. We'll parse the URLs and compare the host and path.
 	if fromTo.IsS2S() {
@@ -256,7 +263,6 @@ func anyToRemote_file(jptm IJobPartTransferMgr, info *TransferInfo, pacer pacer,
 		jptm.ReportTransferDone()
 		return
 	}
-
 	// step 2a. Create sender
 	srcInfoProvider, err := sipf(jptm)
 	if err != nil {

--- a/ste/xferVersionPolicy.go
+++ b/ste/xferVersionPolicy.go
@@ -46,10 +46,19 @@ func (r *versionPolicy) Do(req *policy.Request) (*http.Response, error) {
 	// get the service api version value using the ServiceAPIVersionOverride set in the context.
 	if value := req.Raw().Context().Value(ServiceAPIVersionOverride); value != nil {
 		if !shouldPreserveRequestServiceVersion(req.Raw()) {
-			req.Raw().Header.Set("x-ms-version", value.(string))
+			setServiceVersionHeader(req.Raw(), value.(string))
 		}
 	}
 	return req.Next()
+}
+
+func setServiceVersionHeader(req *http.Request, version string) {
+	for name := range req.Header {
+		if strings.EqualFold(name, "x-ms-version") {
+			delete(req.Header, name)
+		}
+	}
+	req.Header["x-ms-version"] = []string{version}
 }
 
 func shouldPreserveRequestServiceVersion(req *http.Request) bool {

--- a/ste/xferVersionPolicy.go
+++ b/ste/xferVersionPolicy.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"net/http"
+	"strings"
 )
 
 type serviceAPIVersionOverride struct{}
@@ -44,7 +45,16 @@ func NewVersionPolicy() policy.Policy {
 func (r *versionPolicy) Do(req *policy.Request) (*http.Response, error) {
 	// get the service api version value using the ServiceAPIVersionOverride set in the context.
 	if value := req.Raw().Context().Value(ServiceAPIVersionOverride); value != nil {
-		req.Raw().Header["x-ms-version"] = []string{value.(string)}
+		if !shouldPreserveRequestServiceVersion(req.Raw()) {
+			req.Raw().Header.Set("x-ms-version", value.(string))
+		}
 	}
 	return req.Next()
+}
+
+func shouldPreserveRequestServiceVersion(req *http.Request) bool {
+	return req != nil &&
+		strings.EqualFold(req.Method, http.MethodGet) &&
+		strings.EqualFold(req.URL.Query().Get("comp"), "hash") &&
+		req.Header.Get("x-ms-version") != ""
 }

--- a/ste/xferVersionPolicy_test.go
+++ b/ste/xferVersionPolicy_test.go
@@ -1,0 +1,77 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ste
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldPreserveRequestServiceVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		method   string
+		url      string
+		version  string
+		expected bool
+	}{
+		{
+			name:     "GetBlobHash preserves SDK version",
+			method:   http.MethodGet,
+			url:      "https://acct.blob.core.windows.net/c/b?comp=hash",
+			version:  "2025-11-05",
+			expected: true,
+		},
+		{
+			name:     "GetBlobHash without SDK version uses override",
+			method:   http.MethodGet,
+			url:      "https://acct.blob.core.windows.net/c/b?comp=hash",
+			expected: false,
+		},
+		{
+			name:     "Other GET uses override",
+			method:   http.MethodGet,
+			url:      "https://acct.blob.core.windows.net/c/b?comp=blocklist",
+			version:  "2025-11-05",
+			expected: false,
+		},
+		{
+			name:     "Non-GET hash request uses override",
+			method:   http.MethodPut,
+			url:      "https://acct.blob.core.windows.net/c/b?comp=hash",
+			version:  "2025-11-05",
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req, err := http.NewRequest(test.method, test.url, nil)
+			assert.NoError(t, err)
+			if test.version != "" {
+				req.Header.Set("x-ms-version", test.version)
+			}
+			assert.Equal(t, test.expected, shouldPreserveRequestServiceVersion(req))
+		})
+	}
+}

--- a/ste/xferVersionPolicy_test.go
+++ b/ste/xferVersionPolicy_test.go
@@ -22,6 +22,7 @@ package ste
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -74,4 +75,21 @@ func TestShouldPreserveRequestServiceVersion(t *testing.T) {
 			assert.Equal(t, test.expected, shouldPreserveRequestServiceVersion(req))
 		})
 	}
+}
+
+func TestSetServiceVersionHeaderRemovesCaseVariants(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://acct.blob.core.windows.net/c", nil)
+	assert.NoError(t, err)
+	req.Header["x-ms-version"] = []string{"2025-11-05"}
+	req.Header["X-Ms-Version"] = []string{"duplicate"}
+
+	setServiceVersionHeader(req, "2025-05-05")
+
+	var values []string
+	for name, headerValues := range req.Header {
+		if strings.EqualFold(name, "x-ms-version") {
+			values = append(values, headerValues...)
+		}
+	}
+	assert.Equal(t, []string{"2025-05-05"}, values)
 }


### PR DESCRIPTION
## Review intent

**This draft PR is for code review only and is not intended to be merged as-is.**

This replaces #3502 with the current Mover-compatible C2C-stage implementation.

## What this prototype adds

- Retrieves XStore-provided committed-block offsets, CRC64, and SHA256 values.
- Uses source committed-block ranges for source-grid chunk scheduling.
- Maintains a concurrency-safe, job-local destination block index.
- Requires CRC64, SHA256, and block length to match before reuse.
- Reuses matching ranges from already-committed destination blobs.
- Guards target reuse with the recorded destination ETag.
- Falls back to the original source when target reuse fails.
- Preserves source and destination SAS values in memory through the embedded
  `AddJobPart` path without writing them to plan files.
- Emits externally readable per-job dedupe, transfer, failure, small-file,
  WAN-savings, and hash CPU-time metrics.
- Uses XStore offsets when present and derives offsets only for legacy
  responses that omit them.

## Dependency

This branch uses the ProgramPedro azblob SDK fork:

```text
github.com/ProgramPedro/azure-sdk-for-go/sdk/storage/azblob
v1.6.3-0.20260727190053-93e310a26728
```

The SDK extension exposes:

- committed-block `Offset`;
- per-block `Crc64`;
- per-block `Sha256`;
- `x-ms-test-dedupe-crc64-cpu-time-us`; and
- `x-ms-test-dedupe-sha256-cpu-time-us`.

## Safety properties

- Literal SAS values are not persisted in AzCopy plan files.
- CRC64 collisions are confirmed with SHA256.
- Only committed destination content is eligible for reuse.
- Missing ETags, invalid ranges, size mismatches, and same-target reuse are
  rejected.
- Target reuse failure falls back to normal source staging.
- Dedupe state is cleared after terminal job completion.

## Validation

- Focused hash-table, source-grid, target-selection, fallback, runtime-SAS,
  external-log, small-file, CPU-metric, and offset tests pass.
- `go test ./ste -run '^$' -count=1` passes with the checked-in dependency
  graph.
- Full live STE tests require configured Azure test account credentials and
  were not run as part of this local validation.

## Known prototype limitations

- Block-blob to block-blob S2S only.
- Candidate index is in-memory and job-local.
- Worker restart or a separate job does not share indexed candidates.
- Requires the XStore hash-capable `GetBlockList` response and SDK fork above.
- Observe and shadow modes remain in the branch; Storage Mover currently uses
  enforce mode.
