### PR TITLE
Increased Pipeline Responsiveness

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
           echo 'Running GO Vet'
           go vet 
         workingDirectory: $(System.DefaultWorkingDirectory)
-        displayName: 'Golang Vet - Linux'
+        displayName: 'Golang Vet'
 
       - script: |
           sudo apt-get update

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,14 +44,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libsecret-1-dev libglib2.0-dev
         displayName: 'Install dependencies'
-        # Don't run if job is canceled
-        condition: and(succeededOrFailed(), eq(variables.type, 'linux'))
+        # Don't run if job is canceled or fails
+        condition: and(succeeded(), eq(variables.type, 'linux'))
 
       - script: |
           go run "common/manifest/main.go"
         displayName: 'Create resource.syso files'
-        # Don't run if job is canceled
-        condition: and(succeededOrFailed(), eq(variables.type, 'windows'))
+        # Don't run if job is canceled or fails
+        condition: and(succeeded(), eq(variables.type, 'windows'))
         
       - script: |
           go build -tags "netgo" -o "$(Build.ArtifactStagingDirectory)/azcopy_linux_amd64"
@@ -59,8 +59,8 @@ jobs:
           GOARCH: amd64
           GOOS: linux
         displayName: 'Generate Linux AMD64'
-        # Don't run if job is canceled
-        condition: and(succeededOrFailed(), eq(variables.type, 'linux'))
+        # Don't run if job is canceled or fails
+        condition: and(succeeded(), eq(variables.type, 'linux'))
 
       - script: |
           go build -tags "netgo,se_integration" -o "$(Build.ArtifactStagingDirectory)/azcopy_linux_se_amd64"
@@ -68,8 +68,8 @@ jobs:
           GOARCH: amd64
           GOOS: linux
         displayName: 'Generate Linux AMD64 SE Integration'
-        # Don't run if job is canceled
-        condition: and(succeededOrFailed(), eq(variables.type, 'linux'))
+        # Don't run if job is canceled or fails
+        condition: and(succeeded(), eq(variables.type, 'linux'))
 
       - script: |
           go build -tags "netgo" -o "$(Build.ArtifactStagingDirectory)/azcopy_linux_arm64"
@@ -77,8 +77,8 @@ jobs:
           GOARCH: arm64
           GOOS: linux
         displayName: 'Generate Linux ARM64'
-        # Don't run if job is canceled
-        condition: and(succeededOrFailed(), eq(variables.type, 'linux'))
+        # Don't run if job is canceled or fails
+        condition: and(succeeded(), eq(variables.type, 'linux'))
 
       - script: |
           go build -o "$(Build.ArtifactStagingDirectory)/azcopy_windows_amd64.exe"
@@ -87,8 +87,8 @@ jobs:
           GOOS: windows
           CGO_ENABLED: 0
         displayName: 'Generate Windows AMD64'
-        # Don't run if job is canceled
-        condition: and(succeededOrFailed(), eq(variables.type, 'windows'))
+        # Don't run if job is canceled or fails
+        condition: and(succeeded(), eq(variables.type, 'windows'))
 
       - script: |
           go build -o "$(Build.ArtifactStagingDirectory)/azcopy_windows_386.exe"
@@ -97,29 +97,29 @@ jobs:
           GOOS: windows
           CGO_ENABLED: 0
         displayName: 'Generate Windows i386'
-        # Don't run if job is canceled
-        condition: and(succeededOrFailed(), eq(variables.type, 'windows'))
+        # Don't run if job is canceled or fails
+        condition: and(succeeded(), eq(variables.type, 'windows'))
 
       - script: |
           cp NOTICE.txt $(Build.ArtifactStagingDirectory)
         displayName: 'Copy NOTICE.txt'
-        # Don't run if job is canceled
-        condition: and(succeededOrFailed(), eq(variables.type, 'linux'))
+        # Don't run if job is canceled or fails
+        condition: and(succeeded(), eq(variables.type, 'linux'))
 
       - script: |
           go build -o "$(Build.ArtifactStagingDirectory)/azcopy_darwin_amd64"
         env:
           CGO_ENABLED: 1
         displayName: 'Generate MacOS Build with AMD64'
-        # Don't run if job is canceled
-        condition: and(succeededOrFailed(), eq(variables.type, 'mac-os'))
+        # Don't run if job is canceled or fails
+        condition: and(succeeded(), eq(variables.type, 'mac-os'))
 
       # uncomment below when manually releasing for m1
       # - script: |
       #     curl -o "$(Build.ArtifactStagingDirectory)/azcopy_darwin_arm64" -L "BUILD_URL"
       #   displayName: 'Generate MacOS Build with ARM64'
-      #   # Don't run if job is canceled
-      #   condition: and(succeededOrFailed(), eq(variables.type, 'mac-os'))
+      #   # Don't run if job is canceled or fails
+      #   condition: and(succeeded(), eq(variables.type, 'mac-os'))
 
       # cross compile to make sure nothing broke
       - script: |
@@ -128,8 +128,8 @@ jobs:
           GOARCH: arm64
           CGO_ENABLED: 1
         displayName: 'Test Cross-compiled MacOS Build with ARM64'
-        # Don't run if job is canceled
-        condition: and(succeededOrFailed(), eq(variables.type, 'mac-os'))
+        # Don't run if job is canceled or fails
+        condition: and(succeeded(), eq(variables.type, 'mac-os'))
 
       - task: PublishBuildArtifacts@1
         displayName: 'Publish Artifacts'
@@ -348,8 +348,8 @@ jobs:
           curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
           az --version
         displayName: 'Install Azure CLI - Linux'
-        # Don't run if job is canceled
-        condition: and(succeededOrFailed(), eq(variables.GOOS, 'linux'))
+        # Don't run if job is canceled or fails
+        condition: and(succeeded(), eq(variables.GOOS, 'linux'))
 
       - task: PowerShell@2
         inputs:
@@ -358,8 +358,8 @@ jobs:
             choco install azure-cli -y
             az --version
         displayName: 'Install Azure CLI - Windows'
-        # Don't run if job is canceled
-        condition: and(succeededOrFailed(), eq(variables.GOOS, 'windows'))
+        # Don't run if job is canceled or fails
+        condition: and(succeeded(), eq(variables.GOOS, 'windows'))
 
       - template: azurePipelineTemplates/run_scenarios.yml
         parameters:


### PR DESCRIPTION
An earlier commit stopped several conditional tasks from running after their job was canceled; this commit goes further by stopping them from running after job failure, where appropriate. This commit also corrects a copy+paste mistake that caused conditional tasks in the merged "Additional_E2E_Tests" job to run after job failure.

[Update: The second commit:] **Corrected a pipeline task name.**

The "Golang Vet - Linux" task of the "Build" jobs runs on all OSs. It seems useful for it to do so, so the name was changed to "Golang Vet", rather than limiting the task to run only on Linux.

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->
The commit title and detail message (which are automatically used as the PR title and inserted above this section) say it all.

**Related Links**
- [Pipeline Conditions](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops#conditions-a-stage-job-or-step-runs-under)

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [x] Code quality improvement
- [x] Other (describe): Pipeline optimization

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->
Before the second commit renamed an irrelevant task noticed in the test runs below:
- https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31491&view=results - A smoke test. The tests that failed in jobs this PR didn't update are irrelevant and can be ignored; the point is that the pipeline still ran the expected jobs and tasks and the jobs and tasks this PR updated ran successfully.
- https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31493&view=results - A derivative branch that injects a task into the affected jobs that fails at the start; this branch only runs the jobs this PR updated.

After the second commit:
- TODO when running the pipeline to satisfy checks after double-approval