### PR TITLE
High-perf profile gating: scope perf knobs behind MOVER_HIGH_PERF

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -1414,7 +1414,7 @@ func (cca *CookedCopyCmdArgs) ReportProgressOrExit(lcm common.LifecycleMgr) (tot
 			}
 
 			throughput := computeThroughput()
-			throughputString := fmt.Sprintf("2-sec Throughput (Mb/s): %v", jobsAdmin.ToFixed(throughput, 4))
+			throughputString := jobsAdmin.FormatThroughput(throughput)
 			if throughput == 0 {
 				// As there would be case when no bits sent from local, e.g. service side copy, when throughput = 0, hide it.
 				throughputString = ""

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -1414,7 +1414,7 @@ func (cca *CookedCopyCmdArgs) ReportProgressOrExit(lcm common.LifecycleMgr) (tot
 			}
 
 			throughput := computeThroughput()
-			throughputString := jobsAdmin.FormatThroughput(throughput)
+			throughputString := fmt.Sprintf("2-sec Throughput (Mb/s): %v", jobsAdmin.ToFixed(throughput, 4))
 			if throughput == 0 {
 				// As there would be case when no bits sent from local, e.g. service side copy, when throughput = 0, hide it.
 				throughputString = ""

--- a/cmd/jobsResume.go
+++ b/cmd/jobsResume.go
@@ -128,7 +128,7 @@ func (cca *resumeJobController) ReportProgressOrExit(lcm common.LifecycleMgr) (t
 			}
 
 			throughput := computeThroughput()
-			throughputString := fmt.Sprintf("2-sec Throughput (Mb/s): %v", jobsAdmin.ToFixed(throughput, 4))
+			throughputString := jobsAdmin.FormatThroughput(throughput)
 			if throughput == 0 {
 				// As there would be case when no bits sent from local, e.g. service side copy, when throughput = 0, hide it.
 				throughputString = ""

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net/http"
 	"os"
 	"path"
 	"path/filepath"
@@ -255,7 +254,8 @@ func Initialize(resumeJobID common.JobID, isBench bool) error {
 	}
 
 	if buildmode.IsMover {
-		StartSystemStatsMonitorForJob(jobID)
+		// Disabled in prod (matches mover/c2c-stage): rolling-stats/pprof diagnostics not needed.
+		// StartSystemStatsMonitorForJob(jobID)
 	}
 
 	return nil
@@ -298,15 +298,6 @@ func StartSystemStatsMonitorForJob(jobId common.JobID) {
 	common.GlobalSystemStatsMonitor, _ = common.NewSystemStatsMonitor(config)
 
 	common.GlobalSystemStatsMonitor.Start(context.TODO())
-
-	// Optional pprof endpoint for live heap/goroutine profiling (debug only). The net/http/pprof
-	// handlers are already registered on the default mux; only start the listener when a port is
-	// set via AZCOPY_PPROF_PORT so normal runs are unaffected.
-	if pprofPort := os.Getenv("AZCOPY_PPROF_PORT"); pprofPort != "" {
-		go func() {
-			_ = http.ListenAndServe("localhost:"+pprofPort, nil)
-		}()
-	}
 
 	glcm.RegisterCloseFunc(func() {
 		common.GlobalSystemStatsMonitor.UnregisterAllCustomStatsCallbacks()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,11 +26,13 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 	"os"
 	"path"
 	"path/filepath"
 	"runtime"
 	"runtime/pprof"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -253,7 +255,7 @@ func Initialize(resumeJobID common.JobID, isBench bool) error {
 	}
 
 	if buildmode.IsMover {
-		//StartSystemStatsMonitorForJob(jobID)
+		StartSystemStatsMonitorForJob(jobID)
 	}
 
 	return nil
@@ -274,18 +276,37 @@ func StartSystemStatsMonitorForJob(jobId common.JobID) {
 		logger.CloseLog()
 	})
 
+	// Stats sampling cadence is env-tunable (AZCOPY_STATS_INTERVAL_SEC, default 10s). The system
+	// stats collection calls runtime.ReadMemStats (a stop-the-world pause) and parses /proc for
+	// socket/FD counts, so a too-aggressive interval steals throughput on large (30k-conn) jobs.
+	statsInterval := 10 * time.Second
+	if v := os.Getenv("AZCOPY_STATS_INTERVAL_SEC"); v != "" {
+		if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
+			statsInterval = time.Duration(secs) * time.Second
+		}
+	}
+
 	config := common.StatsMonitorConfig{
-		Interval:     5 * time.Second,
+		Interval:     statsInterval,
 		MonitorPaths: []string{azcopyLogPathFolder, common.AzcopyJobPlanFolder},
 		Logger:       logger,
 		LogConditions: common.LogConditions{
-			LogInterval: 60 * time.Second, // Regular logging
+			LogInterval: statsInterval,
 		},
 	}
 
 	common.GlobalSystemStatsMonitor, _ = common.NewSystemStatsMonitor(config)
 
 	common.GlobalSystemStatsMonitor.Start(context.TODO())
+
+	// Optional pprof endpoint for live heap/goroutine profiling (debug only). The net/http/pprof
+	// handlers are already registered on the default mux; only start the listener when a port is
+	// set via AZCOPY_PPROF_PORT so normal runs are unaffected.
+	if pprofPort := os.Getenv("AZCOPY_PPROF_PORT"); pprofPort != "" {
+		go func() {
+			_ = http.ListenAndServe("localhost:"+pprofPort, nil)
+		}()
+	}
 
 	glcm.RegisterCloseFunc(func() {
 		common.GlobalSystemStatsMonitor.UnregisterAllCustomStatsCallbacks()

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"runtime"
 	"strings"
 	"sync/atomic"
@@ -734,7 +735,7 @@ func (cca *cookedSyncCmdArgs) reportScanningProgress(lcm common.LifecycleMgr, th
 		// text output
 		throughputString := ""
 		if cca.firstPartOrdered() {
-			throughputString = fmt.Sprintf(", 2-sec Throughput (Mb/s): %v", jobsAdmin.ToFixed(throughput, 4))
+			throughputString = ", " + jobsAdmin.FormatThroughput(throughput)
 		}
 		return fmt.Sprintf("%v Files Scanned at Source, %v Files Scanned at Destination%s",
 			srcScanned, dstScanned, throughputString)
@@ -788,12 +789,12 @@ func (cca *cookedSyncCmdArgs) ReportProgressOrExit(lcm common.LifecycleMgr) (tot
 		// indicate whether constrained by disk or not
 		perfString, diskString := getPerfDisplayText(summary.PerfStrings, summary.PerfConstraint, duration, false)
 
-		return fmt.Sprintf("%.1f %%, %v Done, %v Failed, %v Pending, %v Total%s, 2-sec Throughput (Mb/s): %v%s",
+		return fmt.Sprintf("%.1f %%, %v Done, %v Failed, %v Pending, %v Total%s, %s%s",
 			summary.PercentComplete,
 			summary.TransfersCompleted,
 			summary.TransfersFailed,
 			summary.TotalTransfers-summary.TransfersCompleted-summary.TransfersFailed,
-			summary.TotalTransfers, perfString, jobsAdmin.ToFixed(throughput, 4), diskString)
+			summary.TotalTransfers, perfString, jobsAdmin.FormatThroughput(throughput), diskString)
 	})
 
 	if jobDone {
@@ -1117,6 +1118,25 @@ func init() {
 			}
 			if raw.isNFSCopy && ((raw.preserveSMBInfo && runtime.GOOS == "linux") || raw.preserveSMBPermissions) {
 				glcm.Error(InvalidFlagsForNFSMsg)
+			}
+
+			// Streaming merge-join enablement for the standalone CLI (perf branch): in mover builds the
+			// high-throughput streaming merge-join sync path is enabled BY DEFAULT so a customer running
+			// this azcopy directly gets it without extra flags. Actual use is still restricted by
+			// useStreamingMergeJoin() (only S3->Blob and Azure->Azure) and the orchestrator (which
+			// requires --recursive=false), so ineligible jobs transparently fall back to the classic sync
+			// path. USE_STREAMING_MERGE_JOIN is an explicit override / kill switch: set it to false/0/off
+			// to force the classic path, or true to force-enable in a non-mover build.
+			// (The mover's programmatic RawMoverSyncCmdArgs path sets this flag itself and does not reach
+			// this CLI code, so it is unaffected.)
+			if buildmode.IsMover {
+				raw.useStreamingMergeJoin = true
+			}
+			switch strings.ToLower(strings.TrimSpace(os.Getenv("USE_STREAMING_MERGE_JOIN"))) {
+			case "false", "0", "no", "off":
+				raw.useStreamingMergeJoin = false
+			case "true", "1", "yes", "on":
+				raw.useStreamingMergeJoin = true
 			}
 
 			cooked, err := raw.cook()

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -114,9 +114,32 @@ type rawSyncCmdArgs struct {
 	blockBlobTier string
 	// useStreamingMergeJoin opts this job into the channel-based streaming merge-join sync path
 	// (for eligible remote source/dest pairs). Set per-job by the mover when the job's subscription
-	// is allowlisted for the feature OR the USE_STREAMING_MERGE_JOIN env var is set (the mover
+	// is allowlisted for the feature OR the MOVER_SYNC_MJ env var is set (legacy aliases:
+	// MOVER_SYNC_STREAMING_MERGE_JOIN, USE_STREAMING_MERGE_JOIN) (the mover
 	// combines both into this single flag; azcopy does not read any enablement env var itself).
 	useStreamingMergeJoin bool
+}
+
+func parseTruthyBoolEnvValue(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "true", "1", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func getSyncMergeJoinOverride() (set bool, enabled bool) {
+	if v, ok := os.LookupEnv("MOVER_SYNC_MJ"); ok {
+		return true, parseTruthyBoolEnvValue(v)
+	}
+	if v, ok := os.LookupEnv("MOVER_SYNC_STREAMING_MERGE_JOIN"); ok {
+		return true, parseTruthyBoolEnvValue(v)
+	}
+	if v, ok := os.LookupEnv("USE_STREAMING_MERGE_JOIN"); ok {
+		return true, parseTruthyBoolEnvValue(v)
+	}
+	return false, false
 }
 
 // it is assume that the given url has the SAS stripped, and safe to print
@@ -1125,18 +1148,17 @@ func init() {
 			// this azcopy directly gets it without extra flags. Actual use is still restricted by
 			// useStreamingMergeJoin() (only S3->Blob and Azure->Azure) and the orchestrator (which
 			// requires --recursive=false), so ineligible jobs transparently fall back to the classic sync
-			// path. USE_STREAMING_MERGE_JOIN is an explicit override / kill switch: set it to false/0/off
-			// to force the classic path, or true to force-enable in a non-mover build.
+			// path. MOVER_SYNC_MJ (legacy aliases: MOVER_SYNC_STREAMING_MERGE_JOIN,
+			// USE_STREAMING_MERGE_JOIN)
+			// is an explicit override / kill switch: set it to false/0/off to force the
+			// classic path, or true to force-enable in a non-mover build.
 			// (The mover's programmatic RawMoverSyncCmdArgs path sets this flag itself and does not reach
 			// this CLI code, so it is unaffected.)
 			if buildmode.IsMover {
 				raw.useStreamingMergeJoin = true
 			}
-			switch strings.ToLower(strings.TrimSpace(os.Getenv("USE_STREAMING_MERGE_JOIN"))) {
-			case "false", "0", "no", "off":
-				raw.useStreamingMergeJoin = false
-			case "true", "1", "yes", "on":
-				raw.useStreamingMergeJoin = true
+			if set, enabled := getSyncMergeJoinOverride(); set {
+				raw.useStreamingMergeJoin = enabled
 			}
 
 			cooked, err := raw.cook()

--- a/cmd/syncEnumerator.go
+++ b/cmd/syncEnumerator.go
@@ -293,6 +293,16 @@ func (cca *cookedSyncCmdArgs) InitEnumerator(ctx context.Context, enumeratorOpti
 		cca.trailingDot = common.ETrailingDotOption.Disable()
 	}
 
+	// Perf: for Blob->Blob (incl. BlobFS), the ListBlobs enumeration already returns full source
+	// properties/metadata, so the per-blob backend GetProperties (S2SGetPropertiesInBackend) and the
+	// pre-transfer source-LMT re-fetch (S2SSourceChangeValidation -> GetFreshFileLastModifiedTime) are
+	// redundant round trips. Skip both for Blob->Blob; keep them for S3/Azure Files whose listings do
+	// not return full properties. (DestLengthValidation still guards against size mismatches.)
+	isBlobToBlob := (cca.fromTo.From() == common.ELocation.Blob() || cca.fromTo.From() == common.ELocation.BlobFS()) &&
+		(cca.fromTo.To() == common.ELocation.Blob() || cca.fromTo.To() == common.ELocation.BlobFS())
+	s2sGetPropertiesInBackend := !isBlobToBlob
+	s2sSourceChangeValidation := !isBlobToBlob
+
 	copyJobTemplate := &common.CopyJobPartOrderRequest{
 		JobID:               cca.jobID,
 		CommandString:       cca.commandString,
@@ -320,9 +330,9 @@ func (cca *cookedSyncCmdArgs) InitEnumerator(ctx context.Context, enumeratorOpti
 		PreservePermissions:            cca.preservePermissions,
 		PreserveInfo:                   cca.preserveInfo,
 		PreservePOSIXProperties:        cca.preservePOSIXProperties,
-		S2SSourceChangeValidation:      true,
+		S2SSourceChangeValidation:      s2sSourceChangeValidation,
 		DestLengthValidation:           true,
-		S2SGetPropertiesInBackend:      true,
+		S2SGetPropertiesInBackend:      s2sGetPropertiesInBackend,
 		S2SInvalidMetadataHandleOption: common.EInvalidMetadataHandleOption.RenameIfInvalid(),
 		CpkOptions:                     cca.cpkOptions,
 		S2SPreserveBlobTags:            cca.s2sPreserveBlobTags,

--- a/cmd/syncMergeJoinTwoWayConsumer.go
+++ b/cmd/syncMergeJoinTwoWayConsumer.go
@@ -410,10 +410,10 @@ func (e *mergeJoinTraversalError) Unwrap() error  { return e.err }
 const mergeJoinDefaultParallelTraversers int32 = 32
 
 // mergeJoinParallelTraversers is the directory-crawl parallelism for streaming merge-join jobs.
-// Override with SYNC_MJ_PARALLEL_TRAVERSERS (positive integer). The indexMap sync path is
-// unaffected and keeps its own parallelism (orchestratorOptions.parallelTraversers).
+// Override with MOVER_SYNC_MJ_TRAV as a positive integer. The indexMap sync path is unaffected and
+// keeps its own parallelism (orchestratorOptions.parallelTraversers).
 var mergeJoinParallelTraversers = func() int32 {
-	if v := strings.TrimSpace(os.Getenv("SYNC_MJ_PARALLEL_TRAVERSERS")); v != "" {
+	if v := strings.TrimSpace(os.Getenv("MOVER_SYNC_MJ_TRAV")); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			return int32(n)
 		}
@@ -425,7 +425,8 @@ var mergeJoinParallelTraversers = func() int32 {
 // this transfer. Enablement is decided entirely in the mover and passed to azcopy as the single
 // per-job flag cca.useStreamingMergeJoin, which the mover sets when EITHER:
 //   - the job's subscription is allowlisted for the feature via featureConfig, OR
-//   - the USE_STREAMING_MERGE_JOIN env var is set (blanket / testing).
+//   - the MOVER_SYNC_MJ env var is set (legacy aliases: MOVER_SYNC_STREAMING_MERGE_JOIN,
+//     USE_STREAMING_MERGE_JOIN) (blanket / testing).
 //
 // azcopy no longer reads any enablement env var itself. When the flag is set, the merge-join is
 // still restricted to the source/destination pairs whose listing order is proven lexicographically

--- a/cmd/syncOrchestrator.go
+++ b/cmd/syncOrchestrator.go
@@ -613,7 +613,8 @@ func syncOrchestratorHandler(cca *cookedSyncCmdArgs, enumerator *syncEnumerator,
 	}
 
 	// Log (once per job) whether the streaming merge-join is used. Enablement is decided in the
-	// mover (subscription allowlist via featureConfig OR the USE_STREAMING_MERGE_JOIN env var) and
+	// mover (subscription allowlist via featureConfig OR the MOVER_SYNC_MJ env var,
+	// legacy aliases MOVER_SYNC_STREAMING_MERGE_JOIN / USE_STREAMING_MERGE_JOIN) and
 	// passed to azcopy as the single cca.useStreamingMergeJoin flag. This makes it easy to confirm
 	// the gating in production logs.
 	if useStreamingMergeJoin(cca) {
@@ -621,13 +622,14 @@ func syncOrchestratorHandler(cca *cookedSyncCmdArgs, enumerator *syncEnumerator,
 			"Streaming merge-join ENABLED (mover flag) for %s->%s", cca.fromTo.From(), cca.fromTo.To()), true)
 
 		// The streaming merge-join uses its own directory-crawl parallelism
-		// (SYNC_MJ_PARALLEL_TRAVERSERS, default 32) — separate from the indexMap path, which keeps
+		// (MOVER_SYNC_MJ_TRAV, default 32)
+		// — separate from the indexMap path, which keeps
 		// orchestratorOptions.parallelTraversers unchanged — because the merge-join also lists
 		// source and destination concurrently within each directory.
 		if orchestratorOptions != nil {
 			orchestratorOptions.parallelTraversers = mergeJoinParallelTraversers
 			syncOrchestratorLog(common.LogInfo, fmt.Sprintf(
-				"Streaming merge-join directory-crawl parallelism set to %d (SYNC_MJ_PARALLEL_TRAVERSERS)", mergeJoinParallelTraversers), true)
+				"Streaming merge-join directory-crawl parallelism set to %d (MOVER_SYNC_MJ_TRAV)", mergeJoinParallelTraversers), true)
 		}
 	} else if cca.useStreamingMergeJoin {
 		syncOrchestratorLog(common.LogInfo, fmt.Sprintf(

--- a/cmd/syncOrchestrator.go
+++ b/cmd/syncOrchestrator.go
@@ -1090,8 +1090,9 @@ func (cca *cookedSyncCmdArgs) runSyncOrchestrator(enumerator *syncEnumerator, ct
 
 	crawlWg.Add(1) // Add the root directory to the WaitGroup
 
-	// Start parallel crawling with specified concurrency
-	parallel.Crawl(mainCtx, root, syncOneDir, int(crawlParallelism))
+	// crawlOutput closes only after every crawler worker (and thus every in-flight syncOneDir + its
+	// merge-join producers) has returned — the drain signal we use on cancellation below.
+	crawlOutput := parallel.Crawl(mainCtx, root, syncOneDir, int(crawlParallelism))
 
 	// Cancellation-aware wait
 	done := make(chan struct{})
@@ -1106,8 +1107,13 @@ func (cca *cookedSyncCmdArgs) runSyncOrchestrator(enumerator *syncEnumerator, ct
 		syncOrchestratorLog(common.LogInfo, "All sync traversers exited.")
 
 	case <-mainCtx.Done():
-		// Cancellation occurred
-		syncOrchestratorLog(common.LogInfo, "Orchestrator cancellation detected.")
+		// On cancel, drain crawlOutput until it closes so no producer is still alive to write to the
+		// caller-owned sync ErrorChannel after it is closed. (crawlWg can't be used here: the crawler
+		// abandons queued dirs on cancel, so it would never reach zero.)
+		syncOrchestratorLog(common.LogInfo, "Orchestrator cancellation detected; waiting for in-flight traversers to drain.")
+		for range crawlOutput {
+		}
+		syncOrchestratorLog(common.LogInfo, "All in-flight traversers drained after cancellation.")
 		return nil
 	}
 

--- a/cmd/syncThrottler.go
+++ b/cmd/syncThrottler.go
@@ -27,7 +27,9 @@ import (
 	"context"
 	"fmt"
 	_ "net/http/pprof"
+	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -36,14 +38,27 @@ import (
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
+// maxActiveGoRoutines caps total process goroutines before the sync throttler pauses source
+// enumeration. In high-throughput transfers the goroutine count is dominated by the HTTP
+// connection pool (~2 goroutines per live connection), NOT scanner activity, so the static 50k
+// default can false-trip and stall enumeration. Env-tunable via AZCOPY_SYNC_MAX_GOROUTINES to
+// decouple the throttle from transfer connections.
+var maxActiveGoRoutines int64 = func() int64 {
+	if v := os.Getenv("AZCOPY_SYNC_MAX_GOROUTINES"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 50_000
+}()
+
 // --- BEGIN Throttling and Concurrency Configuration ---
 const (
 	defaultMaxDirectoryChildCount int64 = 100_000 // Max files per active directory
 
 	// These are static limits as of now. This can be dynamically adjusted later
 	// by the StatsMonitor based on available system resources.
-	maxActiveGoRoutines      int64   = 50_000 // Max active goroutines, used for dynamic limits
-	maxMemoryUsageMultiplier float64 = 0.7    // Max memory usage percentage, used for dynamic limits
+	maxMemoryUsageMultiplier float64 = 0.7 // Max memory usage percentage, used for dynamic limits
 
 	throttleLogIntervalSecs       int           = 60 * 60                               // How often to log during throttling
 	semaphoreThrottleWaitInterval time.Duration = time.Duration(time.Millisecond * 100) // How often to check semaphore after throttle limit is hit
@@ -481,14 +496,32 @@ func (ds *ThrottleSemaphore) shouldThrottleBasedOnFiles() bool {
 
 // shouldThrottleBasedOnMemory applies hysteresis to memory pressure throttling
 func (ds *ThrottleSemaphore) shouldThrottleBasedOnMemory() bool {
-	var memStats runtime.MemStats
-	runtime.ReadMemStats(&memStats)
+	var usagePercent float64
 
-	totalMemoryBytes, err := common.GetTotalPhysicalMemory()
-	if err != nil {
-		totalMemoryBytes = int64(defaultPhysicalMemoryGB) * gbToBytesMultiplier
+	// Prefer the cached OS-level (container/cgroup-aware) memory percentage from the
+	// stats monitor. It is refreshed on the monitor's interval and avoids the
+	// runtime.ReadMemStats stop-the-world pause that would otherwise serialize every
+	// directory acquisition. It also reflects true process RSS rather than just the
+	// Go heap arena, which is what actually drives the container OOM killer.
+	gotFromMonitor := false
+	if common.GlobalSystemStatsMonitor != nil {
+		if p := common.GlobalSystemStatsMonitor.GetMemoryPercent(); p >= 0 {
+			usagePercent = p
+			gotFromMonitor = true
+		}
 	}
-	usagePercent := float64(memStats.Sys) / float64(totalMemoryBytes) * 100
+
+	if !gotFromMonitor {
+		// Fallback (e.g. non-linux dev, or monitor not yet started): use runtime stats.
+		var memStats runtime.MemStats
+		runtime.ReadMemStats(&memStats)
+
+		totalMemoryBytes, err := common.GetTotalPhysicalMemory()
+		if err != nil {
+			totalMemoryBytes = int64(defaultPhysicalMemoryGB) * gbToBytesMultiplier
+		}
+		usagePercent = float64(memStats.Sys) / float64(totalMemoryBytes) * 100
+	}
 
 	if !ds.memoryThrottleActive {
 		// Not currently throttling - check if we should start
@@ -564,6 +597,8 @@ func (ds *ThrottleSemaphore) getOrchestratorStats() []common.CustomStatEntry {
 		{Key: "SrcEnum", Value: fmt.Sprintf("%d", srcDirEnumerating.Load())},
 		{Key: "DstEnum", Value: fmt.Sprintf("%d", dstDirEnumerating.Load())},
 		{Key: "Done", Value: fmt.Sprintf("%d", totalDirectoriesProcessed.Load())},
+		{Key: "ChanFull", Value: fmt.Sprintf("%d", mergeJoinChanFullEvents.Load())},
+		{Key: "ChanDry", Value: fmt.Sprintf("%d", mergeJoinChanDryEvents.Load())},
 	}
 
 	waitingSource := ds.waitingForSourceSemaphore.Load()

--- a/cmd/syncThrottler.go
+++ b/cmd/syncThrottler.go
@@ -27,27 +27,24 @@ import (
 	"context"
 	"fmt"
 	_ "net/http/pprof"
-	"os"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common/buildmode"
 )
 
 // maxActiveGoRoutines caps total process goroutines before the sync throttler pauses source
 // enumeration. In high-throughput transfers the goroutine count is dominated by the HTTP
 // connection pool (~2 goroutines per live connection), NOT scanner activity, so the static 50k
-// default can false-trip and stall enumeration. Env-tunable via AZCOPY_SYNC_MAX_GOROUTINES to
-// decouple the throttle from transfer connections.
+// default can false-trip and stall enumeration. Only the high-perf mover profile raises the cap
+// (buildmode.SyncMaxGoroutines(): 300000); every other build keeps 50k.
 var maxActiveGoRoutines int64 = func() int64 {
-	if v := os.Getenv("AZCOPY_SYNC_MAX_GOROUTINES"); v != "" {
-		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
-			return n
-		}
+	if buildmode.IsMover && buildmode.HighPerf() {
+		return int64(buildmode.SyncMaxGoroutines())
 	}
 	return 50_000
 }()

--- a/cmd/zc_enumerator.go
+++ b/cmd/zc_enumerator.go
@@ -303,7 +303,10 @@ func newStoredObject(morpher objectMorpher, name string, relativePath string, en
 		name:               name,
 		relativePath:       relativePath,
 		entityType:         entityType,
-		lastModifiedTime:   lmt,
+		// Normalize to UTC so the time references the shared time.UTC location instead of a
+		// per-blob fixedZone("GMT") allocated by the SDK's RFC1123 date parse. With millions of
+		// enumerated blobs buffered in the shuffle window, those per-blob zones added GBs of live heap.
+		lastModifiedTime:   lmt.UTC(),
 		size:               size,
 		cacheControl:       props.CacheControl(),
 		contentDisposition: props.ContentDisposition(),

--- a/cmd/zc_processor.go
+++ b/cmd/zc_processor.go
@@ -23,7 +23,10 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"net/url"
+	"os"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -34,6 +37,75 @@ import (
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
+
+// Shuffle/backpressure tuning. The scanner buffers transfers, shuffles a window across the key range,
+// then dispatches plan parts asynchronously (plan files on the SMB share are the durable store).
+//
+// inMemoryWindowMultiplier: park watermark = this * shuffle window. Parking at 2x keeps the park point
+// above the flush point (so a full window can fill without deadlock) with a double-buffer of runway.
+const inMemoryWindowMultiplier = 2
+
+// scannerBackpressureWindowParts: floor (in plan-parts) for the park watermark, which is
+// max(getShuffleThresholdParts()*inMemoryWindowMultiplier, scannerBackpressureWindowParts). The floor
+// keeps a wide hysteresis band for small windows (avoids per-part parking, the sawtooth cause).
+// Env-tunable via AZCOPY_SCANNER_WINDOW_PARTS. The old fixed 100 (=1M buffered transfers => ~12GB of
+// CopyTransfer structs for a 10MiB workload) dwarfed the shuffle window; the watermark now adapts to
+// the shuffle threshold and this floor only sets the small-window hysteresis band.
+var scannerBackpressureWindowParts = func() int {
+	if v := os.Getenv("AZCOPY_SCANNER_WINDOW_PARTS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 16
+}()
+
+// defaultShuffleThresholdParts: shuffle window (plan-parts) when AZCOPY_SHUFFLE_THRESHOLD_PARTS is unset.
+// 500 * 10k/part = ~5M transfers shuffled across the full key range to spread adjacent sorted keys
+// across storage partitions (reduces ServerBusy).
+const defaultShuffleThresholdParts = 500
+
+var shuffleThresholdLogOnce sync.Once
+
+// getShuffleThresholdParts is the shuffle window in plan-parts; override via AZCOPY_SHUFFLE_THRESHOLD_PARTS (>=1).
+func getShuffleThresholdParts() int {
+	effective := defaultShuffleThresholdParts
+	rawValue := common.GetEnvironmentVariable(common.EEnvironmentVariable.ShuffleThresholdParts())
+	if rawValue != "" {
+		if n, err := strconv.Atoi(rawValue); err == nil && n >= 1 {
+			effective = n
+		}
+	}
+	shuffleThresholdLogOnce.Do(func() {
+		fmt.Printf("[ShuffleConfig] AZCOPY_SHUFFLE_THRESHOLD_PARTS raw=%q effective=%d\n", rawValue, effective)
+	})
+	return effective
+}
+
+var shuffleEnabledLogOnce sync.Once
+
+func isShuffleEnabled() bool {
+	enabled := false
+	rawValue := common.GetEnvironmentVariable(common.EEnvironmentVariable.ShuffleTransfers())
+	if rawValue != "" {
+		switch strings.ToLower(rawValue) {
+		case "true", "1":
+			enabled = true
+		}
+	}
+	shuffleEnabledLogOnce.Do(func() {
+		fmt.Printf("[ShuffleConfig] AZCOPY_SHUFFLE_TRANSFERS raw=%q enabled=%v\n", rawValue, enabled)
+	})
+	return enabled
+}
+
+// dispatchItem is a snapshot of a single part ready for async dispatch to STE.
+// It captures all state needed so the dispatch goroutine can call sendPartToSte
+// without holding any locks on the processor.
+type dispatchItem struct {
+	transfers common.Transfers
+	partNum   common.PartNumber
+}
 
 type copyTransferProcessor struct {
 	numOfTransfersPerPart int
@@ -52,10 +124,36 @@ type copyTransferProcessor struct {
 	hardlinkHandlingType   common.HardlinkHandlingType
 
 	//XDM: This is only essential when sync is through syncOrchestrator
-	syncTransferMutex sync.Mutex // mutex to synchronize access to the transfer scheduler
+	syncTransferMutex sync.Mutex // mutex to synchronize access to the shuffle buffer
+	flushMutex        sync.Mutex // mutex to serialize flush operations (sendPartToSte uses shared copyJobTemplate)
+
+	// shuffleBuffer accumulates transfers across multiple plan parts before shuffling and flushing.
+	// This ensures each plan part contains transfers from diverse key-space prefixes rather than
+	// consecutive ranges, improving storage partition utilization at high throughput.
+	shuffleBuffer            []common.CopyTransfer
+	shuffleBufferSizeInBytes uint64
+	shuffleBufferFileCounts  common.Transfers // tracks entity type counts for the buffer
+
+	// flushWindowCounter is a monotonically increasing flush window ID used for diagnostics.
+	flushWindowCounter uint32
+
+	// Pipelined dispatch: assembled plan parts are pushed directly into dispatchCh and a pool
+	// of background goroutines calls sendPartToSte asynchronously, allowing the shuffle buffer
+	// to refill concurrently. The transfer-level shuffle in flushShuffleBuffer already gives each
+	// part diverse key-space prefixes, so parts are dispatched as soon as they are assembled —
+	// there is no intermediate part-buffering/reorder stage.
+	dispatchCh   chan dispatchItem
+	dispatchOnce sync.Once
+	dispatchErr  error         // first error from dispatch goroutine
+	dispatchWg   sync.WaitGroup // tracks all dispatch workers
+	dispatchDone chan struct{}  // closed when all dispatch workers exit
+
+	// Backpressure signaling
+	bufferDrainCond *sync.Cond // condition variable signaled when the shuffle buffer drains below the high watermark
 }
 
 func newCopyTransferProcessor(copyJobTemplate *common.CopyJobPartOrderRequest, numOfTransfersPerPart int, source, destination common.ResourceString, reportFirstPartDispatched func(bool), reportFinalPartDispatched func(), preserveAccessTier, dryrunMode bool) *copyTransferProcessor {
+	m := &sync.Mutex{}
 	return &copyTransferProcessor{
 		numOfTransfersPerPart:     numOfTransfersPerPart,
 		copyJobTemplate:           copyJobTemplate,
@@ -67,7 +165,77 @@ func newCopyTransferProcessor(copyJobTemplate *common.CopyJobPartOrderRequest, n
 		folderPropertiesOption:    copyJobTemplate.Fpo,
 		symlinkHandlingType:       copyJobTemplate.SymlinkHandlingType,
 		dryrunMode:                dryrunMode,
+		dispatchCh:                make(chan dispatchItem, dispatchChParts()), // async dispatch buffer (in plan-parts); env-tunable
+		dispatchDone:              make(chan struct{}),
+		bufferDrainCond:           sync.NewCond(m),
 	}
+}
+
+// dispatchChParts returns the async-dispatch channel depth in plan-parts (AZCOPY_DISPATCH_CH_PARTS).
+// Each buffered item is a full part (numOfTransfersPerPart CopyTransfers with source+dest URLs), so
+// this directly caps how many transfers sit between flush and the STE when the engine is backpressured.
+// The old hardcoded 5000 (=50M transfers => tens of GB of live CopyTransfers) was the dominant heap holder.
+func dispatchChParts() int {
+	if v := os.Getenv("AZCOPY_DISPATCH_CH_PARTS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 128
+}
+
+// startDispatchPipeline ensures the background dispatch worker pool is running.
+// Called lazily on first use via sync.Once.
+func (s *copyTransferProcessor) startDispatchPipeline() {
+	s.dispatchOnce.Do(func() {
+		const numDispatchWorkers = 32 // parallelize fsync-heavy plan file creation
+		s.dispatchWg.Add(numDispatchWorkers)
+		for i := 0; i < numDispatchWorkers; i++ {
+			go s.dispatchWorker()
+		}
+		// Close dispatchDone when all workers finish
+		go func() {
+			s.dispatchWg.Wait()
+			close(s.dispatchDone)
+		}()
+	})
+}
+
+// dispatchWorker is a background goroutine that reads dispatchItems and sends them to STE.
+// Multiple workers run concurrently to parallelize plan file creation (fsync).
+func (s *copyTransferProcessor) dispatchWorker() {
+	defer s.dispatchWg.Done()
+	for item := range s.dispatchCh {
+		if s.dispatchErr != nil {
+			continue // drain channel after first error
+		}
+		// Build a local copy of the template for this part
+		template := *s.copyJobTemplate
+		template.Transfers = item.transfers
+		template.PartNum = item.partNum
+
+		var resp common.CopyJobPartOrderResponse
+		Rpc(common.ERpcCmd.CopyJobPartOrder(), &template, &resp)
+
+		// Report first part dispatched if this is part 0
+		if item.partNum == 0 && s.reportFirstPartDispatched != nil {
+			s.reportFirstPartDispatched(resp.JobStarted)
+		}
+
+		if resp.ErrorMsg != "" {
+			s.dispatchErr = errors.New(string(resp.ErrorMsg))
+		}
+	}
+}
+
+// waitForDispatchPipeline closes the dispatch channel and waits for all workers, returning the first
+// dispatch error. startDispatchPipeline is called first (idempotent) so small jobs that never flushed
+// a full part don't deadlock on an unclosed dispatchDone.
+func (s *copyTransferProcessor) waitForDispatchPipeline() error {
+	s.startDispatchPipeline()
+	close(s.dispatchCh)
+	<-s.dispatchDone
+	return s.dispatchErr
 }
 
 type DryrunTransfer struct {
@@ -287,8 +455,63 @@ func (s *copyTransferProcessor) scheduleCopyTransfer(storedObject StoredObject) 
 	}
 
 	if UseSyncOrchestrator {
-		s.syncTransferMutex.Lock()
-		defer s.syncTransferMutex.Unlock()
+		if isShuffleEnabled() {
+			shuffleThreshold := getShuffleThresholdParts()
+
+			// Backpressure: park the scanner only when the buffer runs far ahead of async dispatch.
+			// Park point sits above the flush point (double-buffer) to avoid deadlock, with a floor for
+			// wide hysteresis (no per-part parking -> no sawtooth).
+			parkParts := shuffleThreshold * inMemoryWindowMultiplier
+			if parkParts < scannerBackpressureWindowParts {
+				parkParts = scannerBackpressureWindowParts
+			}
+			highWatermark := s.numOfTransfersPerPart * parkParts
+			s.bufferDrainCond.L.Lock()
+			for len(s.shuffleBuffer) >= highWatermark {
+				s.bufferDrainCond.Wait()
+			}
+			s.bufferDrainCond.L.Unlock()
+
+			var needsFlush bool
+
+			s.syncTransferMutex.Lock()
+			s.shuffleBuffer = append(s.shuffleBuffer, copyTransfer)
+			s.shuffleBufferSizeInBytes += uint64(copyTransfer.SourceSize)
+			switch copyTransfer.EntityType {
+			case common.EEntityType.File():
+				s.shuffleBufferFileCounts.FileTransferCount++
+			case common.EEntityType.Folder():
+				s.shuffleBufferFileCounts.FolderTransferCount++
+			case common.EEntityType.Symlink():
+				s.shuffleBufferFileCounts.SymlinkTransferCount++
+			case common.EEntityType.Hardlink():
+				s.shuffleBufferFileCounts.HardlinksConvertedCount++
+			case common.EEntityType.FileProperties():
+				s.shuffleBufferFileCounts.FilePropertyTransferCount++
+			}
+			needsFlush = len(s.shuffleBuffer) >= s.numOfTransfersPerPart*shuffleThreshold
+			s.syncTransferMutex.Unlock()
+
+			if needsFlush {
+				if err := s.flushShuffleBuffer(); err != nil {
+					return err
+				}
+			}
+		} else {
+			// Direct dispatch: accumulate transfers, dispatch immediately when a full part is ready.
+			// No shuffle and no part reordering — bounded O(numOfTransfersPerPart) memory.
+			s.syncTransferMutex.Lock()
+			s.shuffleBuffer = append(s.shuffleBuffer, copyTransfer)
+			needsFlush := len(s.shuffleBuffer) >= s.numOfTransfersPerPart
+			s.syncTransferMutex.Unlock()
+
+			if needsFlush {
+				if err := s.flushDirectBuffer(); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
 	}
 
 	if len(s.copyJobTemplate.Transfers.List) == s.numOfTransfersPerPart {
@@ -325,10 +548,261 @@ func (s *copyTransferProcessor) scheduleCopyTransfer(storedObject StoredObject) 
 	return nil
 }
 
+// flushDirectBuffer dispatches accumulated transfers directly to STE without shuffling or
+// part reordering. Used when AZCOPY_SHUFFLE_TRANSFERS is disabled. Memory usage is bounded
+// at O(numOfTransfersPerPart).
+func (s *copyTransferProcessor) flushDirectBuffer() error {
+	s.flushMutex.Lock()
+	defer s.flushMutex.Unlock()
+
+	s.syncTransferMutex.Lock()
+	if len(s.shuffleBuffer) < s.numOfTransfersPerPart {
+		s.syncTransferMutex.Unlock()
+		return nil
+	}
+	toFlush := s.shuffleBuffer
+	s.shuffleBuffer = make([]common.CopyTransfer, 0, s.numOfTransfersPerPart)
+	s.syncTransferMutex.Unlock()
+
+	for len(toFlush) >= s.numOfTransfersPerPart {
+		// Copy batch to a new right-sized slice to avoid retaining the entire toFlush array
+		batch := make([]common.CopyTransfer, s.numOfTransfersPerPart)
+		copy(batch, toFlush[:s.numOfTransfersPerPart])
+		toFlush = toFlush[s.numOfTransfersPerPart:]
+
+		transfers := common.Transfers{List: batch}
+		for _, t := range batch {
+			transfers.TotalSizeInBytes += uint64(t.SourceSize)
+			switch t.EntityType {
+			case common.EEntityType.File():
+				transfers.FileTransferCount++
+			case common.EEntityType.Folder():
+				transfers.FolderTransferCount++
+			case common.EEntityType.Symlink():
+				transfers.SymlinkTransferCount++
+			case common.EEntityType.Hardlink():
+				transfers.HardlinksConvertedCount++
+			case common.EEntityType.FileProperties():
+				transfers.FilePropertyTransferCount++
+			}
+		}
+
+		// Pipeline: async dispatch
+		s.startDispatchPipeline()
+		s.dispatchCh <- dispatchItem{
+			transfers: transfers,
+			partNum:   s.copyJobTemplate.PartNum,
+		}
+		s.copyJobTemplate.PartNum++
+
+		if s.dispatchErr != nil {
+			return s.dispatchErr
+		}
+	}
+
+	// Put remainder back
+	if len(toFlush) > 0 {
+		s.syncTransferMutex.Lock()
+		s.shuffleBuffer = append(toFlush, s.shuffleBuffer...)
+		s.syncTransferMutex.Unlock()
+	}
+	return nil
+}
+
+// flushShuffleBuffer swaps out the accumulated buffer, shuffles it lock-free, and dispatches it as
+// plan-part-sized batches so transfers from different key-space prefixes are mixed across parts.
+func (s *copyTransferProcessor) flushShuffleBuffer() error {
+	// Phase 1: swap out the buffer under syncTransferMutex so enumeration can refill immediately.
+	s.syncTransferMutex.Lock()
+	if len(s.shuffleBuffer) < s.numOfTransfersPerPart {
+		// Another goroutine already flushed, nothing to do
+		s.syncTransferMutex.Unlock()
+		return nil
+	}
+	// Swap out the buffer — take ownership of the current slice, give the struct a fresh one
+	toFlush := s.shuffleBuffer
+	threshold := getShuffleThresholdParts()
+	newCap := s.numOfTransfersPerPart * threshold
+	if newCap < s.numOfTransfersPerPart*2 {
+		newCap = s.numOfTransfersPerPart * 2
+	}
+	s.shuffleBuffer = make([]common.CopyTransfer, 0, newCap)
+	s.shuffleBufferSizeInBytes = 0
+	s.shuffleBufferFileCounts = common.Transfers{}
+	s.syncTransferMutex.Unlock()
+
+	// Phase 2: shuffle lock-free (we exclusively own toFlush); does not block enumeration.
+	rand.Shuffle(len(toFlush), func(i, j int) {
+		toFlush[i], toFlush[j] = toFlush[j], toFlush[i]
+	})
+
+	// Phase 3: dispatch under flushMutex (serializes copyJobTemplate/PartNum/flushWindowCounter).
+	s.flushMutex.Lock()
+	defer s.flushMutex.Unlock()
+
+	// Track which flush window these batches belong to
+	s.flushWindowCounter++
+	currentWindow := s.flushWindowCounter
+
+	// Log transfer-level shuffle diagnostics
+	if jobsAdmin.JobsAdmin != nil {
+		nBatches := len(toFlush) / s.numOfTransfersPerPart
+		samples := make([]string, 0, 5)
+		step := len(toFlush) / 5
+		if step == 0 {
+			step = 1
+		}
+		for i := 0; i < len(toFlush) && len(samples) < 5; i += step {
+			src := toFlush[i].Source
+			if len(src) > 5 {
+				samples = append(samples, src[:5])
+			}
+		}
+		jobsAdmin.JobsAdmin.LogToJobLog(
+			fmt.Sprintf("[ShuffleDiag] Transfer-level flush window #%d: shuffled %d transfers -> %d batches, sample prefixes: %v",
+				currentWindow, len(toFlush), nBatches, samples),
+			common.LogInfo)
+	}
+
+	// Dispatch part-sized batches straight to the async pipeline (already shuffled above).
+	s.startDispatchPipeline()
+	for len(toFlush) >= s.numOfTransfersPerPart {
+		// Capped 3-index slice: hand out a view (no per-part malloc/copy); backing array frees when
+		// the last part drains from dispatchCh.
+		n := s.numOfTransfersPerPart
+		batch := toFlush[:n:n]
+		toFlush = toFlush[n:]
+
+		transfers := common.Transfers{List: batch}
+		// Calculate size for this batch
+		for _, t := range batch {
+			transfers.TotalSizeInBytes += uint64(t.SourceSize)
+			switch t.EntityType {
+			case common.EEntityType.File():
+				transfers.FileTransferCount++
+			case common.EEntityType.Folder():
+				transfers.FolderTransferCount++
+			case common.EEntityType.Symlink():
+				transfers.SymlinkTransferCount++
+			case common.EEntityType.Hardlink():
+				transfers.HardlinksConvertedCount++
+			case common.EEntityType.FileProperties():
+				transfers.FilePropertyTransferCount++
+			}
+		}
+
+		s.dispatchCh <- dispatchItem{
+			transfers: transfers,
+			partNum:   s.copyJobTemplate.PartNum,
+		}
+		s.copyJobTemplate.PartNum++
+
+		if s.dispatchErr != nil {
+			return s.dispatchErr
+		}
+	}
+
+	// Wake scanners parked on backpressure; they re-check the watermark (wide hysteresis preserved).
+	s.bufferDrainCond.L.Lock()
+	s.bufferDrainCond.Broadcast()
+	s.bufferDrainCond.L.Unlock()
+
+	// Put any remainder (< numOfTransfersPerPart) back into the buffer
+	if len(toFlush) > 0 {
+		s.syncTransferMutex.Lock()
+		// Prepend remainder to whatever new transfers accumulated while we were flushing
+		s.shuffleBuffer = append(toFlush, s.shuffleBuffer...)
+		for _, t := range toFlush {
+			s.shuffleBufferSizeInBytes += uint64(t.SourceSize)
+			switch t.EntityType {
+			case common.EEntityType.File():
+				s.shuffleBufferFileCounts.FileTransferCount++
+			case common.EEntityType.Folder():
+				s.shuffleBufferFileCounts.FolderTransferCount++
+			case common.EEntityType.Symlink():
+				s.shuffleBufferFileCounts.SymlinkTransferCount++
+			case common.EEntityType.Hardlink():
+				s.shuffleBufferFileCounts.HardlinksConvertedCount++
+			case common.EEntityType.FileProperties():
+				s.shuffleBufferFileCounts.FilePropertyTransferCount++
+			}
+		}
+		s.syncTransferMutex.Unlock()
+	}
+
+	return nil
+}
+
 var NothingScheduledError = errors.New("no transfers were scheduled because no files matched the specified criteria")
 var FinalPartCreatedMessage = "Final job part has been created"
 
 func (s *copyTransferProcessor) dispatchFinalPart() (copyJobInitiated bool, err error) {
+	fmt.Printf("[ShuffleConfig] dispatchFinalPart entered: UseSyncOrchestrator=%v, shuffleBufferLen=%d\n", UseSyncOrchestrator, len(s.shuffleBuffer))
+	// Flush any remaining transfers before dispatching the final part
+	if UseSyncOrchestrator && len(s.shuffleBuffer) > 0 {
+		s.flushMutex.Lock()
+
+		// Dispatch any remaining full plan parts straight to the async pipeline.
+		// The transfer-level shuffle already ran when these transfers were enqueued and the
+		// part-buffering/reorder stage has been removed, so the shuffle and non-shuffle paths
+		// are identical here — send each assembled part directly to dispatchCh. Any dispatch
+		// error is surfaced by waitForDispatchPipeline() below.
+		s.startDispatchPipeline()
+		for len(s.shuffleBuffer) > s.numOfTransfersPerPart {
+			batch := make([]common.CopyTransfer, s.numOfTransfersPerPart)
+			copy(batch, s.shuffleBuffer[:s.numOfTransfersPerPart])
+			s.shuffleBuffer = s.shuffleBuffer[s.numOfTransfersPerPart:]
+
+			transfers := common.Transfers{List: batch}
+			for _, t := range batch {
+				transfers.TotalSizeInBytes += uint64(t.SourceSize)
+				switch t.EntityType {
+				case common.EEntityType.File():
+					transfers.FileTransferCount++
+				case common.EEntityType.Folder():
+					transfers.FolderTransferCount++
+				case common.EEntityType.Symlink():
+					transfers.SymlinkTransferCount++
+				case common.EEntityType.Hardlink():
+					transfers.HardlinksConvertedCount++
+				case common.EEntityType.FileProperties():
+					transfers.FilePropertyTransferCount++
+				}
+			}
+			s.dispatchCh <- dispatchItem{
+				transfers: transfers,
+				partNum:   s.copyJobTemplate.PartNum,
+			}
+			s.copyJobTemplate.PartNum++
+		}
+
+		// Place the last remaining transfers (< numOfTransfersPerPart) into the template for the final part
+		s.copyJobTemplate.Transfers = common.Transfers{List: s.shuffleBuffer}
+		for _, t := range s.shuffleBuffer {
+			s.copyJobTemplate.Transfers.TotalSizeInBytes += uint64(t.SourceSize)
+			switch t.EntityType {
+			case common.EEntityType.File():
+				s.copyJobTemplate.Transfers.FileTransferCount++
+			case common.EEntityType.Folder():
+				s.copyJobTemplate.Transfers.FolderTransferCount++
+			case common.EEntityType.Symlink():
+				s.copyJobTemplate.Transfers.SymlinkTransferCount++
+			case common.EEntityType.Hardlink():
+				s.copyJobTemplate.Transfers.HardlinksConvertedCount++
+			case common.EEntityType.FileProperties():
+				s.copyJobTemplate.Transfers.FilePropertyTransferCount++
+			}
+		}
+		s.shuffleBuffer = nil
+		s.flushMutex.Unlock()
+	}
+
+	// Wait for all pipelined parts to finish before sending the final part.
+	// The final part must be the last one sent to STE to signal job completion.
+	if err := s.waitForDispatchPipeline(); err != nil {
+		return false, err
+	}
+
 	var resp common.CopyJobPartOrderResponse
 	s.copyJobTemplate.IsFinalPart = true
 	resp = s.sendPartToSte()

--- a/cmd/zc_processor.go
+++ b/cmd/zc_processor.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common/buildmode"
 )
 
 // Shuffle/backpressure tuning. The scanner buffers transfers, shuffles a window across the key range,
@@ -46,55 +47,40 @@ import (
 const inMemoryWindowMultiplier = 2
 
 // scannerBackpressureWindowParts: floor (in plan-parts) for the park watermark, which is
-// max(getShuffleThresholdParts()*inMemoryWindowMultiplier, scannerBackpressureWindowParts). The floor
-// keeps a wide hysteresis band for small windows (avoids per-part parking, the sawtooth cause).
-// Env-tunable via AZCOPY_SCANNER_WINDOW_PARTS. The old fixed 100 (=1M buffered transfers => ~12GB of
-// CopyTransfer structs for a 10MiB workload) dwarfed the shuffle window; the watermark now adapts to
-// the shuffle threshold and this floor only sets the small-window hysteresis band.
-var scannerBackpressureWindowParts = func() int {
-	if v := os.Getenv("AZCOPY_SCANNER_WINDOW_PARTS"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			return n
-		}
-	}
-	return 16
-}()
-
-// defaultShuffleThresholdParts: shuffle window (plan-parts) when AZCOPY_SHUFFLE_THRESHOLD_PARTS is unset.
-// 500 * 10k/part = ~5M transfers shuffled across the full key range to spread adjacent sorted keys
-// across storage partitions (reduces ServerBusy).
-const defaultShuffleThresholdParts = 500
+// max(getShuffleThresholdParts()*inMemoryWindowMultiplier, scannerBackpressureWindowParts). At 100
+// parts (* 10k transfers/part) the scanner may run ~1M transfers ahead of async dispatch before it
+// parks — a wide hysteresis band that avoids the per-part parking sawtooth. Baked constant (no env).
+const scannerBackpressureWindowParts = 100
 
 var shuffleThresholdLogOnce sync.Once
 
-// getShuffleThresholdParts is the shuffle window in plan-parts; override via AZCOPY_SHUFFLE_THRESHOLD_PARTS (>=1).
+// getShuffleThresholdParts is the shuffle window in plan-parts. Only reached on the high-perf mover
+// path, where the buildmode profile default is overridable by MOVER_SHUFFLE_PARTS (>=1).
 func getShuffleThresholdParts() int {
-	effective := defaultShuffleThresholdParts
-	rawValue := common.GetEnvironmentVariable(common.EEnvironmentVariable.ShuffleThresholdParts())
-	if rawValue != "" {
-		if n, err := strconv.Atoi(rawValue); err == nil && n >= 1 {
+	effective := buildmode.ShuffleThresholdParts()
+	rawMover := strings.TrimSpace(os.Getenv("MOVER_SHUFFLE_PARTS"))
+	if rawMover != "" {
+		if n, err := strconv.Atoi(rawMover); err == nil && n >= 1 {
 			effective = n
 		}
 	}
 	shuffleThresholdLogOnce.Do(func() {
-		fmt.Printf("[ShuffleConfig] AZCOPY_SHUFFLE_THRESHOLD_PARTS raw=%q effective=%d\n", rawValue, effective)
+		fmt.Printf("[ShuffleConfig] MOVER_SHUFFLE_PARTS raw=%q effective=%d\n", rawMover, effective)
 	})
 	return effective
 }
 
 var shuffleEnabledLogOnce sync.Once
 
+// isShuffleEnabled reports whether transfer shuffling is on. Only reached on the high-perf mover path,
+// where the buildmode profile default is overridable by AZCOPY_SHUFFLE_TRANSFERS.
 func isShuffleEnabled() bool {
-	enabled := false
-	rawValue := common.GetEnvironmentVariable(common.EEnvironmentVariable.ShuffleTransfers())
-	if rawValue != "" {
-		switch strings.ToLower(rawValue) {
-		case "true", "1":
-			enabled = true
-		}
+	enabled := buildmode.ShuffleEnabled()
+	if raw := common.GetEnvironmentVariable(common.EEnvironmentVariable.ShuffleTransfers()); raw != "" {
+		enabled = strings.EqualFold(raw, "true") || raw == "1"
 	}
 	shuffleEnabledLogOnce.Do(func() {
-		fmt.Printf("[ShuffleConfig] AZCOPY_SHUFFLE_TRANSFERS raw=%q enabled=%v\n", rawValue, enabled)
+		fmt.Printf("[ShuffleConfig] shuffle enabled=%v\n", enabled)
 	})
 	return enabled
 }
@@ -137,14 +123,13 @@ type copyTransferProcessor struct {
 	// flushWindowCounter is a monotonically increasing flush window ID used for diagnostics.
 	flushWindowCounter uint32
 
-	// Pipelined dispatch: assembled plan parts are pushed directly into dispatchCh and a pool
-	// of background goroutines calls sendPartToSte asynchronously, allowing the shuffle buffer
-	// to refill concurrently. The transfer-level shuffle in flushShuffleBuffer already gives each
-	// part diverse key-space prefixes, so parts are dispatched as soon as they are assembled —
-	// there is no intermediate part-buffering/reorder stage.
+	// High-perf mover path: assembled plan parts are pushed into dispatchCh and a pool
+	// of background goroutines calls sendPartToSte asynchronously, allowing the buffer
+	// to refill concurrently. Non-high-perf stays on synchronous dispatch for mover-default
+	// behavior parity.
 	dispatchCh   chan dispatchItem
 	dispatchOnce sync.Once
-	dispatchErr  error         // first error from dispatch goroutine
+	dispatchErr  error          // first error from dispatch goroutine
 	dispatchWg   sync.WaitGroup // tracks all dispatch workers
 	dispatchDone chan struct{}  // closed when all dispatch workers exit
 
@@ -153,8 +138,7 @@ type copyTransferProcessor struct {
 }
 
 func newCopyTransferProcessor(copyJobTemplate *common.CopyJobPartOrderRequest, numOfTransfersPerPart int, source, destination common.ResourceString, reportFirstPartDispatched func(bool), reportFinalPartDispatched func(), preserveAccessTier, dryrunMode bool) *copyTransferProcessor {
-	m := &sync.Mutex{}
-	return &copyTransferProcessor{
+	p := &copyTransferProcessor{
 		numOfTransfersPerPart:     numOfTransfersPerPart,
 		copyJobTemplate:           copyJobTemplate,
 		source:                    source,
@@ -165,10 +149,15 @@ func newCopyTransferProcessor(copyJobTemplate *common.CopyJobPartOrderRequest, n
 		folderPropertiesOption:    copyJobTemplate.Fpo,
 		symlinkHandlingType:       copyJobTemplate.SymlinkHandlingType,
 		dryrunMode:                dryrunMode,
-		dispatchCh:                make(chan dispatchItem, dispatchChParts()), // async dispatch buffer (in plan-parts); env-tunable
-		dispatchDone:              make(chan struct{}),
-		bufferDrainCond:           sync.NewCond(m),
 	}
+	// High-perf mover only: allocate the async dispatch pipeline + backpressure resources.
+	// Mover-default keeps the original synchronous path with no extra allocation.
+	if useAsyncDispatchPipeline() {
+		p.dispatchCh = make(chan dispatchItem, dispatchChParts())
+		p.dispatchDone = make(chan struct{})
+		p.bufferDrainCond = sync.NewCond(&sync.Mutex{})
+	}
+	return p
 }
 
 // dispatchChParts returns the async-dispatch channel depth in plan-parts (AZCOPY_DISPATCH_CH_PARTS).
@@ -176,17 +165,24 @@ func newCopyTransferProcessor(copyJobTemplate *common.CopyJobPartOrderRequest, n
 // this directly caps how many transfers sit between flush and the STE when the engine is backpressured.
 // The old hardcoded 5000 (=50M transfers => tens of GB of live CopyTransfers) was the dominant heap holder.
 func dispatchChParts() int {
-	if v := os.Getenv("AZCOPY_DISPATCH_CH_PARTS"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			return n
-		}
-	}
 	return 128
+}
+
+func useAsyncDispatchPipeline() bool {
+	return buildmode.IsMover && buildmode.HighPerf()
+}
+
+func useHighPerfSyncPath() bool {
+	return buildmode.IsMover && buildmode.HighPerf()
 }
 
 // startDispatchPipeline ensures the background dispatch worker pool is running.
 // Called lazily on first use via sync.Once.
 func (s *copyTransferProcessor) startDispatchPipeline() {
+	if !useAsyncDispatchPipeline() {
+		return
+	}
+
 	s.dispatchOnce.Do(func() {
 		const numDispatchWorkers = 32 // parallelize fsync-heavy plan file creation
 		s.dispatchWg.Add(numDispatchWorkers)
@@ -209,29 +205,54 @@ func (s *copyTransferProcessor) dispatchWorker() {
 		if s.dispatchErr != nil {
 			continue // drain channel after first error
 		}
-		// Build a local copy of the template for this part
-		template := *s.copyJobTemplate
-		template.Transfers = item.transfers
-		template.PartNum = item.partNum
-
-		var resp common.CopyJobPartOrderResponse
-		Rpc(common.ERpcCmd.CopyJobPartOrder(), &template, &resp)
-
-		// Report first part dispatched if this is part 0
-		if item.partNum == 0 && s.reportFirstPartDispatched != nil {
-			s.reportFirstPartDispatched(resp.JobStarted)
-		}
-
-		if resp.ErrorMsg != "" {
-			s.dispatchErr = errors.New(string(resp.ErrorMsg))
+		if err := s.dispatchPartNow(item); err != nil {
+			s.dispatchErr = err
 		}
 	}
+}
+
+func (s *copyTransferProcessor) dispatchPartNow(item dispatchItem) error {
+	// Build a local copy of the template for this part
+	template := *s.copyJobTemplate
+	template.Transfers = item.transfers
+	template.PartNum = item.partNum
+
+	var resp common.CopyJobPartOrderResponse
+	Rpc(common.ERpcCmd.CopyJobPartOrder(), &template, &resp)
+
+	// Report first part dispatched if this is part 0
+	if item.partNum == 0 && s.reportFirstPartDispatched != nil {
+		s.reportFirstPartDispatched(resp.JobStarted)
+	}
+
+	if resp.ErrorMsg != "" {
+		return errors.New(string(resp.ErrorMsg))
+	}
+
+	return nil
+}
+
+func (s *copyTransferProcessor) dispatchPart(item dispatchItem) error {
+	if useAsyncDispatchPipeline() {
+		s.startDispatchPipeline()
+		s.dispatchCh <- item
+		if s.dispatchErr != nil {
+			return s.dispatchErr
+		}
+		return nil
+	}
+
+	return s.dispatchPartNow(item)
 }
 
 // waitForDispatchPipeline closes the dispatch channel and waits for all workers, returning the first
 // dispatch error. startDispatchPipeline is called first (idempotent) so small jobs that never flushed
 // a full part don't deadlock on an unclosed dispatchDone.
 func (s *copyTransferProcessor) waitForDispatchPipeline() error {
+	if !useAsyncDispatchPipeline() {
+		return nil
+	}
+
 	s.startDispatchPipeline()
 	close(s.dispatchCh)
 	<-s.dispatchDone
@@ -454,7 +475,7 @@ func (s *copyTransferProcessor) scheduleCopyTransfer(storedObject StoredObject) 
 		return nil
 	}
 
-	if UseSyncOrchestrator {
+	if UseSyncOrchestrator && useHighPerfSyncPath() {
 		if isShuffleEnabled() {
 			shuffleThreshold := getShuffleThresholdParts()
 
@@ -512,6 +533,11 @@ func (s *copyTransferProcessor) scheduleCopyTransfer(storedObject StoredObject) 
 			}
 		}
 		return nil
+	}
+
+	if UseSyncOrchestrator {
+		s.syncTransferMutex.Lock()
+		defer s.syncTransferMutex.Unlock()
 	}
 
 	if len(s.copyJobTemplate.Transfers.List) == s.numOfTransfersPerPart {
@@ -587,17 +613,13 @@ func (s *copyTransferProcessor) flushDirectBuffer() error {
 			}
 		}
 
-		// Pipeline: async dispatch
-		s.startDispatchPipeline()
-		s.dispatchCh <- dispatchItem{
+		if err := s.dispatchPart(dispatchItem{
 			transfers: transfers,
 			partNum:   s.copyJobTemplate.PartNum,
+		}); err != nil {
+			return err
 		}
 		s.copyJobTemplate.PartNum++
-
-		if s.dispatchErr != nil {
-			return s.dispatchErr
-		}
 	}
 
 	// Put remainder back
@@ -664,8 +686,7 @@ func (s *copyTransferProcessor) flushShuffleBuffer() error {
 			common.LogInfo)
 	}
 
-	// Dispatch part-sized batches straight to the async pipeline (already shuffled above).
-	s.startDispatchPipeline()
+	// Dispatch part-sized batches; high-perf uses async pipeline, non-high-perf stays synchronous.
 	for len(toFlush) >= s.numOfTransfersPerPart {
 		// Capped 3-index slice: hand out a view (no per-part malloc/copy); backing array frees when
 		// the last part drains from dispatchCh.
@@ -691,15 +712,13 @@ func (s *copyTransferProcessor) flushShuffleBuffer() error {
 			}
 		}
 
-		s.dispatchCh <- dispatchItem{
+		if err := s.dispatchPart(dispatchItem{
 			transfers: transfers,
 			partNum:   s.copyJobTemplate.PartNum,
+		}); err != nil {
+			return err
 		}
 		s.copyJobTemplate.PartNum++
-
-		if s.dispatchErr != nil {
-			return s.dispatchErr
-		}
 	}
 
 	// Wake scanners parked on backpressure; they re-check the watermark (wide hysteresis preserved).
@@ -737,17 +756,15 @@ var NothingScheduledError = errors.New("no transfers were scheduled because no f
 var FinalPartCreatedMessage = "Final job part has been created"
 
 func (s *copyTransferProcessor) dispatchFinalPart() (copyJobInitiated bool, err error) {
-	fmt.Printf("[ShuffleConfig] dispatchFinalPart entered: UseSyncOrchestrator=%v, shuffleBufferLen=%d\n", UseSyncOrchestrator, len(s.shuffleBuffer))
 	// Flush any remaining transfers before dispatching the final part
-	if UseSyncOrchestrator && len(s.shuffleBuffer) > 0 {
+	if UseSyncOrchestrator && useHighPerfSyncPath() && len(s.shuffleBuffer) > 0 {
 		s.flushMutex.Lock()
 
-		// Dispatch any remaining full plan parts straight to the async pipeline.
+		// Dispatch any remaining full plan parts.
 		// The transfer-level shuffle already ran when these transfers were enqueued and the
 		// part-buffering/reorder stage has been removed, so the shuffle and non-shuffle paths
-		// are identical here — send each assembled part directly to dispatchCh. Any dispatch
+		// are identical here — send each assembled part directly. Any dispatch
 		// error is surfaced by waitForDispatchPipeline() below.
-		s.startDispatchPipeline()
 		for len(s.shuffleBuffer) > s.numOfTransfersPerPart {
 			batch := make([]common.CopyTransfer, s.numOfTransfersPerPart)
 			copy(batch, s.shuffleBuffer[:s.numOfTransfersPerPart])
@@ -769,9 +786,12 @@ func (s *copyTransferProcessor) dispatchFinalPart() (copyJobInitiated bool, err 
 					transfers.FilePropertyTransferCount++
 				}
 			}
-			s.dispatchCh <- dispatchItem{
+			if err := s.dispatchPart(dispatchItem{
 				transfers: transfers,
 				partNum:   s.copyJobTemplate.PartNum,
+			}); err != nil {
+				s.flushMutex.Unlock()
+				return false, err
 			}
 			s.copyJobTemplate.PartNum++
 		}

--- a/cmd/zc_traverser_blob.go
+++ b/cmd/zc_traverser_blob.go
@@ -131,6 +131,13 @@ func (t *blobTraverser) destIsBlobFS() bool {
 
 func (t *blobTraverser) writeToBlobErrorChannel(err ErrorBlobInfo) {
 	if t.errorChannel != nil {
+		// Defense-in-depth: the orchestrator drains all traversers before the caller closes this
+		// channel, but recover in case a send still races a close during cancellation.
+		defer func() {
+			if r := recover(); r != nil {
+				WarnStdoutAndScanningLog(fmt.Sprintf("Error channel closed, could not send error: %v", err.ErrorMessage()))
+			}
+		}()
 		select {
 		case t.errorChannel <- err:
 		default:

--- a/cmd/zc_traverser_s3.go
+++ b/cmd/zc_traverser_s3.go
@@ -215,20 +215,14 @@ func (t *s3Traverser) Traverse(preprocessor objectMorpher, processor objectProce
 	// This is because * is both a valid URL path character and a valid portion of an object key in S3.
 	searchPrefix := t.s3URLParts.ObjectKey
 
-	// The streaming merge-join (sync orchestrator) needs each directory level emitted in
-	// lexicographic order. minio's ListObjects yields a page's objects (Contents) before its
-	// sub-dirs (CommonPrefixes), so the raw stream is files-then-dirs per page — not globally
-	// sorted. Collect the level's dirs and files into two runs (each stays sorted: S3 returns
-	// pages in sorted order and each category within a page is sorted) and two-pointer merge
-	// them at the end. Merge key matches buildChildPath: folder = "<name>/", file = "<name>".
-	// Gated to the orchestrator path; the recursive path emits directly.
-	// NOTE: this buffers one directory level. A future memory optimization is a per-page merge
-	// via the minio Core ListObjectsV2 API (mirrors the blob traverser's per-page merge).
-	type s3Entry struct {
-		obj StoredObject
-		key string
-	}
-	var dirEntries, fileEntries []s3Entry
+	// The traverser emits objects in raw S3 listing order (files and sub-dirs as ListObjects
+	// returns them) via processOne — it does NO per-level buffering. Any ordering the streaming
+	// merge-join needs is done in its own producer (traverserToTypedChannels: a folders-only heap
+	// plus a file order-guard), so a single prefix with millions of objects is streamed, not
+	// accumulated in memory. This is safe because S3 Contents are lexicographically sorted across
+	// pages (satisfying the producer's file order-guard) and folders (CommonPrefixes) may arrive in
+	// any order and are reordered by the heap. The non-streaming orchestrator path indexes into a
+	// map, so it is order-independent too.
 	processOne := func(so StoredObject) error {
 		e := processIfPassedFilters(filters, so, processor)
 		_, e = getProcessingError(e)
@@ -242,17 +236,6 @@ func (t *s3Traverser) Traverse(preprocessor objectMorpher, processor objectProce
 			})
 		}
 		return e
-	}
-	emitS3 := func(so StoredObject) error {
-		if !t.includeDirectoryOrPrefix {
-			return processOne(so)
-		}
-		if so.entityType == common.EEntityType.Folder() {
-			dirEntries = append(dirEntries, s3Entry{obj: so, key: strings.TrimSuffix(so.relativePath, common.AZCOPY_PATH_SEPARATOR_STRING) + common.AZCOPY_PATH_SEPARATOR_STRING})
-		} else {
-			fileEntries = append(fileEntries, s3Entry{obj: so, key: so.relativePath})
-		}
-		return nil
 	}
 
 	// It's a bucket or virtual directory.
@@ -376,27 +359,8 @@ func (t *s3Traverser) Traverse(preprocessor objectMorpher, processor objectProce
 				t.s3URLParts.BucketName)
 		}
 
-		if err = emitS3(storedObject); err != nil {
+		if err = processOne(storedObject); err != nil {
 			return
-		}
-	}
-
-	// Flush the buffered level in globally sorted order by merging the two sorted runs
-	// (sub-dirs and files). No-op for the recursive path, which emitted directly above.
-	if t.includeDirectoryOrPrefix {
-		di, fi := 0, 0
-		for di < len(dirEntries) || fi < len(fileEntries) {
-			if fi >= len(fileEntries) || (di < len(dirEntries) && dirEntries[di].key < fileEntries[fi].key) {
-				if err = processOne(dirEntries[di].obj); err != nil {
-					return
-				}
-				di++
-			} else {
-				if err = processOne(fileEntries[fi].obj); err != nil {
-					return
-				}
-				fi++
-			}
 		}
 	}
 	return

--- a/common/azHttpClient.go
+++ b/common/azHttpClient.go
@@ -21,9 +21,13 @@
 package common
 
 import (
+	"context"
+	"crypto/tls"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptrace"
+	"os"
 	"runtime"
 	"strconv"
 	"sync"
@@ -40,40 +44,162 @@ var (
 )
 
 const (
-	maxIdleConnsPerHost_MaxValue = 3000
+	maxIdleConnsPerHost_MaxValue = 30000
 	httpTraceTickerInterval      = time.Minute * 1
 )
+
+// ShardedTransport implements http.RoundTripper by distributing requests across
+// N underlying http.Transport instances via atomic round-robin. Each transport has
+// its own connection pool and connsPerHostMu lock, so contention is reduced by N×.
+// This is critical for high-IOPS workloads where thousands of goroutines compete.
+type ShardedTransport struct {
+	transports []*http.Transport
+	counter    atomic.Uint64
+	shardStats []shardMetrics
+}
+
+// shardMetrics tracks per-shard connection and concurrency statistics.
+type shardMetrics struct {
+	inFlight    atomic.Int64 // current in-flight requests
+	peakFlight  atomic.Int64 // peak in-flight since last log
+	totalReqs   atomic.Int64 // total requests routed to this shard
+	connNew     atomic.Int64 // new connections (not reused)
+	connReused  atomic.Int64 // reused connections
+}
+
+func (s *ShardedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	idx := s.counter.Add(1) % uint64(len(s.transports))
+	m := &s.shardStats[idx]
+
+	// Track in-flight concurrency
+	inflight := m.inFlight.Add(1)
+	m.totalReqs.Add(1)
+	// Update peak (relaxed CAS loop)
+	for {
+		peak := m.peakFlight.Load()
+		if inflight <= peak || m.peakFlight.CompareAndSwap(peak, inflight) {
+			break
+		}
+	}
+
+	// Inject httptrace to count connections per shard
+	trace := &httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) {
+			if info.Reused {
+				m.connReused.Add(1)
+			} else {
+				m.connNew.Add(1)
+			}
+		},
+	}
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
+
+	resp, err := s.transports[idx].RoundTrip(req)
+	m.inFlight.Add(-1)
+	return resp, err
+}
+
+// startShardLogger logs per-shard stats periodically (every 60s).
+func (s *ShardedTransport) startShardLogger() {
+	go func() {
+		ticker := time.NewTicker(60 * time.Second)
+		defer ticker.Stop()
+		for range ticker.C {
+			for i := range s.shardStats {
+				m := &s.shardStats[i]
+				inflight := m.inFlight.Load()
+				peak := m.peakFlight.Swap(0) // reset peak each interval
+				total := m.totalReqs.Load()
+				connNew := m.connNew.Load()
+				connReused := m.connReused.Load()
+				// Only log shards that had traffic
+				if total > 0 {
+					fmt.Fprintf(os.Stderr,
+						"SHARD[%d]: inFlight=%d peakFlight=%d totalReqs=%d connNew=%d connReused=%d activeConns~%d\n",
+						i, inflight, peak, total, connNew, connReused, connNew)
+				}
+			}
+		}
+	}()
+}
+
+// defaultNumTransportShards is the default number of http.Transport instances created. Each shard
+// has its own connection pool + mutex, so N shards reduce pool-lock contention by ~N times. Overridable
+// via AZCOPY_TRANSPORT_SHARDS for perf tuning.
+const defaultNumTransportShards = 32
+
+// getNumTransportShards returns the configured transport shard count from AZCOPY_TRANSPORT_SHARDS,
+// falling back to defaultNumTransportShards when unset or invalid (< 1).
+func getNumTransportShards() int {
+	if raw := os.Getenv("AZCOPY_TRANSPORT_SHARDS"); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n >= 1 {
+			return n
+		}
+	}
+	return defaultNumTransportShards
+}
+
+// newShardedTransport creates N http.Transport instances with identical configuration, where N is
+// getNumTransportShards() (default 32, overridable via AZCOPY_TRANSPORT_SHARDS). Azure Blob Storage
+// only supports HTTP/1.1 (per MS docs), so we optimize for maximum parallel connections. Sharding is
+// what eliminates pool lock contention; maxConnsPerHost is a per-shard ceiling (1024) sized well
+// above observed peak usage (~190 conns/shard) so it never gates concurrency.
+func newShardedTransport(maxConnsPerHost int) *ShardedTransport {
+	numShards := getNumTransportShards()
+	shards := make([]*http.Transport, numShards)
+	for i := range shards {
+		dialer := &net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}
+		shards[i] = &http.Transport{
+			Proxy: GlobalProxyLookup,
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return dialer.DialContext(ctx, network, addr)
+			},
+			MaxConnsPerHost:        maxConnsPerHost,
+			MaxIdleConns:           0,
+			MaxIdleConnsPerHost:    maxConnsPerHost,
+			IdleConnTimeout:        180 * time.Second,
+			TLSHandshakeTimeout:    10 * time.Second,
+			ExpectContinueTimeout:  1 * time.Second,
+			DisableKeepAlives:      false,
+			DisableCompression:     true,
+			MaxResponseHeaderBytes: 0,
+			WriteBufferSize:        64 * 1024,
+			ReadBufferSize:         64 * 1024,
+			ForceAttemptHTTP2:      false, // Azure Blob doesn't support h2
+			TLSClientConfig: &tls.Config{
+				NextProtos: []string{"http/1.1"},
+			},
+		}
+	}
+	st := &ShardedTransport{
+		transports: shards,
+		shardStats: make([]shardMetrics, numShards),
+	}
+	st.startShardLogger()
+	return st
+}
 
 // GetGlobalHTTPClient initializes and returns the process-global HTTP client exactly once.
 // Subsequent calls return the same client. The logger function, if provided on the first call,
 // will be invoked with status messages.
 func GetGlobalHTTPClient(logger ILoggerResetable) *http.Client {
 	globalHTTPClientOnce.Do(func() {
-		const concurrentDialsPerCpu = 10
+		const maxConnsPerHost = 1024
+		shardedTransport := newShardedTransport(maxConnsPerHost)
 		client := &http.Client{
-			Transport: &http.Transport{
-				Proxy:                  GlobalProxyLookup,
-				MaxConnsPerHost:        concurrentDialsPerCpu * runtime.NumCPU(),
-				MaxIdleConns:           0,
-				MaxIdleConnsPerHost:    GetMaxIdleConnsPerHost(),
-				IdleConnTimeout:        180 * time.Second,
-				TLSHandshakeTimeout:    10 * time.Second,
-				ExpectContinueTimeout:  1 * time.Second,
-				DisableKeepAlives:      false,
-				DisableCompression:     true,
-				MaxResponseHeaderBytes: 0,
-			},
+			Transport: shardedTransport,
 		}
 		GlobalHTTPClient = client
+		// Always log to stderr so it shows up in container logs
+		msg := fmt.Sprintf(
+			"GetGlobalHTTPClient: SHARDED_TRANSPORT_V6 initialized %p shards=%d MaxConnsPerHost=%d HTTP1.1_ONLY",
+			client, len(shardedTransport.transports), maxConnsPerHost)
+		fmt.Fprintln(os.Stderr, msg)
 		if logger != nil {
-			if tr, ok := client.Transport.(*http.Transport); ok {
-				logger.Log(LogError, // XDM: This is error level on purpose as we want to make sure it is seen in the logs
-					fmt.Sprintf(
-						"GetGlobalHTTPClient: initialized %p MaxIdleConnsPerHost=%d MaxConnsPerHost=%d MaxIdleConns=%d",
-						client, tr.MaxIdleConnsPerHost, tr.MaxConnsPerHost, tr.MaxIdleConns))
-			} else {
-				logger.Log(LogError, fmt.Sprintf("GetGlobalHTTPClient: initialized %p", client))
-			}
+			logger.Log(LogError, msg)
 		}
 	})
 	return GlobalHTTPClient

--- a/common/azHttpClient.go
+++ b/common/azHttpClient.go
@@ -35,6 +35,8 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+
+	"github.com/Azure/azure-storage-azcopy/v10/common/buildmode"
 )
 
 // GlobalHTTPClient is the process-wide HTTP client used by AzCopy when initialized via InitGlobalHTTPClient.
@@ -44,9 +46,14 @@ var (
 )
 
 const (
-	maxIdleConnsPerHost_MaxValue = 30000
+	maxIdleConnsPerHost_MaxValue = 3000
 	httpTraceTickerInterval      = time.Minute * 1
+	shardStatsLogInterval        = time.Minute * 5
 )
+
+func useHighPerfNetworkPath() bool {
+	return buildmode.IsMover && buildmode.HighPerf()
+}
 
 // ShardedTransport implements http.RoundTripper by distributing requests across
 // N underlying http.Transport instances via atomic round-robin. Each transport has
@@ -60,11 +67,11 @@ type ShardedTransport struct {
 
 // shardMetrics tracks per-shard connection and concurrency statistics.
 type shardMetrics struct {
-	inFlight    atomic.Int64 // current in-flight requests
-	peakFlight  atomic.Int64 // peak in-flight since last log
-	totalReqs   atomic.Int64 // total requests routed to this shard
-	connNew     atomic.Int64 // new connections (not reused)
-	connReused  atomic.Int64 // reused connections
+	inFlight   atomic.Int64 // current in-flight requests
+	peakFlight atomic.Int64 // peak in-flight since last log
+	totalReqs  atomic.Int64 // total requests routed to this shard
+	connNew    atomic.Int64 // new connections (not reused)
+	connReused atomic.Int64 // reused connections
 }
 
 func (s *ShardedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -99,10 +106,10 @@ func (s *ShardedTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	return resp, err
 }
 
-// startShardLogger logs per-shard stats periodically (every 60s).
+// startShardLogger logs per-shard stats periodically (every shardStatsLogInterval).
 func (s *ShardedTransport) startShardLogger() {
 	go func() {
-		ticker := time.NewTicker(60 * time.Second)
+		ticker := time.NewTicker(shardStatsLogInterval)
 		defer ticker.Stop()
 		for range ticker.C {
 			for i := range s.shardStats {
@@ -123,20 +130,10 @@ func (s *ShardedTransport) startShardLogger() {
 	}()
 }
 
-// defaultNumTransportShards is the default number of http.Transport instances created. Each shard
-// has its own connection pool + mutex, so N shards reduce pool-lock contention by ~N times. Overridable
-// via AZCOPY_TRANSPORT_SHARDS for perf tuning.
-const defaultNumTransportShards = 32
-
-// getNumTransportShards returns the configured transport shard count from AZCOPY_TRANSPORT_SHARDS,
-// falling back to defaultNumTransportShards when unset or invalid (< 1).
+// getNumTransportShards returns the shard count for the active high-perf profile. Only reached on the
+// high-perf network path; sharding does not exist in the mover-default path.
 func getNumTransportShards() int {
-	if raw := os.Getenv("AZCOPY_TRANSPORT_SHARDS"); raw != "" {
-		if n, err := strconv.Atoi(raw); err == nil && n >= 1 {
-			return n
-		}
-	}
-	return defaultNumTransportShards
+	return buildmode.TransportShards()
 }
 
 // newShardedTransport creates N http.Transport instances with identical configuration, where N is
@@ -187,19 +184,48 @@ func newShardedTransport(maxConnsPerHost int) *ShardedTransport {
 // will be invoked with status messages.
 func GetGlobalHTTPClient(logger ILoggerResetable) *http.Client {
 	globalHTTPClientOnce.Do(func() {
-		const maxConnsPerHost = 1024
-		shardedTransport := newShardedTransport(maxConnsPerHost)
+		if useHighPerfNetworkPath() {
+			const maxConnsPerHost = 1024
+			shardedTransport := newShardedTransport(maxConnsPerHost)
+			client := &http.Client{
+				Transport: shardedTransport,
+			}
+			GlobalHTTPClient = client
+			msg := fmt.Sprintf(
+				"GetGlobalHTTPClient: SHARDED_TRANSPORT_V6 initialized %p shards=%d MaxConnsPerHost=%d HTTP1.1_ONLY",
+				client, len(shardedTransport.transports), maxConnsPerHost)
+			fmt.Fprintln(os.Stderr, msg)
+			if logger != nil {
+				logger.Log(LogError, msg)
+			}
+			return
+		}
+
+		const concurrentDialsPerCpu = 10
 		client := &http.Client{
-			Transport: shardedTransport,
+			Transport: &http.Transport{
+				Proxy:                  GlobalProxyLookup,
+				MaxConnsPerHost:        concurrentDialsPerCpu * runtime.NumCPU(),
+				MaxIdleConns:           0,
+				MaxIdleConnsPerHost:    GetMaxIdleConnsPerHost(),
+				IdleConnTimeout:        180 * time.Second,
+				TLSHandshakeTimeout:    10 * time.Second,
+				ExpectContinueTimeout:  1 * time.Second,
+				DisableKeepAlives:      false,
+				DisableCompression:     true,
+				MaxResponseHeaderBytes: 0,
+			},
 		}
 		GlobalHTTPClient = client
-		// Always log to stderr so it shows up in container logs
-		msg := fmt.Sprintf(
-			"GetGlobalHTTPClient: SHARDED_TRANSPORT_V6 initialized %p shards=%d MaxConnsPerHost=%d HTTP1.1_ONLY",
-			client, len(shardedTransport.transports), maxConnsPerHost)
-		fmt.Fprintln(os.Stderr, msg)
 		if logger != nil {
-			logger.Log(LogError, msg)
+			if tr, ok := client.Transport.(*http.Transport); ok {
+				logger.Log(LogError,
+					fmt.Sprintf(
+						"GetGlobalHTTPClient: initialized %p MaxIdleConnsPerHost=%d MaxConnsPerHost=%d MaxIdleConns=%d",
+						client, tr.MaxIdleConnsPerHost, tr.MaxConnsPerHost, tr.MaxIdleConns))
+			} else {
+				logger.Log(LogError, fmt.Sprintf("GetGlobalHTTPClient: initialized %p", client))
+			}
 		}
 	})
 	return GlobalHTTPClient
@@ -218,6 +244,13 @@ func GetMaxIdleConnsPerHost() int {
 		concurrencyVal, err := strconv.ParseInt(envValue, 10, 0)
 		if err == nil {
 			concurrencyValue = min(int(concurrencyVal), concurrencyValue)
+			autoTune = false
+		}
+	}
+
+	if autoTune && useHighPerfNetworkPath() {
+		if defaultValue := buildmode.ConcurrencyValue(); defaultValue > 0 {
+			concurrencyValue = min(defaultValue, concurrencyValue)
 			autoTune = false
 		}
 	}

--- a/common/buildmode/default_buildmode.go
+++ b/common/buildmode/default_buildmode.go
@@ -5,3 +5,17 @@ package buildmode
 
 // IsMover always returns false when 'mover' build tag is not defined.
 var IsMover = false
+
+// Non-mover stubs. These keep shared call sites compiling in !mover builds.
+// They are never executed because every call site checks buildmode.IsMover first.
+func HighPerf() bool             { return false }
+func ConcurrencyValue() int      { return 0 }
+func TransportShards() int       { return 0 }
+func ConcurrentFiles() int       { return 0 }
+func ConcurrentSchedulers() int  { return 0 }
+func ConcurrentScan() int        { return 0 }
+func ShuffleEnabled() bool       { return false }
+func ShuffleThresholdParts() int { return 0 }
+func TransferChannelSize() int   { return 0 }
+func ChunkChannelSize() int      { return 0 }
+func SyncMaxGoroutines() int     { return 0 }

--- a/common/buildmode/mover_buildmode.go
+++ b/common/buildmode/mover_buildmode.go
@@ -3,4 +3,56 @@
 
 package buildmode
 
+import (
+	"os"
+	"sync"
+)
+
 var IsMover = true
+
+// High-performance mover profile. These values are consulted ONLY when MOVER_HIGH_PERF is set; every
+// call site is guarded by `buildmode.IsMover && buildmode.HighPerf()`. When MOVER_HIGH_PERF is unset,
+// the mover binary runs the original mover-default code path (env vars + generic defaults) unchanged.
+const (
+	highPerfTransportShards       = 64
+	highPerfConcurrencyValue      = 10000
+	highPerfConcurrentFiles       = 512
+	highPerfConcurrentSchedulers  = 64
+	highPerfConcurrentScan        = 32
+	highPerfShuffleEnabled        = true
+	highPerfShuffleThresholdParts = 1
+	highPerfTransferChannelSize   = 200000
+	highPerfChunkChannelSize      = 200000
+	highPerfSyncMaxGoroutines     = 300000
+)
+
+var (
+	highPerfOnce sync.Once
+	highPerfVal  bool
+)
+
+// HighPerf reports whether the high-performance mover profile is active (MOVER_HIGH_PERF=true|1).
+// Resolved once per process; the env var is not expected to change mid-run.
+func HighPerf() bool {
+	highPerfOnce.Do(func() {
+		switch os.Getenv("MOVER_HIGH_PERF") {
+		case "true", "TRUE", "True", "1":
+			highPerfVal = true
+		}
+	})
+	return highPerfVal
+}
+
+// The functions below return the high-perf profile values. They are consulted only on the high-perf
+// path (callers gate on buildmode.HighPerf()); the mover-default path never calls them.
+
+func ConcurrencyValue() int      { return highPerfConcurrencyValue }
+func TransportShards() int       { return highPerfTransportShards }
+func ConcurrentFiles() int       { return highPerfConcurrentFiles }
+func ConcurrentSchedulers() int  { return highPerfConcurrentSchedulers }
+func ConcurrentScan() int        { return highPerfConcurrentScan }
+func ShuffleEnabled() bool       { return highPerfShuffleEnabled }
+func ShuffleThresholdParts() int { return highPerfShuffleThresholdParts }
+func TransferChannelSize() int   { return highPerfTransferChannelSize }
+func ChunkChannelSize() int      { return highPerfChunkChannelSize }
+func SyncMaxGoroutines() int     { return highPerfSyncMaxGoroutines }

--- a/common/environment.go
+++ b/common/environment.go
@@ -71,6 +71,7 @@ var VisibleEnvironmentVariables = []EnvironmentVariable{
 	EEnvironmentVariable.JobPlanLocation(),
 	EEnvironmentVariable.ConcurrencyValue(),
 	EEnvironmentVariable.TransferInitiationPoolSize(),
+	EEnvironmentVariable.SchedulerParallelism(),
 	EEnvironmentVariable.EnumerationPoolSize(),
 	EEnvironmentVariable.DisableHierarchicalScanning(),
 	EEnvironmentVariable.ParallelStatFiles(),
@@ -276,6 +277,27 @@ func (EnvironmentVariable) TransferInitiationPoolSize() EnvironmentVariable {
 	return EnvironmentVariable{
 		Name:        "AZCOPY_CONCURRENT_FILES",
 		Description: "Overrides the (approximate) number of files that are in progress at any one time, by controlling how many files we concurrently initiate transfers for.",
+	}
+}
+
+func (EnvironmentVariable) SchedulerParallelism() EnvironmentVariable {
+	return EnvironmentVariable{
+		Name:        "AZCOPY_CONCURRENT_SCHEDULERS",
+		Description: "Overrides the number of goroutines that pull job parts off the parts channel and schedule their transfers. Higher values prevent the per-transfer creation loop from becoming a single-threaded bottleneck when copying very large numbers of small files.",
+	}
+}
+
+func (EnvironmentVariable) ShuffleTransfers() EnvironmentVariable {
+	return EnvironmentVariable{
+		Name:        "AZCOPY_SHUFFLE_TRANSFERS",
+		Description: "Sync orchestrator: enable transfer shuffling and part reordering to spread key-space prefixes across plan parts. Default false (disabled). When disabled, transfers are dispatched directly to STE in arrival order with bounded memory. Set to true or 1 to enable.",
+	}
+}
+
+func (EnvironmentVariable) ShuffleThresholdParts() EnvironmentVariable {
+	return EnvironmentVariable{
+		Name:        "AZCOPY_SHUFFLE_THRESHOLD_PARTS",
+		Description: "Sync orchestrator: number of plan-parts worth of transfers to buffer before shuffling and flushing (only when AZCOPY_SHUFFLE_TRANSFERS is enabled). Larger values shuffle across a wider key range (better storage-partition spread) at the cost of more in-memory buffering. Default 500 (~5M transfers at 10k/part). Must be >= 1.",
 	}
 }
 

--- a/common/parallel/TreeCrawler.go
+++ b/common/parallel/TreeCrawler.go
@@ -22,14 +22,24 @@ package parallel
 
 import (
 	"context"
+	"math/rand"
 	"sync"
+	"sync/atomic"
 	"time"
 )
+
+// CrawlStats exposes live counters for a running crawl. All fields are
+// atomically updated and safe to read from any goroutine.
+type CrawlStats struct {
+	ActiveWorkers int64 // number of workers currently processing a directory
+	QueuedDirs    int64 // approximate number of directories waiting to be processed
+}
 
 type crawler struct {
 	output      chan CrawlResult
 	workerBody  EnumerateOneDirFunc
 	parallelism int
+	stats       *CrawlStats
 	cond        *sync.Cond
 	// the following are protected by cond (and must only be accessed when cond.L is held)
 	unstartedDirs      []Directory // not a channel, because channels have length limits, and those get in our way
@@ -55,15 +65,24 @@ type EnumerateOneDirFunc func(dir Directory, enqueueDir func(Directory), enqueue
 // Crawl crawls an abstract directory tree, using the supplied enumeration function.  May be use for whatever
 // that function can enumerate (i.e. not necessarily a local file system, just anything tree-structured)
 func Crawl(ctx context.Context, root Directory, worker EnumerateOneDirFunc, parallelism int) <-chan CrawlResult {
+	ch, _ := CrawlWithStats(ctx, root, worker, parallelism)
+	return ch
+}
+
+// CrawlWithStats is like Crawl but also returns live CrawlStats that the
+// caller can poll to observe active worker count and queue depth.
+func CrawlWithStats(ctx context.Context, root Directory, worker EnumerateOneDirFunc, parallelism int) (<-chan CrawlResult, *CrawlStats) {
+	stats := &CrawlStats{}
 	c := &crawler{
 		unstartedDirs: make([]Directory, 0, 1024),
 		output:        make(chan CrawlResult, 1000),
 		workerBody:    worker,
 		parallelism:   parallelism,
+		stats:         stats,
 		cond:          sync.NewCond(&sync.Mutex{}),
 	}
 	go c.start(ctx, root)
-	return c.output
+	return c.output, stats
 }
 
 func (c *crawler) start(ctx context.Context, root Directory) {
@@ -111,7 +130,6 @@ func (c *crawler) workerLoop(ctx context.Context, wg *sync.WaitGroup, workerInde
 
 func (c *crawler) processOneDirectory(ctx context.Context, workerIndex int) (bool, error) {
 	const maxQueueDirectories = 1000 * 1000
-	const maxQueueDirsForBreadthFirst = 100 * 1000 // figure is somewhat arbitrary.  Want it big, but not huge
 
 	var toExamine Directory
 	stop := false
@@ -130,25 +148,22 @@ func (c *crawler) processOneDirectory(ctx context.Context, workerIndex int) (boo
 		stop = ctx.Err() != nil
 		if !stop {
 			if len(c.unstartedDirs) > 0 {
-				if len(c.unstartedDirs) < maxQueueDirsForBreadthFirst {
-					// pop from start of list. This gives a breadth-first flavour to the search.
-					// (Breadth-first is useful for distributing small-file workloads over the full keyspace, which
-					// is can help performance when uploading small files to Azure Blob Storage)
-					toExamine = c.unstartedDirs[0]
-					c.unstartedDirs = c.unstartedDirs[1:]
-				} else {
-					// Fall back to popping from end of list if list is already pretty big.
-					// This gives more of a depth-first flavour to our processing,
-					// which (we think) will prevent c.unstartedDirs getting really large and using too much RAM.
-					// (Since we think that depth first tends to hit leaf nodes relatively quickly, so total number of
-					// unstarted dirs should tend to grow less in a depth first mode)
-					lastIndex := len(c.unstartedDirs) - 1
-					toExamine = c.unstartedDirs[lastIndex]
-					c.unstartedDirs = c.unstartedDirs[:lastIndex]
-				}
+				// Random dequeue: pick a random directory from the queue and swap-remove it (O(1)).
+				// This spreads workers across diverse prefixes, avoiding partition hotspotting
+				// when writing to Azure Blob Storage (where lexicographically adjacent keys
+				// often land on the same partition). Unlike BFS (FIFO) or DFS (LIFO), random
+				// selection ensures no sustained prefix locality regardless of queue size.
+				idx := rand.Intn(len(c.unstartedDirs))
+				toExamine = c.unstartedDirs[idx]
+				last := len(c.unstartedDirs) - 1
+				c.unstartedDirs[idx] = c.unstartedDirs[last]
+				c.unstartedDirs = c.unstartedDirs[:last]
 
 				c.dirInProgressCount++ // record that we are working on something
 				c.cond.Broadcast()     // and let other threads know of that fact
+				// Update live stats
+				atomic.AddInt64(&c.stats.ActiveWorkers, 1)
+				atomic.StoreInt64(&c.stats.QueuedDirs, int64(len(c.unstartedDirs)))
 			} else {
 				if c.dirInProgressCount > 0 {
 					// something has gone wrong in the design of this algorithm, because we should only get here if all done now
@@ -182,7 +197,10 @@ func (c *crawler) processOneDirectory(ctx context.Context, workerIndex int) (boo
 
 	c.unstartedDirs = append(c.unstartedDirs, foundDirectories...) // do NOT try to wait here if unstartedDirs is getting big. May cause deadlocks, due to all workers waiting and none processing the queue
 	c.dirInProgressCount--                                         // we were doing something, and now we have finished it
-	c.cond.Broadcast()                                             // let other workers know that the state has changed
+	// Update live stats
+	atomic.AddInt64(&c.stats.ActiveWorkers, -1)
+	atomic.StoreInt64(&c.stats.QueuedDirs, int64(len(c.unstartedDirs)))
+	c.cond.Broadcast() // let other workers know that the state has changed
 
 	// If our queue of unstarted stuff is getting really huge,
 	// reduce our parallelism in the hope of preventing further excessive RAM growth.

--- a/common/rpc-models.go
+++ b/common/rpc-models.go
@@ -324,6 +324,13 @@ type ListJobSummaryResponse struct {
 	// Will be zero if read outside the process running the job (e.g. with 'jobs show' command)
 	AverageIOPS            int     `json:",string"`
 	AverageE2EMilliseconds int     `json:",string"`
+	AverageConnWaitMs      int     `json:",string"`
+	AverageWireMs          int     `json:",string"`
+	AverageDNSMs           int     `json:",string"`
+	AverageTLSMs           int     `json:",string"`
+	ConnNewCount           int64   `json:",string"`
+	ConnReusedCount        int64   `json:",string"`
+	AverageChunkQueueMs    int     `json:",string"`
 	ServerBusyPercentage   float32 `json:",string"`
 	NetworkErrorPercentage float32 `json:",string"`
 

--- a/common/statsMonitor.go
+++ b/common/statsMonitor.go
@@ -578,6 +578,21 @@ func (m *SystemStatsMonitor) GetSnapshot() SystemStatsSnapshot {
 	return snapshot
 }
 
+// GetMemoryPercent returns the most recent OS-level memory usage percentage
+// (container/cgroup-aware, via gopsutil) from the latest collected snapshot.
+// It is a lightweight read that avoids the runtime.ReadMemStats stop-the-world
+// pause, so it is safe to call on hot paths such as per-directory throttle checks.
+// Returns -1 if no snapshot has been collected yet (e.g. monitor not started).
+func (m *SystemStatsMonitor) GetMemoryPercent() float64 {
+	m.snapshotMutex.RLock()
+	defer m.snapshotMutex.RUnlock()
+
+	if m.currentSnapshot == nil {
+		return -1
+	}
+	return m.currentSnapshot.MemoryPercent
+}
+
 // logStaticSystemInfo logs static system information once at startup
 func (m *SystemStatsMonitor) logStaticSystemInfo() {
 	if m.config.Logger == nil {
@@ -1478,8 +1493,10 @@ func (m *SystemStatsMonitor) logSnapshot(snapshot SystemStatsSnapshot, reasons [
 		orderedCustomMetrics = m.config.CustomCallbackManager.CollectAllOrderedMetrics()
 	}
 
-	// Log only the compact stats line (single line as before)
-	m.config.Logger.Log(LogInfo, m.buildCompactStatsLine(snapshot, avgCPU, avgNetRead, avgNetWrite, avgDiskRead, avgDiskWrite, avgFileDescriptors, orderedCustomMetrics, reasons))
+	// Log only the compact stats line (single line as before).
+	// Emitted at LogError so the periodic STE channel/starvation/GC stats survive --log-level ERROR
+	// (one line per interval; per-transfer INFO spam stays filtered). Used for throughput-dip debugging.
+	m.config.Logger.Log(LogError, m.buildCompactStatsLine(snapshot, avgCPU, avgNetRead, avgNetWrite, avgDiskRead, avgDiskWrite, avgFileDescriptors, orderedCustomMetrics, reasons))
 }
 
 // buildCompactStatsLine builds the original compact stats line for quick reference

--- a/jobsAdmin/JobsAdmin.go
+++ b/jobsAdmin/JobsAdmin.go
@@ -601,6 +601,15 @@ func getSTEStats() []common.CustomStatEntry {
 	var totalPartsCreatedSize int
 	var totalXferDoneUsed int
 	var totalXferDoneSize int
+	// Diagnostic counters
+	var totalChunkStarveCount int64
+	var totalTransferStarveCount int64
+	var maxMainPoolSize int32
+	var maxNumGoroutines int
+	var e2eMs int
+	var serverBusyPct float32
+	var connWaitMs, wireMs int
+	var connReused, connNew int64
 
 	// Iterate through all jobs to get their metrics
 	for _, jobID := range jobIDs {
@@ -611,6 +620,17 @@ func getSTEStats() []common.CustomStatEntry {
 			totalTransfersCompleted += uint64(jobSummary.TransfersCompleted)
 			totalTransfersFailed += uint64(jobSummary.TransfersFailed)
 			totalTransfersSkipped += uint64(jobSummary.TransfersSkipped)
+
+			// Pipeline network stats (cheap: computed from atomic counters) — E2E round-trip ms
+			// and server-busy% for throttling visibility.
+			if ps := jobMgr.PipelineNetworkStats(); ps != nil {
+				e2eMs = ps.AverageE2EMilliseconds()
+				serverBusyPct = ps.TotalServerBusyPercentage()
+				connWaitMs = ps.AverageConnWaitMs()
+				wireMs = ps.AverageWireMs()
+				connReused = ps.ConnReusedCount()
+				connNew = ps.ConnNewCount()
+			}
 
 			// Get channel statistics through the interface method
 			channelStats := jobMgr.GetChannelStats()
@@ -628,6 +648,14 @@ func getSTEStats() []common.CustomStatEntry {
 			totalPartsCreatedSize += channelStats.PartsCreatedSize
 			totalXferDoneUsed += channelStats.XferDoneUsed
 			totalXferDoneSize += channelStats.XferDoneSize
+			totalChunkStarveCount += channelStats.ChunkStarveCount
+			totalTransferStarveCount += channelStats.TransferStarveCount
+			if channelStats.CurrentMainPoolSize > maxMainPoolSize {
+				maxMainPoolSize = channelStats.CurrentMainPoolSize
+			}
+			if channelStats.NumGoroutines > maxNumGoroutines {
+				maxNumGoroutines = channelStats.NumGoroutines
+			}
 		}
 	}
 
@@ -641,8 +669,20 @@ func getSTEStats() []common.CustomStatEntry {
 		{Key: "low_xfer_ch", Value: fmt.Sprintf("%d/%d", totalLowTransferChannelUsed, totalLowTransferChannelSize)},
 		{Key: "norm_chunk_ch", Value: fmt.Sprintf("%d/%d", totalNormalChunkChannelUsed, totalNormalChunkChannelSize)},
 		{Key: "low_chunk_ch", Value: fmt.Sprintf("%d/%d", totalLowChunkChannelUsed, totalLowChunkChannelSize)},
-		// {Key: "parts_cr_ch", Value: fmt.Sprintf("%d/%d", totalPartsCreatedUsed, totalPartsCreatedSize)},
-		// {Key: "xfer_done_ch", Value: fmt.Sprintf("%d/%d", totalXferDoneUsed, totalXferDoneSize)},
+		{Key: "xfer_done_ch", Value: fmt.Sprintf("%d/%d", totalXferDoneUsed, totalXferDoneSize)},
+		// Diagnostic counters: cumulative starvation events. Sustained high values indicate
+		// the worker pool is idle waiting for new chunks/transfers (dispatcher is the bottleneck);
+		// near-zero values indicate workers are saturated.
+		{Key: "chunk_starve", Value: fmt.Sprintf("%d", totalChunkStarveCount)},
+		{Key: "xfer_starve", Value: fmt.Sprintf("%d", totalTransferStarveCount)},
+		{Key: "pool_size", Value: fmt.Sprintf("%d", maxMainPoolSize)},
+		{Key: "goroutines", Value: fmt.Sprintf("%d", maxNumGoroutines)},
+		{Key: "e2e_ms", Value: fmt.Sprintf("%d", e2eMs)},
+		{Key: "conn_wait_ms", Value: fmt.Sprintf("%d", connWaitMs)},
+		{Key: "wire_ms", Value: fmt.Sprintf("%d", wireMs)},
+		{Key: "conn_reused", Value: fmt.Sprintf("%d", connReused)},
+		{Key: "conn_new", Value: fmt.Sprintf("%d", connNew)},
+		{Key: "serverbusy_pct", Value: fmt.Sprintf("%.2f", serverBusyPct)},
 	}
 }
 

--- a/jobsAdmin/init.go
+++ b/jobsAdmin/init.go
@@ -55,6 +55,11 @@ func ToFixed(num float64, precision int) float64 {
 	return float64(round(num*output)) / output
 }
 
+// FormatThroughput formats throughput in both Mb/s and Gb/s.
+func FormatThroughput(mbps float64) string {
+	return fmt.Sprintf("2-sec Throughput (Mb/s): %v (Gb/s): %v", ToFixed(mbps, 4), ToFixed(mbps/1000, 4))
+}
+
 // MainSTE initializes the Storage Transfer Engine
 func MainSTE(concurrency ste.ConcurrencySettings, targetRateInMegaBitsPerSec float64, azcopyJobPlanFolder, azcopyLogPathFolder string, providePerfAdvice bool) error {
 	// Initialize the JobsAdmin, resurrect Job plan files
@@ -483,9 +488,16 @@ func GetJobSummary(jobID common.JobID) common.ListJobSummaryResponse {
 	if pipeStats != nil {
 		js.AverageIOPS = pipeStats.OperationsPerSecond()
 		js.AverageE2EMilliseconds = pipeStats.AverageE2EMilliseconds()
+		js.AverageConnWaitMs = pipeStats.AverageConnWaitMs()
+		js.AverageWireMs = pipeStats.AverageWireMs()
+		js.AverageDNSMs = pipeStats.AverageDNSMs()
+		js.AverageTLSMs = pipeStats.AverageTLSMs()
+		js.ConnNewCount = pipeStats.ConnNewCount()
+		js.ConnReusedCount = pipeStats.ConnReusedCount()
 		js.NetworkErrorPercentage = pipeStats.NetworkErrorPercentage()
 		js.ServerBusyPercentage = pipeStats.TotalServerBusyPercentage()
 	}
+	js.AverageChunkQueueMs = jm.AverageChunkQueueWaitMs()
 
 	// If the status is cancelled, then no need to check for completerJobOrdered
 	// since user must have provided the consent to cancel an incompleteJob if that
@@ -639,9 +651,16 @@ func resurrectJobSummary(jm ste.IJobMgr) common.ListJobSummaryResponse {
 	if pipeStats != nil {
 		js.AverageIOPS = pipeStats.OperationsPerSecond()
 		js.AverageE2EMilliseconds = pipeStats.AverageE2EMilliseconds()
+		js.AverageConnWaitMs = pipeStats.AverageConnWaitMs()
+		js.AverageWireMs = pipeStats.AverageWireMs()
+		js.AverageDNSMs = pipeStats.AverageDNSMs()
+		js.AverageTLSMs = pipeStats.AverageTLSMs()
+		js.ConnNewCount = pipeStats.ConnNewCount()
+		js.ConnReusedCount = pipeStats.ConnReusedCount()
 		js.NetworkErrorPercentage = pipeStats.NetworkErrorPercentage()
 		js.ServerBusyPercentage = pipeStats.TotalServerBusyPercentage()
 	}
+	js.AverageChunkQueueMs = jm.AverageChunkQueueWaitMs()
 
 	// If the status is cancelled, then no need to check for completerJobOrdered
 	// since user must have provided the consent to cancel an incompleteJob if that

--- a/ste/concurrency.go
+++ b/ste/concurrency.go
@@ -124,6 +124,12 @@ type ConcurrencySettings struct {
 
 	// CheckCpuWhenTuning determines whether CPU usage should be taken into account when auto-tuning
 	CheckCpuWhenTuning *ConfiguredBool
+
+	// SchedulerParallelism is the number of goroutines that pull job parts off the parts channel
+	// and schedule their transfers concurrently. Increasing this prevents the per-transfer creation
+	// loop (ScheduleTransfers) from becoming a single-threaded bottleneck that starves the
+	// transfer-initiation and chunk worker pools when copying huge numbers of small files.
+	SchedulerParallelism *ConfiguredInt
 }
 
 // AutoTuneMainPool says whether the main pool size should by dynamically tuned
@@ -134,6 +140,7 @@ func (c ConcurrencySettings) AutoTuneMainPool() bool {
 const defaultTransferInitiationPoolSize = 64
 const defaultEnumerationPoolSize = 16
 const concurrentFilesFloor = 32
+const defaultSchedulerParallelism = 16
 
 // NewConcurrencySettings gets concurrency settings by referring to the
 // environment variable AZCOPY_CONCURRENCY_VALUE (if set) and to properties of the
@@ -149,6 +156,7 @@ func NewConcurrencySettings(maxFileAndSocketHandles int, requestAutoTuneGRs bool
 		EnumerationPoolSize:        GetEnumerationPoolSize(),
 		ParallelStatFiles:          GetParallelStatFiles(),
 		CheckCpuWhenTuning:         getCheckCpuUsageWhenTuning(),
+		SchedulerParallelism:       getSchedulerParallelism(),
 	}
 
 	s.MaxOpenDownloadFiles = getMaxOpenPayloadFiles(maxFileAndSocketHandles,
@@ -214,7 +222,7 @@ func getMainPoolSize(numOfCPUs int, requestAutoTune bool) (initial int, max *Con
 	maxValue := initialValue
 	if requestAutoTune {
 		reason = "auto-tuning limit"
-		maxValue = 3000 // TODO: what should this be?  Testing indicates that this value is all we're ever likely to need, even in small-files cases
+		maxValue = 20000 // TODO: what should this be?  Testing indicates that this value is all we're ever likely to need, even in small-files cases
 	}
 
 	return initialValue, &ConfiguredInt{maxValue, false, envVar.Name, reason}
@@ -228,6 +236,16 @@ func getTransferInitiationPoolSize() *ConfiguredInt {
 	}
 
 	return &ConfiguredInt{defaultTransferInitiationPoolSize, false, envVar.Name, "hard-coded default"}
+}
+
+func getSchedulerParallelism() *ConfiguredInt {
+	envVar := common.EEnvironmentVariable.SchedulerParallelism()
+
+	if c := tryNewConfiguredInt(envVar); c != nil {
+		return c
+	}
+
+	return &ConfiguredInt{defaultSchedulerParallelism, false, envVar.Name, "hard-coded default"}
 }
 
 func GetEnumerationPoolSize() *ConfiguredInt {

--- a/ste/concurrency.go
+++ b/ste/concurrency.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/common/buildmode"
 )
 
 // ConfiguredInt is an integer which may be optionally configured by user through an environment variable
@@ -200,6 +201,11 @@ func getMainPoolSize(numOfCPUs int, requestAutoTune bool) (initial int, max *Con
 		return c.Value, c // initial and max are same, fixed to the env var
 	}
 
+	if !requestAutoTune && buildmode.IsMover && buildmode.HighPerf() && buildmode.ConcurrencyValue() > 0 {
+		defaultValue := buildmode.ConcurrencyValue()
+		return defaultValue, &ConfiguredInt{defaultValue, false, envVar.Name, "mover high-perf profile"}
+	}
+
 	var initialValue int
 
 	if requestAutoTune {
@@ -222,7 +228,10 @@ func getMainPoolSize(numOfCPUs int, requestAutoTune bool) (initial int, max *Con
 	maxValue := initialValue
 	if requestAutoTune {
 		reason = "auto-tuning limit"
-		maxValue = 20000 // TODO: what should this be?  Testing indicates that this value is all we're ever likely to need, even in small-files cases
+		maxValue = 3000 // TODO: what should this be?  Testing indicates that this value is all we're ever likely to need, even in small-files cases
+		if buildmode.IsMover && buildmode.HighPerf() {
+			maxValue = 20000
+		}
 	}
 
 	return initialValue, &ConfiguredInt{maxValue, false, envVar.Name, reason}
@@ -235,6 +244,10 @@ func getTransferInitiationPoolSize() *ConfiguredInt {
 		return c
 	}
 
+	if buildmode.IsMover && buildmode.HighPerf() {
+		return &ConfiguredInt{buildmode.ConcurrentFiles(), false, envVar.Name, "mover high-perf profile"}
+	}
+
 	return &ConfiguredInt{defaultTransferInitiationPoolSize, false, envVar.Name, "hard-coded default"}
 }
 
@@ -245,6 +258,10 @@ func getSchedulerParallelism() *ConfiguredInt {
 		return c
 	}
 
+	if buildmode.IsMover && buildmode.HighPerf() {
+		return &ConfiguredInt{buildmode.ConcurrentSchedulers(), false, envVar.Name, "mover high-perf profile"}
+	}
+
 	return &ConfiguredInt{defaultSchedulerParallelism, false, envVar.Name, "hard-coded default"}
 }
 
@@ -253,6 +270,10 @@ func GetEnumerationPoolSize() *ConfiguredInt {
 
 	if c := tryNewConfiguredInt(envVar); c != nil {
 		return c
+	}
+
+	if buildmode.IsMover && buildmode.HighPerf() {
+		return &ConfiguredInt{buildmode.ConcurrentScan(), false, envVar.Name, "mover high-perf profile"}
 	}
 
 	return &ConfiguredInt{defaultEnumerationPoolSize, false, envVar.Name, "hard-coded default"}

--- a/ste/jobStatusManager.go
+++ b/ste/jobStatusManager.go
@@ -146,9 +146,6 @@ func (jm *jobMgr) handleStatusUpdateMessage() {
 				continue
 			}
 
-			msg.Src = common.URLStringExtension(msg.Src).RedactSecretQueryParamForLogging()
-			msg.Dst = common.URLStringExtension(msg.Dst).RedactSecretQueryParamForLogging()
-
 			switch msg.TransferStatus {
 			case common.ETransferStatus.Success():
 				if msg.IsFolderProperties {
@@ -163,6 +160,8 @@ func (jm *jobMgr) handleStatusUpdateMessage() {
 					js.FoldersFailed++
 				}
 				js.TransfersFailed++
+				msg.Src = common.URLStringExtension(msg.Src).RedactSecretQueryParamForLogging()
+				msg.Dst = common.URLStringExtension(msg.Dst).RedactSecretQueryParamForLogging()
 				js.FailedTransfers = append(js.FailedTransfers, msg)
 			case common.ETransferStatus.SkippedEntityAlreadyExists(),
 				common.ETransferStatus.SkippedBlobHasSnapshots():
@@ -170,6 +169,8 @@ func (jm *jobMgr) handleStatusUpdateMessage() {
 					js.FoldersSkipped++
 				}
 				js.TransfersSkipped++
+				msg.Src = common.URLStringExtension(msg.Src).RedactSecretQueryParamForLogging()
+				msg.Dst = common.URLStringExtension(msg.Dst).RedactSecretQueryParamForLogging()
 				js.SkippedTransfers = append(js.SkippedTransfers, msg)
 			case common.ETransferStatus.SkippedArchiveNotRestored():
 				js.SkippedArchiveFileCount++

--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -24,7 +24,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -55,6 +57,13 @@ type ChannelStats struct {
 	PartsCreatedSize          int
 	XferDoneUsed              int
 	XferDoneSize              int
+
+	// Diagnostic counters for identifying scheduler-starvation bottlenecks. All are cumulative
+	// since job start; dividing by elapsed seconds gives a per-second rate.
+	ChunkStarveCount    int64 // chunkProcessor goroutines that hit the empty-channel sleep path
+	TransferStarveCount int64 // transferProcessor goroutines that hit the empty-channel sleep path
+	CurrentMainPoolSize int32 // current chunkProcessor goroutine pool size (auto-tuned)
+	NumGoroutines       int   // process-wide runtime.NumGoroutine() at sample time
 }
 
 // ChannelSizeConfig holds channel size configurations
@@ -92,13 +101,26 @@ type ChannelSizeConfig struct {
 	CloseTransferChannelSize int
 }
 
+// steEnvInt reads a positive integer from an env var, falling back to def. Used to make STE
+// channel depths tunable at runtime. Notably, shrinking PartsChannelSize bounds how far
+// enumeration can lead transfer (in-flight transfers ~= PartsChannelSize * numOfTransfersPerPart),
+// capping the live working set and heap growth without disabling backpressure entirely.
+func steEnvInt(name string, def int) int {
+	if v := os.Getenv(name); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return def
+}
+
 // GetChannelSizeConfig returns channel size configuration based on build mode
 func GetChannelSizeConfig() ChannelSizeConfig {
 	if buildmode.IsMover {
 		return ChannelSizeConfig{
-			PartsChannelSize:         1000,
-			TransferChannelSize:      20000,
-			ChunkChannelSize:         20000,
+			PartsChannelSize:         steEnvInt("AZCOPY_STE_PARTS_CH", 5000),
+			TransferChannelSize:      steEnvInt("AZCOPY_STE_XFER_CH", 200000),
+			ChunkChannelSize:         steEnvInt("AZCOPY_STE_CHUNK_CH", 200000),
 			PartCreatedChannelSize:   100,
 			XferDoneChannelSize:      1000,
 			CloseTransferChannelSize: 100,
@@ -162,6 +184,7 @@ type IJobMgr interface {
 	ChunkStatusLogger() common.ChunkStatusLogger
 	HttpClient() *http.Client
 	PipelineNetworkStats() *PipelineNetworkStats
+	AverageChunkQueueWaitMs() int
 	getOverwritePrompter() *overwritePrompter
 	common.ILoggerCloser
 
@@ -314,6 +337,11 @@ func (jm *jobMgr) GetChannelStats() ChannelStats {
 		PartsCreatedSize:          cap(jm.jstm.partCreated),
 		XferDoneUsed:              len(jm.jstm.xferDone),
 		XferDoneSize:              cap(jm.jstm.xferDone),
+
+		ChunkStarveCount:    atomic.LoadInt64(&jm.atomicChunkStarveCount),
+		TransferStarveCount: atomic.LoadInt64(&jm.atomicTransferStarveCount),
+		CurrentMainPoolSize: atomic.LoadInt32(&jm.atomicCurrentMainPoolSize),
+		NumGoroutines:       runtime.NumGoroutine(),
 	}
 }
 
@@ -394,7 +422,14 @@ type jobMgr struct {
 	atomicCurrentConcurrentConnections int64
 	/* Pool sizer related values */
 	atomicSuccessfulBytesInActiveFiles int64 // atomic 64-bit values should always be at the start of a struct to ensure alignment
-	atomicCurrentMainPoolSize          int32
+	// Diagnostic counters: number of times chunkProcessor / transferProcessor hit the
+	// empty-channel time.Sleep fallback. High values indicate worker starvation
+	// (workers spinning on idle channels rather than running chunks/transfers).
+	atomicChunkStarveCount    int64
+	atomicTransferStarveCount int64
+	atomicChunkQueueWaitMs    int64 // total ms chunks spent waiting in the channel
+	atomicChunkQueueCount     int64 // number of chunks dequeued (for averaging)
+	atomicCurrentMainPoolSize int32
 	// atomicAllTransfersScheduled defines whether all job parts have been iterated and resumed or not
 	atomicAllTransfersScheduled     int32
 	atomicFinalPartOrderedIndicator int32
@@ -445,6 +480,13 @@ type jobMgr struct {
 	cacheLimiter        common.CacheLimiter
 	fileCountLimiter    common.CacheLimiter
 	jstm                *jobStatusManager
+
+	// scheduler coordination: several scheduleJobPartsWorker goroutines run concurrently,
+	// so the one-time pool-sizer startup, the one-time pool-sizer shutdown signal, and the
+	// one-time close of scheduleCloseCh are each guarded by a sync.Once.
+	schedulerStartOnce sync.Once
+	schedulerDoneOnce  sync.Once
+	schedulerCloseOnce sync.Once
 
 	isDaemon bool /* is it running as service */
 }
@@ -1013,6 +1055,14 @@ func (jm *jobMgr) CurrentMainPoolSize() int {
 	return int(atomic.LoadInt32(&jm.atomicCurrentMainPoolSize))
 }
 
+func (jm *jobMgr) AverageChunkQueueWaitMs() int {
+	count := atomic.LoadInt64(&jm.atomicChunkQueueCount)
+	if count > 0 {
+		return int(atomic.LoadInt64(&jm.atomicChunkQueueWaitMs) / count)
+	}
+	return 0
+}
+
 func (jm *jobMgr) ScheduleTransfer(priority common.JobPriority, jptm IJobPartTransferMgr) {
 	switch priority { // priority determines which channel handles the job part's transfers
 	case common.EJobPriority.Normal():
@@ -1036,11 +1086,18 @@ func (jm *jobMgr) ScheduleTransfer(priority common.JobPriority, jptm IJobPartTra
 }
 
 func (jm *jobMgr) ScheduleChunk(priority common.JobPriority, chunkFunc chunkFunc) {
+	enqueued := time.Now()
+	wrapped := func(workerID int) {
+		waitMs := time.Since(enqueued).Milliseconds()
+		atomic.AddInt64(&jm.atomicChunkQueueWaitMs, waitMs)
+		atomic.AddInt64(&jm.atomicChunkQueueCount, 1)
+		chunkFunc(workerID)
+	}
 	switch priority { // priority determines which channel handles the job part's transfers
 	case common.EJobPriority.Normal():
-		jm.xferChannels.normalChunckCh <- chunkFunc
+		jm.xferChannels.normalChunckCh <- wrapped
 	case common.EJobPriority.Low():
-		jm.xferChannels.lowChunkCh <- chunkFunc
+		jm.xferChannels.lowChunkCh <- wrapped
 	default:
 		jm.Panic(fmt.Errorf("invalid priority: %q", priority))
 	}
@@ -1067,7 +1124,11 @@ func (jm *jobMgr) deleteJobPartsMgrs() {
 // Note: Created the buffer channel so that, if somehow any thread missing(down), it should not stuck.
 func (jm *jobMgr) cleanupTransferRoutine() {
 	jm.reportCancelCh <- struct{}{}
-	jm.xferChannels.scheduleCloseCh <- struct{}{}
+	// Close (rather than send) scheduleCloseCh so that every scheduleJobPartsWorker
+	// goroutine wakes and exits. Guarded by a sync.Once to avoid a double-close.
+	jm.schedulerCloseOnce.Do(func() {
+		close(jm.xferChannels.scheduleCloseCh)
+	})
 	for cc := 0; cc < jm.concurrency.TransferInitiationPoolSize.Value; cc++ {
 		jm.xferChannels.closeTransferCh <- struct{}{}
 	}
@@ -1172,21 +1233,40 @@ func (jm *jobMgr) RequestTuneSlowly() {
 }
 
 func (jm *jobMgr) scheduleJobParts() {
-	startedPoolSizer := false
+	parallelism := jm.concurrency.SchedulerParallelism.Value
+	if parallelism < 1 {
+		parallelism = 1
+	}
+	for i := 0; i < parallelism; i++ {
+		go jm.scheduleJobPartsWorker()
+	}
+}
+
+// scheduleJobPartsWorker is a single scheduler goroutine. Several of these run
+// concurrently (see SchedulerParallelism). Go channels are safe for concurrent receivers,
+// so each worker pulls a distinct job part off partsChannel and schedules its transfers
+// independently. Running multiple workers keeps the per-transfer creation loop
+// (ScheduleTransfers) from being a single-threaded bottleneck that starves the
+// transfer-initiation and chunk worker pools.
+func (jm *jobMgr) scheduleJobPartsWorker() {
 	for {
 		select {
 		case <-jm.xferChannels.scheduleCloseCh:
 			jm.Log(common.LogInfo, "ScheduleJobParts done called")
-			jm.poolSizingChannels.done <- struct{}{}
+			// scheduleCloseCh is closed (broadcast), so every worker wakes here; only the
+			// first one signals the pool sizer to wind down.
+			jm.schedulerDoneOnce.Do(func() {
+				jm.poolSizingChannels.done <- struct{}{}
+			})
 			return
 
 		case jobPart := <-jm.xferChannels.partsChannel:
-			if !startedPoolSizer {
+			// Spin up the pool sizer exactly once, on the first part that arrives.
+			jm.schedulerStartOnce.Do(func() {
 				// spin up a GR to coordinate dynamic sizing of the main pool
 				// It will automatically spin up the right number of chunk processors
 				go jm.poolSizer()
-				startedPoolSizer = true
-			}
+			})
 
 			inMemoryState := jm.getInMemoryTransitJobState()
 			s3provider := inMemoryState.Provider
@@ -1203,26 +1283,24 @@ func (jm *jobMgr) chunkProcessor(workerID int) {
 	defer func() { jm.poolSizingChannels.exitNotificationCh <- struct{}{} }() // say we have exited
 
 	for {
-		// We check for scalebacks first to shrink goroutine pool
-		// Then, we check chunks: normal & low priority
+		// Priority: scaleback > normal chunks > low chunks
+		// First, try scaleback and normal chunks non-blocking
 		select {
 		case <-jm.poolSizingChannels.scalebackRequestCh:
 			return
+		case chunkFunc := <-jm.xferChannels.normalChunckCh:
+			chunkFunc(workerID)
 		default:
+			// Normal channel is empty — block on all three channels.
+			// Goroutines park here with zero CPU overhead until work arrives
+			// (no polling, no sleep, instant wake-up).
 			select {
+			case <-jm.poolSizingChannels.scalebackRequestCh:
+				return
 			case chunkFunc := <-jm.xferChannels.normalChunckCh:
 				chunkFunc(workerID)
-			default:
-				select {
-				case chunkFunc := <-jm.xferChannels.lowChunkCh:
-					chunkFunc(workerID)
-				default:
-					time.Sleep(100 * time.Millisecond) // Sleep before looping around
-					// TODO: Question: In order to safely support high goroutine counts,
-					// do we need to review sleep duration, or find an approach that does not require waking every x milliseconds
-					// For now, duration has been increased substantially from the previous 1 ms, to reduce cost of
-					// the wake-ups.
-				}
+			case chunkFunc := <-jm.xferChannels.lowChunkCh:
+				chunkFunc(workerID)
 			}
 		}
 	}
@@ -1267,6 +1345,8 @@ func (jm *jobMgr) transferProcessor(workerID int) {
 			case jptm := <-jm.xferChannels.lowTransferCh:
 				startTransfer(jptm)
 			default:
+				// Diagnostic: count transferProcessor starvation events.
+				atomic.AddInt64(&jm.atomicTransferStarveCount, 1)
 				time.Sleep(10 * time.Millisecond) // Sleep before looping around
 			}
 		}

--- a/ste/mgr-JobMgr.go
+++ b/ste/mgr-JobMgr.go
@@ -24,9 +24,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -101,26 +99,13 @@ type ChannelSizeConfig struct {
 	CloseTransferChannelSize int
 }
 
-// steEnvInt reads a positive integer from an env var, falling back to def. Used to make STE
-// channel depths tunable at runtime. Notably, shrinking PartsChannelSize bounds how far
-// enumeration can lead transfer (in-flight transfers ~= PartsChannelSize * numOfTransfersPerPart),
-// capping the live working set and heap growth without disabling backpressure entirely.
-func steEnvInt(name string, def int) int {
-	if v := os.Getenv(name); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			return n
-		}
-	}
-	return def
-}
-
 // GetChannelSizeConfig returns channel size configuration based on build mode
 func GetChannelSizeConfig() ChannelSizeConfig {
-	if buildmode.IsMover {
+	if buildmode.IsMover && buildmode.HighPerf() {
 		return ChannelSizeConfig{
-			PartsChannelSize:         steEnvInt("AZCOPY_STE_PARTS_CH", 5000),
-			TransferChannelSize:      steEnvInt("AZCOPY_STE_XFER_CH", 200000),
-			ChunkChannelSize:         steEnvInt("AZCOPY_STE_CHUNK_CH", 200000),
+			PartsChannelSize:         1000,
+			TransferChannelSize:      buildmode.TransferChannelSize(),
+			ChunkChannelSize:         buildmode.ChunkChannelSize(),
 			PartCreatedChannelSize:   100,
 			XferDoneChannelSize:      1000,
 			CloseTransferChannelSize: 100,

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -2,13 +2,14 @@ package ste
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"mime"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
 	"runtime/debug"
 	"strings"
 	"sync/atomic"
@@ -83,22 +84,38 @@ type IJobPartMgr interface {
 // number of available network sockets on resource-constrained Linux systems. (E.g. when
 // 'ulimit -Hn' is low).
 func NewAzcopyHTTPClient(maxIdleConns int) *http.Client {
-	const concurrentDialsPerCpu = 10 // exact value doesn't matter too much, but too low will be too slow, and too high will reduce the beneficial effect on thread count
+	const maxConnsPerHost = 30000
+	// Go 1.24: Use explicit Protocols field to force HTTP/1.1 only.
+	http1Only := &http.Protocols{}
+	http1Only.SetHTTP1(true)
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 15 * time.Second,
+	}
 	return &http.Client{
 		Transport: &http.Transport{
 			Proxy:                  common.GlobalProxyLookup,
-			MaxConnsPerHost:        concurrentDialsPerCpu * runtime.NumCPU(),
-			MaxIdleConns:           0, // No limit
-			MaxIdleConnsPerHost:    maxIdleConns,
-			IdleConnTimeout:        180 * time.Second,
+			Protocols:              http1Only,
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return dialer.DialContext(ctx, network, addr)
+			},
+			MaxConnsPerHost:        maxConnsPerHost,
+			MaxIdleConns:           0,
+			MaxIdleConnsPerHost:    maxConnsPerHost,
+			IdleConnTimeout:        90 * time.Second,
 			TLSHandshakeTimeout:    10 * time.Second,
-			ResponseHeaderTimeout:  60 * time.Second, // Timeout for reading response headers
+			ResponseHeaderTimeout:  60 * time.Second,
 			ExpectContinueTimeout:  1 * time.Second,
 			DisableKeepAlives:      false,
-			DisableCompression:     true, // must disable the auto-decompression of gzipped files, and just download the gzipped version. See https://github.com/Azure/azure-storage-azcopy/issues/374
+			DisableCompression:     true,
 			MaxResponseHeaderBytes: 0,
-			// ResponseHeaderTimeout:  time.Duration{},
-			// ExpectContinueTimeout:  time.Duration{},
+			WriteBufferSize:        32 * 1024,
+			ReadBufferSize:         32 * 1024,
+			ForceAttemptHTTP2:      false,
+			TLSNextProto:           make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
+			TLSClientConfig: &tls.Config{
+				NextProtos: []string{"http/1.1"},
+			},
 		},
 	}
 }
@@ -400,32 +417,35 @@ func (jpm *jobPartMgr) ScheduleTransfers(jobCtx context.Context) {
 		jpm.Log(common.LogDebug, fmt.Sprintf("scheduling JobID=%v, Part#=%d, Transfer#=%d, priority=%v", plan.JobID, plan.PartNum, t, plan.Priority))
 
 		// ===== TEST KNOB
-		relSrc, relDst := plan.TransferSrcDstRelatives(t)
+		// DebugSkipFiles is empty in production. relSrc/relDst are consumed ONLY by the
+		// DebugSkipFiles lookup below, so when the knob is unused we skip the per-transfer
+		// path decoding (url.PathUnescape, relative-path computation, map lookups) entirely.
+		if len(DebugSkipFiles) > 0 {
+			relSrc, relDst := plan.TransferSrcDstRelatives(t)
 
-		var err error
-		if plan.FromTo.From().IsRemote() {
-			relSrc, err = url.PathUnescape(relSrc)
-		}
-		relSrc = strings.TrimPrefix(relSrc, common.AZCOPY_PATH_SEPARATOR_STRING)
-		common.PanicIfErr(err) // neither of these panics should happen, they already would have had a clean error.
-		if plan.FromTo.To().IsRemote() {
-			relDst, err = url.PathUnescape(relDst)
-		}
-		relDst = strings.TrimPrefix(relDst, common.AZCOPY_PATH_SEPARATOR_STRING)
-		common.PanicIfErr(err)
-
-		_, srcOk := DebugSkipFiles[relSrc]
-		_, dstOk := DebugSkipFiles[relDst]
-		if srcOk || dstOk {
-			if jpm.ShouldLog(common.LogInfo) {
-				jpm.Log(common.LogInfo, fmt.Sprintf("Transfer %d cancelled: %s", jptm.transferIndex, relSrc))
+			var err error
+			if plan.FromTo.From().IsRemote() {
+				relSrc, err = url.PathUnescape(relSrc)
 			}
+			relSrc = strings.TrimPrefix(relSrc, common.AZCOPY_PATH_SEPARATOR_STRING)
+			common.PanicIfErr(err) // neither of these panics should happen, they already would have had a clean error.
+			if plan.FromTo.To().IsRemote() {
+				relDst, err = url.PathUnescape(relDst)
+			}
+			relDst = strings.TrimPrefix(relDst, common.AZCOPY_PATH_SEPARATOR_STRING)
+			common.PanicIfErr(err)
 
-			// cancel the transfer
-			jptm.Cancel()
-			jptm.SetStatus(common.ETransferStatus.Cancelled())
-		} else {
-			if len(DebugSkipFiles) != 0 && jpm.ShouldLog(common.LogInfo) {
+			_, srcOk := DebugSkipFiles[relSrc]
+			_, dstOk := DebugSkipFiles[relDst]
+			if srcOk || dstOk {
+				if jpm.ShouldLog(common.LogInfo) {
+					jpm.Log(common.LogInfo, fmt.Sprintf("Transfer %d cancelled: %s", jptm.transferIndex, relSrc))
+				}
+
+				// cancel the transfer
+				jptm.Cancel()
+				jptm.SetStatus(common.ETransferStatus.Cancelled())
+			} else if jpm.ShouldLog(common.LogInfo) {
 				jpm.Log(common.LogInfo, fmt.Sprintf("Did not exclude: src: %s dst: %s", relSrc, relDst))
 			}
 		}

--- a/ste/sender-blockBlobFromURL.go
+++ b/ste/sender-blockBlobFromURL.go
@@ -33,6 +33,12 @@ type urlToBlockBlobCopier struct {
 	blockBlobSenderBase
 
 	srcURL string
+
+	// srcChangeAC, when non-nil, carries a source access-condition (SourceIfUnmodifiedSince set to the
+	// enumerated source LMT) that is attached to every StageBlockFromURL/UploadBlobFromURL request, so
+	// Azure Storage atomically fails the copy with 412 if the source changed since enumeration. Set
+	// only in mover builds for Blob->Blob, replacing the pre/post-transfer GetProperties change checks.
+	srcChangeAC *blob.SourceModifiedAccessConditions
 }
 
 func newURLToBlockBlobCopier(jptm IJobPartTransferMgr, pacer pacer, srcInfoProvider IRemoteSourceInfoProvider) (s2sCopier, error) {
@@ -55,9 +61,19 @@ func newURLToBlockBlobCopier(jptm IJobPartTransferMgr, pacer pacer, srcInfoProvi
 		return nil, err
 	}
 
+	// In mover Blob->Blob builds, enforce source-change detection via a source access-condition on the
+	// copy request itself (the enumerated LMT), instead of separate GetProperties calls. The service
+	// returns 412 if the source changed since enumeration, which fails the transfer before commit.
+	var srcChangeAC *blob.SourceModifiedAccessConditions
+	if useSourceChangeAccessCondition(jptm) {
+		lmt := jptm.LastModifiedTime()
+		srcChangeAC = &blob.SourceModifiedAccessConditions{SourceIfUnmodifiedSince: &lmt}
+	}
+
 	return &urlToBlockBlobCopier{
 		blockBlobSenderBase: *senderBase,
-		srcURL:              srcURL}, nil
+		srcURL:              srcURL,
+		srcChangeAC:         srcChangeAC}, nil
 }
 
 // Returns a chunk-func for blob copies
@@ -113,10 +129,11 @@ func (c *urlToBlockBlobCopier) generatePutBlockFromURL(id common.ChunkID, blockI
 		}
 		_, err = c.destBlockBlobClient.StageBlockFromURL(c.jptm.Context(), encodedBlockID, c.srcURL,
 			&blockblob.StageBlockFromURLOptions{
-				Range:                   blob.HTTPRange{Offset: id.OffsetInFile(), Count: adjustedChunkSize},
-				CPKInfo:                 c.jptm.CpkInfo(),
-				CPKScopeInfo:            c.jptm.CpkScopeInfo(),
-				CopySourceAuthorization: token,
+				Range:                          blob.HTTPRange{Offset: id.OffsetInFile(), Count: adjustedChunkSize},
+				CPKInfo:                        c.jptm.CpkInfo(),
+				CPKScopeInfo:                   c.jptm.CpkScopeInfo(),
+				CopySourceAuthorization:        token,
+				SourceModifiedAccessConditions: c.srcChangeAC,
 			})
 		if err != nil {
 			c.jptm.FailActiveSend("Staging block from URL", err)
@@ -160,13 +177,14 @@ func (c *urlToBlockBlobCopier) generateStartPutBlobFromURL(id common.ChunkID, bl
 
 		_, err = c.destBlockBlobClient.UploadBlobFromURL(c.jptm.Context(), c.srcURL,
 			&blockblob.UploadBlobFromURLOptions{
-				HTTPHeaders:             &c.headersToApply,
-				Metadata:                c.metadataToApply,
-				Tier:                    destBlobTier,
-				Tags:                    blobTags,
-				CPKInfo:                 c.jptm.CpkInfo(),
-				CPKScopeInfo:            c.jptm.CpkScopeInfo(),
-				CopySourceAuthorization: token,
+				HTTPHeaders:                    &c.headersToApply,
+				Metadata:                       c.metadataToApply,
+				Tier:                           destBlobTier,
+				Tags:                           blobTags,
+				CPKInfo:                        c.jptm.CpkInfo(),
+				CPKScopeInfo:                   c.jptm.CpkScopeInfo(),
+				CopySourceAuthorization:        token,
+				SourceModifiedAccessConditions: c.srcChangeAC,
 			})
 
 		if err != nil {

--- a/ste/xfer-anyToRemote-file.go
+++ b/ste/xfer-anyToRemote-file.go
@@ -365,8 +365,11 @@ func anyToRemote_file(jptm IJobPartTransferMgr, info *TransferInfo, pacer pacer,
 	// 1) Source is local, and source's size is > 1 chunk.  (why not always?  Since getting LMT is not "free" at very small sizes)
 	// 2) Source is remote, i.e. S2S copy case. And source's size is larger than one chunk. So verification can possibly save transfer's cost.
 	jptm.LogChunkStatus(pseudoId, common.EWaitReason.ModifiedTimeRefresh())
+	// When the source-change access-condition is in effect (mover Blob->Blob), the condition is
+	// enforced by the service on each copy request, so skip the redundant pre-transfer GetProperties.
 	if _, isS2SCopier := s.(s2sCopier); numChunks > 1 &&
-		(srcInfoProvider.IsLocal() || isS2SCopier && info.S2SSourceChangeValidation) {
+		(srcInfoProvider.IsLocal() || isS2SCopier && info.S2SSourceChangeValidation) &&
+		!useSourceChangeAccessCondition(jptm) {
 		lmt, err := srcInfoProvider.GetFreshFileLastModifiedTime()
 		if err != nil {
 			jptm.LogSendError(info.Source, info.Destination, "Couldn't get source's last modified time-"+err.Error(), 0)
@@ -615,6 +618,36 @@ func isDummyChunkInEmptyFile(startIndex int64, fileSize int64) bool {
 	return startIndex == 0 && fileSize == 0
 }
 
+// useSourceChangeAccessCondition reports whether source-change detection for this transfer is
+// enforced via a source access-condition (SourceIfUnmodifiedSince) attached to the copy request
+// itself, instead of separate GetProperties round-trips before and after the transfer.
+//
+// It is enabled only in mover builds, only when S2SSourceChangeValidation is requested, and only
+// for Blob->Blob copies: the block-blob "from URL" sender attaches the access-condition to every
+// StageBlockFromURL/UploadBlobFromURL call, and Azure Storage enforces it natively against the
+// source blob (returning 412 Precondition Failed if the source changed since enumeration, which
+// gates CommitBlockList so no torn blob is ever committed). When this is active, BOTH the
+// pre-transfer and post-transfer GetFreshFileLastModifiedTime checks are skipped, so no extra
+// GetProperties calls are made against the source.
+func useSourceChangeAccessCondition(jptm IJobPartTransferMgr) bool {
+	return buildmode.IsMover &&
+		jptm.Info().S2SSourceChangeValidation &&
+		jptm.FromTo() == common.EFromTo.BlobBlob()
+}
+
+// skipDestLengthValidation reports whether the post-commit destination length check should be
+// skipped for this transfer. That check calls GetDestinationLength() (a GetProperties round-trip on
+// the just-written destination blob) in the epilogue to compare the destination content-length
+// against the source size. In mover builds for Blob->Blob server-side copy it is skipped: a
+// successful CommitBlockList already fixes the destination blob length deterministically from the
+// committed block list, so the readback is redundant. It otherwise accounts for ~25% of destination
+// transactions (one per blob), so skipping it reduces service request load and removes a synchronous
+// round-trip from every transfer's critical path.
+func skipDestLengthValidation(jptm IJobPartTransferMgr) bool {
+	return buildmode.IsMover &&
+		jptm.FromTo() == common.EFromTo.BlobBlob()
+}
+
 // Complete epilogue. Handles both success and failure.
 func epilogueWithCleanupSendToRemote(jptm IJobPartTransferMgr, s sender, sip ISourceInfoProvider) {
 	info := jptm.Info()
@@ -629,7 +662,11 @@ func epilogueWithCleanupSendToRemote(jptm IJobPartTransferMgr, s sender, sip ISo
 		jptm.SetStatus(common.ETransferStatus.Cancelled())
 	}
 	if jptm.IsLive() {
-		if _, isS2SCopier := s.(s2sCopier); sip.IsLocal() || (isS2SCopier && info.S2SSourceChangeValidation) {
+		// When the source-change access-condition is in effect (mover Blob->Blob), a source change is
+		// detected atomically by the service on each StageBlockFromURL/UploadBlobFromURL (412), so skip
+		// the redundant post-transfer GetProperties source-change check entirely.
+		if _, isS2SCopier := s.(s2sCopier); !useSourceChangeAccessCondition(jptm) &&
+			(sip.IsLocal() || (isS2SCopier && info.S2SSourceChangeValidation)) {
 			// Check the source to see if it was changed during transfer. If it was, mark the transfer as failed.
 			lmt, err := sip.GetFreshFileLastModifiedTime()
 			if err != nil {
@@ -676,7 +713,7 @@ func epilogueWithCleanupSendToRemote(jptm IJobPartTransferMgr, s sender, sip ISo
 	//  or should we redefine epilogue to be success-path only, and only call it in that case?
 	s.Epilogue() // Perform service-specific cleanup before jptm cleanup. Some services may actually require setup to make the file actually appear.
 
-	if jptm.IsLive() && info.DestLengthValidation {
+	if jptm.IsLive() && info.DestLengthValidation && !skipDestLengthValidation(jptm) {
 		_, isS2SCopier := s.(s2sCopier)
 		shouldCheckLength := true
 		destLength, err := s.GetDestinationLength()

--- a/ste/xfer-anyToRemote-file.go
+++ b/ste/xfer-anyToRemote-file.go
@@ -630,7 +630,7 @@ func isDummyChunkInEmptyFile(startIndex int64, fileSize int64) bool {
 // pre-transfer and post-transfer GetFreshFileLastModifiedTime checks are skipped, so no extra
 // GetProperties calls are made against the source.
 func useSourceChangeAccessCondition(jptm IJobPartTransferMgr) bool {
-	return buildmode.IsMover &&
+	return buildmode.HighPerf() &&
 		jptm.Info().S2SSourceChangeValidation &&
 		jptm.FromTo() == common.EFromTo.BlobBlob()
 }
@@ -644,7 +644,7 @@ func useSourceChangeAccessCondition(jptm IJobPartTransferMgr) bool {
 // transactions (one per blob), so skipping it reduces service request load and removes a synchronous
 // round-trip from every transfer's critical path.
 func skipDestLengthValidation(jptm IJobPartTransferMgr) bool {
-	return buildmode.IsMover &&
+	return buildmode.HighPerf() &&
 		jptm.FromTo() == common.EFromTo.BlobBlob()
 }
 

--- a/ste/xferStatsPolicy.go
+++ b/ste/xferStatsPolicy.go
@@ -23,10 +23,12 @@ package ste
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"io"
 	"net/http"
+	"net/http/httptrace"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -40,8 +42,17 @@ type PipelineNetworkStats struct {
 	atomic503CountUnknown      int64 // counts 503's when we don't know the reason
 	atomicE2ETotalMilliseconds int64 // should this be nanoseconds?  Not really needed, given typical minimum operation lengths that we observe
 	atomicStartSeconds         int64
-	nocopy                     common.NoCopy
-	tunerInterface             ConcurrencyTuner
+
+	// Latency breakdown: connection pool wait vs actual wire time
+	atomicConnWaitTotalMs int64 // time waiting for a connection from http.Transport pool (GetConn → GotConn)
+	atomicWireTotalMs     int64 // time on the wire after connection acquired (GotConn → response complete)
+	atomicDNSTotalMs      int64 // DNS resolution time
+	atomicTLSTotalMs      int64 // TLS handshake time
+	atomicConnNewCount    int64 // number of new connections created (not reused)
+	atomicConnReusedCount int64 // number of reused connections
+
+	nocopy         common.NoCopy
+	tunerInterface ConcurrencyTuner
 }
 
 func newPipelineNetworkStats(tunerInterface ConcurrencyTuner) *PipelineNetworkStats {
@@ -143,6 +154,46 @@ func (s *PipelineNetworkStats) AverageE2EMilliseconds() int {
 	}
 }
 
+func (s *PipelineNetworkStats) AverageConnWaitMs() int {
+	ops := atomic.LoadInt64(&s.atomicOperationCount)
+	if ops > 0 {
+		return int(atomic.LoadInt64(&s.atomicConnWaitTotalMs) / ops)
+	}
+	return 0
+}
+
+func (s *PipelineNetworkStats) AverageWireMs() int {
+	ops := atomic.LoadInt64(&s.atomicOperationCount)
+	if ops > 0 {
+		return int(atomic.LoadInt64(&s.atomicWireTotalMs) / ops)
+	}
+	return 0
+}
+
+func (s *PipelineNetworkStats) AverageDNSMs() int {
+	ops := atomic.LoadInt64(&s.atomicOperationCount)
+	if ops > 0 {
+		return int(atomic.LoadInt64(&s.atomicDNSTotalMs) / ops)
+	}
+	return 0
+}
+
+func (s *PipelineNetworkStats) AverageTLSMs() int {
+	ops := atomic.LoadInt64(&s.atomicOperationCount)
+	if ops > 0 {
+		return int(atomic.LoadInt64(&s.atomicTLSTotalMs) / ops)
+	}
+	return 0
+}
+
+func (s *PipelineNetworkStats) ConnNewCount() int64 {
+	return atomic.LoadInt64(&s.atomicConnNewCount)
+}
+
+func (s *PipelineNetworkStats) ConnReusedCount() int64 {
+	return atomic.LoadInt64(&s.atomicConnReusedCount)
+}
+
 // transparentlyReadBody reads the response body, and then (because body is read-once-only) replaces it with
 // a new body that will return the same content to anyone else who reads it.
 // This looks like a fairly common approach in Go, e.g. https://stackoverflow.com/a/23077519
@@ -172,12 +223,63 @@ type statsPolicy struct {
 func (s statsPolicy) Do(req *policy.Request) (*http.Response, error) {
 	start := time.Now()
 
+	// Add httptrace to measure connection pool wait vs wire time
+	var connWaitStart, gotConnTime, dnsStart, tlsStart time.Time
+	var connWaitMs, dnsMs, tlsMs int64
+	var wasReused bool
+
+	trace := &httptrace.ClientTrace{
+		GetConn: func(hostPort string) {
+			connWaitStart = time.Now()
+		},
+		GotConn: func(info httptrace.GotConnInfo) {
+			gotConnTime = time.Now()
+			connWaitMs = gotConnTime.Sub(connWaitStart).Milliseconds()
+			wasReused = info.Reused
+		},
+		DNSStart: func(info httptrace.DNSStartInfo) {
+			dnsStart = time.Now()
+		},
+		DNSDone: func(info httptrace.DNSDoneInfo) {
+			if !dnsStart.IsZero() {
+				dnsMs = time.Since(dnsStart).Milliseconds()
+			}
+		},
+		TLSHandshakeStart: func() {
+			tlsStart = time.Now()
+		},
+		TLSHandshakeDone: func(state tls.ConnectionState, err error) {
+			if !tlsStart.IsZero() {
+				tlsMs = time.Since(tlsStart).Milliseconds()
+			}
+		},
+	}
+
+	raw := req.Raw()
+	*raw = *raw.WithContext(httptrace.WithClientTrace(raw.Context(), trace))
+
 	response, err := req.Next()
+
 	// Grab the notification callback out of the context and, if its there, call it
 	stats, ok := req.Raw().Context().Value(pipelineNetworkStatsContextKey).(*PipelineNetworkStats)
 	if ok && stats != nil {
+		e2eMs := int64(time.Since(start).Seconds() * 1000)
 		atomic.AddInt64(&stats.atomicOperationCount, 1)
-		atomic.AddInt64(&stats.atomicE2ETotalMilliseconds, int64(time.Since(start).Seconds()*1000))
+		atomic.AddInt64(&stats.atomicE2ETotalMilliseconds, e2eMs)
+
+		// Record latency breakdown
+		atomic.AddInt64(&stats.atomicConnWaitTotalMs, connWaitMs)
+		if !gotConnTime.IsZero() {
+			wireMs := int64(time.Since(gotConnTime).Seconds() * 1000)
+			atomic.AddInt64(&stats.atomicWireTotalMs, wireMs)
+		}
+		atomic.AddInt64(&stats.atomicDNSTotalMs, dnsMs)
+		atomic.AddInt64(&stats.atomicTLSTotalMs, tlsMs)
+		if wasReused {
+			atomic.AddInt64(&stats.atomicConnReusedCount, 1)
+		} else {
+			atomic.AddInt64(&stats.atomicConnNewCount, 1)
+		}
 
 		if err != nil && !isContextCancelledError(err) {
 			// no response from server


### PR DESCRIPTION
## Summary
Scopes all high-performance runtime behavior behind `MOVER_HIGH_PERF` (via `buildmode.HighPerf()`), so the mover-default (D8) path keeps today's `mover/c2c-stage` behavior while the high-perf (D32) path gets the tuned profile.

## Changes
- buildmode: high-perf-only profile constants; removed `moverDefault*` fallbacks.
- ste/concurrency.go: env-first precedence -> high-perf default -> generic default; auto-tune ceiling scoped (3000 default / 20000 high-perf); concurrency default 10000 for high-perf.
- common/azHttpClient.go: high-perf concurrency default; transport sharding remains high-perf-only; simplified shard-count helper; shard-stats log 60s -> 5m.
- cmd/zc_processor.go: simplified shuffle helpers; async dispatch pipeline (and allocations) gated to high-perf; mover-default keeps the c2c-stage synchronous path.
- cmd/syncThrottler.go: SyncMaxGoroutines gated to high-perf (mover-default stays 50k).

## D8 parity
Verified against origin/mover/c2c-stage: mover-default HTTP transport, concurrency defaults, sync mutex, and dispatch path all match c2c-stage. New behavior only active when MOVER_HIGH_PERF=true.