### PR TITLE
During recursive delete wrap delete with DoWithOverrideReadOnlyOnAzureFiles

### DIFF
--- a/cmd/syncProcessor.go
+++ b/cmd/syncProcessor.go
@@ -877,11 +877,16 @@ func (b *remoteResourceDeleter) createFileDeletionFunc(fileClient *file.Client, 
 	return func() {
 		ctx := context.Background()
 
-		if _, err := fileClient.Delete(ctx, nil); err != nil {
+		err := common.DoWithOverrideReadOnlyOnAzureFiles(ctx, func() (interface{}, error) {
+			return fileClient.Delete(ctx, nil)
+		}, fileClient, b.forceIfReadOnly)
+
+		if err != nil {
 			msg := fmt.Sprintf("Failed to delete file %s: %v", filePath, err)
 			if azcopyScanningLogger != nil {
 				azcopyScanningLogger.Log(common.LogError, msg)
 			}
+			return // Don't increment count on failure
 		}
 
 		// Increment deletion count

--- a/common/util.go
+++ b/common/util.go
@@ -392,7 +392,6 @@ func DoWithOverrideReadOnlyOnAzureFiles(ctx context.Context, action func() (inte
 	}
 
 	// retry the action
-	LogToJobLogWithPrefix(fmt.Sprintf("ReadOnly attribute cleared successfully on %s. Retrying the operation.", targetFileOrDir.URL()), LogInfo)
 	_, err = action()
 	return err
 }

--- a/common/util.go
+++ b/common/util.go
@@ -363,6 +363,8 @@ func DoWithOverrideReadOnlyOnAzureFiles(ctx context.Context, action func() (inte
 	}
 
 	// did fail as readonly, and forcing is enabled
+	LogToJobLogWithPrefix(fmt.Sprintf("Target %s has ReadOnly attribute set. Attempting to clear the ReadOnly attribute before retrying the operation.", targetFileOrDir.URL()), LogInfo)
+
 	if f, ok := targetFileOrDir.(*file.Client); ok {
 		h := file.HTTPHeaders{}
 		_, err = f.SetHTTPHeaders(ctx, &file.SetHTTPHeadersOptions{
@@ -385,10 +387,12 @@ func DoWithOverrideReadOnlyOnAzureFiles(ctx context.Context, action func() (inte
 		err = errors.New("cannot remove read-only attribute from unknown target type")
 	}
 	if err != nil {
+		LogToJobLogWithPrefix(fmt.Sprintf("Failed to clear ReadOnly attribute on %s: %s", targetFileOrDir.URL(), err.Error()), LogError)
 		return err
 	}
 
 	// retry the action
+	LogToJobLogWithPrefix(fmt.Sprintf("ReadOnly attribute cleared successfully on %s. Retrying the operation.", targetFileOrDir.URL()), LogInfo)
 	_, err = action()
 	return err
 }


### PR DESCRIPTION
## Description
When mover calls sync job with delete files at destination setting, the recursive file deletion code path needs to handle read-only files.

- **Bug Fix**: File deletion during sync when called by mover is not handling read-only file deletion.

- **Related Links**:
- ADO Workitem 39043423
- ICM Number 21000001086856

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
Manually tested by running mover sync job on the same dataset that does repro with mover agent version 4.0.902_amd64

Thank you for your contribution to AzCopy!
