### PR TITLE
Increased E2E Test Timeout

### DIFF
--- a/azurePipelineTemplates/run-e2e.yml
+++ b/azurePipelineTemplates/run-e2e.yml
@@ -109,7 +109,7 @@ jobs:
             
             # Run tests, write coverage data to a directory, and pipe output to a file
             Write-Output "Running tests. Writing coverage data to `"$(coverageDir)`" directory and test results to $(testReportName).txt."
-            go test -timeout=2h -v ${{ parameters.test_cli_param }} ./e2etest | Tee-Object -FilePath "$(testReportName).txt"
+            go test -timeout=3h -v ${{ parameters.test_cli_param }} ./e2etest | Tee-Object -FilePath "$(testReportName).txt"
             
             # Save the exit code from the previous command
             $exitCode = $LASTEXITCODE


### PR DESCRIPTION
Increased the timeout for the end-to-end tests from two to three hours when running in the test pipeline.

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->
The "New_E2E" jobs routinely run the tests for about two hours. When we're lucky, the tests complete before the timeout. When we're unlucky, the tests are aborted (even if they were within a few minutes or seconds of passing), and we have to re-run the aborted jobs and wait about two hours to see if they'll pass or be aborted again.

**Increasing the test timeout is a workaround.** When we have time, we should do what we can to reduce the total run-time of the tests. If we can't reduce the time in an ideal way, we might need to split the "New_E2E" test suite.

Several of these jobs from pipeline runs from the past month succeeded after about two hours or failed after just over two hours. The links below show the timeout panic from several recent runs.

**Related Links**:
- https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31483&view=logs&j=6f28e20a-089c-532f-db92-0b6ab76d6855&s=d654deb9-056d-50a2-1717-90c08683d50a&t=279020b8-417f-541c-322b-8e74457c0d3f&l=9573 
- https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31483&view=logs&j=9a4fe81a-16b6-5be8-ba1c-883c3703d02d&s=96ac2280-8cb4-5df5-99de-dd2da759617d&t=79a5dcb3-114b-596d-26b3-171ebfdf78a0&l=9699 
- https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31453&view=logs&j=39d5c272-0e67-5d10-063c-8a2a0bfcda10&s=96ac2280-8cb4-5df5-99de-dd2da759617d&t=c982080f-5d57-5177-ebb0-695be9d9e103&l=12402 
- https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31415&view=logs&j=9a4fe81a-16b6-5be8-ba1c-883c3703d02d&s=96ac2280-8cb4-5df5-99de-dd2da759617d&t=79a5dcb3-114b-596d-26b3-171ebfdf78a0&l=9462 
- https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31412&view=logs&j=39d5c272-0e67-5d10-063c-8a2a0bfcda10&s=96ac2280-8cb4-5df5-99de-dd2da759617d&t=c982080f-5d57-5177-ebb0-695be9d9e103&l=12282 
- https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31391&view=logs&j=39d5c272-0e67-5d10-063c-8a2a0bfcda10&t=c982080f-5d57-5177-ebb0-695be9d9e103&l=12202 
- https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31331&view=logs&j=39d5c272-0e67-5d10-063c-8a2a0bfcda10&t=c982080f-5d57-5177-ebb0-695be9d9e103&l=12430 
- https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31182&view=logs&j=39d5c272-0e67-5d10-063c-8a2a0bfcda10&s=96ac2280-8cb4-5df5-99de-dd2da759617d&t=c982080f-5d57-5177-ebb0-695be9d9e103&l=12435 

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [x] Other (describe): Workaround for increased test time

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->
Smoke test: https://dev.azure.com/azstorage/AzCopy-NextGen/_build/results?buildId=31498&view=results
