### PR TITLE
Honor explicit concurrency for Azure Files copies

### DIFF
--- a/azcopy/copy.go
+++ b/azcopy/copy.go
@@ -128,6 +128,10 @@ func (c *CopyOptions) SetInternalOptions(listOfFiles string, s2sGetPropertiesInB
 	c.commandString = cmd
 }
 
+func shouldSetConcurrencySettingsToAuto(fromTo common.FromTo, concurrencyValue string) bool {
+	return (fromTo.From().IsFile() || fromTo.To().IsFile()) && concurrencyValue == ""
+}
+
 // Copy copies the contents from source to destination.
 func (c *Client) Copy(ctx context.Context, src, dest string, opts CopyOptions) (CopyResult, error) {
 	// Input
@@ -192,8 +196,9 @@ func (c *Client) Copy(ctx context.Context, src, dest string, opts CopyOptions) (
 
 		// Make AUTO default for Azure Files since Azure Files throttles too easily unless user specified concurrency value
 		if jobsAdmin.JobsAdmin != nil &&
-			(t.opts.fromTo.From().IsFile() || (t.opts.fromTo.To().IsFile() &&
-				common.GetEnvironmentVariable(common.EEnvironmentVariable.ConcurrencyValue()) == "")) {
+			shouldSetConcurrencySettingsToAuto(
+				t.opts.fromTo,
+				common.GetEnvironmentVariable(common.EEnvironmentVariable.ConcurrencyValue())) {
 			jobsAdmin.JobsAdmin.SetConcurrencySettingsToAuto()
 		}
 

--- a/azcopy/copy_test.go
+++ b/azcopy/copy_test.go
@@ -1,0 +1,74 @@
+package azcopy
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+)
+
+func TestShouldSetConcurrencySettingsToAuto(t *testing.T) {
+	tests := []struct {
+		name             string
+		fromTo           common.FromTo
+		concurrencyValue string
+		want             bool
+	}{
+		{
+			name:             "file source with explicit value",
+			fromTo:           common.EFromTo.FileBlob(),
+			concurrencyValue: "2000",
+			want:             false,
+		},
+		{
+			name:             "file destination with explicit value",
+			fromTo:           common.EFromTo.BlobFile(),
+			concurrencyValue: "2000",
+			want:             false,
+		},
+		{
+			name:             "file to file with explicit value",
+			fromTo:           common.EFromTo.FileFile(),
+			concurrencyValue: "2000",
+			want:             false,
+		},
+		{
+			name:             "file source without explicit value",
+			fromTo:           common.EFromTo.FileBlob(),
+			concurrencyValue: "",
+			want:             true,
+		},
+		{
+			name:             "file destination without explicit value",
+			fromTo:           common.EFromTo.BlobFile(),
+			concurrencyValue: "",
+			want:             true,
+		},
+		{
+			name:             "file NFS without explicit value",
+			fromTo:           common.EFromTo.FileNFSFileNFS(),
+			concurrencyValue: "",
+			want:             true,
+		},
+		{
+			name:             "file NFS with explicit value",
+			fromTo:           common.EFromTo.FileNFSFileNFS(),
+			concurrencyValue: "2000",
+			want:             false,
+		},
+		{
+			name:             "non-file transfer without explicit value",
+			fromTo:           common.EFromTo.BlobBlob(),
+			concurrencyValue: "",
+			want:             false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := shouldSetConcurrencySettingsToAuto(test.fromTo, test.concurrencyValue); got != test.want {
+				t.Fatalf("shouldSetConcurrencySettingsToAuto(%s, %q) = %t, want %t",
+					test.fromTo, test.concurrencyValue, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

- **Bug Fix**: Honor an explicitly configured `AZCOPY_CONCURRENCY_VALUE` when Azure Files is either the copy source or destination. The current condition applies the environment-variable guard only to destination-side Azure Files transfers, so source-side transfers incorrectly switch back to `AUTO`.

- **Related Links**:
- [Issue #3446](https://github.com/Azure/azure-storage-azcopy/issues/3446)

Fixes #3446.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?

- Added a table-driven unit test covering File source, File destination, File-to-File, File NFS, non-File transfers, and both explicit and unset concurrency values.
- Confirmed the new test fails to compile before the helper is implemented, then passes with the fix.
- Rebased the single commit onto current `main` (`35dc27add1e640506b1221172f6c0f3d317dff65`) without conflicts; the rebased commit has the same stable patch-id as the original.
- `GOTOOLCHAIN=go1.25.11 go test ./azcopy -count=20 -timeout=1h` (all 15 top-level tests, including the new table test)
- `GOTOOLCHAIN=go1.25.11 go test -race ./azcopy -count=1 -timeout=1h`
- `GOTOOLCHAIN=go1.25.11 go test -cover ./azcopy -count=1 -timeout=1h`
- `GOTOOLCHAIN=go1.25.11 go test -vet=off ./... -run '^$' -count=1`
- `GOTOOLCHAIN=go1.25.11 go vet ./azcopy`
- `golangci-lint run --config=.config/.golangci.yaml --tests=false --max-issues-per-linter=0 --max-same-issues=0 --timeout 5m0s` (0 issues)
- `GOTOOLCHAIN=go1.25.11 go build ./...`
- Linux amd64 and Windows amd64 `CGO_ENABLED=0` cross-builds of `./...`
- `gofmt` and `git diff --check`

Current `main` now includes `azcopy` in `azure-pipelines.yml`'s unit-test list, so the added regression test is covered by the current PR validation configuration.

The repository-wide `go vet ./...` and default package-pattern no-test compile currently report three unrelated diagnostics in `ste/JobPartPlan.go` and `e2etest`; each was reproduced on the exact unchanged `35dc27a` baseline. The affected `azcopy` package passes its full tests, race detector, coverage run, and vet.
