### PR TITLE
Azcopy: Add client side telemetry

### DIFF
--- a/azcopy/client.go
+++ b/azcopy/client.go
@@ -21,7 +21,9 @@
 package azcopy
 
 import (
+	"fmt"
 	"log"
+	"math"
 	"runtime"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
@@ -59,12 +61,18 @@ type Client struct {
 }
 
 type ClientOptions struct {
-	CapMbps         float64
-	TrustedSuffixes string
-	LogLevel        *common.LogLevel
+	CapMbps               float64
+	TrustedSuffixes       string
+	LogLevel              *common.LogLevel
+	DisableTelemetry      bool
+	TelemetrySamplingRate *float64
 }
 
 func NewClient(opts ClientOptions) (Client, error) {
+	if err := configureTelemetrySamplingRate(opts.TelemetrySamplingRate); err != nil {
+		return Client{}, err
+	}
+	telemetryDisabledByFlag = opts.DisableTelemetry
 	c := Client{
 		logLevel: common.IffNil(opts.LogLevel, common.ELogLevel.Info()), // Default: Info
 	}
@@ -100,6 +108,18 @@ func NewClient(opts ClientOptions) (Client, error) {
 		AccountName:   common.Iff(cacheName != "", cacheName, oauthLoginSessionCacheAccountName),
 	})
 	return c, nil
+}
+
+func configureTelemetrySamplingRate(rate *float64) error {
+	telemetrySamplingRate = defaultTelemetrySamplingRate
+	if rate == nil {
+		return nil
+	}
+	if math.IsNaN(*rate) || math.IsInf(*rate, 0) || *rate < 0 || *rate > 1 {
+		return fmt.Errorf("telemetry sampling rate must be between 0.0 and 1.0, got %v", *rate)
+	}
+	telemetrySamplingRate = *rate
+	return nil
 }
 
 // GetUserOAuthTokenManagerInstance gets or creates OAuthTokenManager for current user.

--- a/azcopy/client.go
+++ b/azcopy/client.go
@@ -21,9 +21,7 @@
 package azcopy
 
 import (
-	"fmt"
 	"log"
-	"math"
 	"runtime"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
@@ -61,17 +59,13 @@ type Client struct {
 }
 
 type ClientOptions struct {
-	CapMbps               float64
-	TrustedSuffixes       string
-	LogLevel              *common.LogLevel
-	DisableTelemetry      bool
-	TelemetrySamplingRate *float64
+	CapMbps          float64
+	TrustedSuffixes  string
+	LogLevel         *common.LogLevel
+	DisableTelemetry bool
 }
 
 func NewClient(opts ClientOptions) (Client, error) {
-	if err := configureTelemetrySamplingRate(opts.TelemetrySamplingRate); err != nil {
-		return Client{}, err
-	}
 	telemetryDisabledByFlag = opts.DisableTelemetry
 	c := Client{
 		logLevel: common.IffNil(opts.LogLevel, common.ELogLevel.Info()), // Default: Info
@@ -108,18 +102,6 @@ func NewClient(opts ClientOptions) (Client, error) {
 		AccountName:   common.Iff(cacheName != "", cacheName, oauthLoginSessionCacheAccountName),
 	})
 	return c, nil
-}
-
-func configureTelemetrySamplingRate(rate *float64) error {
-	telemetrySamplingRate = defaultTelemetrySamplingRate
-	if rate == nil {
-		return nil
-	}
-	if math.IsNaN(*rate) || math.IsInf(*rate, 0) || *rate < 0 || *rate > 1 {
-		return fmt.Errorf("telemetry sampling rate must be between 0.0 and 1.0, got %v", *rate)
-	}
-	telemetrySamplingRate = *rate
-	return nil
 }
 
 // GetUserOAuthTokenManagerInstance gets or creates OAuthTokenManager for current user.

--- a/azcopy/copy.go
+++ b/azcopy/copy.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-azcopy/v10/jobsAdmin"
 	"github.com/Azure/azure-storage-azcopy/v10/ste"
+	"github.com/Azure/azure-storage-azcopy/v10/telemetry"
 	"github.com/Azure/azure-storage-azcopy/v10/traverser"
 )
 
@@ -98,6 +99,17 @@ type CopyOptions struct {
 	dryrunJobPartOrderHandler        func(request common.CopyJobPartOrderRequest) common.CopyJobPartOrderResponse
 	s2SGetPropertiesInBackend        *bool // Default true
 	deleteDestinationFileIfNecessary bool
+	telemetryOptions                 telemetry.OptionAttributes
+	benchmarkTelemetry               *benchmarkTelemetryOptions
+}
+
+type benchmarkTelemetryOptions struct {
+	mode             string
+	fileCount        int64
+	fileSizeBytes    int64
+	folderCount      int64
+	cleanupRequested bool
+	isCleanup        bool
 }
 
 type CopyHandler interface {
@@ -128,8 +140,24 @@ func (c *CopyOptions) SetInternalOptions(listOfFiles string, s2sGetPropertiesInB
 	c.commandString = cmd
 }
 
+func (c *CopyOptions) SetTelemetryOptions(options telemetry.OptionAttributes) {
+	c.telemetryOptions = options.Clone()
+}
+
+// SetBenchmarkTelemetry identifies benchmark copy work using bounded inputs.
+func (c *CopyOptions) SetBenchmarkTelemetry(mode string, fileCount, fileSizeBytes, folderCount int64, cleanupRequested, isCleanup bool) {
+	c.benchmarkTelemetry = &benchmarkTelemetryOptions{
+		mode:             mode,
+		fileCount:        fileCount,
+		fileSizeBytes:    fileSizeBytes,
+		folderCount:      folderCount,
+		cleanupRequested: cleanupRequested,
+		isCleanup:        isCleanup,
+	}
+}
+
 // Copy copies the contents from source to destination.
-func (c *Client) Copy(ctx context.Context, src, dest string, opts CopyOptions) (CopyResult, error) {
+func (c *Client) Copy(ctx context.Context, src, dest string, opts CopyOptions) (result CopyResult, err error) {
 	// Input
 	if src == "" || dest == "" {
 		return CopyResult{}, fmt.Errorf("source and destination must be specified for copy")
@@ -149,6 +177,7 @@ func (c *Client) Copy(ctx context.Context, src, dest string, opts CopyOptions) (
 		c.CurrentJobID = jobID
 	}
 	timeAtPrestart := time.Now()
+	telemetryInvocationID := newTelemetryInvocationID()
 	if common.AzcopyCurrentJobLogger == nil { // In the unlikely case, logger is not initialized in root.go
 		common.AzcopyCurrentJobLogger = common.NewJobLogger(c.CurrentJobID, c.GetLogLevel(), common.LogPathFolder, "")
 		common.AzcopyCurrentJobLogger.OpenLog()
@@ -203,12 +232,34 @@ func (c *Client) Copy(ctx context.Context, src, dest string, opts CopyOptions) (
 		if err != nil {
 			return CopyResult{}, err
 		}
+
+		telemetryAgent := getTelemetryAgent()
+		telemetryDims := copyJobDimensions(t.opts, t.trp.srcCredType, t.trp.dstCredType)
+		defer jobsAdmin.JobsAdmin.JobMgrCleanUp(jobID)
+		var telemetryFinalizer *attemptTelemetryFinalizer
+		if shouldEmitCopyTelemetry(t.opts) {
+			telemetryFinalizer = newAttemptTelemetryFinalizer(telemetryAgent, telemetryDims, jobID.String(), telemetryInvocationID, timeAtPrestart)
+			telemetryFinalizer.summaryFn = func() (common.ListJobSummaryResponse, bool) {
+				return jobsAdmin.GetJobSummary(t.tpt.jobID), true
+			}
+			telemetryFinalizer.enumerationElapsedFn = t.tpt.GetEnumerationElapsedTime
+			telemetryFinalizer.transferElapsedFn = t.tpt.GetTransferElapsedTime
+			telemetryFinalizer.shapeFn = t.tpt.GetSourceShapeSummary
+			telemetryFinalizer.startEvent()
+			telemetryFinalizer.setStage("enumeration")
+			defer func() {
+				attemptErr := err
+				if errors.Is(ctx.Err(), context.Canceled) {
+					attemptErr = context.Canceled
+				}
+				telemetryFinalizer.finish(attemptErr)
+			}()
+		}
 		if !t.opts.dryrun {
 			common.GetLifecycleMgr().Info("Scanning...")
 			mgr.InitiateProgressReporting(ctx, t.tpt)
 		}
 		err = enumerator.Enumerate()
-		defer jobsAdmin.JobsAdmin.JobMgrCleanUp(jobID)
 
 		if err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
@@ -225,9 +276,15 @@ func (c *Client) Copy(ctx context.Context, src, dest string, opts CopyOptions) (
 			return CopyResult{}, nil
 		}
 
+		if telemetryFinalizer != nil {
+			telemetryFinalizer.setStage("transfer")
+		}
 		err = mgr.Wait()
 		if err != nil {
 			return CopyResult{}, err
+		}
+		if telemetryFinalizer != nil {
+			telemetryFinalizer.setStage("completion")
 		}
 
 		// Get final job summary
@@ -236,9 +293,13 @@ func (c *Client) Copy(ctx context.Context, src, dest string, opts CopyOptions) (
 		finalSummary.SkippedSpecialFileCount = t.tpt.getSkippedSpecialFileCount()
 		finalSummary.SkippedHardlinkCount = t.tpt.getSkippedHardlinkCount()
 
-		result := CopyResult{
+		result = CopyResult{
 			ListJobSummaryResponse: finalSummary,
 			ElapsedTime:            t.tpt.GetElapsedTime(),
+		}
+		if telemetryFinalizer != nil {
+			telemetryFinalizer.setFinalSummary(finalSummary)
+			telemetryFinalizer.finish(nil)
 		}
 
 		if common.AzcopyCurrentJobLogger != nil {
@@ -287,7 +348,7 @@ func newCopyTransferExecutor(ctx context.Context, jobID common.JobID, src, dst s
 		return nil, fmt.Errorf("failed to initialize inode store: %w", err)
 	}
 
-	progressTracker := newTransferProgressTracker(jobID, opts.Handler, cookedOpts.fromTo)
+	progressTracker := newTransferProgressTracker(jobID, opts.Handler, cookedOpts.fromTo, cookedOpts.symlinks, cookedOpts.hardlinks)
 
 	return &transferExecutor{opts: cookedOpts, trp: copyRemote, tpt: progressTracker, inodeStore: store}, nil
 }

--- a/azcopy/copy.go
+++ b/azcopy/copy.go
@@ -354,7 +354,7 @@ func newCopyTransferExecutor(ctx context.Context, jobID common.JobID, src, dst s
 		cookedOpts.fromTo,
 		cookedOpts.symlinks,
 		cookedOpts.hardlinks,
-		getTelemetryAgent().shouldCollectSourceShape(jobID.String()))
+		getTelemetryAgent().shouldCollectSourceShape())
 
 	return &transferExecutor{opts: cookedOpts, trp: copyRemote, tpt: progressTracker, inodeStore: store}, nil
 }

--- a/azcopy/copy.go
+++ b/azcopy/copy.go
@@ -348,7 +348,13 @@ func newCopyTransferExecutor(ctx context.Context, jobID common.JobID, src, dst s
 		return nil, fmt.Errorf("failed to initialize inode store: %w", err)
 	}
 
-	progressTracker := newTransferProgressTracker(jobID, opts.Handler, cookedOpts.fromTo, cookedOpts.symlinks, cookedOpts.hardlinks)
+	progressTracker := newTransferProgressTracker(
+		jobID,
+		opts.Handler,
+		cookedOpts.fromTo,
+		cookedOpts.symlinks,
+		cookedOpts.hardlinks,
+		getTelemetryAgent().shouldCollectSourceShape(jobID.String()))
 
 	return &transferExecutor{opts: cookedOpts, trp: copyRemote, tpt: progressTracker, inodeStore: store}, nil
 }

--- a/azcopy/copyEnumerator.go
+++ b/azcopy/copyEnumerator.go
@@ -155,6 +155,9 @@ func (t *transferExecutor) initCopyEnumerator(ctx context.Context, logLevel comm
 	if err != nil {
 		return nil, err
 	}
+	if err = t.tpt.shapeTracker.initializeScopes(sourceTraverser); err != nil {
+		return nil, err
+	}
 
 	// Ensure we're only copying a directory under valid conditions
 	isSourceDir, err := sourceTraverser.IsDirectory(true)
@@ -315,6 +318,9 @@ func (t *transferExecutor) initCopyEnumerator(ctx context.Context, logLevel comm
 	transferScheduler := t.newCopyTransferProcessor(NumOfFilesPerDispatchJobPart, jobPartOrder)
 
 	processor := func(object traverser.StoredObject) error {
+		if err := t.tpt.shapeTracker.recordScanned(object); err != nil {
+			return err
+		}
 		// Start by resolving the name and creating the container
 		if object.ContainerName != "" {
 			// set up the destination container name.
@@ -444,7 +450,9 @@ func (t *transferExecutor) newCopyTransferProcessor(numOfTransfersPerPart int,
 	reportFinalPart := func() { t.tpt.setScanningComplete() }
 	// note that the source and destination, along with the template are given to the generic processor's constructor
 	// this means that given an object with a relative path, this processor already knows how to schedule the right kind of transfers
-	return NewCopyTransferProcessor(true, copyJobTemplate, numOfTransfersPerPart, t.opts.source, t.opts.destination, reportFirstPart, reportFinalPart, t.opts.s2sPreserveAccessTier.Get(), t.opts.dryrun, t.opts.dryrunJobPartOrderHandler)
+	processor := NewCopyTransferProcessor(true, copyJobTemplate, numOfTransfersPerPart, t.opts.source, t.opts.destination, reportFirstPart, reportFinalPart, t.opts.s2sPreserveAccessTier.Get(), t.opts.dryrun, t.opts.dryrunJobPartOrderHandler)
+	processor.SetTransferScheduledObserver(t.tpt.shapeTracker.recordScheduled)
+	return processor
 }
 
 func isResourceDirectory(ctx context.Context, res common.ResourceString, loc common.Location, serviceClient *common.ServiceClient, isSource bool, trailingDotOption common.TrailingDotOption) bool {

--- a/azcopy/hostinfo.go
+++ b/azcopy/hostinfo.go
@@ -1,0 +1,143 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package azcopy
+
+import (
+	"net/http"
+	"strings"
+	"time"
+)
+
+// hostHardwareInfo holds best-effort hardware/OS facts about the machine running
+// AzCopy. Each field carries a sentinel ("" or -1) when it cannot be determined
+// on the current platform. The per-field probes are implemented in the
+// platform-specific hostinfo_*.go files.
+type hostHardwareInfo struct {
+	osVersion     string // e.g. "Ubuntu 22.04.4 LTS" / "Windows 10 Pro 19045"
+	cpuModel      string // e.g. "Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz"
+	memoryTotalGB int    // total physical memory rounded to GiB, 0 when unknown
+	nicMbps       int    // best NIC link speed in Mbps, -1 when unknown
+}
+
+// probeHostHardware gathers best-effort host hardware facts. It never blocks on
+// the network and never fails: missing values are returned as sentinels.
+func probeHostHardware() hostHardwareInfo {
+	return hostHardwareInfo{
+		osVersion:     osVersion(),
+		cpuModel:      cpuModel(),
+		memoryTotalGB: totalMemoryGB(),
+		nicMbps:       nicSpeedMbps(),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Azure Instance Metadata Service (IMDS)
+// ---------------------------------------------------------------------------
+
+// imdsTimeout bounds how long the IMDS probe may block job startup. IMDS lives
+// on a non-routable link-local address and replies almost instantly when
+// present, so a short timeout is enough to detect "not on an Azure VM".
+const imdsTimeout = 1 * time.Second
+
+// imdsInfo captures the subset of IMDS data the telemetry agent cares about.
+type imdsInfo struct {
+	isAzureVM bool // true when IMDS responded (i.e. running on an Azure VM)
+}
+
+// probeIMDS queries the Azure Instance Metadata Service to determine whether
+// AzCopy is running on an Azure VM and, if so, in which region. It is
+// best-effort: any error (including not being on an Azure VM) yields a zero
+// value with isAzureVM=false. No proxy is used because IMDS is a non-routable
+// link-local address visible only to Azure VMs, and the response is not
+// security-sensitive.
+func probeIMDS() imdsInfo {
+	return probeIMDSWithClient(&http.Client{Timeout: imdsTimeout})
+}
+
+// probeIMDSWithClient is the testable core of probeIMDS.
+func probeIMDSWithClient(client *http.Client) imdsInfo {
+	const url = "http://169.254.169.254/metadata/instance/compute/location?api-version=2021-02-01&format=text"
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return imdsInfo{}
+	}
+	req.Header.Add("Metadata", "true")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return imdsInfo{}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		// A response (even a non-200) still tells us we are on an Azure VM.
+		return imdsInfo{isAzureVM: true}
+	}
+
+	return imdsInfo{isAzureVM: true}
+}
+
+// ---------------------------------------------------------------------------
+// Mount-table parsing helpers (used by the Linux localMountType probe; kept
+// here, platform-independent, so they remain unit-testable on any OS).
+// ---------------------------------------------------------------------------
+
+// parseMountinfoLine extracts the mount point (field 5) and filesystem type (the
+// first field after the " - " separator) from a /proc/self/mountinfo line.
+func parseMountinfoLine(line string) (mountPoint, fsType string, ok bool) {
+	sep := strings.Index(line, " - ")
+	if sep < 0 {
+		return "", "", false
+	}
+	left := strings.Fields(line[:sep])
+	right := strings.Fields(line[sep+len(" - "):])
+	if len(left) < 5 || len(right) < 1 {
+		return "", "", false
+	}
+	// Field 5 (index 4) is the mount point; octal-style escapes (e.g. \040 for
+	// space) are left as-is, which is acceptable for prefix matching of typical
+	// mount roots.
+	return left[4], right[0], true
+}
+
+// pathHasMountPrefix reports whether mountPoint is the mount point covering path
+// (either identical, the filesystem root "/", or a path-segment prefix).
+func pathHasMountPrefix(path, mountPoint string) bool {
+	if mountPoint == "/" || path == mountPoint {
+		return true
+	}
+	return strings.HasPrefix(path, mountPoint+"/")
+}
+
+// classifyFSType maps a Linux filesystem type to a telemetry mount category:
+// "nas-nfs" | "nas-smb" | "local-disk", or "" for an empty input.
+func classifyFSType(fsType string) string {
+	switch {
+	case fsType == "":
+		return ""
+	case strings.HasPrefix(fsType, "nfs"): // nfs, nfs4
+		return "nas-nfs"
+	case fsType == "cifs" || strings.HasPrefix(fsType, "smb"): // cifs, smb3, smbfs
+		return "nas-smb"
+	default:
+		return "local-disk"
+	}
+}

--- a/azcopy/hostinfo.go
+++ b/azcopy/hostinfo.go
@@ -22,7 +22,6 @@ package azcopy
 
 import (
 	"net/http"
-	"strings"
 	"time"
 )
 
@@ -97,51 +96,4 @@ func probeIMDSWithClient(client *http.Client) imdsInfo {
 	defer func() { _ = resp.Body.Close() }()
 
 	return imdsInfo{isAzureVM: resp.StatusCode == http.StatusOK}
-}
-
-// ---------------------------------------------------------------------------
-// Mount-table parsing helpers (used by the Linux localMountType probe; kept
-// here, platform-independent, so they remain unit-testable on any OS).
-// ---------------------------------------------------------------------------
-
-// parseMountinfoLine extracts the mount point (field 5) and filesystem type (the
-// first field after the " - " separator) from a /proc/self/mountinfo line.
-func parseMountinfoLine(line string) (mountPoint, fsType string, ok bool) {
-	sep := strings.Index(line, " - ")
-	if sep < 0 {
-		return "", "", false
-	}
-	left := strings.Fields(line[:sep])
-	right := strings.Fields(line[sep+len(" - "):])
-	if len(left) < 5 || len(right) < 1 {
-		return "", "", false
-	}
-	// Field 5 (index 4) is the mount point; octal-style escapes (e.g. \040 for
-	// space) are left as-is, which is acceptable for prefix matching of typical
-	// mount roots.
-	return left[4], right[0], true
-}
-
-// pathHasMountPrefix reports whether mountPoint is the mount point covering path
-// (either identical, the filesystem root "/", or a path-segment prefix).
-func pathHasMountPrefix(path, mountPoint string) bool {
-	if mountPoint == "/" || path == mountPoint {
-		return true
-	}
-	return strings.HasPrefix(path, mountPoint+"/")
-}
-
-// classifyFSType maps a Linux filesystem type to a telemetry mount category:
-// "nas-nfs" | "nas-smb" | "local-disk", or "" for an empty input.
-func classifyFSType(fsType string) string {
-	switch {
-	case fsType == "":
-		return ""
-	case strings.HasPrefix(fsType, "nfs"): // nfs, nfs4
-		return "nas-nfs"
-	case fsType == "cifs" || strings.HasPrefix(fsType, "smb"): // cifs, smb3, smbfs
-		return "nas-smb"
-	default:
-		return "local-disk"
-	}
 }

--- a/azcopy/hostinfo.go
+++ b/azcopy/hostinfo.go
@@ -69,7 +69,16 @@ type imdsInfo struct {
 // link-local address visible only to Azure VMs, and the response is not
 // security-sensitive.
 func probeIMDS() imdsInfo {
-	return probeIMDSWithClient(&http.Client{Timeout: imdsTimeout})
+	return probeIMDSWithClient(newIMDSHTTPClient())
+}
+
+func newIMDSHTTPClient() *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	return &http.Client{
+		Timeout:   imdsTimeout,
+		Transport: transport,
+	}
 }
 
 // probeIMDSWithClient is the testable core of probeIMDS.
@@ -87,12 +96,7 @@ func probeIMDSWithClient(client *http.Client) imdsInfo {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
-		// A response (even a non-200) still tells us we are on an Azure VM.
-		return imdsInfo{isAzureVM: true}
-	}
-
-	return imdsInfo{isAzureVM: true}
+	return imdsInfo{isAzureVM: resp.StatusCode == http.StatusOK}
 }
 
 // ---------------------------------------------------------------------------

--- a/azcopy/hostinfo_darwin.go
+++ b/azcopy/hostinfo_darwin.go
@@ -77,7 +77,7 @@ func localMountType(path string) string {
 	if err := unix.Statfs(path, &st); err != nil {
 		return ""
 	}
-	fsType := int8SliceToString(st.Fstypename[:])
+	fsType := unix.ByteSliceToString(st.Fstypename[:])
 	switch {
 	case strings.HasPrefix(fsType, "nfs"):
 		return "nas-nfs"
@@ -88,17 +88,4 @@ func localMountType(path string) string {
 	default:
 		return "local-disk"
 	}
-}
-
-// int8SliceToString converts a NUL-terminated [16]int8-style C string (as used
-// by statfs f_fstypename) to a Go string.
-func int8SliceToString(b []int8) string {
-	buf := make([]byte, 0, len(b))
-	for _, c := range b {
-		if c == 0 {
-			break
-		}
-		buf = append(buf, byte(c))
-	}
-	return string(buf)
 }

--- a/azcopy/hostinfo_darwin.go
+++ b/azcopy/hostinfo_darwin.go
@@ -1,0 +1,104 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build darwin
+
+package azcopy
+
+import (
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// osVersion returns the macOS product version, e.g. "macOS 14.5", from the
+// kern.osproductversion sysctl. Returns "" when unavailable.
+func osVersion() string {
+	v, err := unix.Sysctl("kern.osproductversion")
+	if err != nil {
+		return ""
+	}
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return ""
+	}
+	return "macOS " + v
+}
+
+// cpuModel returns the CPU brand string from the machdep.cpu.brand_string
+// sysctl. Returns "" when unavailable (e.g. on some Apple Silicon configs).
+func cpuModel() string {
+	v, err := unix.Sysctl("machdep.cpu.brand_string")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(v)
+}
+
+// totalMemoryGB returns total physical memory in GiB from the hw.memsize sysctl
+// (reported in bytes). Returns 0 when unavailable.
+func totalMemoryGB() int {
+	bytes, err := unix.SysctlUint64("hw.memsize")
+	if err != nil || bytes == 0 {
+		return 0
+	}
+	const gib = 1 << 30
+	return int((bytes + gib/2) / gib)
+}
+
+// nicSpeedMbps is not probed on macOS; link speed is not exposed through a
+// stable, dependency-free API. Returns -1.
+func nicSpeedMbps() int {
+	return -1
+}
+
+// localMountType classifies the filesystem backing a local macOS path as
+// "nas-nfs", "nas-smb", or "local-disk" using statfs(2)'s f_fstypename. Returns
+// "" when statfs fails (caller falls back to "local-disk").
+func localMountType(path string) string {
+	var st unix.Statfs_t
+	if err := unix.Statfs(path, &st); err != nil {
+		return ""
+	}
+	fsType := int8SliceToString(st.Fstypename[:])
+	switch {
+	case strings.HasPrefix(fsType, "nfs"):
+		return "nas-nfs"
+	case strings.HasPrefix(fsType, "smb"): // smbfs
+		return "nas-smb"
+	case fsType == "":
+		return ""
+	default:
+		return "local-disk"
+	}
+}
+
+// int8SliceToString converts a NUL-terminated [16]int8-style C string (as used
+// by statfs f_fstypename) to a Go string.
+func int8SliceToString(b []int8) string {
+	buf := make([]byte, 0, len(b))
+	for _, c := range b {
+		if c == 0 {
+			break
+		}
+		buf = append(buf, byte(c))
+	}
+	return string(buf)
+}

--- a/azcopy/hostinfo_linux.go
+++ b/azcopy/hostinfo_linux.go
@@ -1,0 +1,157 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build linux
+
+package azcopy
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// osVersion returns a human-readable OS version derived from /etc/os-release
+// (PRETTY_NAME), e.g. "Ubuntu 22.04.4 LTS". Returns "" when unavailable.
+func osVersion() string {
+	f, err := os.Open("/etc/os-release")
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if v, ok := strings.CutPrefix(line, "PRETTY_NAME="); ok {
+			return strings.Trim(strings.TrimSpace(v), `"`)
+		}
+	}
+	return ""
+}
+
+// cpuModel returns the CPU model name from /proc/cpuinfo ("model name").
+// Returns "" when unavailable.
+func cpuModel() string {
+	f, err := os.Open("/proc/cpuinfo")
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if k, v, ok := strings.Cut(line, ":"); ok && strings.TrimSpace(k) == "model name" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+// totalMemoryGB returns total physical memory in GiB from /proc/meminfo
+// (MemTotal, reported in kB). Returns 0 when unavailable.
+func totalMemoryGB() int {
+	f, err := os.Open("/proc/meminfo")
+	if err != nil {
+		return 0
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if v, ok := strings.CutPrefix(line, "MemTotal:"); ok {
+			fields := strings.Fields(v) // e.g. "16384000 kB"
+			if len(fields) >= 1 {
+				if kb, err := strconv.ParseInt(fields[0], 10, 64); err == nil {
+					return int((kb + (1 << 20 / 2)) / (1 << 20)) // kB -> GiB, rounded
+				}
+			}
+			return 0
+		}
+	}
+	return 0
+}
+
+// nicSpeedMbps returns the highest link speed (in Mbps) among non-loopback
+// network interfaces, read from /sys/class/net/<iface>/speed. Returns -1 when no
+// speed can be determined (e.g. virtualized NICs report -1 or are unreadable).
+func nicSpeedMbps() int {
+	entries, err := os.ReadDir("/sys/class/net")
+	if err != nil {
+		return -1
+	}
+	best := -1
+	for _, e := range entries {
+		name := e.Name()
+		if name == "lo" {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join("/sys/class/net", name, "speed"))
+		if err != nil {
+			continue
+		}
+		speed, err := strconv.Atoi(strings.TrimSpace(string(b)))
+		if err != nil || speed <= 0 {
+			continue
+		}
+		if speed > best {
+			best = speed
+		}
+	}
+	return best
+}
+
+// localMountType inspects /proc/self/mountinfo to classify the filesystem backing
+// the given local path: "nas-nfs", "nas-smb", or "local-disk". Returns "" when
+// the mount table cannot be read or the path cannot be resolved (caller falls
+// back to "local-disk").
+func localMountType(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return ""
+	}
+	abs = filepath.Clean(abs)
+
+	f, err := os.Open("/proc/self/mountinfo")
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = f.Close() }()
+
+	bestLen := -1
+	bestFSType := ""
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		mountPoint, fsType, ok := parseMountinfoLine(scanner.Text())
+		if !ok {
+			continue
+		}
+		if pathHasMountPrefix(abs, mountPoint) && len(mountPoint) > bestLen {
+			bestLen = len(mountPoint)
+			bestFSType = fsType
+		}
+	}
+	return classifyFSType(bestFSType)
+}

--- a/azcopy/hostinfo_linux.go
+++ b/azcopy/hostinfo_linux.go
@@ -155,3 +155,45 @@ func localMountType(path string) string {
 	}
 	return classifyFSType(bestFSType)
 }
+
+// parseMountinfoLine extracts the mount point (field 5) and filesystem type (the
+// first field after the " - " separator) from a /proc/self/mountinfo line.
+func parseMountinfoLine(line string) (mountPoint, fsType string, ok bool) {
+	sep := strings.Index(line, " - ")
+	if sep < 0 {
+		return "", "", false
+	}
+	left := strings.Fields(line[:sep])
+	right := strings.Fields(line[sep+len(" - "):])
+	if len(left) < 5 || len(right) < 1 {
+		return "", "", false
+	}
+	// Field 5 (index 4) is the mount point; octal-style escapes (e.g. \040 for
+	// space) are left as-is, which is acceptable for prefix matching of typical
+	// mount roots.
+	return left[4], right[0], true
+}
+
+// pathHasMountPrefix reports whether mountPoint is the mount point covering path
+// (either identical, the filesystem root "/", or a path-segment prefix).
+func pathHasMountPrefix(path, mountPoint string) bool {
+	if mountPoint == "/" || path == mountPoint {
+		return true
+	}
+	return strings.HasPrefix(path, mountPoint+"/")
+}
+
+// classifyFSType maps a Linux filesystem type to a telemetry mount category:
+// "nas-nfs" | "nas-smb" | "local-disk", or "" for an empty input.
+func classifyFSType(fsType string) string {
+	switch {
+	case fsType == "":
+		return ""
+	case strings.HasPrefix(fsType, "nfs"): // nfs, nfs4
+		return "nas-nfs"
+	case fsType == "cifs" || strings.HasPrefix(fsType, "smb"): // cifs, smb3, smbfs
+		return "nas-smb"
+	default:
+		return "local-disk"
+	}
+}

--- a/azcopy/hostinfo_linux_test.go
+++ b/azcopy/hostinfo_linux_test.go
@@ -1,0 +1,66 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build linux
+
+package azcopy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClassifyFSType(t *testing.T) {
+	a := assert.New(t)
+	a.Equal("nas-nfs", classifyFSType("nfs"))
+	a.Equal("nas-nfs", classifyFSType("nfs4"))
+	a.Equal("nas-smb", classifyFSType("cifs"))
+	a.Equal("nas-smb", classifyFSType("smb3"))
+	a.Equal("nas-smb", classifyFSType("smbfs"))
+	a.Equal("local-disk", classifyFSType("ext4"))
+	a.Equal("local-disk", classifyFSType("xfs"))
+	a.Equal("", classifyFSType(""))
+}
+
+func TestParseMountinfoLine(t *testing.T) {
+	a := assert.New(t)
+	mp, fs, ok := parseMountinfoLine("36 35 98:0 / /mnt/nas rw,noatime - nfs4 1.2.3.4:/export rw")
+	a.True(ok)
+	a.Equal("/mnt/nas", mp)
+	a.Equal("nfs4", fs)
+
+	mp, fs, ok = parseMountinfoLine("22 30 0:21 / / rw,relatime shared:1 - ext4 /dev/root rw")
+	a.True(ok)
+	a.Equal("/", mp)
+	a.Equal("ext4", fs)
+
+	_, _, ok = parseMountinfoLine("garbage line without separator")
+	a.False(ok)
+}
+
+func TestPathHasMountPrefix(t *testing.T) {
+	a := assert.New(t)
+	a.True(pathHasMountPrefix("/mnt/nas/data", "/mnt/nas"))
+	a.True(pathHasMountPrefix("/mnt/nas", "/mnt/nas"))
+	a.True(pathHasMountPrefix("/anything", "/"))
+	a.False(pathHasMountPrefix("/mnt/nasextra", "/mnt/nas"))
+	a.False(pathHasMountPrefix("/home/user", "/mnt/nas"))
+}

--- a/azcopy/hostinfo_other.go
+++ b/azcopy/hostinfo_other.go
@@ -1,0 +1,36 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build !linux && !windows && !darwin
+
+package azcopy
+
+// On platforms without a dedicated probe implementation, host hardware facts are
+// reported as sentinels (unknown). The telemetry pipeline treats these as
+// "not collected".
+
+func osVersion() string  { return "" }
+func cpuModel() string   { return "" }
+func totalMemoryGB() int { return 0 }
+func nicSpeedMbps() int  { return -1 }
+
+// localMountType is not implemented on this platform; the caller falls back to
+// "local-disk".
+func localMountType(string) string { return "" }

--- a/azcopy/hostinfo_test.go
+++ b/azcopy/hostinfo_test.go
@@ -1,0 +1,58 @@
+package azcopy
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type imdsRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f imdsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestProbeIMDSRequiresSuccessfulMetadataResponse(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		err        error
+		wantAzure  bool
+	}{
+		{name: "success", statusCode: http.StatusOK, wantAzure: true},
+		{name: "not found", statusCode: http.StatusNotFound},
+		{name: "server error", statusCode: http.StatusInternalServerError},
+		{name: "transport failure", err: errors.New("unreachable")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &http.Client{Transport: imdsRoundTripper(func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, "http://169.254.169.254/metadata/instance/compute/location", req.URL.Scheme+"://"+req.URL.Host+req.URL.Path)
+				assert.Equal(t, "true", req.Header.Get("Metadata"))
+				if test.err != nil {
+					return nil, test.err
+				}
+				return &http.Response{
+					StatusCode: test.statusCode,
+					Body:       io.NopCloser(strings.NewReader("eastus")),
+					Header:     make(http.Header),
+				}, nil
+			})}
+
+			assert.Equal(t, test.wantAzure, probeIMDSWithClient(client).isAzureVM)
+		})
+	}
+}
+
+func TestIMDSTransportBypassesProxy(t *testing.T) {
+	client := newIMDSHTTPClient()
+	transport, ok := client.Transport.(*http.Transport)
+	assert.True(t, ok)
+	assert.Nil(t, transport.Proxy)
+	assert.Equal(t, imdsTimeout, client.Timeout)
+}

--- a/azcopy/hostinfo_windows.go
+++ b/azcopy/hostinfo_windows.go
@@ -1,0 +1,263 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build windows
+
+package azcopy
+
+import (
+	"fmt"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
+)
+
+// osVersion returns a human-readable Windows version composed from the registry,
+// e.g. "Windows 11 Pro 23H2 (22631)". Returns "" when the registry cannot be
+// read.
+func osVersion() string {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows NT\CurrentVersion`, registry.QUERY_VALUE)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = k.Close() }()
+
+	product, _, _ := k.GetStringValue("ProductName")
+	display, _, _ := k.GetStringValue("DisplayVersion")
+	if display == "" {
+		display, _, _ = k.GetStringValue("ReleaseId")
+	}
+	build, _, _ := k.GetStringValue("CurrentBuild")
+
+	parts := make([]string, 0, 3)
+	if product != "" {
+		parts = append(parts, strings.TrimSpace(product))
+	}
+	if display != "" {
+		parts = append(parts, strings.TrimSpace(display))
+	}
+	out := strings.Join(parts, " ")
+	if build != "" {
+		out = strings.TrimSpace(fmt.Sprintf("%s (%s)", out, strings.TrimSpace(build)))
+	}
+	return strings.TrimSpace(out)
+}
+
+// cpuModel returns the processor name string from the registry. Returns "" when
+// unavailable.
+func cpuModel() string {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `HARDWARE\DESCRIPTION\System\CentralProcessor\0`, registry.QUERY_VALUE)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = k.Close() }()
+
+	name, _, err := k.GetStringValue("ProcessorNameString")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(name)
+}
+
+// memoryStatusEx mirrors the Win32 MEMORYSTATUSEX structure.
+type memoryStatusEx struct {
+	cbSize                  uint32
+	dwMemoryLoad            uint32
+	ullTotalPhys            uint64
+	ullAvailPhys            uint64
+	ullTotalPageFile        uint64
+	ullAvailPageFile        uint64
+	ullTotalVirtual         uint64
+	ullAvailVirtual         uint64
+	ullAvailExtendedVirtual uint64
+}
+
+var (
+	modkernel32             = windows.NewLazySystemDLL("kernel32.dll")
+	procGlobalMemoryStatusE = modkernel32.NewProc("GlobalMemoryStatusEx")
+)
+
+// totalMemoryGB returns total physical memory in GiB via GlobalMemoryStatusEx.
+// Returns 0 when the call fails.
+func totalMemoryGB() int {
+	var ms memoryStatusEx
+	ms.cbSize = uint32(unsafe.Sizeof(ms))
+	ret, _, _ := procGlobalMemoryStatusE.Call(uintptr(unsafe.Pointer(&ms)))
+	if ret == 0 || ms.ullTotalPhys == 0 {
+		return 0
+	}
+	const gib = 1 << 30
+	return int((ms.ullTotalPhys + gib/2) / gib)
+}
+
+type windowsNICAdapter struct {
+	interfaceType    uint32
+	operStatus       uint32
+	transmitBitsPerS uint64
+	receiveBitsPerS  uint64
+}
+
+func bestWindowsNICSpeedMbps(adapters []windowsNICAdapter) int {
+	best := -1
+	for _, adapter := range adapters {
+		if adapter.operStatus != windows.IfOperStatusUp ||
+			adapter.interfaceType == windows.IF_TYPE_SOFTWARE_LOOPBACK ||
+			adapter.interfaceType == windows.IF_TYPE_TUNNEL {
+			continue
+		}
+
+		bitsPerSecond := adapter.transmitBitsPerS
+		if adapter.receiveBitsPerS > bitsPerSecond {
+			bitsPerSecond = adapter.receiveBitsPerS
+		}
+		if bitsPerSecond == 0 {
+			continue
+		}
+
+		mbps := int(bitsPerSecond / 1_000_000)
+		if mbps > best {
+			best = mbps
+		}
+	}
+	return best
+}
+
+// nicSpeedMbps returns the highest advertised transmit or receive link speed
+// among operational non-loopback, non-tunnel adapters. Returns -1 when Windows
+// does not report a usable speed.
+func nicSpeedMbps() int {
+	const flags = windows.GAA_FLAG_SKIP_UNICAST |
+		windows.GAA_FLAG_SKIP_ANYCAST |
+		windows.GAA_FLAG_SKIP_MULTICAST |
+		windows.GAA_FLAG_SKIP_DNS_SERVER |
+		windows.GAA_FLAG_SKIP_FRIENDLY_NAME
+
+	var bufferSize uint32
+	err := windows.GetAdaptersAddresses(windows.AF_UNSPEC, flags, 0, nil, &bufferSize)
+	if err != windows.ERROR_BUFFER_OVERFLOW || bufferSize == 0 {
+		return -1
+	}
+
+	for attempts := 0; attempts < 2; attempts++ {
+		buffer := make([]byte, bufferSize)
+		first := (*windows.IpAdapterAddresses)(unsafe.Pointer(&buffer[0]))
+		err = windows.GetAdaptersAddresses(windows.AF_UNSPEC, flags, 0, first, &bufferSize)
+		if err == windows.ERROR_BUFFER_OVERFLOW {
+			continue
+		}
+		if err != nil {
+			return -1
+		}
+
+		adapters := make([]windowsNICAdapter, 0, 8)
+		for adapter := first; adapter != nil; adapter = adapter.Next {
+			adapters = append(adapters, windowsNICAdapter{
+				interfaceType:    adapter.IfType,
+				operStatus:       adapter.OperStatus,
+				transmitBitsPerS: adapter.TransmitLinkSpeed,
+				receiveBitsPerS:  adapter.ReceiveLinkSpeed,
+			})
+		}
+		return bestWindowsNICSpeedMbps(adapters)
+	}
+
+	return -1
+}
+
+// localMountType classifies the filesystem backing a local Windows path as
+// "nas-smb" (UNC share or mapped network drive) or "local-disk". Returns "" when
+// the drive type cannot be determined (caller falls back to "local-disk").
+//
+// Windows does not expose a stable, dependency-free way to distinguish SMB from
+// NFS (Client for NFS) mounts, so network-backed paths are reported as "nas-smb"
+// on a best-effort basis.
+func localMountType(path string) string {
+	p := stripExtendedLengthPrefix(path)
+	if isUNCPath(p) {
+		return "nas-smb"
+	}
+	root := volumeRoot(p)
+	if root == "" {
+		return ""
+	}
+	switch driveType(root) {
+	case driveRemote:
+		return "nas-smb"
+	case driveFixed, driveRemovable, driveCDROM, driveRAMDisk:
+		return "local-disk"
+	default:
+		return ""
+	}
+}
+
+// Win32 GetDriveType return values.
+const (
+	driveUnknown   = 0
+	driveNoRootDir = 1
+	driveRemovable = 2
+	driveFixed     = 3
+	driveRemote    = 4
+	driveCDROM     = 5
+	driveRAMDisk   = 6
+)
+
+var procGetDriveTypeW = modkernel32.NewProc("GetDriveTypeW")
+
+// driveType wraps GetDriveTypeW for a volume root path such as `C:\`.
+func driveType(root string) int {
+	p, err := windows.UTF16PtrFromString(root)
+	if err != nil {
+		return driveUnknown
+	}
+	ret, _, _ := procGetDriveTypeW.Call(uintptr(unsafe.Pointer(p)))
+	return int(ret)
+}
+
+// stripExtendedLengthPrefix removes the Windows extended-length path prefixes
+// `\\?\` and `\\?\UNC\` so the remaining path can be classified normally. For
+// the UNC form it restores a leading `\\`.
+func stripExtendedLengthPrefix(p string) string {
+	if rest, ok := strings.CutPrefix(p, `\\?\UNC\`); ok {
+		return `\\` + rest
+	}
+	if rest, ok := strings.CutPrefix(p, `\\?\`); ok {
+		return rest
+	}
+	return p
+}
+
+// isUNCPath reports whether p is a UNC path (e.g. `\\server\share\...`).
+func isUNCPath(p string) bool {
+	return strings.HasPrefix(p, `\\`) || strings.HasPrefix(p, `//`)
+}
+
+// volumeRoot returns the `X:\` volume root for a drive-letter path, or "" when p
+// is not a drive-letter path.
+func volumeRoot(p string) string {
+	if len(p) >= 2 && p[1] == ':' {
+		c := p[0]
+		if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') {
+			return string(c) + `:\`
+		}
+	}
+	return ""
+}

--- a/azcopy/hostinfo_windows_test.go
+++ b/azcopy/hostinfo_windows_test.go
@@ -1,0 +1,36 @@
+//go:build windows
+
+package azcopy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/windows"
+)
+
+func TestBestWindowsNICSpeedMbps(t *testing.T) {
+	adapters := []windowsNICAdapter{
+		{interfaceType: 6, operStatus: windows.IfOperStatusDown, transmitBitsPerS: 100_000_000_000},
+		{interfaceType: windows.IF_TYPE_SOFTWARE_LOOPBACK, operStatus: windows.IfOperStatusUp, transmitBitsPerS: 100_000_000_000},
+		{interfaceType: windows.IF_TYPE_TUNNEL, operStatus: windows.IfOperStatusUp, transmitBitsPerS: 100_000_000_000},
+		{interfaceType: 6, operStatus: windows.IfOperStatusUp},
+		{interfaceType: 6, operStatus: windows.IfOperStatusUp, transmitBitsPerS: 1_000_000_000, receiveBitsPerS: 2_500_000_000},
+		{interfaceType: 71, operStatus: windows.IfOperStatusUp, transmitBitsPerS: 10_000_000_000, receiveBitsPerS: 5_000_000_000},
+	}
+
+	assert.Equal(t, 10000, bestWindowsNICSpeedMbps(adapters))
+	assert.Equal(t, -1, bestWindowsNICSpeedMbps(nil))
+	assert.Equal(t, -1, bestWindowsNICSpeedMbps(adapters[:4]))
+	assert.Equal(t, 0, bestWindowsNICSpeedMbps([]windowsNICAdapter{{
+		interfaceType:    6,
+		operStatus:       windows.IfOperStatusUp,
+		transmitBitsPerS: 999_999,
+	}}))
+}
+
+func TestNICSpeedMbpsWindows(t *testing.T) {
+	speedMbps := nicSpeedMbps()
+	assert.GreaterOrEqual(t, speedMbps, -1)
+	t.Logf("detected Windows NIC speed: %d Mbps", speedMbps)
+}

--- a/azcopy/jobsResume.go
+++ b/azcopy/jobsResume.go
@@ -30,14 +30,20 @@ import (
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-azcopy/v10/jobsAdmin"
 	"github.com/Azure/azure-storage-azcopy/v10/ste"
+	"github.com/Azure/azure-storage-azcopy/v10/telemetry"
 	"github.com/Azure/azure-storage-azcopy/v10/traverser"
 )
 
 // ResumeJobOptions contains the optional parameters for resuming a job.
 type ResumeJobOptions struct {
-	SourceSAS      string
-	DestinationSAS string
-	Handler        ResumeJobHandler
+	SourceSAS        string
+	DestinationSAS   string
+	Handler          ResumeJobHandler
+	telemetryOptions telemetry.OptionAttributes
+}
+
+func (o *ResumeJobOptions) SetTelemetryOptions(options telemetry.OptionAttributes) {
+	o.telemetryOptions = options.Clone()
 }
 
 // ResumeJobProgress contains the progress information for a resumed job.
@@ -54,13 +60,14 @@ type ResumeJobHandler interface {
 type ResumeJobResult CopyResult
 
 // ResumeJob resumes a job with the specified JobID.
-func (c *Client) ResumeJob(ctx context.Context, jobID common.JobID, opts ResumeJobOptions) (ResumeJobResult, error) {
+func (c *Client) ResumeJob(ctx context.Context, jobID common.JobID, opts ResumeJobOptions) (result ResumeJobResult, err error) {
 	if jobID.IsEmpty() {
 		return ResumeJobResult{}, errors.New("resume job requires the JobID")
 	}
 	// Initialization of logs
 	c.CurrentJobID = jobID
 	timeAtPrestart := time.Now()
+	telemetryInvocationID := newTelemetryInvocationID()
 
 	if common.AzcopyCurrentJobLogger == nil { // In the unlikely case, logger is not initialized in root.go
 		common.AzcopyCurrentJobLogger = common.NewJobLogger(c.CurrentJobID, c.GetLogLevel(), common.LogPathFolder, "")
@@ -116,7 +123,7 @@ func (c *Client) ResumeJob(ctx context.Context, jobID common.JobID, opts ResumeJ
 
 	ctx = context.WithValue(ctx, ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
 
-	srcServiceClient, dstServiceClient, err := getSourceAndDestinationServiceClients(
+	srcServiceClient, dstServiceClient, srcCredType, dstCredType, err := getSourceAndDestinationServiceClients(
 		ctx,
 		srcResourceString,
 		dstResourceString,
@@ -139,6 +146,34 @@ func (c *Client) ResumeJob(ctx context.Context, jobID common.JobID, opts ResumeJ
 	mgr := NewJobLifecycleManager(resumeHandler)
 	rpt := newResumeProgressTracker(jobID, opts.Handler)
 
+	cleanupJobManager := false
+	defer func() {
+		if cleanupJobManager {
+			jobsAdmin.JobsAdmin.JobMgrCleanUp(jobID)
+		}
+	}()
+
+	telemetryAgent := getTelemetryAgent()
+	telemetryDims := resumeJobDimensions(jobDetails, srcResourceString, dstResourceString, srcCredType, dstCredType, opts.telemetryOptions)
+	telemetryFinalizer := newAttemptTelemetryFinalizer(telemetryAgent, telemetryDims, jobID.String(), telemetryInvocationID, timeAtPrestart)
+	summaryAvailable := false
+	telemetryFinalizer.summaryFn = func() (common.ListJobSummaryResponse, bool) {
+		if !summaryAvailable {
+			return common.ListJobSummaryResponse{}, false
+		}
+		return jobsAdmin.GetJobSummary(jobID), true
+	}
+	telemetryFinalizer.transferElapsedFn = rpt.GetElapsedTime
+	telemetryFinalizer.startEvent()
+	telemetryFinalizer.setStage("transfer")
+	defer func() {
+		attemptErr := err
+		if errors.Is(ctx.Err(), context.Canceled) {
+			attemptErr = context.Canceled
+		}
+		telemetryFinalizer.finish(attemptErr)
+	}()
+
 	// Send resume job request.
 	resumeJobResponse := jobsAdmin.ResumeJobOrder(common.ResumeJobRequest{
 		JobID:            jobID,
@@ -146,11 +181,12 @@ func (c *Client) ResumeJob(ctx context.Context, jobID common.JobID, opts ResumeJ
 		DstServiceClient: dstServiceClient,
 		JobErrorHandler:  mgr,
 	})
-	defer jobsAdmin.JobsAdmin.JobMgrCleanUp(jobID)
+	cleanupJobManager = true
 
 	if !resumeJobResponse.CancelledPauseResumed {
 		return ResumeJobResult{}, errors.New(resumeJobResponse.ErrorMsg)
 	}
+	summaryAvailable = true
 	mgr.InitiateProgressReporting(ctx, rpt)
 
 	err = mgr.Wait()
@@ -161,10 +197,13 @@ func (c *Client) ResumeJob(ctx context.Context, jobID common.JobID, opts ResumeJ
 	// Get final job summary
 	finalSummary := jobsAdmin.GetJobSummary(jobID)
 
-	result := ResumeJobResult{
+	result = ResumeJobResult{
 		ListJobSummaryResponse: finalSummary,
 		ElapsedTime:            rpt.GetElapsedTime(),
 	}
+	telemetryFinalizer.setStage("completion")
+	telemetryFinalizer.setFinalSummary(finalSummary)
+	telemetryFinalizer.finish(nil)
 
 	if opts.Handler != nil {
 		opts.Handler.OnComplete(result)
@@ -187,12 +226,12 @@ func getSourceAndDestinationServiceClients(
 	destination common.ResourceString,
 	jobDetails common.GetJobDetailsResponse,
 	uotm *common.UserOAuthTokenManager,
-) (*common.ServiceClient, *common.ServiceClient, error) {
+) (*common.ServiceClient, *common.ServiceClient, common.CredentialType, common.CredentialType, error) {
 	fromTo := jobDetails.FromTo
 
 	srcCredType, isSrcPublic, err := GetCredentialTypeForLocation(ctx, fromTo.From(), source, true, common.CpkOptions{}, uotm)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, common.ECredentialType.Unknown(), common.ECredentialType.Unknown(), err
 	}
 
 	var errorMsg = ""
@@ -206,7 +245,7 @@ func getSourceAndDestinationServiceClients(
 
 	dstCredType, isDstPublic, err := GetCredentialTypeForLocation(ctx, fromTo.To(), destination, false, common.CpkOptions{}, uotm)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, srcCredType, common.ECredentialType.Unknown(), err
 	}
 
 	if fromTo.To().IsAzure() && dstCredType == common.ECredentialType.Anonymous() && destination.SAS == "" {
@@ -219,7 +258,7 @@ func getSourceAndDestinationServiceClients(
 		}
 	}
 	if errorMsg != "" {
-		return nil, nil, fmt.Errorf("the %s switch must be provided to resume the job", errorMsg)
+		return nil, nil, srcCredType, dstCredType, fmt.Errorf("the %s switch must be provided to resume the job", errorMsg)
 	}
 
 	var tc azcore.TokenCredential
@@ -227,12 +266,12 @@ func getSourceAndDestinationServiceClients(
 		// Get token from env var or cache.
 		tokenInfo, err := uotm.GetTokenInfo(ctx)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, srcCredType, dstCredType, err
 		}
 
 		tc, err = tokenInfo.GetTokenCredential()
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, srcCredType, dstCredType, err
 		}
 	}
 
@@ -252,7 +291,7 @@ func getSourceAndDestinationServiceClients(
 	}
 	srcServiceClient, err := common.GetServiceClientForLocation(fromTo.From(), source, srcCredType, tc, &options, fileSrcClientOptions)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, srcCredType, dstCredType, err
 	}
 
 	var srcCred *common.ScopedToken
@@ -269,9 +308,9 @@ func getSourceAndDestinationServiceClients(
 	}
 	dstServiceClient, err := common.GetServiceClientForLocation(fromTo.To(), destination, dstCredType, tc, &options, fileClientOptions)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, srcCredType, dstCredType, err
 	}
-	return srcServiceClient, dstServiceClient, nil
+	return srcServiceClient, dstServiceClient, srcCredType, dstCredType, nil
 }
 
 type resumeProgressTracker struct {
@@ -351,6 +390,9 @@ func (r *resumeProgressTracker) GetJobID() common.JobID {
 }
 
 func (r *resumeProgressTracker) GetElapsedTime() time.Duration {
+	if r.jobStartTime.IsZero() {
+		return 0
+	}
 	return time.Since(r.jobStartTime)
 }
 

--- a/azcopy/sync.go
+++ b/azcopy/sync.go
@@ -300,7 +300,7 @@ func newSyncer(ctx context.Context, jobID common.JobID, src, dst string, opts Sy
 		cookedOpts.fromTo,
 		cookedOpts.symlinks,
 		cookedOpts.hardlinks,
-		getTelemetryAgent().shouldCollectSourceShape(jobID.String()))
+		getTelemetryAgent().shouldCollectSourceShape())
 	sync := &syncer{opts: cookedOpts, srp: syncRemote, spt: progressTracker, inodeStore: store}
 
 	// Ensure that resources are eventually released even if the caller forgets to close the syncer.

--- a/azcopy/sync.go
+++ b/azcopy/sync.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-azcopy/v10/jobsAdmin"
 	"github.com/Azure/azure-storage-azcopy/v10/ste"
+	"github.com/Azure/azure-storage-azcopy/v10/telemetry"
 	"github.com/Azure/azure-storage-azcopy/v10/traverser"
 )
 
@@ -75,6 +76,7 @@ type SyncOptions struct {
 	commandString                    string
 	dryrunJobPartOrderHandler        func(request common.CopyJobPartOrderRequest) common.CopyJobPartOrderResponse
 	dryrunDeleteHandler              ObjectDeleter
+	telemetryOptions                 telemetry.OptionAttributes
 }
 
 type SyncHandler interface {
@@ -118,7 +120,11 @@ func (s *SyncOptions) SetInternalOptions(dryrun, deleteDestinationFileIfNecessar
 	s.commandString = cmd
 }
 
-func (c *Client) Sync(ctx context.Context, src, dest string, opts SyncOptions) (SyncResult, error) {
+func (s *SyncOptions) SetTelemetryOptions(options telemetry.OptionAttributes) {
+	s.telemetryOptions = options.Clone()
+}
+
+func (c *Client) Sync(ctx context.Context, src, dest string, opts SyncOptions) (result SyncResult, err error) {
 	// Input
 	if src == "" || dest == "" {
 		return SyncResult{}, fmt.Errorf("source and destination must be specified for sync")
@@ -138,6 +144,7 @@ func (c *Client) Sync(ctx context.Context, src, dest string, opts SyncOptions) (
 		c.CurrentJobID = jobID
 	}
 	timeAtPrestart := time.Now()
+	telemetryInvocationID := newTelemetryInvocationID()
 	if common.AzcopyCurrentJobLogger == nil { // In the unlikely case, logger is not initialized in root.go
 		common.AzcopyCurrentJobLogger = common.NewJobLogger(c.CurrentJobID, c.GetLogLevel(), common.LogPathFolder, "")
 		common.AzcopyCurrentJobLogger.OpenLog()
@@ -168,7 +175,7 @@ func (c *Client) Sync(ctx context.Context, src, dest string, opts SyncOptions) (
 
 	var s *syncer
 	ctx = context.WithValue(ctx, ste.ServiceAPIVersionOverride, ste.DefaultServiceApiVersion)
-	s, err := newSyncer(ctx, jobID, src, dest, opts, c.GetUserOAuthTokenManagerInstance())
+	s, err = newSyncer(ctx, jobID, src, dest, opts, c.GetUserOAuthTokenManagerInstance())
 	if err != nil {
 		return SyncResult{}, err
 	}
@@ -181,11 +188,30 @@ func (c *Client) Sync(ctx context.Context, src, dest string, opts SyncOptions) (
 		return SyncResult{}, err
 	}
 
+	telemetryAgent := getTelemetryAgent()
+	telemetryDims := syncJobDimensions(s.opts, s.srp.srcCredType, s.srp.dstCredType)
+	defer jobsAdmin.JobsAdmin.JobMgrCleanUp(jobID)
+	var telemetryFinalizer *attemptTelemetryFinalizer
 	if !s.opts.dryrun {
+		telemetryFinalizer = newAttemptTelemetryFinalizer(telemetryAgent, telemetryDims, jobID.String(), telemetryInvocationID, timeAtPrestart)
+		telemetryFinalizer.summaryFn = func() (common.ListJobSummaryResponse, bool) {
+			return jobsAdmin.GetJobSummary(s.spt.jobID), true
+		}
+		telemetryFinalizer.enumerationElapsedFn = s.spt.GetEnumerationElapsedTime
+		telemetryFinalizer.transferElapsedFn = s.spt.GetTransferElapsedTime
+		telemetryFinalizer.shapeFn = s.spt.GetSourceShapeSummary
+		telemetryFinalizer.startEvent()
+		telemetryFinalizer.setStage("enumeration")
+		defer func() {
+			attemptErr := err
+			if errors.Is(ctx.Err(), context.Canceled) {
+				attemptErr = context.Canceled
+			}
+			telemetryFinalizer.finish(attemptErr)
+		}()
 		mgr.InitiateProgressReporting(ctx, s.spt)
 	}
 	err = enumerator.Enumerate()
-	defer jobsAdmin.JobsAdmin.JobMgrCleanUp(jobID)
 
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
@@ -202,10 +228,12 @@ func (c *Client) Sync(ctx context.Context, src, dest string, opts SyncOptions) (
 		return SyncResult{}, nil
 	}
 
+	telemetryFinalizer.setStage("transfer")
 	err = mgr.Wait()
 	if err != nil {
 		return SyncResult{}, err
 	}
+	telemetryFinalizer.setStage("completion")
 
 	// Get final job summary
 	finalSummary := jobsAdmin.GetJobSummary(s.spt.jobID)
@@ -213,7 +241,7 @@ func (c *Client) Sync(ctx context.Context, src, dest string, opts SyncOptions) (
 	finalSummary.SkippedSpecialFileCount = s.spt.getSkippedSpecialFileCount()
 	finalSummary.SkippedHardlinkCount = s.spt.getSkippedHardlinkCount()
 
-	result := SyncResult{
+	result = SyncResult{
 		SourceFilesScanned:       s.spt.getSourceFilesScanned(),
 		DestinationFilesScanned:  s.spt.getDestinationFilesScanned(),
 		ListJobSummaryResponse:   finalSummary,
@@ -221,6 +249,8 @@ func (c *Client) Sync(ctx context.Context, src, dest string, opts SyncOptions) (
 		DeleteTransfersCompleted: s.spt.getDeletionCount(),
 		ElapsedTime:              s.spt.GetElapsedTime(),
 	}
+	telemetryFinalizer.setFinalSummary(finalSummary)
+	telemetryFinalizer.finish(nil)
 
 	if common.AzcopyCurrentJobLogger != nil {
 		common.AzcopyCurrentJobLogger.Log(common.LogInfo, GetSyncResult(result, true))
@@ -264,7 +294,7 @@ func newSyncer(ctx context.Context, jobID common.JobID, src, dst string, opts Sy
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize inode store: %w", err)
 	}
-	progressTracker := newSyncProgressTracker(jobID, opts.Handler)
+	progressTracker := newSyncProgressTracker(jobID, opts.Handler, cookedOpts.fromTo, cookedOpts.symlinks, cookedOpts.hardlinks)
 	sync := &syncer{opts: cookedOpts, srp: syncRemote, spt: progressTracker, inodeStore: store}
 
 	// Ensure that resources are eventually released even if the caller forgets to close the syncer.

--- a/azcopy/sync.go
+++ b/azcopy/sync.go
@@ -294,7 +294,13 @@ func newSyncer(ctx context.Context, jobID common.JobID, src, dst string, opts Sy
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize inode store: %w", err)
 	}
-	progressTracker := newSyncProgressTracker(jobID, opts.Handler, cookedOpts.fromTo, cookedOpts.symlinks, cookedOpts.hardlinks)
+	progressTracker := newSyncProgressTracker(
+		jobID,
+		opts.Handler,
+		cookedOpts.fromTo,
+		cookedOpts.symlinks,
+		cookedOpts.hardlinks,
+		getTelemetryAgent().shouldCollectSourceShape(jobID.String()))
 	sync := &syncer{opts: cookedOpts, srp: syncRemote, spt: progressTracker, inodeStore: store}
 
 	// Ensure that resources are eventually released even if the caller forgets to close the syncer.

--- a/azcopy/syncEnumerator.go
+++ b/azcopy/syncEnumerator.go
@@ -81,6 +81,9 @@ func (s *syncer) initEnumerator(ctx context.Context, logLevel common.LogLevel, m
 	if err != nil {
 		return nil, err
 	}
+	if err = s.spt.shapeTracker.initializeScopes(sourceTraverser); err != nil {
+		return nil, err
+	}
 	// TODO: enable symlink support in a future release after evaluating the implications
 	// GetProperties is enabled by default as sync supports both upload and download.
 	// This property only supports Files and S3 at the moment, but provided that Files sync is coming soon, enable to avoid stepping on Files sync work
@@ -311,7 +314,8 @@ func (s *syncer) initEnumerator(ctx context.Context, logLevel common.LogLevel, m
 			return nil
 		}
 
-		return traverser.NewSyncEnumerator(sourceTraverser, destinationTraverser, indexer, filters, comparator, finalize), nil
+		return traverser.NewSyncEnumeratorWithObservers(sourceTraverser, destinationTraverser, indexer, filters, comparator, finalize,
+			s.spt.shapeTracker.recordScanned, nil), nil
 	default:
 		indexer.IsDestinationCaseInsensitive = isDestinationCaseInsensitive(s.opts.fromTo)
 		// in all other cases (download and S2S), the destination is scanned/indexed first
@@ -348,7 +352,8 @@ func (s *syncer) initEnumerator(ctx context.Context, logLevel common.LogLevel, m
 			return nil
 		}
 
-		return traverser.NewSyncEnumerator(destinationTraverser, sourceTraverser, indexer, filters, comparator, finalize), nil
+		return traverser.NewSyncEnumeratorWithObservers(destinationTraverser, sourceTraverser, indexer, filters, comparator, finalize,
+			nil, s.spt.shapeTracker.recordScanned), nil
 	}
 }
 

--- a/azcopy/syncOptions.go
+++ b/azcopy/syncOptions.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/telemetry"
 	"github.com/Azure/azure-storage-azcopy/v10/traverser"
 )
 
@@ -75,6 +76,7 @@ type cookedSyncOptions struct {
 	dryrunDeleteHandler              ObjectDeleter
 	deleteDestinationFileIfNecessary bool
 	commandString                    string
+	telemetryOptions                 telemetry.OptionAttributes
 }
 
 func newCookedSyncOptions(src, dst string, opts SyncOptions) (s *cookedSyncOptions, err error) {
@@ -197,6 +199,7 @@ func (s *cookedSyncOptions) applyDefaultsAndInferOptions(opts SyncOptions) (err 
 	s.dryrun = opts.dryrun
 	s.deleteDestinationFileIfNecessary = opts.deleteDestinationFileIfNecessary
 	s.commandString = opts.commandString
+	s.telemetryOptions = opts.telemetryOptions.Clone()
 	s.dryrunJobPartOrderHandler = opts.dryrunJobPartOrderHandler
 	s.dryrunDeleteHandler = opts.dryrunDeleteHandler
 

--- a/azcopy/syncProcessor.go
+++ b/azcopy/syncProcessor.go
@@ -43,8 +43,10 @@ func (s *syncer) newSyncTransferProcessor(
 
 	// note that the source and destination, along with the template are given to the generic processor's constructor
 	// this means that given an object with a relative path, this processor already knows how to schedule the right kind of transfers
-	return NewCopyTransferProcessor(false, copyJobTemplate, numOfTransfersPerPart, s.opts.source, s.opts.destination,
+	processor := NewCopyTransferProcessor(false, copyJobTemplate, numOfTransfersPerPart, s.opts.source, s.opts.destination,
 		reportFirstPart, reportFinalPart, s.opts.s2SPreserveAccessTier, s.opts.dryrun, s.opts.dryrunJobPartOrderHandler)
+	processor.SetTransferScheduledObserver(s.spt.shapeTracker.recordScheduled)
+	return processor
 }
 
 // base for delete processors targeting different resources

--- a/azcopy/syncProgressTracker.go
+++ b/azcopy/syncProgressTracker.go
@@ -36,6 +36,8 @@ type syncProgressTracker struct {
 	// so the 64 bit integers are placed first in the struct to avoid future breaks
 	// refer to: https://golang.org/pkg/sync/atomic/#pkg-note-BUG
 	// incremented by traversers
+	atomicTransferStartUnixNano   int64
+	atomicEnumerationEndUnixNano  int64
 	atomicSourceFilesScanned      uint64
 	atomicDestinationFilesScanned uint64
 	atomicScanningStatus          uint32
@@ -56,14 +58,16 @@ type syncProgressTracker struct {
 	// used to calculate job summary
 	jobStartTime time.Time
 
-	jobID   common.JobID
-	handler SyncHandler
+	jobID        common.JobID
+	handler      SyncHandler
+	shapeTracker *sourceShapeTracker
 }
 
-func newSyncProgressTracker(jobID common.JobID, handler SyncHandler) *syncProgressTracker {
+func newSyncProgressTracker(jobID common.JobID, handler SyncHandler, fromTo common.FromTo, symlinkHandling common.SymlinkHandlingType, hardlinkHandling common.HardlinkHandlingType) *syncProgressTracker {
 	return &syncProgressTracker{
-		jobID:   jobID,
-		handler: handler,
+		jobID:        jobID,
+		handler:      handler,
+		shapeTracker: newSourceShapeTracker(fromTo.From(), symlinkHandling, hardlinkHandling),
 	}
 }
 
@@ -151,6 +155,34 @@ func (spt *syncProgressTracker) GetElapsedTime() time.Duration {
 	return time.Since(spt.jobStartTime)
 }
 
+func (spt *syncProgressTracker) GetSourceShapeSummary() sourceShapeSummary {
+	return spt.shapeTracker.snapshot()
+}
+
+func (spt *syncProgressTracker) GetTransferElapsedTime() time.Duration {
+	start := atomic.LoadInt64(&spt.atomicTransferStartUnixNano)
+	if start == 0 {
+		return 0
+	}
+	elapsed := time.Since(time.Unix(0, start))
+	if elapsed < 0 {
+		return 0
+	}
+	return elapsed
+}
+
+func (spt *syncProgressTracker) GetEnumerationElapsedTime() time.Duration {
+	end := atomic.LoadInt64(&spt.atomicEnumerationEndUnixNano)
+	if end == 0 || spt.jobStartTime.IsZero() {
+		return 0
+	}
+	elapsed := time.Unix(0, end).Sub(spt.jobStartTime)
+	if elapsed < 0 {
+		return 0
+	}
+	return elapsed
+}
+
 func (spt *syncProgressTracker) incSourceEnumeration(entityType common.EntityType, symlinkOption common.SymlinkHandlingType, hardlinkHandling common.HardlinkHandlingType) {
 	if entityType == common.EEntityType.File() {
 		atomic.AddUint64(&spt.atomicSourceFilesScanned, 1)
@@ -205,6 +237,7 @@ func (spt *syncProgressTracker) getDeletionCount() uint32 {
 
 // setFirstPartOrdered sets the value of atomicFirstPartOrdered to 1
 func (spt *syncProgressTracker) setFirstPartOrdered() {
+	atomic.CompareAndSwapInt64(&spt.atomicTransferStartUnixNano, 0, time.Now().UnixNano())
 	atomic.StoreUint32(&spt.atomicFirstPartOrdered, 1)
 }
 
@@ -215,6 +248,7 @@ func (spt *syncProgressTracker) firstPartOrdered() bool {
 
 // setScanningComplete sets the value of atomicScanningStatus to 1.
 func (spt *syncProgressTracker) setScanningComplete() {
+	atomic.CompareAndSwapInt64(&spt.atomicEnumerationEndUnixNano, 0, time.Now().UnixNano())
 	atomic.StoreUint32(&spt.atomicScanningStatus, 1)
 }
 

--- a/azcopy/syncProgressTracker.go
+++ b/azcopy/syncProgressTracker.go
@@ -63,11 +63,15 @@ type syncProgressTracker struct {
 	shapeTracker *sourceShapeTracker
 }
 
-func newSyncProgressTracker(jobID common.JobID, handler SyncHandler, fromTo common.FromTo, symlinkHandling common.SymlinkHandlingType, hardlinkHandling common.HardlinkHandlingType) *syncProgressTracker {
+func newSyncProgressTracker(jobID common.JobID, handler SyncHandler, fromTo common.FromTo, symlinkHandling common.SymlinkHandlingType, hardlinkHandling common.HardlinkHandlingType, collectSourceShape bool) *syncProgressTracker {
+	var shapeTracker *sourceShapeTracker
+	if collectSourceShape {
+		shapeTracker = newSourceShapeTracker(fromTo.From(), symlinkHandling, hardlinkHandling)
+	}
 	return &syncProgressTracker{
 		jobID:        jobID,
 		handler:      handler,
-		shapeTracker: newSourceShapeTracker(fromTo.From(), symlinkHandling, hardlinkHandling),
+		shapeTracker: shapeTracker,
 	}
 }
 

--- a/azcopy/telemetry.go
+++ b/azcopy/telemetry.go
@@ -23,8 +23,6 @@ package azcopy
 import (
 	"context"
 	"crypto/rand"
-	"crypto/sha256"
-	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -45,12 +43,8 @@ import (
 )
 
 const (
-	telemetrySchemaVersion       = "3"
-	defaultTelemetrySamplingRate = 0.01
-	telemetrySamplerVersion      = "job-id-sha256-v1"
+	telemetrySchemaVersion = "3"
 )
-
-var telemetrySamplingRate = defaultTelemetrySamplingRate
 
 // telemetryConnectionString is injected into official binaries at build time.
 // It remains empty for local builds, which fail closed with telemetry disabled.
@@ -74,8 +68,11 @@ const (
 	// envE2ETelemetryRunID optionally correlates telemetry emitted by one E2E
 	// pipeline matrix leg. It is unset in normal AzCopy usage.
 	envE2ETelemetryRunID = "AZCOPY_E2E_TELEMETRY_RUN_ID"
-	// telemetrySendTimeout bounds how long a single send may block.
-	telemetrySendTimeout = 5 * time.Second
+	// Individual sends are bounded so an ordered started/finished pair fits
+	// within the process-wide shutdown drain.
+	telemetrySendTimeout = time.Second
+	// telemetryFlushTimeout is the maximum telemetry may add to process exit.
+	telemetryFlushTimeout = 2 * time.Second
 	// installationIDFileName stores the anonymous, per-install identifier.
 	installationIDFileName       = "installation_id"
 	installationIDLockRetryDelay = 10 * time.Millisecond
@@ -90,19 +87,38 @@ type telemetryAgent struct {
 	reporter     *telemetry.Reporter
 	resource     telemetry.ResourceAttributes
 	startedSends sync.Map
+	pendingSends sync.WaitGroup
+	sendTimeout  time.Duration
 }
 
 var (
-	telemetryOnce sync.Once
-	telemetryInst *telemetryAgent
+	telemetryOnce   sync.Once
+	telemetryInst   *telemetryAgent
+	telemetryInstMu sync.RWMutex
 )
 
 // getTelemetryAgent lazily builds the process-wide telemetry agent.
 func getTelemetryAgent() *telemetryAgent {
 	telemetryOnce.Do(func() {
-		telemetryInst = newTelemetryAgent()
+		agent := newTelemetryAgent()
+		telemetryInstMu.Lock()
+		telemetryInst = agent
+		telemetryInstMu.Unlock()
 	})
+	telemetryInstMu.RLock()
+	defer telemetryInstMu.RUnlock()
 	return telemetryInst
+}
+
+// FlushTelemetry gives outstanding best-effort telemetry one bounded chance to
+// complete before process exit.
+func FlushTelemetry() {
+	telemetryInstMu.RLock()
+	agent := telemetryInst
+	telemetryInstMu.RUnlock()
+	if agent != nil {
+		agent.flush(telemetryFlushTimeout)
+	}
 }
 
 func newTelemetryAgent() *telemetryAgent {
@@ -145,7 +161,7 @@ func ReportCommandInvoked(command, runID string, options telemetry.OptionAttribu
 // reportStarted emits a job.started event asynchronously (best-effort). It never
 // blocks the caller and never surfaces errors to the user.
 func (a *telemetryAgent) reportStarted(dims telemetry.JobDimensions, runID, invocationID string, start time.Time) {
-	if a == nil || !a.enabled || !shouldSampleTelemetry(runID, telemetrySamplingRate) {
+	if a == nil || !a.enabled {
 		return
 	}
 	evt := telemetry.JobStartedEvent{
@@ -156,28 +172,26 @@ func (a *telemetryAgent) reportStarted(dims telemetry.JobDimensions, runID, invo
 		Timestamp:    start,
 		StartedCount: 1,
 	}
-	sendComplete := make(chan struct{})
-	a.startedSends.Store(startedSendKey(runID, invocationID), sendComplete)
+	key := startedSendKey(runID, invocationID)
+	sendComplete := a.dispatch(evt, nil)
+	a.startedSends.Store(key, sendComplete)
 	go func() {
-		defer func() {
-			close(sendComplete)
-			a.startedSends.CompareAndDelete(startedSendKey(runID, invocationID), sendComplete)
-		}()
-		a.sendSafely(evt)
+		<-sendComplete
+		a.startedSends.CompareAndDelete(key, sendComplete)
 	}()
 }
 
-// reportFinished emits a job.finished event synchronously (bounded by
-// telemetrySendTimeout) so the event is delivered before the process exits.
-// Failures are logged to the job log only.
+// reportFinished queues job.finished after its matching job.started send. The
+// process-wide flush provides the bounded delivery opportunity before exit.
 func (a *telemetryAgent) reportFinished(evt telemetry.JobFinishedEvent) {
-	if a == nil || !a.enabled || !shouldSampleTelemetry(evt.JobID, telemetrySamplingRate) {
+	if a == nil || !a.enabled {
 		return
 	}
+	var startedComplete <-chan struct{}
 	if sendComplete, ok := a.startedSends.LoadAndDelete(startedSendKey(evt.JobID, evt.InvocationID)); ok {
-		<-sendComplete.(chan struct{})
+		startedComplete = sendComplete.(chan struct{})
 	}
-	a.sendSafely(evt)
+	a.dispatch(evt, startedComplete)
 }
 
 func startedSendKey(jobID, invocationID string) string {
@@ -395,14 +409,13 @@ func sanitizeJobErrorCode(code string) string {
 	return code
 }
 
-// reportCommand emits a single command.invoked event synchronously (bounded by
-// telemetrySendTimeout). Used for commands that do not emit paired job-attempt
-// start/finish events. Best-effort; no-op when disabled.
+// reportCommand queues a single command.invoked event without delaying command
+// execution. Best-effort; no-op when disabled.
 func (a *telemetryAgent) reportCommand(command, runID, invocationID string, options telemetry.OptionAttributes) {
-	if a == nil || !a.enabled || !shouldSampleTelemetry(runID, telemetrySamplingRate) {
+	if a == nil || !a.enabled {
 		return
 	}
-	a.sendSafely(telemetry.CommandInvokedEvent{
+	a.dispatch(telemetry.CommandInvokedEvent{
 		Resource:     a.resource,
 		Command:      command,
 		Options:      options.Clone(),
@@ -410,7 +423,7 @@ func (a *telemetryAgent) reportCommand(command, runID, invocationID string, opti
 		InvocationID: invocationID,
 		Timestamp:    time.Now(),
 		InvokedCount: 1,
-	})
+	}, nil)
 }
 
 func newTelemetryInvocationID() string {
@@ -421,23 +434,39 @@ func newTelemetryInvocationID() string {
 	return hex.EncodeToString(buf)
 }
 
-func shouldSampleTelemetry(jobID string, rate float64) bool {
-	if jobID == "" || rate <= 0 {
-		return false
-	}
-	if rate >= 1 {
-		return true
-	}
-	sum := sha256.Sum256([]byte(telemetrySamplerVersion + ":" + jobID))
-	// Use 53 bits so conversion to float64 is exact. Raising the threshold
-	// creates a nested cohort without changing any JobID's stable hash.
-	value := binary.BigEndian.Uint64(sum[:8]) >> 11
-	const bucketCount = uint64(1) << 53
-	return float64(value)/float64(bucketCount) < rate
+func (a *telemetryAgent) shouldCollectSourceShape() bool {
+	return a != nil && a.enabled
 }
 
-func (a *telemetryAgent) shouldCollectSourceShape(jobID string) bool {
-	return a != nil && a.enabled && shouldSampleTelemetry(jobID, telemetrySamplingRate)
+func (a *telemetryAgent) dispatch(evt telemetry.MetricEvent, waitFor <-chan struct{}) chan struct{} {
+	complete := make(chan struct{})
+	a.pendingSends.Add(1)
+	go func() {
+		defer a.pendingSends.Done()
+		defer close(complete)
+		if waitFor != nil {
+			<-waitFor
+		}
+		a.sendSafely(evt)
+	}()
+	return complete
+}
+
+func (a *telemetryAgent) flush(timeout time.Duration) {
+	if a == nil || !a.enabled {
+		return
+	}
+	complete := make(chan struct{})
+	go func() {
+		a.pendingSends.Wait()
+		close(complete)
+	}()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-complete:
+	case <-timer.C:
+	}
 }
 
 func (a *telemetryAgent) sendSafely(evt telemetry.MetricEvent) {
@@ -446,7 +475,11 @@ func (a *telemetryAgent) sendSafely(evt telemetry.MetricEvent) {
 			common.LogToJobLogWithPrefix(fmt.Sprintf("telemetry: recovered from panic while sending %s: %v", evt.EventName(), r), common.LogError)
 		}
 	}()
-	ctx, cancel := context.WithTimeout(context.Background(), telemetrySendTimeout)
+	timeout := a.sendTimeout
+	if timeout <= 0 {
+		timeout = telemetrySendTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	if err := a.reporter.ReportEvent(ctx, evt); err != nil {
 		common.LogToJobLogWithPrefix(fmt.Sprintf("telemetry: failed to send %s: %v", evt.EventName(), err), common.LogWarning)
@@ -464,8 +497,6 @@ func buildResourceAttributes() telemetry.ResourceAttributes {
 	return telemetry.ResourceAttributes{
 		AzCopyVersion:      common.AzcopyVersion,
 		SchemaVersion:      telemetrySchemaVersion,
-		SamplingRate:       telemetrySamplingRate,
-		SamplerVersion:     telemetrySamplerVersion,
 		E2ETestRunID:       strings.TrimSpace(os.Getenv(envE2ETelemetryRunID)),
 		OSType:             runtime.GOOS,
 		OSVersion:          hw.osVersion,

--- a/azcopy/telemetry.go
+++ b/azcopy/telemetry.go
@@ -77,7 +77,9 @@ const (
 	// telemetrySendTimeout bounds how long a single send may block.
 	telemetrySendTimeout = 5 * time.Second
 	// installationIDFileName stores the anonymous, per-install identifier.
-	installationIDFileName = "installation_id"
+	installationIDFileName       = "installation_id"
+	installationIDLockRetryDelay = 10 * time.Millisecond
+	installationIDLockAttempts   = 100
 )
 
 // telemetryAgent owns the (optional) telemetry reporter plus the cached,
@@ -475,24 +477,92 @@ func nicSpeedBucket(speedMbps int) string {
 }
 
 // installationID returns a stable, anonymous per-install identifier. It is a
-// random 128-bit value persisted alongside the job plan files. It is NOT derived
-// from any machine identity and contains no PII.
+// random 128-bit value persisted with AzCopy's application data. It is NOT
+// derived from any machine identity and contains no PII.
 func installationID() string {
-	if common.AzcopyJobPlanFolder == "" {
+	return installationIDInDir(common.GetAzCopyAppPath())
+}
+
+func installationIDInDir(appDataDir string) string {
+	if appDataDir == "" {
 		return ""
 	}
-	p := filepath.Join(common.AzcopyJobPlanFolder, installationIDFileName)
-	if b, err := os.ReadFile(p); err == nil {
-		if id := strings.TrimSpace(string(b)); id != "" {
+	if err := os.MkdirAll(appDataDir, 0700); err != nil {
+		return ""
+	}
+
+	p := filepath.Join(appDataDir, installationIDFileName)
+	lockPath := p + ".lock"
+	for attempt := 0; attempt < installationIDLockAttempts; attempt++ {
+		if id := readInstallationID(p); id != "" {
 			return id
 		}
+
+		lockFile, err := os.OpenFile(lockPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+		if err == nil {
+			if closeErr := lockFile.Close(); closeErr != nil {
+				_ = os.Remove(lockPath)
+				return ""
+			}
+			return createInstallationID(p, lockPath, appDataDir)
+		}
+		if !os.IsExist(err) {
+			return ""
+		}
+		time.Sleep(installationIDLockRetryDelay)
 	}
+	return ""
+}
+
+func readInstallationID(path string) string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	id := strings.TrimSpace(string(b))
+	if len(id) != 32 {
+		return ""
+	}
+	if _, err = hex.DecodeString(id); err != nil {
+		return ""
+	}
+	return id
+}
+
+func createInstallationID(path, lockPath, appDataDir string) string {
+	defer os.Remove(lockPath)
+
+	if id := readInstallationID(path); id != "" {
+		return id
+	}
+
 	buf := make([]byte, 16)
 	if _, err := rand.Read(buf); err != nil {
 		return ""
 	}
 	id := hex.EncodeToString(buf)
-	_ = os.WriteFile(p, []byte(id), 0600)
+
+	tempFile, err := os.CreateTemp(appDataDir, "."+installationIDFileName+"-*")
+	if err != nil {
+		return ""
+	}
+	tempPath := tempFile.Name()
+	defer os.Remove(tempPath)
+
+	if _, err = tempFile.WriteString(id); err != nil {
+		_ = tempFile.Close()
+		return ""
+	}
+	if err = tempFile.Close(); err != nil {
+		return ""
+	}
+
+	if err = os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return ""
+	}
+	if err = os.Rename(tempPath, path); err != nil {
+		return ""
+	}
 	return id
 }
 

--- a/azcopy/telemetry.go
+++ b/azcopy/telemetry.go
@@ -86,9 +86,10 @@ const (
 // process-wide resource attributes. All methods are safe to call when the agent
 // is nil or disabled, in which case they are no-ops.
 type telemetryAgent struct {
-	enabled  bool
-	reporter *telemetry.Reporter
-	resource telemetry.ResourceAttributes
+	enabled      bool
+	reporter     *telemetry.Reporter
+	resource     telemetry.ResourceAttributes
+	startedSends sync.Map
 }
 
 var (
@@ -155,7 +156,15 @@ func (a *telemetryAgent) reportStarted(dims telemetry.JobDimensions, runID, invo
 		Timestamp:    start,
 		StartedCount: 1,
 	}
-	go a.sendSafely(evt)
+	sendComplete := make(chan struct{})
+	a.startedSends.Store(startedSendKey(runID, invocationID), sendComplete)
+	go func() {
+		defer func() {
+			close(sendComplete)
+			a.startedSends.CompareAndDelete(startedSendKey(runID, invocationID), sendComplete)
+		}()
+		a.sendSafely(evt)
+	}()
 }
 
 // reportFinished emits a job.finished event synchronously (bounded by
@@ -165,7 +174,14 @@ func (a *telemetryAgent) reportFinished(evt telemetry.JobFinishedEvent) {
 	if a == nil || !a.enabled || !shouldSampleTelemetry(evt.JobID, telemetrySamplingRate) {
 		return
 	}
+	if sendComplete, ok := a.startedSends.LoadAndDelete(startedSendKey(evt.JobID, evt.InvocationID)); ok {
+		<-sendComplete.(chan struct{})
+	}
 	a.sendSafely(evt)
+}
+
+func startedSendKey(jobID, invocationID string) string {
+	return jobID + "\x00" + invocationID
 }
 
 type attemptTelemetryFinalizer struct {
@@ -420,6 +436,10 @@ func shouldSampleTelemetry(jobID string, rate float64) bool {
 	return float64(value)/float64(bucketCount) < rate
 }
 
+func (a *telemetryAgent) shouldCollectSourceShape(jobID string) bool {
+	return a != nil && a.enabled && shouldSampleTelemetry(jobID, telemetrySamplingRate)
+}
+
 func (a *telemetryAgent) sendSafely(evt telemetry.MetricEvent) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -599,9 +619,7 @@ func resumeJobDimensions(jobDetails common.GetJobDetailsResponse, source, destin
 	d := baseJobDimensions("jobs.resume", jobDetails.FromTo, srcCredType, dstCredType)
 	d.SummaryCounterScope = "job-cumulative"
 	d.SourceMountType = sourceMountType(jobDetails.FromTo.From(), source.Value)
-	d.SourceStorageAccount = storageAccountName(source, jobDetails.FromTo.From())
 	d.SourceScope = scopeForLocation(source, jobDetails.FromTo.From(), true)
-	d.DestStorageAccount = storageAccountName(destination, jobDetails.FromTo.To())
 	d.DestScope = scopeForLocation(destination, jobDetails.FromTo.To(), false)
 	d.SourceAuthMechanism = authMechanism(srcCredType, source, jobDetails.FromTo.From())
 	d.DestAuthMechanism = authMechanism(dstCredType, destination, jobDetails.FromTo.To())
@@ -662,38 +680,6 @@ func sourceMountType(loc common.Location, localPath string) string {
 		return mt
 	}
 	return "local-disk"
-}
-
-// storageAccountName returns the Azure storage account name (the first DNS
-// label of the host) for recognized Azure Storage endpoints. It returns "" for
-// non-Azure resources, custom endpoints, and values that cannot be parsed.
-func storageAccountName(r common.ResourceString, loc common.Location) string {
-	if !loc.IsAzure() {
-		return ""
-	}
-	host := hostOf(r)
-	if host == "" || !isRecognizedAzureStorageHost(host) {
-		return ""
-	}
-	if i := strings.IndexByte(host, '.'); i > 0 {
-		return host[:i]
-	}
-	return ""
-}
-
-func isRecognizedAzureStorageHost(host string) bool {
-	for _, suffix := range []string{
-		".core.windows.net",
-		".storage.azure.net",
-		".core.usgovcloudapi.net",
-		".core.chinacloudapi.cn",
-		".core.cloudapi.de",
-	} {
-		if strings.HasSuffix(host, suffix) {
-			return true
-		}
-	}
-	return false
 }
 
 func authMechanism(credType common.CredentialType, resource common.ResourceString, location common.Location) string {
@@ -805,9 +791,7 @@ func cloudTypeFromHost(host string) string {
 func copyJobDimensions(o *CookedTransferOptions, srcCredType, dstCredType common.CredentialType) telemetry.JobDimensions {
 	d := baseJobDimensions("copy", o.fromTo, srcCredType, dstCredType)
 	d.SourceMountType = sourceMountType(o.fromTo.From(), o.source.Value)
-	d.SourceStorageAccount = storageAccountName(o.source, o.fromTo.From())
 	d.SourceScope = scopeForLocation(o.source, o.fromTo.From(), true)
-	d.DestStorageAccount = storageAccountName(o.destination, o.fromTo.To())
 	d.DestScope = scopeForLocation(o.destination, o.fromTo.To(), false)
 	d.SourceAuthMechanism = authMechanism(srcCredType, o.source, o.fromTo.From())
 	d.DestAuthMechanism = authMechanism(dstCredType, o.destination, o.fromTo.To())
@@ -834,9 +818,7 @@ func shouldEmitCopyTelemetry(o *CookedTransferOptions) bool {
 func syncJobDimensions(o *cookedSyncOptions, srcCredType, dstCredType common.CredentialType) telemetry.JobDimensions {
 	d := baseJobDimensions("sync", o.fromTo, srcCredType, dstCredType)
 	d.SourceMountType = sourceMountType(o.fromTo.From(), o.source.Value)
-	d.SourceStorageAccount = storageAccountName(o.source, o.fromTo.From())
 	d.SourceScope = scopeForLocation(o.source, o.fromTo.From(), true)
-	d.DestStorageAccount = storageAccountName(o.destination, o.fromTo.To())
 	d.DestScope = scopeForLocation(o.destination, o.fromTo.To(), false)
 	d.SourceAuthMechanism = authMechanism(srcCredType, o.source, o.fromTo.From())
 	d.DestAuthMechanism = authMechanism(dstCredType, o.destination, o.fromTo.To())

--- a/azcopy/telemetry.go
+++ b/azcopy/telemetry.go
@@ -914,15 +914,6 @@ func countExcludingFolders(total, folders uint32) int64 {
 // with many different failure codes cannot create an unbounded dimension value.
 const maxErrorCodeBuckets = 10
 
-// aggregateErrorCodes summarizes the error codes across failed transfers into a
-// compact, bounded "code:count" histogram ordered by descending count (then by
-// code for stability), e.g. "403:5,500:2". Only the numeric codes are included
-// (no paths/messages), so the result contains no PII. Returns "" when empty.
-func aggregateErrorCodes(failed []common.TransferDetail) string {
-	histogram, _ := aggregateErrorCodesWithOther(failed)
-	return histogram
-}
-
 func aggregateErrorCodesWithOther(failed []common.TransferDetail) (string, int64) {
 	if len(failed) == 0 {
 		return "", 0

--- a/azcopy/telemetry.go
+++ b/azcopy/telemetry.go
@@ -1,0 +1,954 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package azcopy
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/telemetry"
+)
+
+const (
+	telemetrySchemaVersion       = "3"
+	defaultTelemetrySamplingRate = 0.01
+	telemetrySamplerVersion      = "job-id-sha256-v1"
+)
+
+var telemetrySamplingRate = defaultTelemetrySamplingRate
+
+// telemetryConnectionString is injected into official binaries at build time.
+// It remains empty for local builds, which fail closed with telemetry disabled.
+// It may be set at build time, e.g.:
+//
+//	-ldflags "-X github.com/Azure/azure-storage-azcopy/v10/azcopy.telemetryConnectionString=<conn>"
+//
+// or overridden at runtime via AZCOPY_TELEMETRY_CONNECTION_STRING.
+var telemetryConnectionString string
+
+// telemetryDisabledByFlag is set from the --disable-telemetry CLI flag (wired
+// through ClientOptions.DisableTelemetry). When true, telemetry is disabled
+// regardless of the connection string.
+var telemetryDisabledByFlag bool
+
+const (
+	// envTelemetryConnectionString overrides the build-time connection string.
+	envTelemetryConnectionString = "AZCOPY_TELEMETRY_CONNECTION_STRING"
+	// envDisableTelemetry, when set to "true", disables telemetry entirely.
+	envDisableTelemetry = "AZCOPY_DISABLE_TELEMETRY"
+	// envE2ETelemetryRunID optionally correlates telemetry emitted by one E2E
+	// pipeline matrix leg. It is unset in normal AzCopy usage.
+	envE2ETelemetryRunID = "AZCOPY_E2E_TELEMETRY_RUN_ID"
+	// telemetrySendTimeout bounds how long a single send may block.
+	telemetrySendTimeout = 5 * time.Second
+	// installationIDFileName stores the anonymous, per-install identifier.
+	installationIDFileName = "installation_id"
+)
+
+// telemetryAgent owns the (optional) telemetry reporter plus the cached,
+// process-wide resource attributes. All methods are safe to call when the agent
+// is nil or disabled, in which case they are no-ops.
+type telemetryAgent struct {
+	enabled  bool
+	reporter *telemetry.Reporter
+	resource telemetry.ResourceAttributes
+}
+
+var (
+	telemetryOnce sync.Once
+	telemetryInst *telemetryAgent
+)
+
+// getTelemetryAgent lazily builds the process-wide telemetry agent.
+func getTelemetryAgent() *telemetryAgent {
+	telemetryOnce.Do(func() {
+		telemetryInst = newTelemetryAgent()
+	})
+	return telemetryInst
+}
+
+func newTelemetryAgent() *telemetryAgent {
+	a := &telemetryAgent{}
+	if telemetryDisabledByFlag || strings.EqualFold(os.Getenv(envDisableTelemetry), "true") {
+		return a
+	}
+	conn := configuredTelemetryConnectionString(os.Getenv)
+	if conn == "" {
+		return a
+	}
+	a.reporter = telemetry.NewReporter(telemetry.Config{
+		Backend:          telemetry.BackendAppInsights,
+		ConnectionString: conn,
+	})
+	a.resource = buildResourceAttributes()
+	a.enabled = true
+	return a
+}
+
+func configuredTelemetryConnectionString(getenv func(string) string) string {
+	conn := strings.TrimSpace(getenv(envTelemetryConnectionString))
+	if conn == "" {
+		conn = strings.TrimSpace(telemetryConnectionString)
+	}
+	if conn == "" || strings.Contains(strings.ToLower(conn), "instrumentationkey=00000000-0000-0000-0000-000000000000") {
+		return ""
+	}
+	return conn
+}
+
+// ReportCommandInvoked emits a single command.invoked telemetry event for the
+// given canonical command path. It is intended for commands that do not emit
+// paired job-attempt start/finish events. It is best-effort and a no-op when
+// telemetry is disabled.
+func ReportCommandInvoked(command, runID string, options telemetry.OptionAttributes) {
+	getTelemetryAgent().reportCommand(command, runID, newTelemetryInvocationID(), options)
+}
+
+// reportStarted emits a job.started event asynchronously (best-effort). It never
+// blocks the caller and never surfaces errors to the user.
+func (a *telemetryAgent) reportStarted(dims telemetry.JobDimensions, runID, invocationID string, start time.Time) {
+	if a == nil || !a.enabled || !shouldSampleTelemetry(runID, telemetrySamplingRate) {
+		return
+	}
+	evt := telemetry.JobStartedEvent{
+		Resource:     a.resource,
+		Dimensions:   dims,
+		JobID:        runID,
+		InvocationID: invocationID,
+		Timestamp:    start,
+		StartedCount: 1,
+	}
+	go a.sendSafely(evt)
+}
+
+// reportFinished emits a job.finished event synchronously (bounded by
+// telemetrySendTimeout) so the event is delivered before the process exits.
+// Failures are logged to the job log only.
+func (a *telemetryAgent) reportFinished(evt telemetry.JobFinishedEvent) {
+	if a == nil || !a.enabled || !shouldSampleTelemetry(evt.JobID, telemetrySamplingRate) {
+		return
+	}
+	a.sendSafely(evt)
+}
+
+type attemptTelemetryFinalizer struct {
+	agent        *telemetryAgent
+	dimensions   telemetry.JobDimensions
+	runID        string
+	invocationID string
+	start        time.Time
+	stage        string
+	finished     bool
+
+	summaryFn            func() (common.ListJobSummaryResponse, bool)
+	enumerationElapsedFn func() time.Duration
+	transferElapsedFn    func() time.Duration
+	shapeFn              func() sourceShapeSummary
+	finalSummary         *common.ListJobSummaryResponse
+}
+
+func newAttemptTelemetryFinalizer(agent *telemetryAgent, dimensions telemetry.JobDimensions, runID, invocationID string, start time.Time) *attemptTelemetryFinalizer {
+	return &attemptTelemetryFinalizer{
+		agent:        agent,
+		dimensions:   dimensions,
+		runID:        runID,
+		invocationID: invocationID,
+		start:        start,
+		stage:        "initialization",
+	}
+}
+
+func (f *attemptTelemetryFinalizer) startEvent() {
+	if f == nil {
+		return
+	}
+	f.agent.reportStarted(f.dimensions, f.runID, f.invocationID, f.start)
+}
+
+func (f *attemptTelemetryFinalizer) setStage(stage string) {
+	if f != nil {
+		f.stage = stage
+	}
+}
+
+func (f *attemptTelemetryFinalizer) setFinalSummary(summary common.ListJobSummaryResponse) {
+	if f != nil {
+		copy := summary
+		f.finalSummary = &copy
+	}
+}
+
+func (f *attemptTelemetryFinalizer) finish(attemptErr error) {
+	if f == nil || f.finished {
+		return
+	}
+	f.finished = true
+
+	summary := common.ListJobSummaryResponse{}
+	if f.finalSummary != nil {
+		summary = *f.finalSummary
+	} else if f.summaryFn != nil {
+		if liveSummary, ok := f.summaryFn(); ok {
+			summary = liveSummary
+		}
+	}
+	terminalStatus, terminalReason := terminalAttemptStatus(summary.JobStatus, attemptErr)
+	summary.JobStatus = terminalStatus
+	terminalStage := f.stage
+	if terminalReason == "completed" || terminalReason == "completed-with-errors" {
+		terminalStage = "completed"
+	}
+
+	enumerationElapsed := durationOrZero(f.enumerationElapsedFn)
+	transferElapsed := durationOrZero(f.transferElapsedFn)
+	shape := sourceShapeSummary{}
+	if f.shapeFn != nil {
+		shape = f.shapeFn()
+	}
+	resource := telemetry.ResourceAttributes{}
+	if f.agent != nil {
+		resource = f.agent.resource
+	}
+	event := buildFinishedEvent(resource, f.dimensions, f.runID, f.invocationID, f.start, time.Now(), summary, time.Since(f.start), enumerationElapsed, transferElapsed, shape)
+	event.TerminalStage = terminalStage
+	event.JobErrorCategory, event.JobErrorCode = jobErrorAttributes(attemptErr, terminalReason, terminalStage)
+	f.agent.reportFinished(event)
+}
+
+func durationOrZero(fn func() time.Duration) time.Duration {
+	if fn == nil {
+		return 0
+	}
+	return fn()
+}
+
+func terminalAttemptStatus(status common.JobStatus, attemptErr error) (common.JobStatus, string) {
+	if status == common.EJobStatus.Cancelled() || errors.Is(attemptErr, context.Canceled) {
+		return common.EJobStatus.Cancelled(), "cancelled"
+	}
+	if attemptErr != nil {
+		return common.EJobStatus.Failed(), "failed"
+	}
+	switch status {
+	case common.EJobStatus.CompletedWithErrors(), common.EJobStatus.CompletedWithErrorsAndSkipped():
+		return status, "completed-with-errors"
+	case common.EJobStatus.CompletedWithSkipped(), common.EJobStatus.Completed():
+		return status, "completed"
+	case common.EJobStatus.Failed():
+		return status, "failed"
+	default:
+		return common.EJobStatus.Completed(), "completed"
+	}
+}
+
+func jobErrorAttributes(attemptErr error, terminalReason, terminalStage string) (string, string) {
+	switch terminalReason {
+	case "completed", "cancelled":
+		return "", ""
+	case "completed-with-errors":
+		return "transfer", "transfer-failures"
+	}
+
+	var responseErr *azcore.ResponseError
+	if errors.As(attemptErr, &responseErr) {
+		code := sanitizeJobErrorCode(responseErr.ErrorCode)
+		if code == "" && responseErr.StatusCode > 0 {
+			code = "http-" + strconv.Itoa(responseErr.StatusCode)
+		}
+		if code == "" {
+			code = "storage-service-error"
+		}
+		return responseErrorCategory(responseErr.ErrorCode, responseErr.StatusCode), code
+	}
+
+	if errors.Is(attemptErr, context.DeadlineExceeded) {
+		return "timeout", "context-deadline-exceeded"
+	}
+	var pathErr *os.PathError
+	if errors.As(attemptErr, &pathErr) {
+		return "local-io", "local-path-error"
+	}
+	var urlErr *url.Error
+	if errors.As(attemptErr, &urlErr) {
+		if urlErr.Timeout() {
+			return "timeout", "network-timeout"
+		}
+		return "network", "network-error"
+	}
+	var networkErr net.Error
+	if errors.As(attemptErr, &networkErr) {
+		if networkErr.Timeout() {
+			return "timeout", "network-timeout"
+		}
+		return "network", "network-error"
+	}
+	var azErr common.AzError
+	if errors.As(attemptErr, &azErr) {
+		return "azcopy", "azcopy-" + strconv.FormatUint(azErr.ErrorCode(), 10)
+	}
+
+	switch terminalStage {
+	case "initialization", "enumeration", "transfer", "completion":
+		return terminalStage, terminalStage + "-error"
+	default:
+		return "unknown", "job-failed"
+	}
+}
+
+func responseErrorCategory(errorCode string, statusCode int) string {
+	switch strings.ToLower(errorCode) {
+	case "authenticationfailed", "invalidauthenticationinfo", "noauthenticationinformation":
+		return "authentication"
+	case "authorizationfailure", "authorizationpermissionmismatch":
+		return "authorization"
+	case "serverbusy":
+		return "throttling"
+	case "operationtimedout":
+		return "timeout"
+	}
+
+	switch statusCode {
+	case 401:
+		return "authentication"
+	case 403:
+		return "authorization"
+	case 404:
+		return "not-found"
+	case 408:
+		return "timeout"
+	case 409, 412:
+		return "conflict"
+	case 429, 503:
+		return "throttling"
+	}
+	if statusCode >= 500 {
+		return "service"
+	}
+	return "service"
+}
+
+func sanitizeJobErrorCode(code string) string {
+	code = strings.TrimSpace(code)
+	if code == "" || len(code) > 64 {
+		return ""
+	}
+	for _, char := range code {
+		if (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') ||
+			(char >= '0' && char <= '9') || char == '_' || char == '-' || char == '.' {
+			continue
+		}
+		return ""
+	}
+	return code
+}
+
+// reportCommand emits a single command.invoked event synchronously (bounded by
+// telemetrySendTimeout). Used for commands that do not emit paired job-attempt
+// start/finish events. Best-effort; no-op when disabled.
+func (a *telemetryAgent) reportCommand(command, runID, invocationID string, options telemetry.OptionAttributes) {
+	if a == nil || !a.enabled || !shouldSampleTelemetry(runID, telemetrySamplingRate) {
+		return
+	}
+	a.sendSafely(telemetry.CommandInvokedEvent{
+		Resource:     a.resource,
+		Command:      command,
+		Options:      options.Clone(),
+		JobID:        runID,
+		InvocationID: invocationID,
+		Timestamp:    time.Now(),
+		InvokedCount: 1,
+	})
+}
+
+func newTelemetryInvocationID() string {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(buf)
+}
+
+func shouldSampleTelemetry(jobID string, rate float64) bool {
+	if jobID == "" || rate <= 0 {
+		return false
+	}
+	if rate >= 1 {
+		return true
+	}
+	sum := sha256.Sum256([]byte(telemetrySamplerVersion + ":" + jobID))
+	// Use 53 bits so conversion to float64 is exact. Raising the threshold
+	// creates a nested cohort without changing any JobID's stable hash.
+	value := binary.BigEndian.Uint64(sum[:8]) >> 11
+	const bucketCount = uint64(1) << 53
+	return float64(value)/float64(bucketCount) < rate
+}
+
+func (a *telemetryAgent) sendSafely(evt telemetry.MetricEvent) {
+	defer func() {
+		if r := recover(); r != nil {
+			common.LogToJobLogWithPrefix(fmt.Sprintf("telemetry: recovered from panic while sending %s: %v", evt.EventName(), r), common.LogError)
+		}
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), telemetrySendTimeout)
+	defer cancel()
+	if err := a.reporter.ReportEvent(ctx, evt); err != nil {
+		common.LogToJobLogWithPrefix(fmt.Sprintf("telemetry: failed to send %s: %v", evt.EventName(), err), common.LogWarning)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Resource attributes (host probe)
+// ---------------------------------------------------------------------------
+
+func buildResourceAttributes() telemetry.ResourceAttributes {
+	hw := probeHostHardware()
+	imds := probeIMDS()
+
+	return telemetry.ResourceAttributes{
+		AzCopyVersion:      common.AzcopyVersion,
+		SchemaVersion:      telemetrySchemaVersion,
+		SamplingRate:       telemetrySamplingRate,
+		SamplerVersion:     telemetrySamplerVersion,
+		E2ETestRunID:       strings.TrimSpace(os.Getenv(envE2ETelemetryRunID)),
+		OSType:             runtime.GOOS,
+		OSVersion:          hw.osVersion,
+		HostArch:           runtime.GOARCH,
+		HostNumCPU:         runtime.NumCPU(),
+		HostCPUModel:       hw.cpuModel,
+		HostMemoryTotalGB:  hw.memoryTotalGB,
+		HostNICSpeedMbps:   hw.nicMbps,
+		HostNICSpeedBucket: nicSpeedBucket(hw.nicMbps),
+		AzureVMDetected:    imds.isAzureVM,
+		InstallationID:     installationID(),
+		InvocationContext:  detectInvocationContext(os.Getenv),
+	}
+}
+
+func nicSpeedBucket(speedMbps int) string {
+	switch {
+	case speedMbps < 0:
+		return "unknown"
+	case speedMbps < 1000:
+		return "<1gbps"
+	case speedMbps < 10000:
+		return "1-<10gbps"
+	case speedMbps < 40000:
+		return "10-<40gbps"
+	default:
+		return ">=40gbps"
+	}
+}
+
+// installationID returns a stable, anonymous per-install identifier. It is a
+// random 128-bit value persisted alongside the job plan files. It is NOT derived
+// from any machine identity and contains no PII.
+func installationID() string {
+	if common.AzcopyJobPlanFolder == "" {
+		return ""
+	}
+	p := filepath.Join(common.AzcopyJobPlanFolder, installationIDFileName)
+	if b, err := os.ReadFile(p); err == nil {
+		if id := strings.TrimSpace(string(b)); id != "" {
+			return id
+		}
+	}
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return ""
+	}
+	id := hex.EncodeToString(buf)
+	_ = os.WriteFile(p, []byte(id), 0600)
+	return id
+}
+
+// detectInvocationContext infers how AzCopy was invoked. getenv is injected for
+// testability.
+func detectInvocationContext(getenv func(string) string) string {
+	for _, k := range []string{"TF_BUILD", "GITHUB_ACTIONS", "CI", "JENKINS_URL", "GITLAB_CI", "BUILD_BUILDID"} {
+		if getenv(k) != "" {
+			return "ci"
+		}
+	}
+	return "interactive"
+}
+
+// ---------------------------------------------------------------------------
+// Job dimensions
+// ---------------------------------------------------------------------------
+
+func baseJobDimensions(command string, fromTo common.FromTo, srcCredType, dstCredType common.CredentialType) telemetry.JobDimensions {
+	return telemetry.JobDimensions{
+		Command:             command,
+		FromTo:              fromTo.String(),
+		SourceType:          fromTo.From().String(),
+		DestType:            fromTo.To().String(),
+		SourceProtocol:      protocolForLocation(fromTo.From()),
+		SourceMountType:     mountTypeForLocation(fromTo.From()),
+		DestProtocol:        protocolForLocation(fromTo.To()),
+		SourceAuthMechanism: srcCredType.String(),
+		DestAuthMechanism:   dstCredType.String(),
+	}
+}
+
+func resumeJobDimensions(jobDetails common.GetJobDetailsResponse, source, destination common.ResourceString, srcCredType, dstCredType common.CredentialType, options telemetry.OptionAttributes) telemetry.JobDimensions {
+	d := baseJobDimensions("jobs.resume", jobDetails.FromTo, srcCredType, dstCredType)
+	d.SummaryCounterScope = "job-cumulative"
+	d.SourceMountType = sourceMountType(jobDetails.FromTo.From(), source.Value)
+	d.SourceStorageAccount = storageAccountName(source, jobDetails.FromTo.From())
+	d.SourceScope = scopeForLocation(source, jobDetails.FromTo.From(), true)
+	d.DestStorageAccount = storageAccountName(destination, jobDetails.FromTo.To())
+	d.DestScope = scopeForLocation(destination, jobDetails.FromTo.To(), false)
+	d.SourceAuthMechanism = authMechanism(srcCredType, source, jobDetails.FromTo.From())
+	d.DestAuthMechanism = authMechanism(dstCredType, destination, jobDetails.FromTo.To())
+	d.DestEndpointKind = endpointKind(destination, jobDetails.FromTo.To())
+	d.SourceCloudType = endpointCloudType(source, jobDetails.FromTo.From())
+	d.DestCloudType = endpointCloudType(destination, jobDetails.FromTo.To())
+	d.Options = options.Clone()
+	return d
+}
+
+// protocolForLocation maps a transfer endpoint location to the wire/access
+// protocol used to reach it.
+func protocolForLocation(loc common.Location) string {
+	switch loc {
+	case common.ELocation.Local():
+		return "local"
+	case common.ELocation.Blob(), common.ELocation.BlobFS(), common.ELocation.File():
+		return "https"
+	case common.ELocation.FileNFS():
+		return "nfs"
+	case common.ELocation.S3():
+		return "s3"
+	case common.ELocation.GCP():
+		return "gcs"
+	default:
+		return ""
+	}
+}
+
+// mountTypeForLocation classifies the storage backing an endpoint location at a
+// coarse level (no path inspection). For local paths it reports "local-disk";
+// callers that have the concrete local path should prefer sourceMountType to
+// distinguish NAS (SMB/NFS) mounts.
+func mountTypeForLocation(loc common.Location) string {
+	switch {
+	case loc == common.ELocation.Local():
+		return "local-disk"
+	case loc.IsAzure():
+		return "cloud-azure"
+	case loc == common.ELocation.S3():
+		return "cloud-s3"
+	case loc == common.ELocation.GCP():
+		return "cloud-gcs"
+	default:
+		return ""
+	}
+}
+
+// sourceMountType refines mountTypeForLocation for local sources by inspecting
+// the OS mount table to distinguish network-attached storage from local disk:
+// "nas-nfs" | "nas-smb" | "local-disk". For remote locations it defers to the
+// coarse classification. localPath is ignored for non-local sources.
+func sourceMountType(loc common.Location, localPath string) string {
+	if loc != common.ELocation.Local() {
+		return mountTypeForLocation(loc)
+	}
+	if mt := localMountType(localPath); mt != "" {
+		return mt
+	}
+	return "local-disk"
+}
+
+// storageAccountName returns the Azure storage account name (the first DNS
+// label of the host) for recognized Azure Storage endpoints. It returns "" for
+// non-Azure resources, custom endpoints, and values that cannot be parsed.
+func storageAccountName(r common.ResourceString, loc common.Location) string {
+	if !loc.IsAzure() {
+		return ""
+	}
+	host := hostOf(r)
+	if host == "" || !isRecognizedAzureStorageHost(host) {
+		return ""
+	}
+	if i := strings.IndexByte(host, '.'); i > 0 {
+		return host[:i]
+	}
+	return ""
+}
+
+func isRecognizedAzureStorageHost(host string) bool {
+	for _, suffix := range []string{
+		".core.windows.net",
+		".storage.azure.net",
+		".core.usgovcloudapi.net",
+		".core.chinacloudapi.cn",
+		".core.cloudapi.de",
+	} {
+		if strings.HasSuffix(host, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func authMechanism(credType common.CredentialType, resource common.ResourceString, location common.Location) string {
+	if location.IsLocal() || location == common.ELocation.Pipe() || location == common.ELocation.Benchmark() || location == common.ELocation.None() {
+		return "NotApplicable"
+	}
+	if resource.SAS != "" {
+		return "SAS"
+	}
+	if credType == common.ECredentialType.Anonymous() {
+		return "PublicAnonymous"
+	}
+	return credType.String()
+}
+
+func scopeForLocation(resource common.ResourceString, location common.Location, source bool) string {
+	switch location {
+	case common.ELocation.Pipe():
+		return "stream"
+	case common.ELocation.Benchmark():
+		return "benchmark"
+	case common.ELocation.None():
+		return "none"
+	}
+	level, err := DetermineLocationLevel(resource.Value, location, source)
+	if err != nil {
+		return "unknown"
+	}
+	if location.IsLocal() {
+		if level == ELocationLevel.Container() {
+			return "local-directory"
+		}
+		return "local-object"
+	}
+	switch level {
+	case ELocationLevel.Service():
+		return "service"
+	case ELocationLevel.Object():
+		return "object-or-prefix"
+	case ELocationLevel.Container():
+		switch location {
+		case common.ELocation.File(), common.ELocation.FileNFS():
+			return "share"
+		case common.ELocation.S3(), common.ELocation.GCP():
+			return "bucket"
+		default:
+			return "container"
+		}
+	default:
+		return "unknown"
+	}
+}
+
+// hostOf returns the lower-cased hostname of a resource URL, or "" when it
+// cannot be parsed or has no host.
+func hostOf(r common.ResourceString) string {
+	u, err := url.Parse(r.Value)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	return strings.ToLower(u.Hostname())
+}
+
+// endpointKind reports whether the destination is reached via an Azure Private
+// Endpoint ("private-endpoint") or the public endpoint ("public"). It returns ""
+// for non-Azure destinations or when the host cannot be parsed.
+func endpointKind(r common.ResourceString, loc common.Location) string {
+	if !loc.IsAzure() {
+		return ""
+	}
+	host := hostOf(r)
+	if host == "" {
+		return ""
+	}
+	if strings.Contains(host, ".privatelink.") {
+		return "private-endpoint"
+	}
+	return "public"
+}
+
+func endpointCloudType(resource common.ResourceString, location common.Location) string {
+	if !location.IsAzure() {
+		return ""
+	}
+	if cloud := cloudTypeFromHost(hostOf(resource)); cloud != "" {
+		return cloud
+	}
+	return "unknown"
+}
+
+// cloudTypeFromHost maps an Azure storage host suffix to a cloud environment.
+func cloudTypeFromHost(host string) string {
+	switch {
+	case host == "":
+		return ""
+	case strings.HasSuffix(host, ".core.usgovcloudapi.net"):
+		return "gov"
+	case strings.HasSuffix(host, ".core.chinacloudapi.cn"):
+		return "china"
+	case strings.HasSuffix(host, ".core.cloudapi.de"):
+		return "germany"
+	case strings.HasSuffix(host, ".core.windows.net"), strings.HasSuffix(host, ".storage.azure.net"):
+		return "public"
+	default:
+		return ""
+	}
+}
+
+func copyJobDimensions(o *CookedTransferOptions, srcCredType, dstCredType common.CredentialType) telemetry.JobDimensions {
+	d := baseJobDimensions("copy", o.fromTo, srcCredType, dstCredType)
+	d.SourceMountType = sourceMountType(o.fromTo.From(), o.source.Value)
+	d.SourceStorageAccount = storageAccountName(o.source, o.fromTo.From())
+	d.SourceScope = scopeForLocation(o.source, o.fromTo.From(), true)
+	d.DestStorageAccount = storageAccountName(o.destination, o.fromTo.To())
+	d.DestScope = scopeForLocation(o.destination, o.fromTo.To(), false)
+	d.SourceAuthMechanism = authMechanism(srcCredType, o.source, o.fromTo.From())
+	d.DestAuthMechanism = authMechanism(dstCredType, o.destination, o.fromTo.To())
+	d.DestEndpointKind = endpointKind(o.destination, o.fromTo.To())
+	d.SourceCloudType = endpointCloudType(o.source, o.fromTo.From())
+	d.DestCloudType = endpointCloudType(o.destination, o.fromTo.To())
+	d.Options = o.telemetryOptions.Clone()
+	if o.benchmarkTelemetry != nil {
+		d.Command = "bench"
+		d.BenchmarkMode = o.benchmarkTelemetry.mode
+		d.BenchmarkFileCount = o.benchmarkTelemetry.fileCount
+		d.BenchmarkFileSizeBytes = o.benchmarkTelemetry.fileSizeBytes
+		d.BenchmarkFolderCount = o.benchmarkTelemetry.folderCount
+		d.BenchmarkCleanupRequested = o.benchmarkTelemetry.cleanupRequested
+		d.BenchmarkIsCleanup = o.benchmarkTelemetry.isCleanup
+	}
+	return d
+}
+
+func shouldEmitCopyTelemetry(o *CookedTransferOptions) bool {
+	return o != nil && !o.dryrun && (o.benchmarkTelemetry == nil || !o.benchmarkTelemetry.isCleanup)
+}
+
+func syncJobDimensions(o *cookedSyncOptions, srcCredType, dstCredType common.CredentialType) telemetry.JobDimensions {
+	d := baseJobDimensions("sync", o.fromTo, srcCredType, dstCredType)
+	d.SourceMountType = sourceMountType(o.fromTo.From(), o.source.Value)
+	d.SourceStorageAccount = storageAccountName(o.source, o.fromTo.From())
+	d.SourceScope = scopeForLocation(o.source, o.fromTo.From(), true)
+	d.DestStorageAccount = storageAccountName(o.destination, o.fromTo.To())
+	d.DestScope = scopeForLocation(o.destination, o.fromTo.To(), false)
+	d.SourceAuthMechanism = authMechanism(srcCredType, o.source, o.fromTo.From())
+	d.DestAuthMechanism = authMechanism(dstCredType, o.destination, o.fromTo.To())
+	d.DestEndpointKind = endpointKind(o.destination, o.fromTo.To())
+	d.SourceCloudType = endpointCloudType(o.source, o.fromTo.From())
+	d.DestCloudType = endpointCloudType(o.destination, o.fromTo.To())
+	d.Options = o.telemetryOptions.Clone()
+	return d
+}
+
+// ---------------------------------------------------------------------------
+// Finished event
+// ---------------------------------------------------------------------------
+
+func buildFinishedEvent(resource telemetry.ResourceAttributes, dims telemetry.JobDimensions, runID, invocationID string, start, end time.Time, summary common.ListJobSummaryResponse, elapsed, enumerationElapsed, transferElapsed time.Duration, shape sourceShapeSummary) telemetry.JobFinishedEvent {
+	jobDurationSeconds := elapsed.Seconds()
+	enumerationPhaseDurationSeconds := enumerationElapsed.Seconds()
+	transferPhaseDurationSeconds := transferElapsed.Seconds()
+	failureErrorCodes, failureErrorOtherCount := aggregateErrorCodesWithOther(summary.FailedTransfers)
+	performanceConstraint, adviceCodes := performanceAdviceAttributes(summary.PerfConstraint, summary.PerformanceAdvice)
+	return telemetry.JobFinishedEvent{
+		Resource:                        resource,
+		Dimensions:                      dims,
+		JobID:                           runID,
+		InvocationID:                    invocationID,
+		StartTimestamp:                  start,
+		EndTimestamp:                    end,
+		FinishedCount:                   1,
+		JobStatus:                       summary.JobStatus.String(),
+		BytesEnumerated:                 int64(summary.TotalBytesEnumerated),
+		BytesExpected:                   int64(summary.TotalBytesExpected),
+		BytesTransferred:                int64(summary.TotalBytesTransferred),
+		BytesOverWire:                   int64(summary.BytesOverWire),
+		ObjectsScheduled:                countExcludingFolders(summary.TotalTransfers, summary.FolderPropertyTransfers),
+		RegularFilesScheduled:           int64(summary.FileTransfers),
+		SymlinksScheduled:               int64(summary.SymlinkTransfers),
+		HardlinksConvertedScheduled:     int64(summary.HardlinksConvertedCount),
+		FolderPropertiesScheduled:       int64(summary.FolderPropertyTransfers),
+		ObjectsCompleted:                countExcludingFolders(summary.TransfersCompleted, summary.FoldersCompleted),
+		ObjectsFailed:                   countExcludingFolders(summary.TransfersFailed, summary.FoldersFailed),
+		ObjectsSkipped:                  countExcludingFolders(summary.TransfersSkipped, summary.FoldersSkipped),
+		FolderPropertiesCompleted:       int64(summary.FoldersCompleted),
+		FolderPropertiesFailed:          int64(summary.FoldersFailed),
+		FolderPropertiesSkipped:         int64(summary.FoldersSkipped),
+		SourceObjectsScanned:            shape.ObjectsScanned,
+		SourceBytesScanned:              shape.BytesScanned,
+		SourceAverageObjectSizeBytes:    shape.AverageObjectSizeBytes,
+		SourceObjectSizeP50BytesApprox:  shape.ObjectSizeP50BytesApprox,
+		SourceObjectSizeP90BytesApprox:  shape.ObjectSizeP90BytesApprox,
+		SourceObjectSizeP95BytesApprox:  shape.ObjectSizeP95BytesApprox,
+		SourceObjectsUnder1MiB:          shape.ObjectsUnder1MiB,
+		SourceObjectsUnder1MiBRatioPct:  shape.ObjectsUnder1MiBRatioPct,
+		SourceMaxDirectoryDepth:         shape.MaxDirectoryDepth,
+		ContainersScanned:               shape.ContainersScanned,
+		ContainersTouched:               shape.ContainersTouched,
+		BucketsScanned:                  shape.BucketsScanned,
+		BucketsTouched:                  shape.BucketsTouched,
+		TransfersCompleted:              int64(summary.TransfersCompleted),
+		TransfersFailed:                 int64(summary.TransfersFailed),
+		TransfersSkipped:                int64(summary.TransfersSkipped),
+		TransfersTotal:                  int64(summary.TotalTransfers),
+		JobDurationSeconds:              jobDurationSeconds,
+		EnumerationPhaseDurationSeconds: enumerationPhaseDurationSeconds,
+		TransferPhaseDurationSeconds:    transferPhaseDurationSeconds,
+		JobThroughputMbps:               throughputMbps(int64(summary.TotalBytesTransferred), jobDurationSeconds),
+		TransferPhaseThroughputMbps:     throughputMbps(int64(summary.TotalBytesTransferred), transferPhaseDurationSeconds),
+		AverageStorageHTTPAttemptE2EMs:  int64(summary.AverageE2EMilliseconds),
+		AvgIOPS:                         int64(summary.AverageIOPS),
+		StorageHTTPAttemptCount:         summary.StorageHTTPAttemptCount,
+		NetworkErrorAttemptCount:        summary.NetworkErrorAttemptCount,
+		ServerBusy503Count:              summary.ServerBusy503Count,
+		ServerBusyThroughputCount:       summary.ServerBusyThroughputCount,
+		ServerBusyIOPSCount:             summary.ServerBusyIOPSCount,
+		ServerBusyOtherCount:            summary.ServerBusyOtherCount,
+		ServerBusyPct:                   float64(summary.ServerBusyPercentage),
+		NetworkErrorPct:                 float64(summary.NetworkErrorPercentage),
+		PercentComplete:                 float64(summary.PercentComplete),
+		FailureErrorCodes:               failureErrorCodes,
+		FailureErrorOtherCount:          failureErrorOtherCount,
+		PerformanceConstraint:           performanceConstraint,
+		PerformanceAdviceCodes:          adviceCodes,
+	}
+}
+
+func countExcludingFolders(total, folders uint32) int64 {
+	if folders >= total {
+		return 0
+	}
+	return int64(total - folders)
+}
+
+// maxErrorCodeBuckets bounds how many distinct error codes are reported so a job
+// with many different failure codes cannot create an unbounded dimension value.
+const maxErrorCodeBuckets = 10
+
+// aggregateErrorCodes summarizes the error codes across failed transfers into a
+// compact, bounded "code:count" histogram ordered by descending count (then by
+// code for stability), e.g. "403:5,500:2". Only the numeric codes are included
+// (no paths/messages), so the result contains no PII. Returns "" when empty.
+func aggregateErrorCodes(failed []common.TransferDetail) string {
+	histogram, _ := aggregateErrorCodesWithOther(failed)
+	return histogram
+}
+
+func aggregateErrorCodesWithOther(failed []common.TransferDetail) (string, int64) {
+	if len(failed) == 0 {
+		return "", 0
+	}
+	counts := make(map[int32]int)
+	for _, t := range failed {
+		counts[t.ErrorCode]++
+	}
+	type bucket struct {
+		code  int32
+		count int
+	}
+	buckets := make([]bucket, 0, len(counts))
+	for code, count := range counts {
+		buckets = append(buckets, bucket{code, count})
+	}
+	sort.Slice(buckets, func(i, j int) bool {
+		if buckets[i].count != buckets[j].count {
+			return buckets[i].count > buckets[j].count
+		}
+		return buckets[i].code < buckets[j].code
+	})
+	var otherCount int64
+	if len(buckets) > maxErrorCodeBuckets {
+		for _, bucket := range buckets[maxErrorCodeBuckets:] {
+			otherCount += int64(bucket.count)
+		}
+		buckets = buckets[:maxErrorCodeBuckets]
+	}
+	parts := make([]string, 0, len(buckets))
+	for _, b := range buckets {
+		parts = append(parts, strconv.Itoa(int(b.code))+":"+strconv.Itoa(b.count))
+	}
+	return strings.Join(parts, ","), otherCount
+}
+
+const maxPerformanceAdviceCodes = 8
+
+func performanceAdviceAttributes(constraint common.PerfConstraint, advice []common.PerformanceAdvice) (string, []string) {
+	constraintValue := ""
+	if constraint != common.EPerfConstraint.Unknown() {
+		constraintValue = constraint.String()
+	}
+
+	seen := make(map[string]struct{})
+	codes := make([]string, 0, len(advice))
+	for _, item := range advice {
+		code := sanitizeAdviceCode(item.Code)
+		if code == "" {
+			continue
+		}
+		if _, exists := seen[code]; exists || len(codes) == maxPerformanceAdviceCodes {
+			continue
+		}
+		seen[code] = struct{}{}
+		codes = append(codes, code)
+	}
+	return constraintValue, codes
+}
+
+func sanitizeAdviceCode(code string) string {
+	code = strings.TrimSpace(code)
+	if code == "" || len(code) > 64 {
+		return ""
+	}
+	for _, char := range code {
+		if (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') ||
+			(char >= '0' && char <= '9') || char == '_' || char == '-' || char == '.' {
+			continue
+		}
+		return ""
+	}
+	return code
+}
+
+func throughputMbps(bytes int64, durationSeconds float64) float64 {
+	if durationSeconds <= 0 {
+		return 0
+	}
+	return float64(bytes) * 8 / 1e6 / durationSeconds
+}

--- a/azcopy/telemetryShape.go
+++ b/azcopy/telemetryShape.go
@@ -1,0 +1,248 @@
+package azcopy
+
+import (
+	"math"
+	"strings"
+	"sync"
+
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/traverser"
+)
+
+const (
+	smallSourceObjectThresholdBytes = int64(1024 * 1024)
+	directSourceScopeKey            = "\x00direct"
+)
+
+var sourceObjectSizeBucketUpperBounds = [...]int64{
+	0,
+	1024,
+	16 * 1024,
+	256 * 1024,
+	1024 * 1024,
+	16 * 1024 * 1024,
+	256 * 1024 * 1024,
+	1024 * 1024 * 1024,
+	16 * 1024 * 1024 * 1024,
+	math.MaxInt64,
+}
+
+type sourceScopeKind uint8
+
+const (
+	sourceScopeNone sourceScopeKind = iota
+	sourceScopeContainer
+	sourceScopeBucket
+)
+
+type sourceShapeSummary struct {
+	ObjectsScanned           int64
+	BytesScanned             int64
+	AverageObjectSizeBytes   float64
+	ObjectSizeP50BytesApprox int64
+	ObjectSizeP90BytesApprox int64
+	ObjectSizeP95BytesApprox int64
+	ObjectsUnder1MiB         int64
+	ObjectsUnder1MiBRatioPct float64
+	MaxDirectoryDepth        int64
+	ContainersScanned        int64
+	ContainersTouched        int64
+	BucketsScanned           int64
+	BucketsTouched           int64
+}
+
+type sourceShapeTracker struct {
+	mu sync.Mutex
+
+	scopeKind        sourceScopeKind
+	accountScope     bool
+	symlinkHandling  common.SymlinkHandlingType
+	hardlinkHandling common.HardlinkHandlingType
+	scannedScope     map[string]struct{}
+	touchedScope     map[string]struct{}
+
+	objectCount   uint64
+	bytesScanned  uint64
+	smallCount    uint64
+	maxDepth      int64
+	maxObjectSize int64
+	sizeBuckets   [len(sourceObjectSizeBucketUpperBounds)]uint64
+}
+
+func newSourceShapeTracker(location common.Location, symlinkHandling common.SymlinkHandlingType, hardlinkHandling common.HardlinkHandlingType) *sourceShapeTracker {
+	kind := sourceScopeNone
+	switch location {
+	case common.ELocation.S3(), common.ELocation.GCP():
+		kind = sourceScopeBucket
+	default:
+		if location.IsAzure() {
+			kind = sourceScopeContainer
+		}
+	}
+	return &sourceShapeTracker{
+		scopeKind:        kind,
+		symlinkHandling:  symlinkHandling,
+		hardlinkHandling: hardlinkHandling,
+		scannedScope:     make(map[string]struct{}),
+		touchedScope:     make(map[string]struct{}),
+	}
+}
+
+func (t *sourceShapeTracker) initializeScopes(resourceTraverser traverser.ResourceTraverser) error {
+	if t == nil || t.scopeKind == sourceScopeNone {
+		return nil
+	}
+
+	accountTraverser, isAccount := resourceTraverser.(traverser.AccountTraverser)
+	t.mu.Lock()
+	t.accountScope = isAccount
+	t.mu.Unlock()
+	if !isAccount {
+		t.addScannedScope(directSourceScopeKey)
+		return nil
+	}
+
+	scopes, err := accountTraverser.ListContainers()
+	if err != nil {
+		return err
+	}
+	for _, scope := range scopes {
+		t.addScannedScope(scope)
+	}
+	return nil
+}
+
+func (t *sourceShapeTracker) recordScanned(object traverser.StoredObject) error {
+	if t == nil || !t.isShapePayloadObject(object.EntityType) {
+		return nil
+	}
+
+	size := object.Size
+	if size < 0 {
+		size = 0
+	}
+	depth := relativePathDepth(object.RelativePath)
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.objectCount++
+	t.bytesScanned += uint64(size)
+	if size < smallSourceObjectThresholdBytes {
+		t.smallCount++
+	}
+	if size > t.maxObjectSize {
+		t.maxObjectSize = size
+	}
+	if depth > t.maxDepth {
+		t.maxDepth = depth
+	}
+	for index, upperBound := range sourceObjectSizeBucketUpperBounds {
+		if size <= upperBound {
+			t.sizeBuckets[index]++
+			break
+		}
+	}
+	return nil
+}
+
+func (t *sourceShapeTracker) recordScheduled(object traverser.StoredObject) {
+	if t == nil || !t.isShapePayloadObject(object.EntityType) || t.scopeKind == sourceScopeNone {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	key := directSourceScopeKey
+	if t.accountScope {
+		key = object.ContainerName
+		if key == "" {
+			return
+		}
+	}
+	t.touchedScope[key] = struct{}{}
+}
+
+func (t *sourceShapeTracker) addScannedScope(scope string) {
+	if t == nil || scope == "" {
+		return
+	}
+	t.mu.Lock()
+	t.scannedScope[scope] = struct{}{}
+	t.mu.Unlock()
+}
+
+func (t *sourceShapeTracker) snapshot() sourceShapeSummary {
+	if t == nil {
+		return sourceShapeSummary{}
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	summary := sourceShapeSummary{
+		ObjectsScanned:           int64(t.objectCount),
+		BytesScanned:             int64(t.bytesScanned),
+		ObjectSizeP50BytesApprox: t.approximatePercentile(0.50),
+		ObjectSizeP90BytesApprox: t.approximatePercentile(0.90),
+		ObjectSizeP95BytesApprox: t.approximatePercentile(0.95),
+		ObjectsUnder1MiB:         int64(t.smallCount),
+		MaxDirectoryDepth:        t.maxDepth,
+	}
+	if t.objectCount > 0 {
+		summary.AverageObjectSizeBytes = float64(t.bytesScanned) / float64(t.objectCount)
+		summary.ObjectsUnder1MiBRatioPct = 100 * float64(t.smallCount) / float64(t.objectCount)
+	}
+	switch t.scopeKind {
+	case sourceScopeContainer:
+		summary.ContainersScanned = int64(len(t.scannedScope))
+		summary.ContainersTouched = int64(len(t.touchedScope))
+	case sourceScopeBucket:
+		summary.BucketsScanned = int64(len(t.scannedScope))
+		summary.BucketsTouched = int64(len(t.touchedScope))
+	}
+	return summary
+}
+
+func (t *sourceShapeTracker) approximatePercentile(percentile float64) int64 {
+	if t.objectCount == 0 {
+		return 0
+	}
+	rank := uint64(math.Ceil(percentile * float64(t.objectCount)))
+	if rank == 0 {
+		rank = 1
+	}
+	var cumulative uint64
+	for index, count := range t.sizeBuckets {
+		cumulative += count
+		if cumulative >= rank {
+			upperBound := sourceObjectSizeBucketUpperBounds[index]
+			if upperBound == math.MaxInt64 {
+				return t.maxObjectSize
+			}
+			return upperBound
+		}
+	}
+	return t.maxObjectSize
+}
+
+func (t *sourceShapeTracker) isShapePayloadObject(entityType common.EntityType) bool {
+	switch entityType {
+	case common.EEntityType.File():
+		return true
+	case common.EEntityType.Symlink():
+		return t.symlinkHandling == common.ESymlinkHandlingType.Preserve()
+	case common.EEntityType.Hardlink():
+		return t.hardlinkHandling == common.EHardlinkHandlingType.Follow()
+	default:
+		return false
+	}
+}
+
+func relativePathDepth(relativePath string) int64 {
+	if relativePath == "" || relativePath == "\x00" {
+		return 0
+	}
+	parts := strings.FieldsFunc(relativePath, func(r rune) bool { return r == '/' || r == '\\' })
+	if len(parts) <= 1 {
+		return 0
+	}
+	return int64(len(parts) - 1)
+}

--- a/azcopy/telemetryShape.go
+++ b/azcopy/telemetryShape.go
@@ -93,7 +93,7 @@ func (t *sourceShapeTracker) initializeScopes(resourceTraverser traverser.Resour
 		return nil
 	}
 
-	accountTraverser, isAccount := resourceTraverser.(traverser.AccountTraverser)
+	_, isAccount := resourceTraverser.(traverser.AccountTraverser)
 	t.mu.Lock()
 	t.accountScope = isAccount
 	t.mu.Unlock()
@@ -102,13 +102,6 @@ func (t *sourceShapeTracker) initializeScopes(resourceTraverser traverser.Resour
 		return nil
 	}
 
-	scopes, err := accountTraverser.ListContainers()
-	if err != nil {
-		return err
-	}
-	for _, scope := range scopes {
-		t.addScannedScope(scope)
-	}
 	return nil
 }
 
@@ -125,6 +118,9 @@ func (t *sourceShapeTracker) recordScanned(object traverser.StoredObject) error 
 
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	if t.accountScope && object.ContainerName != "" {
+		t.scannedScope[object.ContainerName] = struct{}{}
+	}
 	t.objectCount++
 	t.bytesScanned += uint64(size)
 	if size < smallSourceObjectThresholdBytes {

--- a/azcopy/telemetryShape_test.go
+++ b/azcopy/telemetryShape_test.go
@@ -1,11 +1,13 @@
 package azcopy
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-azcopy/v10/traverser"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSourceShapeTracker(t *testing.T) {
@@ -57,6 +59,26 @@ func TestSourceShapeTrackerEmptyAndDirectBucket(t *testing.T) {
 	assert.Zero(t, summary.ObjectsUnder1MiBRatioPct)
 	assert.Equal(t, int64(1), summary.BucketsScanned)
 	assert.Equal(t, int64(1), summary.BucketsTouched)
+}
+
+func TestSourceShapeTrackerDerivesAccountScopesWithoutPreEnumeration(t *testing.T) {
+	tracker := newSourceShapeTracker(common.ELocation.Blob(), common.ESymlinkHandlingType.Skip(), common.EHardlinkHandlingType.Follow())
+	accountTraverser := traverser.NewBlobAccountTraverser(nil, "", context.Background(), traverser.InitResourceTraverserOptions{})
+
+	require.NoError(t, tracker.initializeScopes(accountTraverser))
+	for _, object := range []traverser.StoredObject{
+		{EntityType: common.EEntityType.File(), ContainerName: "one"},
+		{EntityType: common.EEntityType.File(), ContainerName: "one"},
+		{EntityType: common.EEntityType.File(), ContainerName: "two"},
+		{EntityType: common.EEntityType.File()},
+	} {
+		require.NoError(t, tracker.recordScanned(object))
+		tracker.recordScheduled(object)
+	}
+
+	summary := tracker.snapshot()
+	assert.Equal(t, int64(2), summary.ContainersScanned)
+	assert.Equal(t, int64(2), summary.ContainersTouched)
 }
 
 func TestRelativePathDepth(t *testing.T) {

--- a/azcopy/telemetryShape_test.go
+++ b/azcopy/telemetryShape_test.go
@@ -1,0 +1,86 @@
+package azcopy
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/traverser"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSourceShapeTracker(t *testing.T) {
+	tracker := newSourceShapeTracker(common.ELocation.Blob(), common.ESymlinkHandlingType.Preserve(), common.EHardlinkHandlingType.Follow())
+	tracker.addScannedScope("one")
+	tracker.addScannedScope("two")
+
+	objects := []traverser.StoredObject{
+		{EntityType: common.EEntityType.File(), Size: 0, RelativePath: "root.txt", ContainerName: "one"},
+		{EntityType: common.EEntityType.File(), Size: 512, RelativePath: "a/file.txt", ContainerName: "one"},
+		{EntityType: common.EEntityType.Hardlink(), Size: 8 * 1024, RelativePath: "a/b/file.txt", ContainerName: "two"},
+		{EntityType: common.EEntityType.Symlink(), Size: 2 * 1024 * 1024, RelativePath: "a/b/c/link", ContainerName: "two"},
+		{EntityType: common.EEntityType.File(), Size: 32 * 1024 * 1024, RelativePath: "deep/a/b/c/d/file.bin", ContainerName: "two"},
+		{EntityType: common.EEntityType.Folder(), Size: 0, RelativePath: "ignored"},
+	}
+	for _, object := range objects {
+		assert.NoError(t, tracker.recordScanned(object))
+	}
+	tracker.accountScope = true
+	tracker.recordScheduled(objects[0])
+	tracker.recordScheduled(objects[3])
+
+	summary := tracker.snapshot()
+	assert.Equal(t, int64(5), summary.ObjectsScanned)
+	assert.Equal(t, int64(35660288), summary.BytesScanned)
+	assert.Equal(t, 7132057.6, summary.AverageObjectSizeBytes)
+	assert.Equal(t, int64(16*1024), summary.ObjectSizeP50BytesApprox)
+	assert.Equal(t, int64(256*1024*1024), summary.ObjectSizeP90BytesApprox)
+	assert.Equal(t, int64(256*1024*1024), summary.ObjectSizeP95BytesApprox)
+	assert.Equal(t, int64(3), summary.ObjectsUnder1MiB)
+	assert.Equal(t, 60.0, summary.ObjectsUnder1MiBRatioPct)
+	assert.Equal(t, int64(5), summary.MaxDirectoryDepth)
+	assert.Equal(t, int64(2), summary.ContainersScanned)
+	assert.Equal(t, int64(2), summary.ContainersTouched)
+	assert.Zero(t, summary.BucketsScanned)
+}
+
+func TestSourceShapeTrackerEmptyAndDirectBucket(t *testing.T) {
+	tracker := newSourceShapeTracker(common.ELocation.S3(), common.ESymlinkHandlingType.Skip(), common.EHardlinkHandlingType.Follow())
+	tracker.addScannedScope(directSourceScopeKey)
+	assert.NoError(t, tracker.recordScanned(traverser.StoredObject{EntityType: common.EEntityType.Symlink(), Size: 10}))
+	tracker.recordScheduled(traverser.StoredObject{EntityType: common.EEntityType.File()})
+
+	summary := tracker.snapshot()
+	assert.Zero(t, summary.ObjectsScanned)
+	assert.Zero(t, summary.ObjectSizeP50BytesApprox)
+	assert.Zero(t, summary.BytesScanned)
+	assert.Zero(t, summary.AverageObjectSizeBytes)
+	assert.Zero(t, summary.ObjectsUnder1MiBRatioPct)
+	assert.Equal(t, int64(1), summary.BucketsScanned)
+	assert.Equal(t, int64(1), summary.BucketsTouched)
+}
+
+func TestRelativePathDepth(t *testing.T) {
+	assert.Equal(t, int64(0), relativePathDepth(""))
+	assert.Equal(t, int64(0), relativePathDepth("file.txt"))
+	assert.Equal(t, int64(2), relativePathDepth("a/b/file.txt"))
+	assert.Equal(t, int64(2), relativePathDepth(`a\b\file.txt`))
+}
+
+func TestTransferScheduledObserver(t *testing.T) {
+	template := &common.CopyJobPartOrderRequest{
+		Fpo:                 common.EFolderPropertiesOption.NoFolders(),
+		SymlinkHandlingType: common.ESymlinkHandlingType.Skip(),
+	}
+	processor := NewCopyTransferProcessor(false, template, 10, common.ResourceString{}, common.ResourceString{}, nil, nil, false, false, nil)
+	var scheduled []traverser.StoredObject
+	processor.SetTransferScheduledObserver(func(object traverser.StoredObject) {
+		scheduled = append(scheduled, object)
+	})
+
+	file := traverser.StoredObject{EntityType: common.EEntityType.File(), RelativePath: "file.txt", ContainerName: "one"}
+	folder := traverser.StoredObject{EntityType: common.EEntityType.Folder(), RelativePath: "folder", ContainerName: "two"}
+	assert.NoError(t, processor.ScheduleSyncRemoveSetPropertiesTransfer(file))
+	assert.NoError(t, processor.ScheduleSyncRemoveSetPropertiesTransfer(folder))
+	assert.Equal(t, []traverser.StoredObject{file}, scheduled)
+	assert.Len(t, processor.dispatcher.PendingTransfers.List, 1)
+}

--- a/azcopy/telemetry_test.go
+++ b/azcopy/telemetry_test.go
@@ -24,11 +24,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"math"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -291,7 +294,6 @@ func TestResumeJobDimensions(t *testing.T) {
 	assert.Equal(t, "job-cumulative", dimensions.SummaryCounterScope)
 	assert.Equal(t, "NotApplicable", dimensions.SourceAuthMechanism)
 	assert.Equal(t, "SAS", dimensions.DestAuthMechanism)
-	assert.Equal(t, "account", dimensions.DestStorageAccount)
 	assert.Empty(t, dimensions.SourceCloudType)
 	assert.Equal(t, "public", dimensions.DestCloudType)
 	assert.Equal(t, []string{"include"}, dimensions.Options.FlagsSet)
@@ -466,39 +468,6 @@ func TestPerformanceAdviceAttributes(t *testing.T) {
 	assert.Equal(t, []string{"NetworkErrors", "AccountIOPS"}, codes)
 }
 
-func TestStorageAccountName(t *testing.T) {
-	a := assert.New(t)
-	// Azure remote: first DNS label is the account name.
-	a.Equal("myaccount", storageAccountName(
-		common.ResourceString{Value: "https://myaccount.blob.core.windows.net/container/path"},
-		common.ELocation.Blob()))
-	a.Equal("acct2", storageAccountName(
-		common.ResourceString{Value: "https://acct2.dfs.core.windows.net/fs"},
-		common.ELocation.BlobFS()))
-	a.Equal("privateacct", storageAccountName(
-		common.ResourceString{Value: "https://privateacct.privatelink.blob.core.windows.net/container"},
-		common.ELocation.Blob()))
-	// Azure-typed custom endpoints do not emit a hostname-derived identity.
-	a.Equal("", storageAccountName(
-		common.ResourceString{Value: "https://acct.blob.example.com/container"},
-		common.ELocation.Blob()))
-	// Local locations return empty.
-	a.Equal("", storageAccountName(
-		common.ResourceString{Value: "/local/path"},
-		common.ELocation.Local()))
-	// Non-Azure providers never emit bucket names.
-	a.Equal("", storageAccountName(
-		common.ResourceString{Value: "https://bucket.s3.amazonaws.com/key"},
-		common.ELocation.S3()))
-	a.Equal("", storageAccountName(
-		common.ResourceString{Value: "https://storage.cloud.google.com/mybucket/object"},
-		common.ELocation.GCP()))
-	// Hostless values return empty.
-	a.Equal("", storageAccountName(
-		common.ResourceString{Value: "relative/path"},
-		common.ELocation.Blob()))
-}
-
 func TestAuthMechanism(t *testing.T) {
 	resourceWithSAS := common.ResourceString{Value: "https://account.blob.core.windows.net/container", SAS: "?sig=secret"}
 	assert.Equal(t, "SAS", authMechanism(common.ECredentialType.Anonymous(), resourceWithSAS, common.ELocation.Blob()))
@@ -617,6 +586,56 @@ func TestShouldSampleTelemetry(t *testing.T) {
 	}
 	assert.Greater(t, includedAtOnePercent, 70)
 	assert.Less(t, includedAtOnePercent, 130)
+}
+
+func TestShouldCollectSourceShape(t *testing.T) {
+	original := telemetrySamplingRate
+	t.Cleanup(func() { telemetrySamplingRate = original })
+
+	telemetrySamplingRate = 1
+	assert.False(t, (*telemetryAgent)(nil).shouldCollectSourceShape("job"))
+	assert.False(t, (&telemetryAgent{}).shouldCollectSourceShape("job"))
+	assert.True(t, (&telemetryAgent{enabled: true}).shouldCollectSourceShape("job"))
+
+	telemetrySamplingRate = 0
+	assert.False(t, (&telemetryAgent{enabled: true}).shouldCollectSourceShape("job"))
+}
+
+func TestProgressTrackersOnlyCollectSourceShapeWhenEligible(t *testing.T) {
+	jobID := common.NewJobID()
+	copyWithoutShape := newTransferProgressTracker(
+		jobID,
+		nil,
+		common.EFromTo.LocalBlob(),
+		common.ESymlinkHandlingType.Skip(),
+		common.EHardlinkHandlingType.Follow(),
+		false)
+	copyWithShape := newTransferProgressTracker(
+		jobID,
+		nil,
+		common.EFromTo.LocalBlob(),
+		common.ESymlinkHandlingType.Skip(),
+		common.EHardlinkHandlingType.Follow(),
+		true)
+	syncWithoutShape := newSyncProgressTracker(
+		jobID,
+		nil,
+		common.EFromTo.LocalBlob(),
+		common.ESymlinkHandlingType.Skip(),
+		common.EHardlinkHandlingType.Follow(),
+		false)
+	syncWithShape := newSyncProgressTracker(
+		jobID,
+		nil,
+		common.EFromTo.LocalBlob(),
+		common.ESymlinkHandlingType.Skip(),
+		common.EHardlinkHandlingType.Follow(),
+		true)
+
+	assert.Nil(t, copyWithoutShape.shapeTracker)
+	assert.NotNil(t, copyWithShape.shapeTracker)
+	assert.Nil(t, syncWithoutShape.shapeTracker)
+	assert.NotNil(t, syncWithShape.shapeTracker)
 }
 
 func TestBuildResourceAttributesSamplingMetadata(t *testing.T) {
@@ -781,6 +800,97 @@ func TestDisabledAgentIsNoop(t *testing.T) {
 	disabled.reportStarted(telemetry.JobDimensions{}, "id", "invocation", time.Now())
 	disabled.reportFinished(telemetry.JobFinishedEvent{})
 	a.False(disabled.enabled)
+}
+
+type orderedTelemetryClient struct {
+	mu           sync.Mutex
+	eventNames   []string
+	firstEntered chan struct{}
+	releaseFirst chan struct{}
+}
+
+func (c *orderedTelemetryClient) Do(req *http.Request) (*http.Response, error) {
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	eventName := ""
+	for _, candidate := range []string{"azcopy.job.started", "azcopy.job.finished"} {
+		if strings.Contains(string(body), candidate) {
+			eventName = candidate
+			break
+		}
+	}
+
+	c.mu.Lock()
+	c.eventNames = append(c.eventNames, eventName)
+	callNumber := len(c.eventNames)
+	c.mu.Unlock()
+	if callNumber == 1 {
+		close(c.firstEntered)
+		<-c.releaseFirst
+	}
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("")),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func TestFinishedTelemetryWaitsForStartedDelivery(t *testing.T) {
+	original := telemetrySamplingRate
+	telemetrySamplingRate = 1
+	t.Cleanup(func() { telemetrySamplingRate = original })
+
+	client := &orderedTelemetryClient{
+		firstEntered: make(chan struct{}),
+		releaseFirst: make(chan struct{}),
+	}
+	agent := &telemetryAgent{
+		enabled: true,
+		reporter: telemetry.NewReporter(telemetry.Config{
+			Backend:          telemetry.BackendAppInsights,
+			ConnectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000001;IngestionEndpoint=https://example.test",
+			HTTPClient:       client,
+		}),
+	}
+	const jobID = "job"
+	const invocationID = "invocation"
+	agent.reportStarted(telemetry.JobDimensions{}, jobID, invocationID, time.Now())
+	<-client.firstEntered
+
+	finished := make(chan struct{})
+	go func() {
+		agent.reportFinished(telemetry.JobFinishedEvent{
+			JobID:        jobID,
+			InvocationID: invocationID,
+			EndTimestamp: time.Now(),
+		})
+		close(finished)
+	}()
+
+	select {
+	case <-finished:
+		t.Fatal("finished telemetry completed before started telemetry")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	client.mu.Lock()
+	assert.Equal(t, []string{"azcopy.job.started"}, client.eventNames)
+	client.mu.Unlock()
+
+	close(client.releaseFirst)
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatal("finished telemetry did not complete after started telemetry")
+	}
+
+	client.mu.Lock()
+	assert.Equal(t, []string{"azcopy.job.started", "azcopy.job.finished"}, client.eventNames)
+	client.mu.Unlock()
 }
 
 func telemetryResourceForTest() telemetry.ResourceAttributes {

--- a/azcopy/telemetry_test.go
+++ b/azcopy/telemetry_test.go
@@ -68,43 +68,6 @@ func TestSourceMountType(t *testing.T) {
 	a.Equal("local-disk", sourceMountType(common.ELocation.Local(), "this-path-does-not-exist-xyz"))
 }
 
-func TestClassifyFSType(t *testing.T) {
-	a := assert.New(t)
-	a.Equal("nas-nfs", classifyFSType("nfs"))
-	a.Equal("nas-nfs", classifyFSType("nfs4"))
-	a.Equal("nas-smb", classifyFSType("cifs"))
-	a.Equal("nas-smb", classifyFSType("smb3"))
-	a.Equal("nas-smb", classifyFSType("smbfs"))
-	a.Equal("local-disk", classifyFSType("ext4"))
-	a.Equal("local-disk", classifyFSType("xfs"))
-	a.Equal("", classifyFSType(""))
-}
-
-func TestParseMountinfoLine(t *testing.T) {
-	a := assert.New(t)
-	mp, fs, ok := parseMountinfoLine("36 35 98:0 / /mnt/nas rw,noatime - nfs4 1.2.3.4:/export rw")
-	a.True(ok)
-	a.Equal("/mnt/nas", mp)
-	a.Equal("nfs4", fs)
-
-	mp, fs, ok = parseMountinfoLine("22 30 0:21 / / rw,relatime shared:1 - ext4 /dev/root rw")
-	a.True(ok)
-	a.Equal("/", mp)
-	a.Equal("ext4", fs)
-
-	_, _, ok = parseMountinfoLine("garbage line without separator")
-	a.False(ok)
-}
-
-func TestPathHasMountPrefix(t *testing.T) {
-	a := assert.New(t)
-	a.True(pathHasMountPrefix("/mnt/nas/data", "/mnt/nas"))
-	a.True(pathHasMountPrefix("/mnt/nas", "/mnt/nas"))
-	a.True(pathHasMountPrefix("/anything", "/"))
-	a.False(pathHasMountPrefix("/mnt/nasextra", "/mnt/nas")) // not a path-segment prefix
-	a.False(pathHasMountPrefix("/home/user", "/mnt/nas"))
-}
-
 func TestProtocolForLocation(t *testing.T) {
 	a := assert.New(t)
 	a.Equal("local", protocolForLocation(common.ELocation.Local()))
@@ -427,23 +390,33 @@ func TestCountExcludingFolders(t *testing.T) {
 func TestAggregateErrorCodes(t *testing.T) {
 	a := assert.New(t)
 	// No failures -> empty.
-	a.Equal("", aggregateErrorCodes(nil))
-	a.Equal("", aggregateErrorCodes([]common.TransferDetail{}))
+	histogram, other := aggregateErrorCodesWithOther(nil)
+	a.Empty(histogram)
+	a.Zero(other)
+
+	histogram, other = aggregateErrorCodesWithOther([]common.TransferDetail{})
+	a.Empty(histogram)
+	a.Zero(other)
 	// Ordered by descending count, then ascending code.
-	a.Equal("403:3,500:1", aggregateErrorCodes([]common.TransferDetail{
+	histogram, other = aggregateErrorCodesWithOther([]common.TransferDetail{
 		{ErrorCode: 500}, {ErrorCode: 403}, {ErrorCode: 403}, {ErrorCode: 403},
-	}))
+	})
+	a.Equal("403:3,500:1", histogram)
+	a.Zero(other)
 	// Tie on count -> lower code first.
-	a.Equal("404:1,409:1", aggregateErrorCodes([]common.TransferDetail{
+	histogram, other = aggregateErrorCodesWithOther([]common.TransferDetail{
 		{ErrorCode: 409}, {ErrorCode: 404},
-	}))
+	})
+	a.Equal("404:1,409:1", histogram)
+	a.Zero(other)
 	// Bounded to maxErrorCodeBuckets distinct codes.
 	many := make([]common.TransferDetail, 0, maxErrorCodeBuckets+5)
 	for i := 0; i < maxErrorCodeBuckets+5; i++ {
 		many = append(many, common.TransferDetail{ErrorCode: int32(600 + i)})
 	}
-	res := aggregateErrorCodes(many)
-	a.Equal(maxErrorCodeBuckets, strings.Count(res, ":"))
+	histogram, other = aggregateErrorCodesWithOther(many)
+	a.Equal(maxErrorCodeBuckets, strings.Count(histogram, ":"))
+	a.Equal(int64(5), other)
 }
 
 func TestAggregateErrorCodesWithOther(t *testing.T) {

--- a/azcopy/telemetry_test.go
+++ b/azcopy/telemetry_test.go
@@ -1,0 +1,732 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package azcopy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/telemetry"
+	"github.com/Azure/azure-storage-azcopy/v10/traverser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBaseJobDimensions(t *testing.T) {
+	a := assert.New(t)
+	d := baseJobDimensions("copy", common.EFromTo.LocalBlob(), common.ECredentialType.OAuthToken(), common.ECredentialType.SharedKey())
+	a.Equal("copy", d.Command)
+	a.Empty(d.SummaryCounterScope)
+	a.Equal(common.EFromTo.LocalBlob().String(), d.FromTo)
+	a.Equal(common.ELocation.Local().String(), d.SourceType)
+	a.Equal(common.ELocation.Blob().String(), d.DestType)
+	a.Equal("local", d.SourceProtocol)
+	a.Equal("local-disk", d.SourceMountType)
+	a.Equal("https", d.DestProtocol)
+	a.Equal(common.ECredentialType.OAuthToken().String(), d.SourceAuthMechanism)
+	a.Equal(common.ECredentialType.SharedKey().String(), d.DestAuthMechanism)
+}
+
+func TestSourceMountType(t *testing.T) {
+	a := assert.New(t)
+	// Remote sources use the coarse cloud classification (no path inspection).
+	a.Equal("cloud-azure", sourceMountType(common.ELocation.Blob(), ""))
+	a.Equal("cloud-s3", sourceMountType(common.ELocation.S3(), ""))
+	a.Equal("cloud-gcs", sourceMountType(common.ELocation.GCP(), ""))
+	// A local path that cannot be classified falls back to local-disk (never empty).
+	a.Equal("local-disk", sourceMountType(common.ELocation.Local(), "this-path-does-not-exist-xyz"))
+}
+
+func TestClassifyFSType(t *testing.T) {
+	a := assert.New(t)
+	a.Equal("nas-nfs", classifyFSType("nfs"))
+	a.Equal("nas-nfs", classifyFSType("nfs4"))
+	a.Equal("nas-smb", classifyFSType("cifs"))
+	a.Equal("nas-smb", classifyFSType("smb3"))
+	a.Equal("nas-smb", classifyFSType("smbfs"))
+	a.Equal("local-disk", classifyFSType("ext4"))
+	a.Equal("local-disk", classifyFSType("xfs"))
+	a.Equal("", classifyFSType(""))
+}
+
+func TestParseMountinfoLine(t *testing.T) {
+	a := assert.New(t)
+	mp, fs, ok := parseMountinfoLine("36 35 98:0 / /mnt/nas rw,noatime - nfs4 1.2.3.4:/export rw")
+	a.True(ok)
+	a.Equal("/mnt/nas", mp)
+	a.Equal("nfs4", fs)
+
+	mp, fs, ok = parseMountinfoLine("22 30 0:21 / / rw,relatime shared:1 - ext4 /dev/root rw")
+	a.True(ok)
+	a.Equal("/", mp)
+	a.Equal("ext4", fs)
+
+	_, _, ok = parseMountinfoLine("garbage line without separator")
+	a.False(ok)
+}
+
+func TestPathHasMountPrefix(t *testing.T) {
+	a := assert.New(t)
+	a.True(pathHasMountPrefix("/mnt/nas/data", "/mnt/nas"))
+	a.True(pathHasMountPrefix("/mnt/nas", "/mnt/nas"))
+	a.True(pathHasMountPrefix("/anything", "/"))
+	a.False(pathHasMountPrefix("/mnt/nasextra", "/mnt/nas")) // not a path-segment prefix
+	a.False(pathHasMountPrefix("/home/user", "/mnt/nas"))
+}
+
+func TestProtocolForLocation(t *testing.T) {
+	a := assert.New(t)
+	a.Equal("local", protocolForLocation(common.ELocation.Local()))
+	a.Equal("https", protocolForLocation(common.ELocation.Blob()))
+	a.Equal("https", protocolForLocation(common.ELocation.BlobFS()))
+	a.Equal("https", protocolForLocation(common.ELocation.File()))
+	a.Equal("nfs", protocolForLocation(common.ELocation.FileNFS()))
+	a.Equal("s3", protocolForLocation(common.ELocation.S3()))
+	a.Equal("gcs", protocolForLocation(common.ELocation.GCP()))
+}
+
+func TestMountTypeForLocation(t *testing.T) {
+	a := assert.New(t)
+	a.Equal("local-disk", mountTypeForLocation(common.ELocation.Local()))
+	a.Equal("cloud-azure", mountTypeForLocation(common.ELocation.Blob()))
+	a.Equal("cloud-azure", mountTypeForLocation(common.ELocation.FileNFS()))
+	a.Equal("cloud-s3", mountTypeForLocation(common.ELocation.S3()))
+	a.Equal("cloud-gcs", mountTypeForLocation(common.ELocation.GCP()))
+}
+
+func TestEndpointKind(t *testing.T) {
+	a := assert.New(t)
+	a.Equal("public", endpointKind(
+		common.ResourceString{Value: "https://acct.blob.core.windows.net/c"},
+		common.ELocation.Blob()))
+	a.Equal("private-endpoint", endpointKind(
+		common.ResourceString{Value: "https://acct.privatelink.blob.core.windows.net/c"},
+		common.ELocation.Blob()))
+	// Non-Azure destinations have no endpoint kind.
+	a.Equal("", endpointKind(
+		common.ResourceString{Value: "/local/path"},
+		common.ELocation.Local()))
+}
+
+func TestEndpointCloudType(t *testing.T) {
+	a := assert.New(t)
+	a.Equal("public", endpointCloudType(
+		common.ResourceString{Value: "https://acct.blob.core.windows.net/c"}, common.ELocation.Blob()))
+	a.Equal("gov", endpointCloudType(
+		common.ResourceString{Value: "https://acct.blob.core.usgovcloudapi.net/c"}, common.ELocation.Blob()))
+	a.Equal("china", endpointCloudType(
+		common.ResourceString{Value: "https://acct.blob.core.chinacloudapi.cn/c"}, common.ELocation.Blob()))
+	a.Equal("germany", endpointCloudType(
+		common.ResourceString{Value: "https://acct.blob.core.cloudapi.de/c"}, common.ELocation.Blob()))
+	a.Equal("unknown", endpointCloudType(
+		common.ResourceString{Value: "https://acct.blob.example.com/c"}, common.ELocation.Blob()))
+	a.Empty(endpointCloudType(
+		common.ResourceString{Value: "https://s3.amazonaws.com/bucket"}, common.ELocation.S3()))
+	a.Empty(endpointCloudType(
+		common.ResourceString{Value: "/local/path"}, common.ELocation.Local()))
+}
+
+func TestNICSpeedBucket(t *testing.T) {
+	assert.Equal(t, "unknown", nicSpeedBucket(-1))
+	assert.Equal(t, "<1gbps", nicSpeedBucket(100))
+	assert.Equal(t, "1-<10gbps", nicSpeedBucket(1000))
+	assert.Equal(t, "10-<40gbps", nicSpeedBucket(10000))
+	assert.Equal(t, ">=40gbps", nicSpeedBucket(40000))
+}
+
+func TestCopyJobDimensions(t *testing.T) {
+	a := assert.New(t)
+	o := &CookedTransferOptions{
+		fromTo:      common.EFromTo.LocalBlob(),
+		source:      common.ResourceString{Value: "local"},
+		destination: common.ResourceString{Value: "https://account.blob.core.windows.net/container"},
+		telemetryOptions: telemetry.OptionAttributes{
+			FlagsSet: []string{"block-size-mb", "put-md5", "recursive"},
+			Values: map[string]string{
+				"OptBlockSizeMB": "8",
+				"OptPutMD5":      "true",
+				"OptRecursive":   "true",
+			},
+		},
+	}
+	d := copyJobDimensions(o, common.ECredentialType.Anonymous(), common.ECredentialType.OAuthToken())
+	a.Equal("copy", d.Command)
+	a.Equal("NotApplicable", d.SourceAuthMechanism)
+	a.Equal(common.ECredentialType.OAuthToken().String(), d.DestAuthMechanism)
+	a.Empty(d.SourceCloudType)
+	a.Equal("public", d.DestCloudType)
+	a.Equal([]string{"block-size-mb", "put-md5", "recursive"}, d.Options.FlagsSet)
+	a.Equal("8", d.Options.Values["OptBlockSizeMB"])
+	o.telemetryOptions.FlagsSet[0] = "mutated"
+	o.telemetryOptions.Values["OptBlockSizeMB"] = "mutated"
+	a.Equal([]string{"block-size-mb", "put-md5", "recursive"}, d.Options.FlagsSet)
+	a.Equal("8", d.Options.Values["OptBlockSizeMB"])
+}
+
+func TestCopyJobDimensionsS3ToAzureGovernment(t *testing.T) {
+	o := &CookedTransferOptions{
+		fromTo:      common.EFromTo.S3Blob(),
+		source:      common.ResourceString{Value: "https://s3.amazonaws.com/source-bucket"},
+		destination: common.ResourceString{Value: "https://account.blob.core.usgovcloudapi.net/container"},
+	}
+	dimensions := copyJobDimensions(o, common.ECredentialType.S3AccessKey(), common.ECredentialType.OAuthToken())
+	assert.Equal(t, "S3Blob", dimensions.FromTo)
+	assert.Empty(t, dimensions.SourceCloudType)
+	assert.Equal(t, "gov", dimensions.DestCloudType)
+}
+
+func TestCopyJobDimensionsBenchmark(t *testing.T) {
+	o := &CookedTransferOptions{
+		fromTo:      common.EFromTo.BenchmarkBlob(),
+		source:      common.ResourceString{Value: "https://benchmark"},
+		destination: common.ResourceString{Value: "https://account.blob.core.windows.net/container/benchmark-job"},
+		benchmarkTelemetry: &benchmarkTelemetryOptions{
+			mode:             "upload",
+			fileCount:        100,
+			fileSizeBytes:    256 * 1024 * 1024,
+			folderCount:      10,
+			cleanupRequested: true,
+		},
+	}
+	dimensions := copyJobDimensions(o, common.ECredentialType.Anonymous(), common.ECredentialType.OAuthToken())
+	assert.Equal(t, "bench", dimensions.Command)
+	assert.Equal(t, "upload", dimensions.BenchmarkMode)
+	assert.Equal(t, int64(100), dimensions.BenchmarkFileCount)
+	assert.Equal(t, int64(256*1024*1024), dimensions.BenchmarkFileSizeBytes)
+	assert.Equal(t, int64(10), dimensions.BenchmarkFolderCount)
+	assert.True(t, dimensions.BenchmarkCleanupRequested)
+	assert.False(t, dimensions.BenchmarkIsCleanup)
+}
+
+func TestShouldEmitCopyTelemetry(t *testing.T) {
+	assert.True(t, shouldEmitCopyTelemetry(&CookedTransferOptions{}))
+	assert.False(t, shouldEmitCopyTelemetry(&CookedTransferOptions{dryrun: true}))
+	assert.True(t, shouldEmitCopyTelemetry(&CookedTransferOptions{benchmarkTelemetry: &benchmarkTelemetryOptions{}}))
+	assert.False(t, shouldEmitCopyTelemetry(&CookedTransferOptions{benchmarkTelemetry: &benchmarkTelemetryOptions{isCleanup: true}}))
+}
+
+func TestBenchmarkTelemetrySurvivesOptionCooking(t *testing.T) {
+	options := CopyOptions{
+		FromTo:    common.EFromTo.BenchmarkBlob(),
+		Recursive: true,
+	}
+	options.SetBenchmarkTelemetry("upload", 25, 4*1024*1024, 5, true, false)
+	source := traverser.BenchmarkSourceHelper{}.ToUrl(25, 4*1024*1024, 5)
+	cooked, err := newCookedCopyOptions(source, "https://account.blob.core.windows.net/container/benchmark-job", options)
+	require.NoError(t, err)
+	dimensions := copyJobDimensions(cooked, common.ECredentialType.Anonymous(), common.ECredentialType.OAuthToken())
+	assert.Equal(t, "bench", dimensions.Command)
+	assert.Equal(t, "upload", dimensions.BenchmarkMode)
+	assert.Equal(t, int64(25), dimensions.BenchmarkFileCount)
+	assert.Equal(t, int64(4*1024*1024), dimensions.BenchmarkFileSizeBytes)
+	assert.Equal(t, int64(5), dimensions.BenchmarkFolderCount)
+	assert.True(t, dimensions.BenchmarkCleanupRequested)
+}
+
+func TestSyncJobDimensions(t *testing.T) {
+	a := assert.New(t)
+	o := &cookedSyncOptions{
+		fromTo:      common.EFromTo.LocalBlob(),
+		source:      common.ResourceString{Value: "local"},
+		destination: common.ResourceString{Value: "https://account.blob.core.windows.net/container"},
+		telemetryOptions: telemetry.OptionAttributes{
+			FlagsSet: []string{"delete-destination", "mirror-mode", "recursive"},
+			Values: map[string]string{
+				"OptDeleteDestination": "true",
+				"OptMirrorMode":        "true",
+				"OptRecursive":         "false",
+			},
+		},
+	}
+	d := syncJobDimensions(o, common.ECredentialType.SharedKey(), common.ECredentialType.Anonymous())
+	a.Equal("sync", d.Command)
+	a.Empty(d.SourceCloudType)
+	a.Equal("public", d.DestCloudType)
+	a.Equal([]string{"delete-destination", "mirror-mode", "recursive"}, d.Options.FlagsSet)
+	a.Equal("false", d.Options.Values["OptRecursive"])
+}
+
+func TestResumeJobDimensions(t *testing.T) {
+	options := telemetry.OptionAttributes{
+		FlagsSet: []string{"include"},
+		Values:   map[string]string{"OptExample": "value"},
+	}
+	dimensions := resumeJobDimensions(
+		common.GetJobDetailsResponse{FromTo: common.EFromTo.LocalBlob()},
+		common.ResourceString{Value: "local"},
+		common.ResourceString{Value: "https://account.blob.core.windows.net/container", SAS: "?sig=redacted"},
+		common.ECredentialType.Anonymous(),
+		common.ECredentialType.Anonymous(),
+		options,
+	)
+	assert.Equal(t, "jobs.resume", dimensions.Command)
+	assert.Equal(t, "job-cumulative", dimensions.SummaryCounterScope)
+	assert.Equal(t, "NotApplicable", dimensions.SourceAuthMechanism)
+	assert.Equal(t, "SAS", dimensions.DestAuthMechanism)
+	assert.Equal(t, "account", dimensions.DestStorageAccount)
+	assert.Empty(t, dimensions.SourceCloudType)
+	assert.Equal(t, "public", dimensions.DestCloudType)
+	assert.Equal(t, []string{"include"}, dimensions.Options.FlagsSet)
+	options.FlagsSet[0] = "mutated"
+	options.Values["OptExample"] = "mutated"
+	assert.Equal(t, []string{"include"}, dimensions.Options.FlagsSet)
+	assert.Equal(t, "value", dimensions.Options.Values["OptExample"])
+}
+
+func TestResumeProgressTrackerElapsedTimeBeforeStart(t *testing.T) {
+	assert.Zero(t, (&resumeProgressTracker{}).GetElapsedTime())
+}
+
+func TestBuildFinishedEvent(t *testing.T) {
+	a := assert.New(t)
+	start := time.Now()
+	end := start.Add(2 * time.Second)
+	summary := common.ListJobSummaryResponse{
+		JobStatus:                 common.EJobStatus.Completed(),
+		TotalBytesEnumerated:      1500000,
+		TotalBytesExpected:        1200000,
+		TotalBytesTransferred:     1000000,
+		BytesOverWire:             1100000,
+		FileTransfers:             6,
+		FolderPropertyTransfers:   4,
+		SymlinkTransfers:          2,
+		HardlinksConvertedCount:   1,
+		FoldersCompleted:          3,
+		FoldersFailed:             0,
+		FoldersSkipped:            1,
+		TransfersCompleted:        10,
+		TransfersFailed:           1,
+		TransfersSkipped:          2,
+		TotalTransfers:            13,
+		AverageE2EMilliseconds:    50,
+		AverageIOPS:               7,
+		ServerBusyPercentage:      1.5,
+		NetworkErrorPercentage:    0.5,
+		StorageHTTPAttemptCount:   200,
+		NetworkErrorAttemptCount:  1,
+		ServerBusy503Count:        3,
+		ServerBusyThroughputCount: 2,
+		ServerBusyIOPSCount:       1,
+		ServerBusyOtherCount:      0,
+		PerfConstraint:            common.EPerfConstraint.Service(),
+		PerformanceAdvice: []common.PerformanceAdvice{
+			{Code: "NetworkErrors", PriorityAdvice: true},
+			{Code: "ConcurrencyHitUpperLimit"},
+		},
+		PercentComplete: 100,
+		FailedTransfers: []common.TransferDetail{
+			{ErrorCode: 403}, {ErrorCode: 500}, {ErrorCode: 403}, {ErrorCode: 403},
+		},
+	}
+	dims := baseJobDimensions("copy", common.EFromTo.LocalBlob(), common.ECredentialType.OAuthToken(), common.ECredentialType.SharedKey())
+	shape := sourceShapeSummary{
+		ObjectsScanned:           20,
+		BytesScanned:             40960,
+		AverageObjectSizeBytes:   2048,
+		ObjectSizeP50BytesApprox: 1024,
+		ObjectSizeP90BytesApprox: 16 * 1024 * 1024,
+		ObjectSizeP95BytesApprox: 256 * 1024 * 1024,
+		ObjectsUnder1MiB:         12,
+		ObjectsUnder1MiBRatioPct: 60,
+		MaxDirectoryDepth:        5,
+		ContainersScanned:        3,
+		ContainersTouched:        2,
+	}
+	evt := buildFinishedEvent(telemetryResourceForTest(), dims, "job-1234", "invocation-1234", start, end, summary, 2*time.Second, 1500*time.Millisecond, time.Second, shape)
+
+	a.Equal("job-1234", evt.JobID)
+	a.Equal("invocation-1234", evt.InvocationID)
+	a.Equal(int64(1), evt.FinishedCount)
+	a.Equal(common.EJobStatus.Completed().String(), evt.JobStatus)
+	a.Equal("403:3,500:1", evt.FailureErrorCodes)
+	a.Equal(int64(0), evt.FailureErrorOtherCount)
+	a.Equal(common.EPerfConstraint.Service().String(), evt.PerformanceConstraint)
+	a.Equal([]string{"NetworkErrors", "ConcurrencyHitUpperLimit"}, evt.PerformanceAdviceCodes)
+	a.Equal(100.0, evt.PercentComplete)
+	a.Equal(int64(1500000), evt.BytesEnumerated)
+	a.Equal(int64(1200000), evt.BytesExpected)
+	a.Equal(int64(1000000), evt.BytesTransferred)
+	a.Equal(int64(1100000), evt.BytesOverWire)
+	a.Equal(int64(9), evt.ObjectsScheduled)
+	a.Equal(int64(6), evt.RegularFilesScheduled)
+	a.Equal(int64(2), evt.SymlinksScheduled)
+	a.Equal(int64(1), evt.HardlinksConvertedScheduled)
+	a.Equal(int64(4), evt.FolderPropertiesScheduled)
+	a.Equal(int64(7), evt.ObjectsCompleted)
+	a.Equal(int64(1), evt.ObjectsFailed)
+	a.Equal(int64(1), evt.ObjectsSkipped)
+	a.Equal(int64(3), evt.FolderPropertiesCompleted)
+	a.Equal(int64(0), evt.FolderPropertiesFailed)
+	a.Equal(int64(1), evt.FolderPropertiesSkipped)
+	a.Equal(int64(20), evt.SourceObjectsScanned)
+	a.Equal(int64(40960), evt.SourceBytesScanned)
+	a.Equal(2048.0, evt.SourceAverageObjectSizeBytes)
+	a.Equal(int64(1024), evt.SourceObjectSizeP50BytesApprox)
+	a.Equal(int64(16*1024*1024), evt.SourceObjectSizeP90BytesApprox)
+	a.Equal(int64(256*1024*1024), evt.SourceObjectSizeP95BytesApprox)
+	a.Equal(int64(12), evt.SourceObjectsUnder1MiB)
+	a.Equal(60.0, evt.SourceObjectsUnder1MiBRatioPct)
+	a.Equal(int64(5), evt.SourceMaxDirectoryDepth)
+	a.Equal(int64(3), evt.ContainersScanned)
+	a.Equal(int64(2), evt.ContainersTouched)
+	a.Equal(int64(10), evt.TransfersCompleted)
+	a.Equal(int64(1), evt.TransfersFailed)
+	a.Equal(int64(2), evt.TransfersSkipped)
+	a.Equal(int64(13), evt.TransfersTotal)
+	a.Equal(2.0, evt.JobDurationSeconds)
+	a.Equal(1.5, evt.EnumerationPhaseDurationSeconds)
+	a.Equal(1.0, evt.TransferPhaseDurationSeconds)
+	a.InDelta(4.0, evt.JobThroughputMbps, 1e-9)           // 1e6 bytes * 8 / 1e6 / 2s
+	a.InDelta(8.0, evt.TransferPhaseThroughputMbps, 1e-9) // 1e6 bytes * 8 / 1e6 / 1s
+	a.Equal(int64(50), evt.AverageStorageHTTPAttemptE2EMs)
+	a.Equal(int64(7), evt.AvgIOPS)
+	a.Equal(int64(200), evt.StorageHTTPAttemptCount)
+	a.Equal(int64(1), evt.NetworkErrorAttemptCount)
+	a.Equal(int64(3), evt.ServerBusy503Count)
+	a.Equal(int64(2), evt.ServerBusyThroughputCount)
+	a.Equal(int64(1), evt.ServerBusyIOPSCount)
+	a.Equal(int64(0), evt.ServerBusyOtherCount)
+}
+
+func TestCountExcludingFolders(t *testing.T) {
+	assert.Equal(t, int64(7), countExcludingFolders(10, 3))
+	assert.Zero(t, countExcludingFolders(3, 3))
+	assert.Zero(t, countExcludingFolders(2, 3))
+}
+
+func TestAggregateErrorCodes(t *testing.T) {
+	a := assert.New(t)
+	// No failures -> empty.
+	a.Equal("", aggregateErrorCodes(nil))
+	a.Equal("", aggregateErrorCodes([]common.TransferDetail{}))
+	// Ordered by descending count, then ascending code.
+	a.Equal("403:3,500:1", aggregateErrorCodes([]common.TransferDetail{
+		{ErrorCode: 500}, {ErrorCode: 403}, {ErrorCode: 403}, {ErrorCode: 403},
+	}))
+	// Tie on count -> lower code first.
+	a.Equal("404:1,409:1", aggregateErrorCodes([]common.TransferDetail{
+		{ErrorCode: 409}, {ErrorCode: 404},
+	}))
+	// Bounded to maxErrorCodeBuckets distinct codes.
+	many := make([]common.TransferDetail, 0, maxErrorCodeBuckets+5)
+	for i := 0; i < maxErrorCodeBuckets+5; i++ {
+		many = append(many, common.TransferDetail{ErrorCode: int32(600 + i)})
+	}
+	res := aggregateErrorCodes(many)
+	a.Equal(maxErrorCodeBuckets, strings.Count(res, ":"))
+}
+
+func TestAggregateErrorCodesWithOther(t *testing.T) {
+	failed := make([]common.TransferDetail, 0, 12)
+	for code := int32(400); code < 412; code++ {
+		failed = append(failed, common.TransferDetail{ErrorCode: code})
+	}
+	histogram, other := aggregateErrorCodesWithOther(failed)
+	assert.Equal(t, "400:1,401:1,402:1,403:1,404:1,405:1,406:1,407:1,408:1,409:1", histogram)
+	assert.Equal(t, int64(2), other)
+}
+
+func TestPerformanceAdviceAttributes(t *testing.T) {
+	advice := []common.PerformanceAdvice{
+		{Code: "NetworkErrors", PriorityAdvice: true},
+		{Code: "NetworkErrors"},
+		{Code: "invalid value"},
+		{Code: "AccountIOPS"},
+	}
+	constraint, codes := performanceAdviceAttributes(common.EPerfConstraint.Service(), advice)
+	assert.Equal(t, common.EPerfConstraint.Service().String(), constraint)
+	assert.Equal(t, []string{"NetworkErrors", "AccountIOPS"}, codes)
+}
+
+func TestStorageAccountName(t *testing.T) {
+	a := assert.New(t)
+	// Azure remote: first DNS label is the account name.
+	a.Equal("myaccount", storageAccountName(
+		common.ResourceString{Value: "https://myaccount.blob.core.windows.net/container/path"},
+		common.ELocation.Blob()))
+	a.Equal("acct2", storageAccountName(
+		common.ResourceString{Value: "https://acct2.dfs.core.windows.net/fs"},
+		common.ELocation.BlobFS()))
+	a.Equal("privateacct", storageAccountName(
+		common.ResourceString{Value: "https://privateacct.privatelink.blob.core.windows.net/container"},
+		common.ELocation.Blob()))
+	// Azure-typed custom endpoints do not emit a hostname-derived identity.
+	a.Equal("", storageAccountName(
+		common.ResourceString{Value: "https://acct.blob.example.com/container"},
+		common.ELocation.Blob()))
+	// Local locations return empty.
+	a.Equal("", storageAccountName(
+		common.ResourceString{Value: "/local/path"},
+		common.ELocation.Local()))
+	// Non-Azure providers never emit bucket names.
+	a.Equal("", storageAccountName(
+		common.ResourceString{Value: "https://bucket.s3.amazonaws.com/key"},
+		common.ELocation.S3()))
+	a.Equal("", storageAccountName(
+		common.ResourceString{Value: "https://storage.cloud.google.com/mybucket/object"},
+		common.ELocation.GCP()))
+	// Hostless values return empty.
+	a.Equal("", storageAccountName(
+		common.ResourceString{Value: "relative/path"},
+		common.ELocation.Blob()))
+}
+
+func TestAuthMechanism(t *testing.T) {
+	resourceWithSAS := common.ResourceString{Value: "https://account.blob.core.windows.net/container", SAS: "?sig=secret"}
+	assert.Equal(t, "SAS", authMechanism(common.ECredentialType.Anonymous(), resourceWithSAS, common.ELocation.Blob()))
+	assert.Equal(t, "PublicAnonymous", authMechanism(common.ECredentialType.Anonymous(), common.ResourceString{}, common.ELocation.Blob()))
+	assert.Equal(t, common.ECredentialType.OAuthToken().String(), authMechanism(common.ECredentialType.OAuthToken(), common.ResourceString{}, common.ELocation.Blob()))
+	assert.Equal(t, "NotApplicable", authMechanism(common.ECredentialType.Anonymous(), common.ResourceString{}, common.ELocation.Local()))
+}
+
+func TestScopeForLocation(t *testing.T) {
+	assert.Equal(t, "service", scopeForLocation(common.ResourceString{Value: "https://account.blob.core.windows.net"}, common.ELocation.Blob(), true))
+	assert.Equal(t, "container", scopeForLocation(common.ResourceString{Value: "https://account.blob.core.windows.net/container"}, common.ELocation.Blob(), true))
+	assert.Equal(t, "share", scopeForLocation(common.ResourceString{Value: "https://account.file.core.windows.net/share"}, common.ELocation.File(), true))
+	assert.Equal(t, "bucket", scopeForLocation(common.ResourceString{Value: "https://s3.amazonaws.com/bucket"}, common.ELocation.S3(), true))
+	assert.Equal(t, "object-or-prefix", scopeForLocation(common.ResourceString{Value: "https://account.blob.core.windows.net/container/path"}, common.ELocation.Blob(), true))
+	assert.Equal(t, "stream", scopeForLocation(common.ResourceString{}, common.ELocation.Pipe(), true))
+	assert.Equal(t, "benchmark", scopeForLocation(common.ResourceString{}, common.ELocation.Benchmark(), true))
+}
+
+func TestThroughputMbps(t *testing.T) {
+	a := assert.New(t)
+	a.Equal(0.0, throughputMbps(1000, 0))
+	a.Equal(0.0, throughputMbps(1000, -1))
+	a.InDelta(8.0, throughputMbps(1_000_000, 1), 1e-9)
+}
+
+func TestDetectInvocationContext(t *testing.T) {
+	a := assert.New(t)
+	a.Equal("interactive", detectInvocationContext(func(string) string { return "" }))
+	a.Equal("ci", detectInvocationContext(func(k string) string {
+		if k == "GITHUB_ACTIONS" {
+			return "true"
+		}
+		return ""
+	}))
+}
+
+func TestNewTelemetryInvocationID(t *testing.T) {
+	first := newTelemetryInvocationID()
+	second := newTelemetryInvocationID()
+	assert.Len(t, first, 32)
+	assert.Len(t, second, 32)
+	assert.NotEqual(t, first, second)
+}
+
+func TestShouldSampleTelemetry(t *testing.T) {
+	assert.False(t, shouldSampleTelemetry("", 1))
+	assert.False(t, shouldSampleTelemetry("job", 0))
+	assert.True(t, shouldSampleTelemetry("job", 1))
+
+	includedAtOnePercent := 0
+	for index := 0; index < 10000; index++ {
+		jobID := fmt.Sprintf("job-%d", index)
+		atOnePercent := shouldSampleTelemetry(jobID, 0.01)
+		assert.Equal(t, atOnePercent, shouldSampleTelemetry(jobID, 0.01))
+		if atOnePercent {
+			includedAtOnePercent++
+			assert.True(t, shouldSampleTelemetry(jobID, 0.10), jobID)
+		}
+	}
+	assert.Greater(t, includedAtOnePercent, 70)
+	assert.Less(t, includedAtOnePercent, 130)
+}
+
+func TestBuildResourceAttributesSamplingMetadata(t *testing.T) {
+	resource := buildResourceAttributes()
+	assert.Equal(t, telemetrySchemaVersion, resource.SchemaVersion)
+	assert.Equal(t, telemetrySamplingRate, resource.SamplingRate)
+	assert.Equal(t, telemetrySamplerVersion, resource.SamplerVersion)
+}
+
+func TestBuildResourceAttributesE2ETestRunID(t *testing.T) {
+	t.Setenv(envE2ETelemetryRunID, "pipeline-run-123")
+	assert.Equal(t, "pipeline-run-123", buildResourceAttributes().E2ETestRunID)
+
+	t.Setenv(envE2ETelemetryRunID, "   ")
+	assert.Empty(t, buildResourceAttributes().E2ETestRunID)
+}
+
+func TestConfigureTelemetrySamplingRate(t *testing.T) {
+	original := telemetrySamplingRate
+	t.Cleanup(func() { telemetrySamplingRate = original })
+
+	assert.NoError(t, configureTelemetrySamplingRate(nil))
+	assert.Equal(t, defaultTelemetrySamplingRate, telemetrySamplingRate)
+
+	for _, rate := range []float64{0, 0.25, 1} {
+		rate := rate
+		t.Run(fmt.Sprintf("rate-%g", rate), func(t *testing.T) {
+			assert.NoError(t, configureTelemetrySamplingRate(&rate))
+			assert.Equal(t, rate, telemetrySamplingRate)
+			assert.Equal(t, rate, buildResourceAttributes().SamplingRate)
+		})
+	}
+
+	for _, rate := range []float64{-0.01, 1.01, math.NaN(), math.Inf(1), math.Inf(-1)} {
+		rate := rate
+		t.Run(fmt.Sprintf("invalid-%v", rate), func(t *testing.T) {
+			assert.Error(t, configureTelemetrySamplingRate(&rate))
+		})
+	}
+}
+
+func TestConfiguredTelemetryConnectionString(t *testing.T) {
+	original := telemetryConnectionString
+	t.Cleanup(func() { telemetryConnectionString = original })
+
+	telemetryConnectionString = ""
+	assert.Empty(t, configuredTelemetryConnectionString(func(string) string { return "" }))
+
+	telemetryConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000"
+	assert.Empty(t, configuredTelemetryConnectionString(func(string) string { return "" }))
+
+	telemetryConnectionString = "InstrumentationKey=build-time"
+	assert.Equal(t, "InstrumentationKey=build-time", configuredTelemetryConnectionString(func(string) string { return "" }))
+	assert.Equal(t, "InstrumentationKey=runtime", configuredTelemetryConnectionString(func(name string) string {
+		if name == envTelemetryConnectionString {
+			return "InstrumentationKey=runtime"
+		}
+		return ""
+	}))
+}
+
+func TestTerminalAttemptStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     common.JobStatus
+		err        error
+		wantStatus common.JobStatus
+		wantReason string
+	}{
+		{"completed", common.EJobStatus.Completed(), nil, common.EJobStatus.Completed(), "completed"},
+		{"completed with errors", common.EJobStatus.CompletedWithErrors(), nil, common.EJobStatus.CompletedWithErrors(), "completed-with-errors"},
+		{"failed error", common.EJobStatus.InProgress(), errors.New("failed"), common.EJobStatus.Failed(), "failed"},
+		{"cancelled context", common.EJobStatus.InProgress(), context.Canceled, common.EJobStatus.Cancelled(), "cancelled"},
+		{"cancelled summary", common.EJobStatus.Cancelled(), nil, common.EJobStatus.Cancelled(), "cancelled"},
+		{"missing success summary", common.EJobStatus.InProgress(), nil, common.EJobStatus.Completed(), "completed"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			status, reason := terminalAttemptStatus(test.status, test.err)
+			assert.Equal(t, test.wantStatus, status)
+			assert.Equal(t, test.wantReason, reason)
+		})
+	}
+}
+
+func TestAttemptTelemetryFinalizerIsIdempotent(t *testing.T) {
+	finalizer := newAttemptTelemetryFinalizer(nil, telemetry.JobDimensions{}, "job", "invocation", time.Now())
+	finalizer.finish(errors.New("first"))
+	assert.True(t, finalizer.finished)
+	finalizer.finish(errors.New("second"))
+	assert.True(t, finalizer.finished)
+}
+
+func TestJobErrorAttributes(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		reason       string
+		stage        string
+		wantCategory string
+		wantCode     string
+	}{
+		{"success", nil, "completed", "completed", "", ""},
+		{"cancelled", context.Canceled, "cancelled", "enumeration", "", ""},
+		{"partial success", nil, "completed-with-errors", "completed", "transfer", "transfer-failures"},
+		{"authentication", &azcore.ResponseError{ErrorCode: "AuthenticationFailed", StatusCode: 403}, "failed", "enumeration", "authentication", "AuthenticationFailed"},
+		{"authorization", &azcore.ResponseError{ErrorCode: "AuthorizationPermissionMismatch", StatusCode: 403}, "failed", "transfer", "authorization", "AuthorizationPermissionMismatch"},
+		{"throttling", &azcore.ResponseError{ErrorCode: "ServerBusy", StatusCode: 503}, "failed", "transfer", "throttling", "ServerBusy"},
+		{"http fallback", &azcore.ResponseError{StatusCode: 404}, "failed", "enumeration", "not-found", "http-404"},
+		{"deadline", context.DeadlineExceeded, "failed", "transfer", "timeout", "context-deadline-exceeded"},
+		{"local path", &os.PathError{Op: "open", Path: "secret", Err: os.ErrNotExist}, "failed", "enumeration", "local-io", "local-path-error"},
+		{"network", &url.Error{Op: "Get", URL: "https://secret", Err: errors.New("connection refused")}, "failed", "transfer", "network", "network-error"},
+		{"azcopy", common.EAzError.InvalidServiceClient(), "failed", "initialization", "azcopy", "azcopy-4"},
+		{"stage fallback", errors.New("contains sensitive text"), "failed", "enumeration", "enumeration", "enumeration-error"},
+		{"unknown fallback", errors.New("contains sensitive text"), "failed", "", "unknown", "job-failed"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			category, code := jobErrorAttributes(test.err, test.reason, test.stage)
+			assert.Equal(t, test.wantCategory, category)
+			assert.Equal(t, test.wantCode, code)
+		})
+	}
+}
+
+func TestSanitizeJobErrorCode(t *testing.T) {
+	assert.Equal(t, "AuthorizationPermissionMismatch", sanitizeJobErrorCode(" AuthorizationPermissionMismatch "))
+	assert.Empty(t, sanitizeJobErrorCode("code with spaces"))
+	assert.Empty(t, sanitizeJobErrorCode(strings.Repeat("a", 65)))
+}
+
+func TestTransferPhaseElapsedTime(t *testing.T) {
+	copyTracker := &transferProgressTracker{}
+	syncTracker := &syncProgressTracker{}
+	assert.Zero(t, copyTracker.GetTransferElapsedTime())
+	assert.Zero(t, syncTracker.GetTransferElapsedTime())
+	assert.Zero(t, copyTracker.GetEnumerationElapsedTime())
+	assert.Zero(t, syncTracker.GetEnumerationElapsedTime())
+
+	now := time.Now()
+	started := now.Add(-2 * time.Second).UnixNano()
+	copyTracker.atomicTransferStartUnixNano = started
+	syncTracker.atomicTransferStartUnixNano = started
+	copyTracker.jobStartTime = now.Add(-3 * time.Second)
+	syncTracker.jobStartTime = now.Add(-3 * time.Second)
+	copyTracker.atomicEnumerationEndUnixNano = now.Add(-time.Second).UnixNano()
+	syncTracker.atomicEnumerationEndUnixNano = now.Add(-time.Second).UnixNano()
+	assert.InDelta(t, 2*time.Second, copyTracker.GetTransferElapsedTime(), float64(250*time.Millisecond))
+	assert.InDelta(t, 2*time.Second, syncTracker.GetTransferElapsedTime(), float64(250*time.Millisecond))
+	assert.InDelta(t, 2*time.Second, copyTracker.GetEnumerationElapsedTime(), float64(250*time.Millisecond))
+	assert.InDelta(t, 2*time.Second, syncTracker.GetEnumerationElapsedTime(), float64(250*time.Millisecond))
+}
+
+func TestDisabledAgentIsNoop(t *testing.T) {
+	a := assert.New(t)
+	var agent *telemetryAgent
+	// nil agent must not panic.
+	agent.reportStarted(telemetry.JobDimensions{}, "id", "invocation", time.Now())
+	agent.reportFinished(telemetry.JobFinishedEvent{})
+
+	disabled := &telemetryAgent{enabled: false}
+	disabled.reportStarted(telemetry.JobDimensions{}, "id", "invocation", time.Now())
+	disabled.reportFinished(telemetry.JobFinishedEvent{})
+	a.False(disabled.enabled)
+}
+
+func telemetryResourceForTest() telemetry.ResourceAttributes {
+	return telemetry.ResourceAttributes{
+		AzCopyVersion: common.AzcopyVersion,
+	}
+}

--- a/azcopy/telemetry_test.go
+++ b/azcopy/telemetry_test.go
@@ -23,9 +23,7 @@ package azcopy
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -542,36 +540,10 @@ func TestNewTelemetryInvocationID(t *testing.T) {
 	assert.NotEqual(t, first, second)
 }
 
-func TestShouldSampleTelemetry(t *testing.T) {
-	assert.False(t, shouldSampleTelemetry("", 1))
-	assert.False(t, shouldSampleTelemetry("job", 0))
-	assert.True(t, shouldSampleTelemetry("job", 1))
-
-	includedAtOnePercent := 0
-	for index := 0; index < 10000; index++ {
-		jobID := fmt.Sprintf("job-%d", index)
-		atOnePercent := shouldSampleTelemetry(jobID, 0.01)
-		assert.Equal(t, atOnePercent, shouldSampleTelemetry(jobID, 0.01))
-		if atOnePercent {
-			includedAtOnePercent++
-			assert.True(t, shouldSampleTelemetry(jobID, 0.10), jobID)
-		}
-	}
-	assert.Greater(t, includedAtOnePercent, 70)
-	assert.Less(t, includedAtOnePercent, 130)
-}
-
 func TestShouldCollectSourceShape(t *testing.T) {
-	original := telemetrySamplingRate
-	t.Cleanup(func() { telemetrySamplingRate = original })
-
-	telemetrySamplingRate = 1
-	assert.False(t, (*telemetryAgent)(nil).shouldCollectSourceShape("job"))
-	assert.False(t, (&telemetryAgent{}).shouldCollectSourceShape("job"))
-	assert.True(t, (&telemetryAgent{enabled: true}).shouldCollectSourceShape("job"))
-
-	telemetrySamplingRate = 0
-	assert.False(t, (&telemetryAgent{enabled: true}).shouldCollectSourceShape("job"))
+	assert.False(t, (*telemetryAgent)(nil).shouldCollectSourceShape())
+	assert.False(t, (&telemetryAgent{}).shouldCollectSourceShape())
+	assert.True(t, (&telemetryAgent{enabled: true}).shouldCollectSourceShape())
 }
 
 func TestProgressTrackersOnlyCollectSourceShapeWhenEligible(t *testing.T) {
@@ -611,11 +583,9 @@ func TestProgressTrackersOnlyCollectSourceShapeWhenEligible(t *testing.T) {
 	assert.NotNil(t, syncWithShape.shapeTracker)
 }
 
-func TestBuildResourceAttributesSamplingMetadata(t *testing.T) {
+func TestBuildResourceAttributesSchemaVersion(t *testing.T) {
 	resource := buildResourceAttributes()
 	assert.Equal(t, telemetrySchemaVersion, resource.SchemaVersion)
-	assert.Equal(t, telemetrySamplingRate, resource.SamplingRate)
-	assert.Equal(t, telemetrySamplerVersion, resource.SamplerVersion)
 }
 
 func TestBuildResourceAttributesE2ETestRunID(t *testing.T) {
@@ -624,30 +594,6 @@ func TestBuildResourceAttributesE2ETestRunID(t *testing.T) {
 
 	t.Setenv(envE2ETelemetryRunID, "   ")
 	assert.Empty(t, buildResourceAttributes().E2ETestRunID)
-}
-
-func TestConfigureTelemetrySamplingRate(t *testing.T) {
-	original := telemetrySamplingRate
-	t.Cleanup(func() { telemetrySamplingRate = original })
-
-	assert.NoError(t, configureTelemetrySamplingRate(nil))
-	assert.Equal(t, defaultTelemetrySamplingRate, telemetrySamplingRate)
-
-	for _, rate := range []float64{0, 0.25, 1} {
-		rate := rate
-		t.Run(fmt.Sprintf("rate-%g", rate), func(t *testing.T) {
-			assert.NoError(t, configureTelemetrySamplingRate(&rate))
-			assert.Equal(t, rate, telemetrySamplingRate)
-			assert.Equal(t, rate, buildResourceAttributes().SamplingRate)
-		})
-	}
-
-	for _, rate := range []float64{-0.01, 1.01, math.NaN(), math.Inf(1), math.Inf(-1)} {
-		rate := rate
-		t.Run(fmt.Sprintf("invalid-%v", rate), func(t *testing.T) {
-			assert.Error(t, configureTelemetrySamplingRate(&rate))
-		})
-	}
 }
 
 func TestConfiguredTelemetryConnectionString(t *testing.T) {
@@ -813,10 +759,6 @@ func (c *orderedTelemetryClient) Do(req *http.Request) (*http.Response, error) {
 }
 
 func TestFinishedTelemetryWaitsForStartedDelivery(t *testing.T) {
-	original := telemetrySamplingRate
-	telemetrySamplingRate = 1
-	t.Cleanup(func() { telemetrySamplingRate = original })
-
 	client := &orderedTelemetryClient{
 		firstEntered: make(chan struct{}),
 		releaseFirst: make(chan struct{}),
@@ -834,20 +776,19 @@ func TestFinishedTelemetryWaitsForStartedDelivery(t *testing.T) {
 	agent.reportStarted(telemetry.JobDimensions{}, jobID, invocationID, time.Now())
 	<-client.firstEntered
 
-	finished := make(chan struct{})
+	finishedReturned := make(chan struct{})
 	go func() {
 		agent.reportFinished(telemetry.JobFinishedEvent{
 			JobID:        jobID,
 			InvocationID: invocationID,
 			EndTimestamp: time.Now(),
 		})
-		close(finished)
+		close(finishedReturned)
 	}()
-
 	select {
-	case <-finished:
-		t.Fatal("finished telemetry completed before started telemetry")
-	case <-time.After(50 * time.Millisecond):
+	case <-finishedReturned:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("reportFinished blocked on telemetry delivery")
 	}
 
 	client.mu.Lock()
@@ -855,15 +796,85 @@ func TestFinishedTelemetryWaitsForStartedDelivery(t *testing.T) {
 	client.mu.Unlock()
 
 	close(client.releaseFirst)
-	select {
-	case <-finished:
-	case <-time.After(time.Second):
-		t.Fatal("finished telemetry did not complete after started telemetry")
-	}
+	agent.flush(time.Second)
 
 	client.mu.Lock()
 	assert.Equal(t, []string{"azcopy.job.started", "azcopy.job.finished"}, client.eventNames)
 	client.mu.Unlock()
+}
+
+type blockingTelemetryClient struct {
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (c *blockingTelemetryClient) Do(*http.Request) (*http.Response, error) {
+	c.once.Do(func() { close(c.entered) })
+	<-c.release
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("")),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func newBlockingTelemetryAgent(client *blockingTelemetryClient) *telemetryAgent {
+	return &telemetryAgent{
+		enabled: true,
+		reporter: telemetry.NewReporter(telemetry.Config{
+			Backend:          telemetry.BackendAppInsights,
+			ConnectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000001;IngestionEndpoint=https://example.test",
+			HTTPClient:       client,
+		}),
+	}
+}
+
+func TestCommandTelemetryDoesNotDelayCommandExecution(t *testing.T) {
+	client := &blockingTelemetryClient{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	agent := newBlockingTelemetryAgent(client)
+
+	commandReturned := make(chan struct{})
+	go func() {
+		agent.reportCommand("list", "job", "invocation", telemetry.OptionAttributes{})
+		close(commandReturned)
+	}()
+	select {
+	case <-commandReturned:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("reportCommand blocked on telemetry delivery")
+	}
+	<-client.entered
+
+	close(client.release)
+	agent.flush(time.Second)
+}
+
+func TestTelemetryFlushHasSingleBoundedExitBudget(t *testing.T) {
+	client := &blockingTelemetryClient{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	agent := newBlockingTelemetryAgent(client)
+	agent.reportStarted(telemetry.JobDimensions{}, "job", "invocation", time.Now())
+	<-client.entered
+	agent.reportFinished(telemetry.JobFinishedEvent{
+		JobID:        "job",
+		InvocationID: "invocation",
+		EndTimestamp: time.Now(),
+	})
+
+	startedAt := time.Now()
+	agent.flush(40 * time.Millisecond)
+	elapsed := time.Since(startedAt)
+	assert.GreaterOrEqual(t, elapsed, 30*time.Millisecond)
+	assert.Less(t, elapsed, 200*time.Millisecond)
+
+	close(client.release)
+	agent.flush(time.Second)
 }
 
 func telemetryResourceForTest() telemetry.ResourceAttributes {

--- a/azcopy/telemetry_test.go
+++ b/azcopy/telemetry_test.go
@@ -27,6 +27,7 @@ import (
 	"math"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -532,6 +533,63 @@ func TestDetectInvocationContext(t *testing.T) {
 		}
 		return ""
 	}))
+}
+
+func TestInstallationIDPersistsOutsideJobPlanFolder(t *testing.T) {
+	rootDir := t.TempDir()
+	appDataDir := filepath.Join(rootDir, ".azcopy")
+	jobPlanDir := filepath.Join(rootDir, "plans")
+	require.NoError(t, os.Mkdir(jobPlanDir, 0700))
+
+	first := installationIDInDir(appDataDir)
+	second := installationIDInDir(appDataDir)
+
+	assert.Len(t, first, 32)
+	assert.Equal(t, first, second)
+	assert.FileExists(t, filepath.Join(appDataDir, installationIDFileName))
+
+	entries, err := os.ReadDir(jobPlanDir)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestInstallationIDIsStableAcrossConcurrentCalls(t *testing.T) {
+	appDataDir := filepath.Join(t.TempDir(), ".azcopy")
+	const callCount = 16
+	results := make(chan string, callCount)
+
+	for i := 0; i < callCount; i++ {
+		go func() {
+			results <- installationIDInDir(appDataDir)
+		}()
+	}
+
+	first := <-results
+	require.Len(t, first, 32)
+	for i := 1; i < callCount; i++ {
+		assert.Equal(t, first, <-results)
+	}
+}
+
+func TestInstallationIDRecoversMalformedFileAcrossConcurrentCalls(t *testing.T) {
+	appDataDir := filepath.Join(t.TempDir(), ".azcopy")
+	require.NoError(t, os.Mkdir(appDataDir, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(appDataDir, installationIDFileName), []byte("partial"), 0600))
+
+	const callCount = 16
+	results := make(chan string, callCount)
+	for i := 0; i < callCount; i++ {
+		go func() {
+			results <- installationIDInDir(appDataDir)
+		}()
+	}
+
+	first := <-results
+	require.Len(t, first, 32)
+	for i := 1; i < callCount; i++ {
+		assert.Equal(t, first, <-results)
+	}
+	assert.Equal(t, first, readInstallationID(filepath.Join(appDataDir, installationIDFileName)))
 }
 
 func TestNewTelemetryInvocationID(t *testing.T) {

--- a/azcopy/transferOptions.go
+++ b/azcopy/transferOptions.go
@@ -31,6 +31,7 @@ import (
 	"sync"
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/telemetry"
 	"github.com/Azure/azure-storage-azcopy/v10/traverser"
 )
 
@@ -151,6 +152,8 @@ type CookedTransferOptions struct {
 	dryrun                           bool
 	dryrunJobPartOrderHandler        func(request common.CopyJobPartOrderRequest) common.CopyJobPartOrderResponse
 	deleteDestinationFileIfNecessary bool
+	telemetryOptions                 telemetry.OptionAttributes
+	benchmarkTelemetry               *benchmarkTelemetryOptions
 }
 
 func newCookedCopyOptions(src, dst string, opts CopyOptions) (c *CookedTransferOptions, err error) {
@@ -316,6 +319,11 @@ func (c *CookedTransferOptions) applyDefaultsAndInferOptions(opts CopyOptions) (
 	c.posixPropertiesStyle = opts.PosixPropertiesStyle
 	c.s2sInvalidMetadataHandleOption = opts.S2SHandleInvalidateMetadata
 	c.commandString = opts.commandString
+	c.telemetryOptions = opts.telemetryOptions.Clone()
+	if opts.benchmarkTelemetry != nil {
+		benchmark := *opts.benchmarkTelemetry
+		c.benchmarkTelemetry = &benchmark
+	}
 
 	// inference
 	if opts.ContentType != "" {
@@ -338,7 +346,7 @@ func (c *CookedTransferOptions) applyDefaultsAndInferOptions(opts CopyOptions) (
 		(c.fromTo.From().IsFile() &&
 			c.fromTo.To().IsRemote() && (c.s2sSourceChangeValidation || c.filterOptions.IncludeAfter != nil || c.filterOptions.IncludeBefore != nil)) || // If S2S from File to *, and sourceChangeValidation is enabled, we get properties so that we have LMTs. Likewise, if we are using includeAfter or includeBefore, which require LMTs.
 		(c.fromTo.From().IsRemote() && c.fromTo.To().IsRemote() && c.s2sPreserveProperties.Get() && !c.s2sGetPropertiesInBackend) // If S2S and preserve properties AND get properties in backend is on, turn this off, as properties will be obtained in the backend.
-	c.s2sGetPropertiesInBackend = c.s2sPreserveProperties.Get() && !c.getPropertiesInFrontend && c.s2sGetPropertiesInBackend      // Infer GetProperties if GetPropertiesInBackend is enabled.
+	c.s2sGetPropertiesInBackend = c.s2sPreserveProperties.Get() && !c.getPropertiesInFrontend && c.s2sGetPropertiesInBackend // Infer GetProperties if GetPropertiesInBackend is enabled.
 
 	c.srcLevel, err = DetermineLocationLevel(c.source.Value, c.fromTo.From(), true)
 	if err != nil {

--- a/azcopy/transferProgressTracker.go
+++ b/azcopy/transferProgressTracker.go
@@ -32,11 +32,16 @@ import (
 var _ jobProgressTracker = &transferProgressTracker{}
 
 type transferProgressTracker struct {
+	// Keep 64-bit atomics first for correct alignment on 32-bit platforms.
+	atomicTransferStartUnixNano  int64
+	atomicEnumerationEndUnixNano int64
+
 	jobID   common.JobID
 	fromTo  common.FromTo
 	handler CopyHandler
 	//jobType      common.JobType
 	isCleanupJob bool
+	shapeTracker *sourceShapeTracker
 
 	// variables used to calculate progress
 	// intervalStartTime holds the last time value when the progress summary was fetched
@@ -127,18 +132,48 @@ func (tpt *transferProgressTracker) GetElapsedTime() time.Duration {
 	return time.Since(tpt.jobStartTime)
 }
 
-func newTransferProgressTracker(jobID common.JobID, handler CopyHandler, fromTo common.FromTo) *transferProgressTracker {
+func (tpt *transferProgressTracker) GetTransferElapsedTime() time.Duration {
+	start := atomic.LoadInt64(&tpt.atomicTransferStartUnixNano)
+	if start == 0 {
+		return 0
+	}
+	elapsed := time.Since(time.Unix(0, start))
+	if elapsed < 0 {
+		return 0
+	}
+	return elapsed
+}
+
+func (tpt *transferProgressTracker) GetEnumerationElapsedTime() time.Duration {
+	end := atomic.LoadInt64(&tpt.atomicEnumerationEndUnixNano)
+	if end == 0 || tpt.jobStartTime.IsZero() {
+		return 0
+	}
+	elapsed := time.Unix(0, end).Sub(tpt.jobStartTime)
+	if elapsed < 0 {
+		return 0
+	}
+	return elapsed
+}
+
+func newTransferProgressTracker(jobID common.JobID, handler CopyHandler, fromTo common.FromTo, symlinkHandling common.SymlinkHandlingType, hardlinkHandling common.HardlinkHandlingType) *transferProgressTracker {
 	return &transferProgressTracker{
 		jobID:        jobID,
 		handler:      handler,
 		isCleanupJob: false, // TODO: when implementing benchmark, set this properly
 		fromTo:       fromTo,
+		shapeTracker: newSourceShapeTracker(fromTo.From(), symlinkHandling, hardlinkHandling),
 		//jobType:      common.EJobType.Copy(), // TODO: when implementing benchmark, set this properly
 	}
 }
 
+func (tpt *transferProgressTracker) GetSourceShapeSummary() sourceShapeSummary {
+	return tpt.shapeTracker.snapshot()
+}
+
 // setFirstPartOrdered sets the value of atomicFirstPartOrdered to 1
 func (tpt *transferProgressTracker) setFirstPartOrdered() {
+	atomic.CompareAndSwapInt64(&tpt.atomicTransferStartUnixNano, 0, time.Now().UnixNano())
 	atomic.StoreUint32(&tpt.atomicFirstPartOrdered, 1)
 }
 
@@ -149,6 +184,7 @@ func (tpt *transferProgressTracker) firstPartOrdered() bool {
 
 // setScanningComplete sets the value of atomicScanningStatus to 1.
 func (tpt *transferProgressTracker) setScanningComplete() {
+	atomic.CompareAndSwapInt64(&tpt.atomicEnumerationEndUnixNano, 0, time.Now().UnixNano())
 	atomic.StoreUint32(&tpt.atomicScanningStatus, 1)
 }
 

--- a/azcopy/transferProgressTracker.go
+++ b/azcopy/transferProgressTracker.go
@@ -156,13 +156,17 @@ func (tpt *transferProgressTracker) GetEnumerationElapsedTime() time.Duration {
 	return elapsed
 }
 
-func newTransferProgressTracker(jobID common.JobID, handler CopyHandler, fromTo common.FromTo, symlinkHandling common.SymlinkHandlingType, hardlinkHandling common.HardlinkHandlingType) *transferProgressTracker {
+func newTransferProgressTracker(jobID common.JobID, handler CopyHandler, fromTo common.FromTo, symlinkHandling common.SymlinkHandlingType, hardlinkHandling common.HardlinkHandlingType, collectSourceShape bool) *transferProgressTracker {
+	var shapeTracker *sourceShapeTracker
+	if collectSourceShape {
+		shapeTracker = newSourceShapeTracker(fromTo.From(), symlinkHandling, hardlinkHandling)
+	}
 	return &transferProgressTracker{
 		jobID:        jobID,
 		handler:      handler,
 		isCleanupJob: false, // TODO: when implementing benchmark, set this properly
 		fromTo:       fromTo,
-		shapeTracker: newSourceShapeTracker(fromTo.From(), symlinkHandling, hardlinkHandling),
+		shapeTracker: shapeTracker,
 		//jobType:      common.EJobType.Copy(), // TODO: when implementing benchmark, set this properly
 	}
 }

--- a/azcopy/zc_processor.go
+++ b/azcopy/zc_processor.go
@@ -58,8 +58,13 @@ type CopyTransferProcessor struct {
 	dryrunMode                bool
 	dryrunJobPartOrderHandler func(request common.CopyJobPartOrderRequest) common.CopyJobPartOrderResponse
 	// Separate tracking for files/folder/symlink vs hardlink based on processing mode
-	dispatcher     syncJobPartDispatcher
-	processingMode common.JobProcessingMode
+	dispatcher              syncJobPartDispatcher
+	processingMode          common.JobProcessingMode
+	reportTransferScheduled func(traverser.StoredObject)
+}
+
+func (s *CopyTransferProcessor) SetTransferScheduledObserver(observer func(traverser.StoredObject)) {
+	s.reportTransferScheduled = observer
 }
 
 func NewCopyTransferProcessor(isCopy bool, copyJobTemplate *common.CopyJobPartOrderRequest, numOfTransfersPerPart int, source, destination common.ResourceString, reportFirstPartDispatched func(bool), reportFinalPartDispatched func(), preserveAccessTier bool, dryrun bool, dryrunJobPartOrderHandler func(request common.CopyJobPartOrderRequest) common.CopyJobPartOrderResponse) *CopyTransferProcessor {
@@ -149,6 +154,9 @@ func (s *CopyTransferProcessor) scheduleTransfer(srcRelativePath, dstRelativePat
 	err = s.appendTransfer(copyTransfer)
 	if err != nil {
 		return fmt.Errorf("error appending transfer: %w", err)
+	}
+	if s.reportTransferScheduled != nil {
+		s.reportTransferScheduled(storedObject)
 	}
 
 	return nil

--- a/azurePipelineTemplates/build_linux.yml
+++ b/azurePipelineTemplates/build_linux.yml
@@ -38,23 +38,30 @@ steps:
     displayName: 'Create output paths'
 
   - script: |
-      go build -tags "netgo" -o "$(binaries)/azcopy_linux${{ parameters.build_suffix }}_${{ parameters.host_architecture }}"
+      case "$AZCOPY_TELEMETRY_CONNECTION_STRING" in
+        InstrumentationKey=*) ;;
+        *) echo "AZCOPY_TELEMETRY_CONNECTION_STRING_PROD must be configured as a secret pipeline variable"; exit 1 ;;
+      esac
+      telemetry_ldflags="-X github.com/Azure/azure-storage-azcopy/v10/azcopy.telemetryConnectionString=$AZCOPY_TELEMETRY_CONNECTION_STRING"
+      go build -ldflags "$telemetry_ldflags" -tags "netgo" -o "$(binaries)/azcopy_linux${{ parameters.build_suffix }}_${{ parameters.host_architecture }}"
     displayName: 'Build'
     env:
       GOARCH: '${{ parameters.host_architecture }}'
       GOOS: linux
+      AZCOPY_TELEMETRY_CONNECTION_STRING: $(AZCOPY_TELEMETRY_CONNECTION_STRING_PROD)
       ${{ if eq(parameters.build_suffix, '_fips') }}:
         CGO_ENABLED: 1
 
   - script: |
-      go build -tags "netgo,se_integration" -o "$(binaries)/azcopy_linux_se${{ parameters.build_suffix }}_${{ parameters.host_architecture }}"
+      telemetry_ldflags="-X github.com/Azure/azure-storage-azcopy/v10/azcopy.telemetryConnectionString=$AZCOPY_TELEMETRY_CONNECTION_STRING"
+      go build -ldflags "$telemetry_ldflags" -tags "netgo,se_integration" -o "$(binaries)/azcopy_linux_se${{ parameters.build_suffix }}_${{ parameters.host_architecture }}"
     displayName: 'Build SE Integration'
     env:
       GOARCH: '${{ parameters.host_architecture }}'
       GOOS: linux
+      AZCOPY_TELEMETRY_CONNECTION_STRING: $(AZCOPY_TELEMETRY_CONNECTION_STRING_PROD)
       ${{ if eq(parameters.build_suffix, '_fips') }}:
         CGO_ENABLED: 1
-
   - script: |
       linux_dir="$(System.DefaultWorkingDirectory)/azcopy_linux${{ parameters.build_suffix }}_${{ parameters.host_architecture }}_$(azcopy_version)"
       echo "##vso[task.setvariable variable=linux_dir]$linux_dir"

--- a/azurePipelineTemplates/build_macos.yml
+++ b/azurePipelineTemplates/build_macos.yml
@@ -7,12 +7,22 @@ steps:
     displayName: 'Install Go'
 
   - script: |
-      CGO_ENABLED=1 go build -o "$(System.DefaultWorkingDirectory)/azcopy_darwin_amd64"
+      case "$AZCOPY_TELEMETRY_CONNECTION_STRING" in
+        InstrumentationKey=*) ;;
+        *) echo "AZCOPY_TELEMETRY_CONNECTION_STRING_PROD must be configured as a secret pipeline variable"; exit 1 ;;
+      esac
+      telemetry_ldflags="-X github.com/Azure/azure-storage-azcopy/v10/azcopy.telemetryConnectionString=$AZCOPY_TELEMETRY_CONNECTION_STRING"
+      CGO_ENABLED=1 go build -ldflags "$telemetry_ldflags" -o "$(System.DefaultWorkingDirectory)/azcopy_darwin_amd64"
     displayName: 'Generate MacOS Build with AMD64'
+    env:
+      AZCOPY_TELEMETRY_CONNECTION_STRING: $(AZCOPY_TELEMETRY_CONNECTION_STRING_PROD)
 
   - script: |
-      GOARCH=arm64 CGO_ENABLED=1 go build -o "$(System.DefaultWorkingDirectory)/azcopy_darwin_arm64"
+      telemetry_ldflags="-X github.com/Azure/azure-storage-azcopy/v10/azcopy.telemetryConnectionString=$AZCOPY_TELEMETRY_CONNECTION_STRING"
+      GOARCH=arm64 CGO_ENABLED=1 go build -ldflags "$telemetry_ldflags" -o "$(System.DefaultWorkingDirectory)/azcopy_darwin_arm64"
     displayName: 'Test Cross-compiled MacOS Build with ARM64'
+    env:
+      AZCOPY_TELEMETRY_CONNECTION_STRING: $(AZCOPY_TELEMETRY_CONNECTION_STRING_PROD)
 
   - script: |
       darwin_amd_dir="$(System.DefaultWorkingDirectory)/azcopy_darwin_amd64_$(azcopy_version)"

--- a/azurePipelineTemplates/build_windows.yml
+++ b/azurePipelineTemplates/build_windows.yml
@@ -15,25 +15,29 @@ steps:
     displayName: 'Create resource.syso files'
 
   - script: |
-      go build -o "$(binaries)\azcopy_windows_amd64.exe"
+      echo %AZCOPY_TELEMETRY_CONNECTION_STRING% | findstr /B /C:"InstrumentationKey=" >nul || (echo AZCOPY_TELEMETRY_CONNECTION_STRING_PROD must be configured as a secret pipeline variable && exit /b 1)
+      go build -ldflags "-X github.com/Azure/azure-storage-azcopy/v10/azcopy.telemetryConnectionString=%AZCOPY_TELEMETRY_CONNECTION_STRING%" -o "$(binaries)\azcopy_windows_amd64.exe"
     displayName: 'Generate Windows AMD64'
     env:
       GOARCH: amd64
       GOOS: windows
       CGO_ENABLED: 0
+      AZCOPY_TELEMETRY_CONNECTION_STRING: $(AZCOPY_TELEMETRY_CONNECTION_STRING_PROD)
 
   - script: |
-      go build -o "$(binaries)\azcopy_windows_386.exe"
+      go build -ldflags "-X github.com/Azure/azure-storage-azcopy/v10/azcopy.telemetryConnectionString=%AZCOPY_TELEMETRY_CONNECTION_STRING%" -o "$(binaries)\azcopy_windows_386.exe"
     displayName: 'Generate Windows i386'
     env:
       GOARCH: 386
       GOOS: windows
       CGO_ENABLED: 0
+      AZCOPY_TELEMETRY_CONNECTION_STRING: $(AZCOPY_TELEMETRY_CONNECTION_STRING_PROD)
 
   - script: |
-      go build -o "$(binaries)\azcopy_windows_arm64.exe"
+      go build -ldflags "-X github.com/Azure/azure-storage-azcopy/v10/azcopy.telemetryConnectionString=%AZCOPY_TELEMETRY_CONNECTION_STRING%" -o "$(binaries)\azcopy_windows_arm64.exe"
     displayName: 'Generate Windows ARM'
     env:
       GOARCH: arm64
       GOOS: windows
       CGO_ENABLED: 0
+      AZCOPY_TELEMETRY_CONNECTION_STRING: $(AZCOPY_TELEMETRY_CONNECTION_STRING_PROD)

--- a/azurePipelineTemplates/run-e2e.yml
+++ b/azurePipelineTemplates/run-e2e.yml
@@ -72,12 +72,12 @@ jobs:
             if (-Not (Test-Path -Path "./$(coverageDir)")) {
               New-Item -Path "./$(coverageDir)" -ItemType Directory
             }
-            
+
             # Create log directory
             if (-Not (Test-Path -Path "${env:AZCOPY_E2E_LOG_OUTPUT}")) {
               New-Item -Path "${env:AZCOPY_E2E_LOG_OUTPUT}" -ItemType Directory
             }
-            
+
             # Set platform-specific variables
             $tags = ""
             $suffix = ""
@@ -92,7 +92,56 @@ jobs:
               Write-Error "Unsupported operating system"
               exit 1
             }
-            
+
+            $telemetryResourceSettings = @{
+              SubscriptionId = $env:AZCOPY_TELEMETRY_SUBSCRIPTION_ID
+              ResourceGroup = $env:AZCOPY_TELEMETRY_RESOURCE_GROUP
+              AppName = $env:AZCOPY_TELEMETRY_APP_NAME
+            }
+            foreach ($setting in $telemetryResourceSettings.GetEnumerator()) {
+              if ([string]::IsNullOrWhiteSpace($setting.Value) -or $setting.Value.StartsWith('$(')) {
+                throw "The E2E telemetry $($setting.Key) pipeline setting is not configured"
+              }
+            }
+
+            az account set --subscription $telemetryResourceSettings.SubscriptionId
+            if ($LASTEXITCODE -ne 0) {
+              throw "Failed to select the E2E telemetry subscription"
+            }
+
+            $appInsights = az resource show `
+              --resource-group $telemetryResourceSettings.ResourceGroup `
+              --name $telemetryResourceSettings.AppName `
+              --resource-type 'Microsoft.Insights/components' `
+              --api-version '2020-02-02' | ConvertFrom-Json
+            if ($LASTEXITCODE -ne 0 -or $null -eq $appInsights) {
+              throw "Failed to retrieve the E2E Application Insights component"
+            }
+            if ($appInsights.tags.environment -ne 'test') {
+              throw "The configured Application Insights component is not tagged as the test environment"
+            }
+
+            $workspace = az resource show `
+              --ids $appInsights.properties.WorkspaceResourceId `
+              --api-version '2023-09-01' | ConvertFrom-Json
+            if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($workspace.properties.customerId)) {
+              throw "Failed to retrieve the E2E Log Analytics workspace customer ID"
+            }
+
+            $env:AZCOPY_TELEMETRY_CONNECTION_STRING = $appInsights.properties.ConnectionString
+            $env:NEW_E2E_APP_INSIGHTS_WORKSPACE_ID = $workspace.properties.customerId
+            $env:AZCOPY_E2E_TELEMETRY_RUN_ID = "$env:BUILD_BUILDID-$env:SYSTEM_JOBID"
+
+            if ([string]::IsNullOrWhiteSpace($env:AZCOPY_TELEMETRY_CONNECTION_STRING) -or
+                -not $env:AZCOPY_TELEMETRY_CONNECTION_STRING.StartsWith("InstrumentationKey=")) {
+              throw "The E2E Application Insights component returned an invalid connection string"
+            }
+
+            az account set --subscription $env:NEW_E2E_SUBSCRIPTION_ID
+            if ($LASTEXITCODE -ne 0) {
+              throw "Failed to restore the E2E test subscription"
+            }
+
             # Build the Go program
             Write-Output "Building executable"
             # Normally, `go build` has no effect when `go test` is used to run unit tests,
@@ -102,37 +151,37 @@ jobs:
             } else {
               go build -cover -o "$(build_name)"
             }
-            
+
             # Az PS login
             Connect-AzAccount -FederatedToken $env:idToken -Tenant $env:tenantId -ApplicationId $env:servicePrincipalId
             $null = Get-AzAccessToken -AsSecureString
-            
+
             # Run tests, write coverage data to a directory, and pipe output to a file
             Write-Output "Running tests. Writing coverage data to `"$(coverageDir)`" directory and test results to $(testReportName).txt."
             go test -timeout=3h -v ${{ parameters.test_cli_param }} ./e2etest | Tee-Object -FilePath "$(testReportName).txt"
-            
+
             # Save the exit code from the previous command
             $exitCode = $LASTEXITCODE
-            
+
             # Print the test results from the file
             # Get-Content "$(testReportName).txt"
 
             # Generate the jUnit report
             Write-Output "Generating jUnit report $(testReportName).xml"
             Get-Content "$(testReportName).txt" | & "$(go env GOPATH)/bin/go-junit-report" > "$(testReportName).xml"
-            
+
             # Convert coverage data to text format
             Write-Output "Generating plain-text coverage report $(coverageReportName).txt"
             go tool covdata textfmt -i="$(coverageDir)" -o "$(coverageReportName).txt"
-            
+
             # Convert coverage data to JSON format
             Write-Output "Generating JSON coverage report $(coverageReportName).json"
             & "$(go env GOPATH)/bin/gocov$suffix" convert "$(coverageReportName).txt" > "$(coverageReportName).json"
-            
+
             # Convert coverage data to XML format
             Write-Output "Generating XML coverage report $(coverageReportName).xml"
             Get-Content "$(coverageReportName).json" | & "$(go env GOPATH)/bin/gocov-xml$suffix" > "$(coverageReportName).xml"
-            
+
             # Return the exit code from above
             exit $exitCode
         env:
@@ -156,6 +205,9 @@ jobs:
           NEW_E2E_SUBSCRIPTION_ID: $(AZCOPY_NEW_E2E_SUBSCRIPTION_ID)
           NEW_E2E_AZCOPY_PATH: $(System.DefaultWorkingDirectory)/$(build_name)
           NEW_E2E_ENVIRONMENT: "AzurePipeline"
+          AZCOPY_TELEMETRY_SUBSCRIPTION_ID: $(AZCOPY_TELEMETRY_SUBSCRIPTION_ID_TEST)
+          AZCOPY_TELEMETRY_RESOURCE_GROUP: $(AZCOPY_TELEMETRY_RESOURCE_GROUP_TEST)
+          AZCOPY_TELEMETRY_APP_NAME: $(AZCOPY_TELEMETRY_APP_NAME_TEST)
         displayName: 'Run Tests with Workload Identity'
 
       - task: PublishBuildArtifacts@1

--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -21,11 +21,14 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
+	"os/signal"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake"
@@ -99,7 +102,7 @@ func ParseSizeString(s string, name string) (int64, error) {
 // raw benchmark args cook into copyArgs, because the actual work
 // of a benchmark job is doing a copy. Benchmark just doesn't offer so many
 // choices in its raw args
-func (raw rawBenchmarkCmdArgs) cook() (CookedCopyCmdArgs, error) {
+func (raw rawBenchmarkCmdArgs) cook(cmd *cobra.Command) (CookedCopyCmdArgs, error) {
 
 	glcm.Info(common.BenchmarkPreviewNotice)
 
@@ -161,6 +164,18 @@ func (raw rawBenchmarkCmdArgs) cook() (CookedCopyCmdArgs, error) {
 	if err != nil {
 		return cooked, err
 	}
+	copyOptions, err := c.toCopyOptions(cmd)
+	if err != nil {
+		return cooked, err
+	}
+	copyOptions.SetBenchmarkTelemetry(
+		strings.ToLower(benchMode.String()),
+		int64(raw.fileCount),
+		bytesPerFile,
+		int64(raw.numOfFolders),
+		raw.deleteTestData && !downloadMode,
+		false)
+	cooked.benchmarkCopyOptions = &copyOptions
 
 	if downloadMode {
 		glcm.Info(fmt.Sprintf("Benchmarking downloads from %s.", cooked.Source.Value))
@@ -272,17 +287,49 @@ func init() {
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			var cooked CookedCopyCmdArgs // benchmark args cook into copy args
-			cooked, err := raw.cook()
+			cooked, err := raw.cook(cmd)
 			if err != nil {
 				glcm.Error("failed to parse user input due to error: " + err.Error())
 			}
 
 			glcm.Info("Scanning...")
 
-			cooked.commandString = ConstructCommandStringFromArgs()
-			err = cooked.process()
+			source, sourceErr := cooked.Source.String()
+			if sourceErr != nil {
+				glcm.Error("failed to parse benchmark source due to error: " + sourceErr.Error())
+			}
+			destination, destinationErr := cooked.Destination.String()
+			if destinationErr != nil {
+				glcm.Error("failed to parse benchmark destination due to error: " + destinationErr.Error())
+			}
+			options := *cooked.benchmarkCopyOptions
+			options.Handler = cliCopyHandler{isBenchmark: true, hasFollowup: cooked.hasFollowup()}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go func() {
+				sigChan := make(chan os.Signal, 1)
+				signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+				select {
+				case <-sigChan:
+				case <-glcm.CancelFromStdinChannel():
+				}
+				glcm.Info("Cancellation requested")
+				cancel()
+			}()
+
+			result, copyErr := Client.Copy(ctx, source, destination, options)
+			exitCode := EExitCode.Success()
+			if result.TransfersFailed > 0 || result.JobStatus == common.EJobStatus.Cancelled() || result.JobStatus == common.EJobStatus.Cancelling() {
+				exitCode = EExitCode.Error()
+			}
+			err = copyErr
 			if err != nil {
+				exitCode = EExitCode.Error()
 				glcm.Error("failed to perform benchmark command due to error: " + err.Error())
+			}
+			if cooked.hasFollowup() {
+				cooked.launchFollowup(exitCode)
 			}
 
 			glcm.SurrenderControl()

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -325,6 +325,7 @@ func (raw *rawCopyCmdArgs) toCopyOptions(cmd *cobra.Command) (opts azcopy.CopyOp
 		raw.dryrun, dryrunNewCopyJobPartOrder,
 		raw.deleteDestinationFileIfNecessary,
 		ConstructCommandStringFromArgs())
+	opts.SetTelemetryOptions(telemetryOptions(cmd))
 	return opts, nil
 }
 
@@ -739,10 +740,11 @@ type CookedCopyCmdArgs struct {
 
 	// followup/cleanup properties are NOT available on resume, and so should not be used for jobs that may be resumed
 	// TODO: consider find a way to enforce that, or else to allow them to be preserved. Initially, they are just for benchmark jobs, so not a problem immediately because those jobs can't be resumed, by design.
-	followupJobArgs   *CookedCopyCmdArgs
-	priorJobExitCode  *ExitCode
-	isCleanupJob      bool // triggers abbreviated status reporting, since we don't want full reporting for cleanup jobs
-	cleanupJobMessage string
+	followupJobArgs      *CookedCopyCmdArgs
+	priorJobExitCode     *ExitCode
+	isCleanupJob         bool // triggers abbreviated status reporting, since we don't want full reporting for cleanup jobs
+	cleanupJobMessage    string
+	benchmarkCopyOptions *azcopy.CopyOptions
 
 	// whether to include blobs that have metadata 'hdi_isfolder = true'
 	IncludeDirectoryStubs bool
@@ -1283,6 +1285,8 @@ func isStdinPipeIn() (bool, error) {
 var cpCmd *cobra.Command
 
 type cliCopyHandler struct {
+	isBenchmark bool
+	hasFollowup bool
 }
 
 func (c cliCopyHandler) OnStart(ctx azcopy.JobContext) {
@@ -1297,7 +1301,7 @@ func (c cliCopyHandler) OnTransferProgress(progress azcopy.CopyProgress) {
 			common.PanicIfErr(err)
 			return string(jsonOutput)
 		} else {
-			return azcopy.GetCopyProgress(progress, false)
+			return azcopy.GetCopyProgress(progress, c.isBenchmark)
 		}
 	}
 
@@ -1316,11 +1320,14 @@ func (c cliCopyHandler) OnComplete(result azcopy.CopyResult) {
 			common.PanicIfErr(err)
 			return string(jsonOutput)
 		} else {
-			return azcopy.GetCopyResult(result, false)
+			return azcopy.GetCopyResult(result, c.isBenchmark)
 		}
 	}
-
-	glcm.Exit(builder, exitCode)
+	if c.hasFollowup {
+		glcm.Exit(builder, EExitCode.NoExit())
+	} else {
+		glcm.Exit(builder, exitCode)
+	}
 }
 
 // TODO check file size, max is 4.75TB

--- a/cmd/jobsResume.go
+++ b/cmd/jobsResume.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/Azure/azure-storage-azcopy/v10/azcopy"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/Azure/azure-storage-azcopy/v10/telemetry"
 	"github.com/spf13/cobra"
 )
 
@@ -61,6 +62,7 @@ func init() {
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+			commandLineArgs.telemetryOptions = telemetryOptions(cmd)
 			includeTransfer := parseTransfers(commandLineArgs.includeTransfer)
 			excludeTransfer := parseTransfers(commandLineArgs.excludeTransfer)
 			if len(includeTransfer) > 0 || len(excludeTransfer) > 0 {
@@ -89,8 +91,9 @@ type resumeCmdArgs struct {
 	includeTransfer string
 	excludeTransfer string
 
-	SourceSAS      string
-	DestinationSAS string
+	SourceSAS        string
+	DestinationSAS   string
+	telemetryOptions telemetry.OptionAttributes
 }
 
 // processes the resume command,
@@ -108,6 +111,7 @@ func (rca resumeCmdArgs) process() error {
 		DestinationSAS: rca.DestinationSAS,
 		Handler:        cliResumeHandler{},
 	}
+	resumeOptions.SetTelemetryOptions(rca.telemetryOptions)
 	// Create a context that can be cancelled by Ctrl-C
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,6 +35,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/pprof"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -42,7 +44,9 @@ import (
 
 	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-azcopy/v10/ste"
+	"github.com/Azure/azure-storage-azcopy/v10/telemetry"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var outputFormatRaw string
@@ -54,6 +58,8 @@ var OutputLevel OutputVerbosity
 var LogLevel common.LogLevel
 var CapMbps float64
 var SkipVersionCheck bool
+var disableTelemetry bool
+var telemetrySamplingRate float64
 
 var TrustedSuffixes string
 var azcopyAwaitContinue bool
@@ -62,6 +68,306 @@ var isPipeDownload bool
 var retryStatusCodes string
 var debugMemoryProfile string
 var checkAzCopyUpdates bool
+
+var commandsWithJobAttemptTelemetry = map[string]struct{}{
+	"bench":       {},
+	"copy":        {},
+	"jobs.resume": {},
+	"sync":        {},
+}
+
+var commandsExcludedFromTelemetry = map[string]struct{}{
+	"__complete":       {},
+	"__completeNoDesc": {},
+	"completion":       {},
+	"doc":              {},
+	"env":              {},
+	"help":             {},
+	"load.clfs":        {},
+}
+
+// telemetryFlagAllowlist contains reviewed flag names whose presence is safe
+// to report. Values are never read. Unknown flags are excluded until reviewed.
+var telemetryFlagAllowlist = map[string]struct{}{
+	"as-subdir": {}, "backup": {}, "blob-tags": {}, "blob-type": {}, "block-blob-tier": {},
+	"block-size-mb": {}, "cache-control": {}, "cancel-from-stdin": {}, "cap-mbps": {},
+	"check-length": {}, "check-md5": {}, "check-version": {}, "compare-hash": {},
+	"content-disposition": {}, "content-encoding": {}, "content-language": {}, "content-type": {},
+	"cpk-by-name": {}, "cpk-by-value": {}, "decompress": {}, "delete-destination": {},
+	"delete-destination-file": {}, "delete-snapshots": {}, "delete-test-data": {}, "disable-auto-decoding": {},
+	"disable-telemetry": {}, "dry-run": {}, "endpoint": {}, "exclude": {},
+	"exclude-attributes": {}, "exclude-blob-type": {}, "exclude-container": {}, "exclude-path": {},
+	"exclude-pattern": {}, "exclude-regex": {}, "file-count": {}, "flush-threshold": {},
+	"follow-symlinks": {}, "force-if-read-only": {}, "format": {}, "from-to": {}, "hardlinks": {},
+	"identity": {}, "ignore-error-if-completed": {}, "include": {}, "include-after": {},
+	"include-attributes": {}, "include-before": {},
+	"include-directory-stub": {}, "include-path": {}, "include-pattern": {}, "include-regex": {},
+	"include-root": {}, "local-hash-storage-mode": {}, "location": {}, "log-level": {},
+	"login-type": {}, "machine-readable": {}, "mega-units": {}, "metadata": {},
+	"method": {}, "mirror-mode": {}, "mode": {}, "no-guess-mime-type": {},
+	"number-of-folders": {}, "output-level": {}, "output-type": {}, "overwrite": {},
+	"page-blob-tier": {}, "permanent-delete": {}, "posix-properties-style": {},
+	"preserve-info": {}, "preserve-last-modified-time": {}, "preserve-owner": {}, "preserve-permissions": {},
+	"preserve-posix-properties": {}, "preserve-smb-info": {}, "preserve-smb-permissions": {},
+	"preserve-symlinks": {}, "properties": {},
+	"put-blob-size-mb": {}, "put-md5": {}, "quota-gb": {}, "recursive": {},
+	"rehydrate-priority": {}, "request-priority": {}, "retry-status-codes": {}, "running-tally": {},
+	"s2s-detect-source-changed": {}, "s2s-get-properties-in-backend": {},
+	"s2s-handle-invalid-metadata": {}, "s2s-preserve-access-tier": {},
+	"s2s-preserve-blob-tags": {}, "s2s-preserve-properties": {}, "service-principal": {},
+	"size-per-file": {}, "skip-version-check": {}, "telemetry-sampling-rate": {}, "tenant": {}, "trailing-dot": {},
+	"with-status": {},
+}
+
+var telemetryFlagDenylist = map[string]struct{}{
+	"aad-endpoint":               {},
+	"application-id":             {},
+	"await-continue":             {},
+	"await-open":                 {},
+	"certificate-path":           {},
+	"debug-skip-files":           {},
+	"destination-sas":            {},
+	"hash-meta-dir":              {},
+	"help":                       {},
+	"identity-client-id":         {},
+	"identity-object-id":         {},
+	"identity-resource-id":       {},
+	"list-of-files":              {},
+	"list-of-versions":           {},
+	"memory-profile":             {},
+	"output-location":            {},
+	"show-sensitive":             {},
+	"source-sas":                 {},
+	"tenant-id":                  {},
+	"trusted-microsoft-suffixes": {},
+}
+
+type telemetryValuePolicy struct {
+	property  string
+	normalize func(string) (string, bool)
+}
+
+var telemetryFlagValuePolicies = map[string]telemetryValuePolicy{
+	"as-subdir":                     {"OptAsSubdir", normalizeTelemetryBool},
+	"backup":                        {"OptBackup", normalizeTelemetryBool},
+	"blob-type":                     {"OptBlobType", normalizeTelemetryCategory},
+	"block-blob-tier":               {"OptBlockBlobTier", normalizeTelemetryCategory},
+	"block-size-mb":                 {"OptBlockSizeMB", normalizeTelemetryFloat},
+	"cap-mbps":                      {"OptCapMbps", normalizeTelemetryFloat},
+	"check-length":                  {"OptCheckLength", normalizeTelemetryBool},
+	"check-md5":                     {"OptCheckMD5", normalizeTelemetryCategory},
+	"compare-hash":                  {"OptCompareHash", normalizeTelemetryCategory},
+	"decompress":                    {"OptDecompress", normalizeTelemetryBool},
+	"delete-destination":            {"OptDeleteDestination", normalizeTelemetryCategory},
+	"delete-destination-file":       {"OptDeleteDestinationFile", normalizeTelemetryBool},
+	"delete-snapshots":              {"OptDeleteSnapshots", normalizeTelemetryCategory},
+	"delete-test-data":              {"OptBenchmarkDeleteTestData", normalizeTelemetryBool},
+	"disable-auto-decoding":         {"OptDisableAutoDecoding", normalizeTelemetryBool},
+	"dry-run":                       {"OptDryRun", normalizeTelemetryBool},
+	"exclude-blob-type":             {"OptExcludeBlobTypes", normalizeTelemetryCategoryList},
+	"file-count":                    {"OptBenchmarkFileCount", normalizeTelemetryInt},
+	"follow-symlinks":               {"OptFollowSymlinks", normalizeTelemetryBool},
+	"force-if-read-only":            {"OptForceIfReadOnly", normalizeTelemetryBool},
+	"from-to":                       {"OptFromTo", normalizeTelemetryCategory},
+	"hardlinks":                     {"OptHardlinks", normalizeTelemetryCategory},
+	"include-directory-stub":        {"OptIncludeDirectoryStub", normalizeTelemetryBool},
+	"include-root":                  {"OptIncludeRoot", normalizeTelemetryBool},
+	"local-hash-storage-mode":       {"OptLocalHashStorageMode", normalizeTelemetryCategory},
+	"login-type":                    {"OptLoginType", normalizeTelemetryCategory},
+	"mirror-mode":                   {"OptMirrorMode", normalizeTelemetryBool},
+	"mode":                          {"OptBenchmarkMode", normalizeTelemetryCategory},
+	"no-guess-mime-type":            {"OptNoGuessMimeType", normalizeTelemetryBool},
+	"number-of-folders":             {"OptBenchmarkFolderCount", normalizeTelemetryInt},
+	"overwrite":                     {"OptOverwrite", normalizeTelemetryCategory},
+	"page-blob-tier":                {"OptPageBlobTier", normalizeTelemetryCategory},
+	"permanent-delete":              {"OptPermanentDelete", normalizeTelemetryCategory},
+	"posix-properties-style":        {"OptPosixPropertiesStyle", normalizeTelemetryCategory},
+	"preserve-info":                 {"OptPreserveInfo", normalizeTelemetryBool},
+	"preserve-last-modified-time":   {"OptPreserveLastModifiedTime", normalizeTelemetryBool},
+	"preserve-owner":                {"OptPreserveOwner", normalizeTelemetryBool},
+	"preserve-permissions":          {"OptPreservePermissions", normalizeTelemetryBool},
+	"preserve-posix-properties":     {"OptPreservePosixProperties", normalizeTelemetryBool},
+	"preserve-smb-info":             {"OptPreserveSMBInfo", normalizeTelemetryBool},
+	"preserve-smb-permissions":      {"OptPreserveSMBPermissions", normalizeTelemetryBool},
+	"preserve-symlinks":             {"OptPreserveSymlinks", normalizeTelemetryBool},
+	"put-blob-size-mb":              {"OptPutBlobSizeMB", normalizeTelemetryFloat},
+	"put-md5":                       {"OptPutMD5", normalizeTelemetryBool},
+	"quota-gb":                      {"OptQuotaGB", normalizeTelemetryInt},
+	"recursive":                     {"OptRecursive", normalizeTelemetryBool},
+	"rehydrate-priority":            {"OptRehydratePriority", normalizeTelemetryCategory},
+	"request-priority":              {"OptRequestPriority", normalizeTelemetryInt},
+	"s2s-detect-source-changed":     {"OptS2SDetectSourceChanged", normalizeTelemetryBool},
+	"s2s-get-properties-in-backend": {"OptS2SGetPropertiesInBackend", normalizeTelemetryBool},
+	"s2s-handle-invalid-metadata":   {"OptS2SHandleInvalidMetadata", normalizeTelemetryCategory},
+	"s2s-preserve-access-tier":      {"OptS2SPreserveAccessTier", normalizeTelemetryBool},
+	"s2s-preserve-blob-tags":        {"OptS2SPreserveBlobTags", normalizeTelemetryBool},
+	"s2s-preserve-properties":       {"OptS2SPreserveProperties", normalizeTelemetryBool},
+	"service-principal":             {"OptServicePrincipal", normalizeTelemetryBool},
+	"size-per-file":                 {"OptBenchmarkFileSizeBytes", normalizeTelemetrySize},
+	"skip-version-check":            {"OptSkipVersionCheck", normalizeTelemetryBool},
+	"trailing-dot":                  {"OptTrailingDot", normalizeTelemetryCategory},
+}
+
+type telemetryEnvironmentPolicy struct {
+	environment common.EnvironmentVariable
+	value       telemetryValuePolicy
+}
+
+var telemetryEnvironmentPolicies = []telemetryEnvironmentPolicy{
+	{common.EEnvironmentVariable.ConcurrencyValue(), telemetryValuePolicy{"OptConcurrency", normalizeTelemetryConcurrency}},
+	{common.EEnvironmentVariable.TransferInitiationPoolSize(), telemetryValuePolicy{"OptConcurrentFiles", normalizeTelemetryInt}},
+	{common.EEnvironmentVariable.EnumerationPoolSize(), telemetryValuePolicy{"OptConcurrentScan", normalizeTelemetryInt}},
+	{common.EEnvironmentVariable.BufferGB(), telemetryValuePolicy{"OptBufferGB", normalizeTelemetryFloat}},
+	{common.EEnvironmentVariable.ParallelStatFiles(), telemetryValuePolicy{"OptParallelStatFiles", normalizeTelemetryBool}},
+	{common.EEnvironmentVariable.AutoTuneToCpu(), telemetryValuePolicy{"OptTuneToCPU", normalizeTelemetryBool}},
+	{common.EEnvironmentVariable.DisableHierarchicalScanning(), telemetryValuePolicy{"OptDisableHierarchicalScan", normalizeTelemetryBool}},
+	{common.EEnvironmentVariable.PacePageBlobs(), telemetryValuePolicy{"OptPacePageBlobs", normalizeTelemetryBool}},
+	{common.EEnvironmentVariable.RequestTryTimeout(), telemetryValuePolicy{"OptRequestTryTimeoutMinutes", normalizeTelemetryFloat}},
+	{common.EEnvironmentVariable.DownloadToTempPath(), telemetryValuePolicy{"OptDownloadToTempPath", normalizeTelemetryBool}},
+	{common.EEnvironmentVariable.OptimizeSparsePageBlobTransfers(), telemetryValuePolicy{"OptOptimizeSparsePageBlob", normalizeTelemetryBool}},
+	{common.EEnvironmentVariable.CacheProxyLookup(), telemetryValuePolicy{}},
+	{common.EEnvironmentVariable.DisableSyslog(), telemetryValuePolicy{}},
+	{common.EEnvironmentVariable.ShowPerfStates(), telemetryValuePolicy{}},
+}
+
+func normalizeTelemetryBool(value string) (string, bool) {
+	parsed, err := strconv.ParseBool(strings.TrimSpace(value))
+	if err != nil {
+		return "", false
+	}
+	return strconv.FormatBool(parsed), true
+}
+
+func normalizeTelemetryInt(value string) (string, bool) {
+	parsed, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+	if err != nil || parsed < 0 {
+		return "", false
+	}
+	return strconv.FormatInt(parsed, 10), true
+}
+
+func normalizeTelemetryFloat(value string) (string, bool) {
+	parsed, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+	if err != nil || parsed < 0 {
+		return "", false
+	}
+	return strconv.FormatFloat(parsed, 'f', -1, 64), true
+}
+
+func normalizeTelemetryCategory(value string) (string, bool) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" || len(trimmed) > 128 {
+		return "", false
+	}
+	return strings.ToLower(trimmed), true
+}
+
+func normalizeTelemetryCategoryList(value string) (string, bool) {
+	parts := strings.FieldsFunc(value, func(r rune) bool { return r == ';' || r == ',' })
+	if len(parts) == 0 || len(parts) > 16 {
+		return "", false
+	}
+	for index := range parts {
+		parts[index] = strings.ToLower(strings.TrimSpace(parts[index]))
+		if parts[index] == "" || len(parts[index]) > 64 {
+			return "", false
+		}
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ","), true
+}
+
+func normalizeTelemetrySize(value string) (string, bool) {
+	bytes, err := ParseSizeString(strings.TrimSpace(value), common.SizePerFileParam)
+	if err != nil || bytes < 0 {
+		return "", false
+	}
+	return strconv.FormatInt(bytes, 10), true
+}
+
+func normalizeTelemetryConcurrency(value string) (string, bool) {
+	if strings.EqualFold(strings.TrimSpace(value), "AUTO") {
+		return "auto", true
+	}
+	return normalizeTelemetryInt(value)
+}
+
+func commandTelemetryName(cmd *cobra.Command) string {
+	if cmd == nil {
+		return ""
+	}
+
+	pathParts := strings.Fields(cmd.CommandPath())
+	if len(pathParts) <= 1 {
+		return ""
+	}
+	return strings.Join(pathParts[1:], ".")
+}
+
+func commandUsesJobAttemptTelemetry(command string) bool {
+	_, ok := commandsWithJobAttemptTelemetry[command]
+	return ok
+}
+
+func commandExcludedFromTelemetry(command string) bool {
+	_, ok := commandsExcludedFromTelemetry[command]
+	return ok
+}
+
+func telemetryOptions(cmd *cobra.Command) telemetry.OptionAttributes {
+	if cmd == nil {
+		return telemetry.OptionAttributes{}
+	}
+
+	seen := make(map[string]struct{})
+	values := make(map[string]string)
+	visit := func(flags *pflag.FlagSet) {
+		flags.Visit(func(flag *pflag.Flag) {
+			if _, allowed := telemetryFlagAllowlist[flag.Name]; allowed {
+				seen[flag.Name] = struct{}{}
+				if policy, capturesValue := telemetryFlagValuePolicies[flag.Name]; capturesValue {
+					if value, ok := policy.normalize(flag.Value.String()); ok {
+						values[policy.property] = value
+					}
+				}
+			}
+		})
+	}
+	visit(cmd.Flags())
+	for current := cmd; current != nil; current = current.Parent() {
+		visit(current.PersistentFlags())
+	}
+
+	flagsSet := make([]string, 0, len(seen))
+	for name := range seen {
+		flagsSet = append(flagsSet, name)
+	}
+	sort.Strings(flagsSet)
+
+	var envVarsSet []string
+	for _, policy := range telemetryEnvironmentPolicies {
+		raw, explicitlySet := os.LookupEnv(policy.environment.Name)
+		if !explicitlySet || strings.TrimSpace(raw) == "" {
+			continue
+		}
+		envVarsSet = append(envVarsSet, policy.environment.Name)
+		if policy.value.property != "" {
+			if value, ok := policy.value.normalize(raw); ok {
+				values[policy.value.property] = value
+			}
+		}
+	}
+	sort.Strings(envVarsSet)
+
+	if len(values) == 0 {
+		values = nil
+	}
+	return telemetry.OptionAttributes{
+		FlagsSet:   flagsSet,
+		EnvVarsSet: envVarsSet,
+		Values:     values,
+	}
+}
 
 // It would be preferable if this was a local variable, since it just gets altered and shot off to the STE
 var debugSkipFiles string
@@ -192,8 +498,18 @@ var rootCmd = &cobra.Command{
 				break
 			}
 		}
-		isMigratedToLibrary := cmd.Use == "resume [jobID]" || cmd.Use == "sync" || cmd.Use == "copy [source] [destination]"
-		return Initialize(isMigratedToLibrary, isBench, shouldWarn, resumeJobID)
+		isMigratedToLibrary := cmd.Use == "resume [jobID]" || cmd.Use == "sync" || cmd.Use == "copy [source] [destination]" || cmd.Use == "bench [destination]"
+		if err := Initialize(isMigratedToLibrary, isBench, shouldWarn, resumeJobID); err != nil {
+			return err
+		}
+		// Transfer job commands emit their own job-attempt start/finish events.
+		// Other product-operation leaves emit one command.invoked event using
+		// their canonical full command path; tooling-only commands are excluded.
+		command := commandTelemetryName(cmd)
+		if command != "" && !commandUsesJobAttemptTelemetry(command) && !commandExcludedFromTelemetry(command) {
+			azcopy.ReportCommandInvoked(command, Client.CurrentJobID.String(), telemetryOptions(cmd))
+		}
+		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Version checking is done explicitly when the user sets flag
@@ -216,7 +532,13 @@ func Initialize(isMigratedToLibrary, isBench, shouldWarn bool, resumeJobId commo
 	glcm.SetOutputFormat(outputFormat)
 	glcm.SetOutputVerbosity(OutputLevel)
 	jobsAdmin.BenchmarkResults = isBench
-	Client, err = azcopy.NewClient(azcopy.ClientOptions{CapMbps: CapMbps, TrustedSuffixes: TrustedSuffixes, LogLevel: &LogLevel})
+	Client, err = azcopy.NewClient(azcopy.ClientOptions{
+		CapMbps:               CapMbps,
+		TrustedSuffixes:       TrustedSuffixes,
+		LogLevel:              &LogLevel,
+		DisableTelemetry:      disableTelemetry,
+		TelemetrySamplingRate: &telemetrySamplingRate,
+	})
 	// Run MessagHandler to process messages from Input Watcher
 	if jobsAdmin.JobsAdmin != nil {
 		go jobsAdmin.JobsAdmin.MessageHandler(glcm.MsgHandlerChannel())
@@ -349,6 +671,13 @@ func init() {
 	_ = rootCmd.PersistentFlags().MarkHidden("memory-profile")
 	rootCmd.PersistentFlags().BoolVar(&checkAzCopyUpdates, "check-version", false,
 		"Check if a newer AzCopy version is available.")
+
+	rootCmd.PersistentFlags().BoolVar(&disableTelemetry, "disable-telemetry", false,
+		"Opt out of sending anonymous usage telemetry. Telemetry is enabled by default and contains no PII. "+
+			"\n It can also be disabled by setting the AZCOPY_DISABLE_TELEMETRY environment variable to 'true'.")
+	rootCmd.PersistentFlags().Float64Var(&telemetrySamplingRate, "telemetry-sampling-rate", 0.01,
+		"Diagnostic override for the fraction of job IDs included in anonymous telemetry, from 0.0 through 1.0.")
+	_ = rootCmd.PersistentFlags().MarkHidden("telemetry-sampling-rate")
 }
 
 // always spins up a new goroutine, because sometimes the aka.ms URL can't be reached (e.g. a constrained environment where

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,7 +59,6 @@ var LogLevel common.LogLevel
 var CapMbps float64
 var SkipVersionCheck bool
 var disableTelemetry bool
-var telemetrySamplingRate float64
 
 var TrustedSuffixes string
 var azcopyAwaitContinue bool
@@ -115,7 +114,7 @@ var telemetryFlagAllowlist = map[string]struct{}{
 	"s2s-detect-source-changed": {}, "s2s-get-properties-in-backend": {},
 	"s2s-handle-invalid-metadata": {}, "s2s-preserve-access-tier": {},
 	"s2s-preserve-blob-tags": {}, "s2s-preserve-properties": {}, "service-principal": {},
-	"size-per-file": {}, "skip-version-check": {}, "telemetry-sampling-rate": {}, "tenant": {}, "trailing-dot": {},
+	"size-per-file": {}, "skip-version-check": {}, "tenant": {}, "trailing-dot": {},
 	"with-status": {},
 }
 
@@ -476,6 +475,7 @@ var rootCmd = &cobra.Command{
 			}
 		}
 		isMigratedToLibrary := cmd.Use == "resume [jobID]" || cmd.Use == "sync" || cmd.Use == "copy [source] [destination]" || cmd.Use == "bench [destination]"
+		glcm.RegisterCloseFunc(azcopy.FlushTelemetry)
 		if err := Initialize(isMigratedToLibrary, isBench, shouldWarn, resumeJobID); err != nil {
 			return err
 		}
@@ -510,11 +510,10 @@ func Initialize(isMigratedToLibrary, isBench, shouldWarn bool, resumeJobId commo
 	glcm.SetOutputVerbosity(OutputLevel)
 	jobsAdmin.BenchmarkResults = isBench
 	Client, err = azcopy.NewClient(azcopy.ClientOptions{
-		CapMbps:               CapMbps,
-		TrustedSuffixes:       TrustedSuffixes,
-		LogLevel:              &LogLevel,
-		DisableTelemetry:      disableTelemetry,
-		TelemetrySamplingRate: &telemetrySamplingRate,
+		CapMbps:          CapMbps,
+		TrustedSuffixes:  TrustedSuffixes,
+		LogLevel:         &LogLevel,
+		DisableTelemetry: disableTelemetry,
 	})
 	// Run MessagHandler to process messages from Input Watcher
 	if jobsAdmin.JobsAdmin != nil {
@@ -652,9 +651,6 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&disableTelemetry, "disable-telemetry", false,
 		"Opt out of sending anonymous usage telemetry. Telemetry is enabled by default and contains no PII. "+
 			"\n It can also be disabled by setting the AZCOPY_DISABLE_TELEMETRY environment variable to 'true'.")
-	rootCmd.PersistentFlags().Float64Var(&telemetrySamplingRate, "telemetry-sampling-rate", 0.01,
-		"Diagnostic override for the fraction of job IDs included in anonymous telemetry, from 0.0 through 1.0.")
-	_ = rootCmd.PersistentFlags().MarkHidden("telemetry-sampling-rate")
 }
 
 // always spins up a new goroutine, because sometimes the aka.ms URL can't be reached (e.g. a constrained environment where

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -119,29 +119,6 @@ var telemetryFlagAllowlist = map[string]struct{}{
 	"with-status": {},
 }
 
-var telemetryFlagDenylist = map[string]struct{}{
-	"aad-endpoint":               {},
-	"application-id":             {},
-	"await-continue":             {},
-	"await-open":                 {},
-	"certificate-path":           {},
-	"debug-skip-files":           {},
-	"destination-sas":            {},
-	"hash-meta-dir":              {},
-	"help":                       {},
-	"identity-client-id":         {},
-	"identity-object-id":         {},
-	"identity-resource-id":       {},
-	"list-of-files":              {},
-	"list-of-versions":           {},
-	"memory-profile":             {},
-	"output-location":            {},
-	"show-sensitive":             {},
-	"source-sas":                 {},
-	"tenant-id":                  {},
-	"trusted-microsoft-suffixes": {},
-}
-
 type telemetryValuePolicy struct {
 	property  string
 	normalize func(string) (string, bool)

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -104,7 +104,7 @@ type rawSyncCmdArgs struct {
 	hashMetaDir  string
 }
 
-func (raw rawSyncCmdArgs) toOptions() (opts azcopy.SyncOptions, err error) {
+func (raw rawSyncCmdArgs) toOptions(cmd *cobra.Command) (opts azcopy.SyncOptions, err error) {
 	opts = azcopy.SyncOptions{
 		Handler:                 cliSyncHandler{},
 		Recursive:               to.Ptr(raw.recursive),
@@ -170,8 +170,9 @@ func (raw rawSyncCmdArgs) toOptions() (opts azcopy.SyncOptions, err error) {
 		return opts, err
 	}
 	// set internal only options
-	cmd := ConstructCommandStringFromArgs()
-	opts.SetInternalOptions(raw.dryrun, raw.deleteDestinationFileIfNecessary, cmd, dryrunNewCopyJobPartOrder, dryrunDelete)
+	commandString := ConstructCommandStringFromArgs()
+	opts.SetInternalOptions(raw.dryrun, raw.deleteDestinationFileIfNecessary, commandString, dryrunNewCopyJobPartOrder, dryrunDelete)
+	opts.SetTelemetryOptions(telemetryOptions(cmd))
 	return opts, nil
 }
 
@@ -305,7 +306,7 @@ func init() {
 			}
 
 			var opts azcopy.SyncOptions
-			if opts, err = raw.toOptions(); err != nil {
+			if opts, err = raw.toOptions(cmd); err != nil {
 				glcm.Error("error parsing the input given by the user. Failed with error " + err.Error() + getErrorCodeUrl(err))
 			}
 

--- a/cmd/telemetry_test.go
+++ b/cmd/telemetry_test.go
@@ -11,6 +11,29 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var telemetryFlagDenylist = map[string]struct{}{
+	"aad-endpoint":               {},
+	"application-id":             {},
+	"await-continue":             {},
+	"await-open":                 {},
+	"certificate-path":           {},
+	"debug-skip-files":           {},
+	"destination-sas":            {},
+	"hash-meta-dir":              {},
+	"help":                       {},
+	"identity-client-id":         {},
+	"identity-object-id":         {},
+	"identity-resource-id":       {},
+	"list-of-files":              {},
+	"list-of-versions":           {},
+	"memory-profile":             {},
+	"output-location":            {},
+	"show-sensitive":             {},
+	"source-sas":                 {},
+	"tenant-id":                  {},
+	"trusted-microsoft-suffixes": {},
+}
+
 func TestCommandTelemetryName(t *testing.T) {
 	root := &cobra.Command{Use: "azcopy"}
 	jobs := &cobra.Command{Use: "jobs"}

--- a/cmd/telemetry_test.go
+++ b/cmd/telemetry_test.go
@@ -1,0 +1,244 @@
+package cmd
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-storage-azcopy/v10/common"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommandTelemetryName(t *testing.T) {
+	root := &cobra.Command{Use: "azcopy"}
+	jobs := &cobra.Command{Use: "jobs"}
+	jobsList := &cobra.Command{Use: "list", Aliases: []string{"ls"}}
+	hiddenLoad := &cobra.Command{Use: "load", Hidden: true}
+	deprecatedCLFS := &cobra.Command{Use: "clfs", Hidden: true, Deprecated: "deprecated"}
+
+	root.AddCommand(jobs, hiddenLoad)
+	jobs.AddCommand(jobsList)
+	hiddenLoad.AddCommand(deprecatedCLFS)
+
+	assert.Equal(t, "jobs.list", commandTelemetryName(jobsList))
+	assert.Equal(t, "load.clfs", commandTelemetryName(deprecatedCLFS))
+	assert.Equal(t, "", commandTelemetryName(root))
+	assert.Equal(t, "", commandTelemetryName(nil))
+
+	resolved, _, err := root.Find([]string{"jobs", "ls"})
+	assert.NoError(t, err)
+	assert.Equal(t, "jobs.list", commandTelemetryName(resolved))
+}
+
+func TestCommandUsesJobAttemptTelemetry(t *testing.T) {
+	for _, command := range []string{"bench", "copy", "jobs.resume", "sync"} {
+		assert.True(t, commandUsesJobAttemptTelemetry(command), command)
+	}
+
+	for _, command := range []string{
+		"cancel",
+		"doc",
+		"env",
+		"jobs.clean",
+		"jobs.list",
+		"jobs.remove",
+		"jobs.show",
+		"list",
+		"load.clfs",
+		"login",
+		"login.status",
+		"logout",
+		"make",
+		"pause",
+		"remove",
+		"set-properties",
+	} {
+		assert.False(t, commandUsesJobAttemptTelemetry(command), command)
+	}
+}
+
+func TestCommandExcludedFromTelemetry(t *testing.T) {
+	for _, command := range []string{
+		"__complete",
+		"__completeNoDesc",
+		"completion",
+		"doc",
+		"env",
+		"help",
+		"load.clfs",
+	} {
+		assert.True(t, commandExcludedFromTelemetry(command), command)
+	}
+
+	for _, command := range []string{
+		"jobs.clean",
+		"jobs.list",
+		"jobs.remove",
+		"jobs.show",
+		"list",
+		"login",
+		"login.status",
+		"logout",
+		"make",
+		"remove",
+		"set-properties",
+	} {
+		assert.False(t, commandExcludedFromTelemetry(command), command)
+	}
+}
+
+func TestTelemetryOptions(t *testing.T) {
+	for _, policy := range telemetryEnvironmentPolicies {
+		t.Setenv(policy.environment.Name, "")
+	}
+	root := &cobra.Command{Use: "azcopy"}
+	copyCmd := &cobra.Command{Use: "copy"}
+	root.AddCommand(copyCmd)
+
+	root.PersistentFlags().String("output-type", "text", "")
+	copyCmd.Flags().Bool("recursive", false, "")
+	copyCmd.Flags().Bool("preserve-info", true, "")
+	copyCmd.Flags().Float64("block-size-mb", 0, "")
+	copyCmd.Flags().String("include-path", "", "")
+	copyCmd.Flags().String("tenant-id", "", "")
+	copyCmd.Flags().String("list-of-files", "", "")
+	copyCmd.Flags().String("future-unreviewed-flag", "", "")
+
+	assert.NoError(t, root.PersistentFlags().Set("output-type", "json"))
+	assert.NoError(t, copyCmd.Flags().Set("recursive", "true"))
+	assert.NoError(t, copyCmd.Flags().Set("preserve-info", "false"))
+	assert.NoError(t, copyCmd.Flags().Set("block-size-mb", "8.5"))
+	assert.NoError(t, copyCmd.Flags().Set("include-path", "secret/customer/path"))
+	assert.NoError(t, copyCmd.Flags().Set("tenant-id", "customer-tenant-id"))
+	assert.NoError(t, copyCmd.Flags().Set("list-of-files", "C:\\secret\\files.txt"))
+	assert.NoError(t, copyCmd.Flags().Set("future-unreviewed-flag", "future-secret"))
+
+	options := telemetryOptions(copyCmd)
+	assert.Equal(t, []string{"block-size-mb", "include-path", "output-type", "preserve-info", "recursive"}, options.FlagsSet)
+	assert.Equal(t, map[string]string{
+		"OptBlockSizeMB":  "8.5",
+		"OptPreserveInfo": "false",
+		"OptRecursive":    "true",
+	}, options.Values)
+	assert.Empty(t, options.EnvVarsSet)
+
+	serialized := strings.Join(options.FlagsSet, ",")
+	for key, value := range options.Values {
+		serialized += key + value
+	}
+	for _, secret := range []string{"customer-tenant-id", "secret/customer/path", "C:\\secret\\files.txt", "future-secret"} {
+		assert.NotContains(t, serialized, secret)
+	}
+}
+
+func TestTelemetryOptionsExplicitEnvironmentOverrides(t *testing.T) {
+	for _, policy := range telemetryEnvironmentPolicies {
+		t.Setenv(policy.environment.Name, "")
+	}
+	t.Setenv(common.EEnvironmentVariable.ConcurrencyValue().Name, "AUTO")
+	t.Setenv(common.EEnvironmentVariable.TransferInitiationPoolSize().Name, "48")
+	t.Setenv(common.EEnvironmentVariable.EnumerationPoolSize().Name, "32")
+	t.Setenv(common.EEnvironmentVariable.BufferGB().Name, "0.50")
+	t.Setenv(common.EEnvironmentVariable.ParallelStatFiles().Name, "false")
+	t.Setenv(common.EEnvironmentVariable.ShowPerfStates().Name, "1")
+
+	options := telemetryOptions(&cobra.Command{Use: "copy"})
+	assert.Equal(t, []string{
+		"AZCOPY_BUFFER_GB",
+		"AZCOPY_CONCURRENCY_VALUE",
+		"AZCOPY_CONCURRENT_FILES",
+		"AZCOPY_CONCURRENT_SCAN",
+		"AZCOPY_PARALLEL_STAT_FILES",
+		"AZCOPY_SHOW_PERF_STATES",
+	}, options.EnvVarsSet)
+	assert.Equal(t, map[string]string{
+		"OptBufferGB":          "0.5",
+		"OptConcurrency":       "auto",
+		"OptConcurrentFiles":   "48",
+		"OptConcurrentScan":    "32",
+		"OptParallelStatFiles": "false",
+	}, options.Values)
+}
+
+func TestTelemetryOptionsOmitDefaults(t *testing.T) {
+	for _, policy := range telemetryEnvironmentPolicies {
+		t.Setenv(policy.environment.Name, "")
+	}
+	command := &cobra.Command{Use: "copy"}
+	command.Flags().Bool("recursive", true, "")
+
+	options := telemetryOptions(command)
+	assert.Empty(t, options.FlagsSet)
+	assert.Empty(t, options.EnvVarsSet)
+	assert.Empty(t, options.Values)
+}
+
+func TestEveryRegisteredFlagHasTelemetryClassification(t *testing.T) {
+	var unclassified []string
+	var overlap []string
+	seen := make(map[string]struct{})
+
+	var inspectFlags func(*cobra.Command)
+	inspectFlags = func(command *cobra.Command) {
+		visit := func(flags *pflag.FlagSet) {
+			flags.VisitAll(func(flag *pflag.Flag) {
+				if _, alreadySeen := seen[flag.Name]; alreadySeen {
+					return
+				}
+				seen[flag.Name] = struct{}{}
+				_, allowed := telemetryFlagAllowlist[flag.Name]
+				_, denied := telemetryFlagDenylist[flag.Name]
+				switch {
+				case allowed && denied:
+					overlap = append(overlap, flag.Name)
+				case !allowed && !denied:
+					unclassified = append(unclassified, flag.Name)
+				}
+			})
+		}
+		visit(command.LocalNonPersistentFlags())
+		visit(command.PersistentFlags())
+		for _, child := range command.Commands() {
+			inspectFlags(child)
+		}
+	}
+
+	inspectFlags(rootCmd)
+	sort.Strings(unclassified)
+	sort.Strings(overlap)
+	assert.Empty(t, unclassified, "new flags must be explicitly allowed or denied")
+	assert.Empty(t, overlap, "flags cannot be both allowed and denied")
+}
+
+func TestTelemetryValuePoliciesAreReviewed(t *testing.T) {
+	for flag, policy := range telemetryFlagValuePolicies {
+		_, allowed := telemetryFlagAllowlist[flag]
+		_, denied := telemetryFlagDenylist[flag]
+		assert.True(t, allowed, flag)
+		assert.False(t, denied, flag)
+		assert.True(t, strings.HasPrefix(policy.property, "Opt"), policy.property)
+		assert.NotNil(t, policy.normalize, flag)
+	}
+
+	seenEnvironmentVariables := make(map[string]struct{})
+	seenProperties := make(map[string]struct{})
+	for _, policy := range telemetryEnvironmentPolicies {
+		name := policy.environment.Name
+		assert.NotEmpty(t, name)
+		_, duplicateName := seenEnvironmentVariables[name]
+		assert.False(t, duplicateName, name)
+		seenEnvironmentVariables[name] = struct{}{}
+
+		if policy.value.property == "" {
+			assert.Nil(t, policy.value.normalize, name)
+			continue
+		}
+		assert.True(t, strings.HasPrefix(policy.value.property, "Opt"), policy.value.property)
+		assert.NotNil(t, policy.value.normalize, name)
+		_, duplicateProperty := seenProperties[policy.value.property]
+		assert.False(t, duplicateProperty, policy.value.property)
+		seenProperties[policy.value.property] = struct{}{}
+	}
+}

--- a/cmd/zt_parseSize_test.go
+++ b/cmd/zt_parseSize_test.go
@@ -22,8 +22,11 @@ package cmd
 
 import (
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	chk "gopkg.in/check.v1"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 type parseSizeSuite struct{}
@@ -58,4 +61,30 @@ func TestParseSize(t *testing.T) {
 	_, err = ParseSizeString("abcK", "foo-bar") //codespell:ignore
 	a.Equal(expectedError, err.Error())
 
+}
+
+func TestBenchmarkCookAttachesCopyOptionsAndPreservesCleanup(t *testing.T) {
+	base := rawBenchmarkCmdArgs{
+		target:         "https://account.blob.core.windows.net/container",
+		sizePerFile:    "1M",
+		fileCount:      2,
+		deleteTestData: true,
+		numOfFolders:   1,
+		blobType:       "Detect",
+		checkLength:    true,
+	}
+
+	upload := base
+	upload.mode = "upload"
+	uploadCooked, err := upload.cook(&cobra.Command{})
+	require.NoError(t, err)
+	assert.NotNil(t, uploadCooked.benchmarkCopyOptions)
+	assert.True(t, uploadCooked.hasFollowup())
+
+	download := base
+	download.mode = "download"
+	downloadCooked, err := download.cook(&cobra.Command{})
+	require.NoError(t, err)
+	assert.NotNil(t, downloadCooked.benchmarkCopyOptions)
+	assert.False(t, downloadCooked.hasFollowup())
 }

--- a/cmd/zt_scenario_helpers_for_test.go
+++ b/cmd/zt_scenario_helpers_for_test.go
@@ -857,7 +857,7 @@ func (scenarioHelper) containerExists(containerClient *container.Client) bool {
 
 func runSyncAndVerify(a *assert.Assertions, raw rawSyncCmdArgs, mockTransfer func(common.CopyJobPartOrderRequest) common.CopyJobPartOrderResponse, mockDelete azcopy.ObjectDeleter, verifier func(err error)) {
 	// the simulated user input should parse properly
-	opts, err := raw.toOptions()
+	opts, err := raw.toOptions(&cobra.Command{})
 	a.Nil(err)
 	opts.SetInternalOptions(true, raw.deleteDestinationFileIfNecessary, "", mockTransfer, mockDelete)
 	// create the client if it is not already created

--- a/common/init.go
+++ b/common/init.go
@@ -9,13 +9,18 @@ import (
 var AzcopyJobPlanFolder string
 var LogPathFolder string
 
+// GetAzCopyAppPath returns the persistent directory for AzCopy application data.
+func GetAzCopyAppPath() string {
+	return getAzCopyAppPath()
+}
+
 func InitializeFolders() {
 	LogPathFolder = GetEnvironmentVariable(EEnvironmentVariable.LogLocation())           // user specified location for log files
 	AzcopyJobPlanFolder = GetEnvironmentVariable(EEnvironmentVariable.JobPlanLocation()) // user specified location for plan files
 
 	// note: azcopyAppPathFolder is the default location for all AzCopy data (logs, job plans, oauth token on Windows)
 	// but all the above can be put elsewhere as they can become very large
-	azcopyAppPathFolder := getAzCopyAppPath()
+	azcopyAppPathFolder := GetAzCopyAppPath()
 
 	// the user can optionally put the log files somewhere else
 	if LogPathFolder == "" {

--- a/common/rpc-models.go
+++ b/common/rpc-models.go
@@ -253,11 +253,13 @@ type ListJobSummaryResponse struct {
 	CompleteJobOrdered bool
 	JobStatus          JobStatus
 
-	TotalTransfers uint32 `json:",string"` // = FileTransfers + FolderPropertyTransfers. It also = TransfersCompleted + TransfersFailed + TransfersSkipped
-	// FileTransfers and FolderPropertyTransfers just break the total down into the two types.
-	// The name FolderPropertyTransfers is used to emphasize that it is only counting transferring the properties and existence of
+	TotalTransfers uint32 `json:",string"` // = payload-object transfers + folder-property transfers. It also = TransfersCompleted + TransfersFailed + TransfersSkipped when terminal.
+	// The type counters break scheduled transfers down into regular files/objects,
+	// folder properties, preserved symlinks, and converted hardlinks.
+	// The name FolderPropertyTransfers is used to emphasise that is is only counting transferring the properties and existence of
 	// folders. A "folder property transfer" does not include any files that may be in the folder. Those are counted as
-	// FileTransfers.
+	// FileTransfers. SymlinkTransfers and HardlinksConvertedCount are payload
+	// object transfers but are not included in FileTransfers.
 	FileTransfers           uint32 `json:",string"`
 	FolderPropertyTransfers uint32 `json:",string"`
 	SymlinkTransfers        uint32 `json:",string"`
@@ -269,15 +271,21 @@ type ListJobSummaryResponse struct {
 	FoldersSkipped     uint32 `json:",string"`
 	TransfersSkipped   uint32 `json:",string"`
 
-	// includes bytes sent in retries (i.e. has double counting, if there are retries) and in failed transfers
+	// Physical payload bytes observed by the transfer engine. Includes duplicate
+	// bytes sent/received during retries and bytes for transfers that later fail.
 	BytesOverWire uint64 `json:",string"`
 
-	// does not include failed transfers or bytes sent in retries (i.e. no double counting). Includes successful transfers and transfers in progress
+	// Logical payload bytes successfully transferred, plus successfully processed
+	// bytes in currently active transfers for live progress. Excludes failed
+	// transfers and does not double-count retry traffic.
 	TotalBytesTransferred uint64 `json:",string"`
 
-	// sum of the total transfer enumerated so far.
+	// Sum of source sizes for transfers added to job plans after filters and
+	// scheduling decisions. This is scheduled work, not every object scanned.
 	TotalBytesEnumerated uint64 `json:",string"`
-	// sum of total bytes expected in the job (i.e. based on our current expectation of which files will be successful)
+	// Current progress denominator. A live job initializes it from scheduled
+	// bytes; a summary reconstructed from plans excludes failed/skipped transfers.
+	// Consumers should interpret it together with job state and transfer counts.
 	TotalBytesExpected uint64 `json:",string"`
 
 	PercentComplete float32 `json:",string"`
@@ -285,10 +293,16 @@ type ListJobSummaryResponse struct {
 	// Stats measured from the network pipeline
 	// Values are all-time values, for the duration of the job.
 	// Will be zero if read outside the process running the job (e.g. with 'jobs show' command)
-	AverageIOPS            int     `json:",string"`
-	AverageE2EMilliseconds int     `json:",string"`
-	ServerBusyPercentage   float32 `json:",string"`
-	NetworkErrorPercentage float32 `json:",string"`
+	AverageIOPS               int     `json:",string"`
+	AverageE2EMilliseconds    int     `json:",string"`
+	ServerBusyPercentage      float32 `json:",string"`
+	NetworkErrorPercentage    float32 `json:",string"`
+	StorageHTTPAttemptCount   int64   `json:",string"`
+	NetworkErrorAttemptCount  int64   `json:",string"`
+	ServerBusy503Count        int64   `json:",string"`
+	ServerBusyThroughputCount int64   `json:",string"`
+	ServerBusyIOPSCount       int64   `json:",string"`
+	ServerBusyOtherCount      int64   `json:",string"`
 
 	FailedTransfers         []TransferDetail
 	SkippedTransfers        []TransferDetail

--- a/e2etest/newe2e_app_insights_validation.go
+++ b/e2etest/newe2e_app_insights_validation.go
@@ -1,0 +1,440 @@
+package e2etest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	appInsightsQueryEndpoint       = "https://api.loganalytics.azure.com/v1/workspaces"
+	appInsightsQueryRequestTimeout = 30 * time.Second
+	appInsightsPollInterval        = 15 * time.Second
+	appInsightsPollTimeout         = 5 * time.Minute
+	maxQueryErrorBodyBytes         = 8 * 1024
+)
+
+type appInsightsValidationState struct {
+	mu           sync.RWMutex
+	enabled      bool
+	workspaceID  string
+	runID        string
+	startedAt    time.Time
+	expectedJobs map[string]int
+}
+
+var globalAppInsightsValidation appInsightsValidationState
+
+func SetupAppInsightsTelemetryValidation(a Asserter) {
+	resetAppInsightsValidation()
+
+	config := GlobalConfig.AppInsightsValidationConfig
+	config.ConnectionString = strings.TrimSpace(config.ConnectionString)
+	config.WorkspaceID = strings.TrimSpace(config.WorkspaceID)
+	config.RunID = strings.TrimSpace(config.RunID)
+
+	enabled, err := validateAppInsightsValidationConfig(config)
+	if err != nil {
+		a.NoError("configure Application Insights validation", err)
+		return
+	}
+	if !enabled {
+		a.Log("Application Insights validation is disabled.")
+		return
+	}
+
+	globalAppInsightsValidation.mu.Lock()
+	globalAppInsightsValidation.enabled = true
+	globalAppInsightsValidation.workspaceID = config.WorkspaceID
+	globalAppInsightsValidation.runID = config.RunID
+	globalAppInsightsValidation.startedAt = time.Now().UTC()
+	globalAppInsightsValidation.expectedJobs = make(map[string]int)
+	globalAppInsightsValidation.mu.Unlock()
+
+	a.Log("Application Insights validation enabled for run %q.", config.RunID)
+}
+
+func validateAppInsightsValidationConfig(config AppInsightsValidationConfig) (bool, error) {
+	configuredValues := 0
+	for _, value := range []string{config.ConnectionString, config.WorkspaceID, config.RunID} {
+		if strings.TrimSpace(value) != "" {
+			configuredValues++
+		}
+	}
+	if configuredValues == 0 {
+		return false, nil
+	}
+	if configuredValues != 3 {
+		return false, errors.New(
+			"AZCOPY_TELEMETRY_CONNECTION_STRING, NEW_E2E_APP_INSIGHTS_WORKSPACE_ID, and AZCOPY_E2E_TELEMETRY_RUN_ID must all be set")
+	}
+	if !strings.Contains(strings.ToLower(config.ConnectionString), "instrumentationkey=") {
+		return false, errors.New(
+			"AZCOPY_TELEMETRY_CONNECTION_STRING is not a valid Application Insights connection string")
+	}
+	return true, nil
+}
+
+func resetAppInsightsValidation() {
+	globalAppInsightsValidation.mu.Lock()
+	globalAppInsightsValidation.enabled = false
+	globalAppInsightsValidation.workspaceID = ""
+	globalAppInsightsValidation.runID = ""
+	globalAppInsightsValidation.startedAt = time.Time{}
+	globalAppInsightsValidation.expectedJobs = nil
+	globalAppInsightsValidation.mu.Unlock()
+}
+
+func AppInsightsTelemetryValidationEnabled() bool {
+	globalAppInsightsValidation.mu.RLock()
+	defer globalAppInsightsValidation.mu.RUnlock()
+	return globalAppInsightsValidation.enabled
+}
+
+func RegisterExpectedAppInsightsJob(jobID string) {
+	jobID = strings.TrimSpace(jobID)
+	if jobID == "" {
+		return
+	}
+
+	globalAppInsightsValidation.mu.Lock()
+	defer globalAppInsightsValidation.mu.Unlock()
+	if globalAppInsightsValidation.enabled {
+		globalAppInsightsValidation.expectedJobs[jobID]++
+	}
+}
+
+func VerifyAppInsightsTelemetry(a Asserter) {
+	snapshot := snapshotAppInsightsValidation()
+	if !snapshot.enabled {
+		return
+	}
+	if len(snapshot.expectedJobs) == 0 {
+		a.NoError("verify Application Insights telemetry", errors.New(
+			"no AzCopy job IDs were collected during the E2E run"))
+		return
+	}
+
+	verifier := appInsightsVerifier{
+		queryClient: &logAnalyticsQueryClient{
+			tokens: PrimaryOAuthCache,
+			client: &http.Client{Timeout: appInsightsQueryRequestTimeout},
+		},
+		pollInterval: appInsightsPollInterval,
+		timeout:      appInsightsPollTimeout,
+	}
+	err := verifier.Verify(
+		context.Background(),
+		snapshot.workspaceID,
+		snapshot.runID,
+		snapshot.startedAt,
+		snapshot.expectedJobs,
+	)
+	a.NoError("verify Application Insights telemetry", err)
+}
+
+func snapshotAppInsightsValidation() appInsightsValidationState {
+	globalAppInsightsValidation.mu.RLock()
+	defer globalAppInsightsValidation.mu.RUnlock()
+
+	expectedJobs := make(map[string]int, len(globalAppInsightsValidation.expectedJobs))
+	for jobID, count := range globalAppInsightsValidation.expectedJobs {
+		expectedJobs[jobID] = count
+	}
+	return appInsightsValidationState{
+		enabled:      globalAppInsightsValidation.enabled,
+		workspaceID:  globalAppInsightsValidation.workspaceID,
+		runID:        globalAppInsightsValidation.runID,
+		startedAt:    globalAppInsightsValidation.startedAt,
+		expectedJobs: expectedJobs,
+	}
+}
+
+type finishedEventQueryClient interface {
+	QueryFinishedEventCounts(ctx context.Context, workspaceID, query string) (map[string]int, error)
+}
+
+type appInsightsVerifier struct {
+	queryClient  finishedEventQueryClient
+	pollInterval time.Duration
+	timeout      time.Duration
+}
+
+func (v appInsightsVerifier) Verify(
+	ctx context.Context,
+	workspaceID string,
+	runID string,
+	startedAt time.Time,
+	expected map[string]int,
+) error {
+	if v.queryClient == nil {
+		return errors.New("Application Insights query client is nil")
+	}
+	if v.pollInterval <= 0 || v.timeout <= 0 {
+		return errors.New("Application Insights polling interval and timeout must be positive")
+	}
+
+	query := buildFinishedEventQuery(runID, startedAt)
+	deadline := time.Now().Add(v.timeout)
+	var (
+		lastReceived map[string]int
+		lastErr      error
+	)
+
+	for {
+		received, err := v.queryClient.QueryFinishedEventCounts(ctx, workspaceID, query)
+		if err == nil {
+			lastReceived = received
+			missing := missingExpectedEvents(expected, received)
+			if len(missing) == 0 {
+				return nil
+			}
+		} else {
+			lastErr = err
+			if !isRetryableQueryError(err) {
+				return fmt.Errorf("query Application Insights telemetry: %w", err)
+			}
+		}
+
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			break
+		}
+		wait := v.pollInterval
+		if remaining < wait {
+			wait = remaining
+		}
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return fmt.Errorf("wait for Application Insights telemetry: %w", ctx.Err())
+		case <-timer.C:
+		}
+	}
+
+	missing := missingExpectedEvents(expected, lastReceived)
+	return fmt.Errorf(
+		"timed out after %s waiting for Application Insights telemetry for run %q; missing events: %s; last query error: %v; query:\n%s",
+		v.timeout,
+		runID,
+		formatMissingEvents(missing),
+		lastErr,
+		query,
+	)
+}
+
+func buildFinishedEventQuery(runID string, startedAt time.Time) string {
+	return fmt.Sprintf(`AppEvents
+| where TimeGenerated >= datetime(%s)
+| where Name == "azcopy.job.finished"
+| extend EventProperties = todynamic(Properties)
+| where tostring(EventProperties.E2ETestRunID) == "%s"
+| summarize ReceivedCount = count() by JobID = tostring(EventProperties.JobID)`,
+		startedAt.UTC().Format(time.RFC3339Nano),
+		escapeKQLString(runID),
+	)
+}
+
+func escapeKQLString(value string) string {
+	return strings.ReplaceAll(value, `"`, `\"`)
+}
+
+func missingExpectedEvents(expected, received map[string]int) map[string]int {
+	missing := make(map[string]int)
+	for jobID, expectedCount := range expected {
+		if receivedCount := received[jobID]; receivedCount < expectedCount {
+			missing[jobID] = expectedCount - receivedCount
+		}
+	}
+	return missing
+}
+
+func formatMissingEvents(missing map[string]int) string {
+	if len(missing) == 0 {
+		return "none"
+	}
+	jobIDs := make([]string, 0, len(missing))
+	for jobID := range missing {
+		jobIDs = append(jobIDs, jobID)
+	}
+	sort.Strings(jobIDs)
+
+	parts := make([]string, 0, len(jobIDs))
+	for _, jobID := range jobIDs {
+		parts = append(parts, fmt.Sprintf("%s (%d)", jobID, missing[jobID]))
+	}
+	return strings.Join(parts, ", ")
+}
+
+type accessTokenProvider interface {
+	GetAccessToken(scope string) (*AzCoreAccessToken, error)
+}
+
+type httpDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type logAnalyticsQueryClient struct {
+	tokens accessTokenProvider
+	client httpDoer
+}
+
+type logAnalyticsQueryRequest struct {
+	Query string `json:"query"`
+}
+
+type logAnalyticsQueryResponse struct {
+	Tables []struct {
+		Columns []struct {
+			Name string `json:"name"`
+		} `json:"columns"`
+		Rows [][]json.RawMessage `json:"rows"`
+	} `json:"tables"`
+}
+
+func (c *logAnalyticsQueryClient) QueryFinishedEventCounts(
+	ctx context.Context,
+	workspaceID string,
+	query string,
+) (map[string]int, error) {
+	if c.tokens == nil {
+		return nil, errors.New("OAuth token provider is nil")
+	}
+	if c.client == nil {
+		return nil, errors.New("HTTP client is nil")
+	}
+
+	token, err := c.tokens.GetAccessToken(LogAnalyticsResource)
+	if err != nil {
+		return nil, fmt.Errorf("get Log Analytics access token: %w", err)
+	}
+	tokenValue, err := token.FreshToken()
+	if err != nil {
+		return nil, fmt.Errorf("refresh Log Analytics access token: %w", err)
+	}
+
+	payload, err := json.Marshal(logAnalyticsQueryRequest{Query: query})
+	if err != nil {
+		return nil, fmt.Errorf("serialize Log Analytics query: %w", err)
+	}
+	endpoint := fmt.Sprintf("%s/%s/query", appInsightsQueryEndpoint, url.PathEscape(workspaceID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("create Log Analytics query request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+tokenValue)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, retryableQueryError{err: fmt.Errorf("send Log Analytics query: %w", err)}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxQueryErrorBodyBytes))
+		if readErr != nil {
+			return nil, fmt.Errorf("read Log Analytics error response: %w", readErr)
+		}
+		statusErr := fmt.Errorf("Log Analytics query returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		if isRetryableHTTPStatus(resp.StatusCode) {
+			return nil, retryableQueryError{err: statusErr}
+		}
+		return nil, statusErr
+	}
+
+	var result logAnalyticsQueryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode Log Analytics query response: %w", err)
+	}
+	return parseFinishedEventCounts(result)
+}
+
+func parseFinishedEventCounts(result logAnalyticsQueryResponse) (map[string]int, error) {
+	if len(result.Tables) != 1 {
+		return nil, fmt.Errorf("expected one Log Analytics result table, got %d", len(result.Tables))
+	}
+	table := result.Tables[0]
+	columnIndexes := make(map[string]int, len(table.Columns))
+	for index, column := range table.Columns {
+		columnIndexes[column.Name] = index
+	}
+	jobIDIndex, hasJobID := columnIndexes["JobID"]
+	countIndex, hasCount := columnIndexes["ReceivedCount"]
+	if !hasJobID || !hasCount {
+		return nil, fmt.Errorf("Log Analytics response is missing JobID or ReceivedCount columns")
+	}
+
+	counts := make(map[string]int, len(table.Rows))
+	for rowIndex, row := range table.Rows {
+		if jobIDIndex >= len(row) || countIndex >= len(row) {
+			return nil, fmt.Errorf("Log Analytics response row %d has fewer columns than expected", rowIndex)
+		}
+		var jobID string
+		if err := json.Unmarshal(row[jobIDIndex], &jobID); err != nil {
+			return nil, fmt.Errorf("decode JobID in row %d: %w", rowIndex, err)
+		}
+		count, err := parseJSONInt(row[countIndex])
+		if err != nil {
+			return nil, fmt.Errorf("decode ReceivedCount in row %d: %w", rowIndex, err)
+		}
+		if jobID != "" {
+			counts[jobID] = count
+		}
+	}
+	return counts, nil
+}
+
+func parseJSONInt(value json.RawMessage) (int, error) {
+	var number json.Number
+	if err := json.Unmarshal(value, &number); err != nil {
+		return 0, err
+	}
+	parsed, err := strconv.Atoi(number.String())
+	if err != nil {
+		return 0, err
+	}
+	return parsed, nil
+}
+
+type retryableQueryError struct {
+	err error
+}
+
+func (e retryableQueryError) Error() string {
+	return e.err.Error()
+}
+
+func (e retryableQueryError) Unwrap() error {
+	return e.err
+}
+
+func isRetryableQueryError(err error) bool {
+	var retryable retryableQueryError
+	return errors.As(err, &retryable)
+}
+
+func isRetryableHTTPStatus(statusCode int) bool {
+	switch statusCode {
+	case http.StatusRequestTimeout,
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
+}

--- a/e2etest/newe2e_app_insights_validation_test.go
+++ b/e2etest/newe2e_app_insights_validation_test.go
@@ -64,6 +64,26 @@ func TestExpectedAppInsightsJobsAreCountedConcurrently(t *testing.T) {
 	assert.Equal(t, registrations, snapshot.expectedJobs["job-1"])
 }
 
+func TestAzCopyVerbProducesJobFinishedTelemetry(t *testing.T) {
+	for _, verb := range []AzCopyVerb{AzCopyVerbCopy, AzCopyVerbSync, AzCopyVerbJobsResume} {
+		assert.True(t, azCopyVerbProducesJobFinishedTelemetry(verb), verb)
+	}
+
+	for _, verb := range []AzCopyVerb{
+		AzCopyVerbRemove,
+		AzCopyVerbList,
+		AzCopyVerbLogin,
+		AzCopyVerbLoginStatus,
+		AzCopyVerbLogout,
+		AzCopyVerbJobsList,
+		AzCopyVerbJobsClean,
+		AzCopyVerbJobsRemove,
+		AzCopyVerbJobsShow,
+	} {
+		assert.False(t, azCopyVerbProducesJobFinishedTelemetry(verb), verb)
+	}
+}
+
 func TestBuildFinishedEventQuery(t *testing.T) {
 	startedAt := time.Date(2026, 7, 1, 12, 30, 0, 0, time.UTC)
 	query := buildFinishedEventQuery(`run"id`, startedAt)

--- a/e2etest/newe2e_app_insights_validation_test.go
+++ b/e2etest/newe2e_app_insights_validation_test.go
@@ -104,6 +104,68 @@ func TestAzCopyCommandProducesJobFinishedTelemetryExcludesDryRuns(t *testing.T) 
 		map[string]string{"dry-run": "false"}))
 }
 
+func TestDecideAppInsightsJobValidation(t *testing.T) {
+	jobID := common.NewJobID().String()
+	tests := []struct {
+		name       string
+		verb       AzCopyVerb
+		flags      map[string]string
+		shouldFail bool
+		jobID      string
+		expected   appInsightsJobValidationDecision
+	}{
+		{
+			name:     "successful command requires a job ID",
+			verb:     AzCopyVerbCopy,
+			expected: appInsightsJobValidationDecision{missingJobID: true},
+		},
+		{
+			name:       "expected failure may omit a job ID",
+			verb:       AzCopyVerbSync,
+			shouldFail: true,
+			expected:   appInsightsJobValidationDecision{},
+		},
+		{
+			name:       "expected failure still registers an emitted job ID",
+			verb:       AzCopyVerbCopy,
+			shouldFail: true,
+			jobID:      jobID,
+			expected:   appInsightsJobValidationDecision{jobID: jobID},
+		},
+		{
+			name:  "successful command registers an emitted job ID",
+			verb:  AzCopyVerbJobsResume,
+			jobID: jobID,
+			expected: appInsightsJobValidationDecision{
+				jobID: jobID,
+			},
+		},
+		{
+			name:     "dry run does not require or register a job ID",
+			verb:     AzCopyVerbCopy,
+			flags:    map[string]string{"dry-run": "true"},
+			jobID:    jobID,
+			expected: appInsightsJobValidationDecision{},
+		},
+		{
+			name:     "non-terminal command does not require or register a job ID",
+			verb:     AzCopyVerbRemove,
+			jobID:    jobID,
+			expected: appInsightsJobValidationDecision{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, decideAppInsightsJobValidation(
+				test.verb,
+				test.flags,
+				test.shouldFail,
+				test.jobID))
+		})
+	}
+}
+
 func TestAzCopyJobIDCaptureForwardsAndCapturesJSONOutput(t *testing.T) {
 	var target bytes.Buffer
 	capture := newAzCopyJobIDCapture(&testAzCopyStdout{Buffer: &target})

--- a/e2etest/newe2e_app_insights_validation_test.go
+++ b/e2etest/newe2e_app_insights_validation_test.go
@@ -1,0 +1,233 @@
+package e2etest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateAppInsightsValidationConfig(t *testing.T) {
+	enabled, err := validateAppInsightsValidationConfig(AppInsightsValidationConfig{})
+	require.NoError(t, err)
+	assert.False(t, enabled)
+
+	enabled, err = validateAppInsightsValidationConfig(AppInsightsValidationConfig{
+		ConnectionString: "InstrumentationKey=11111111-2222-3333-4444-555555555555",
+		WorkspaceID:      "workspace-id",
+		RunID:            "run-id",
+	})
+	require.NoError(t, err)
+	assert.True(t, enabled)
+
+	_, err = validateAppInsightsValidationConfig(AppInsightsValidationConfig{
+		WorkspaceID: "workspace-id",
+	})
+	assert.ErrorContains(t, err, "must all be set")
+
+	_, err = validateAppInsightsValidationConfig(AppInsightsValidationConfig{
+		ConnectionString: "invalid",
+		WorkspaceID:      "workspace-id",
+		RunID:            "run-id",
+	})
+	assert.ErrorContains(t, err, "not a valid")
+}
+
+func TestExpectedAppInsightsJobsAreCountedConcurrently(t *testing.T) {
+	resetAppInsightsValidation()
+	t.Cleanup(resetAppInsightsValidation)
+
+	globalAppInsightsValidation.mu.Lock()
+	globalAppInsightsValidation.enabled = true
+	globalAppInsightsValidation.expectedJobs = make(map[string]int)
+	globalAppInsightsValidation.mu.Unlock()
+
+	const registrations = 20
+	var wg sync.WaitGroup
+	for index := 0; index < registrations; index++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			RegisterExpectedAppInsightsJob("job-1")
+		}()
+	}
+	wg.Wait()
+
+	snapshot := snapshotAppInsightsValidation()
+	assert.Equal(t, registrations, snapshot.expectedJobs["job-1"])
+}
+
+func TestBuildFinishedEventQuery(t *testing.T) {
+	startedAt := time.Date(2026, 7, 1, 12, 30, 0, 0, time.UTC)
+	query := buildFinishedEventQuery(`run"id`, startedAt)
+
+	assert.Contains(t, query, "AppEvents")
+	assert.Contains(t, query, `datetime(2026-07-01T12:30:00Z)`)
+	assert.Contains(t, query, `E2ETestRunID) == "run\"id"`)
+	assert.Contains(t, query, `Name == "azcopy.job.finished"`)
+}
+
+func TestParseFinishedEventCountsUsesColumnNames(t *testing.T) {
+	result := logAnalyticsQueryResponse{}
+	result.Tables = append(result.Tables, struct {
+		Columns []struct {
+			Name string `json:"name"`
+		} `json:"columns"`
+		Rows [][]json.RawMessage `json:"rows"`
+	}{})
+	result.Tables[0].Columns = append(
+		result.Tables[0].Columns,
+		struct {
+			Name string `json:"name"`
+		}{Name: "ReceivedCount"},
+		struct {
+			Name string `json:"name"`
+		}{Name: "JobID"},
+	)
+	result.Tables[0].Rows = [][]json.RawMessage{
+		{json.RawMessage(`2`), json.RawMessage(`"job-1"`)},
+		{json.RawMessage(`1`), json.RawMessage(`"job-2"`)},
+	}
+
+	counts, err := parseFinishedEventCounts(result)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]int{"job-1": 2, "job-2": 1}, counts)
+}
+
+func TestParseJSONIntRejectsOverflow(t *testing.T) {
+	overflow := "2147483648"
+	if strconv.IntSize == 64 {
+		overflow = "9223372036854775808"
+	}
+
+	_, err := parseJSONInt(json.RawMessage(overflow))
+	require.Error(t, err)
+}
+
+type stubFinishedEventQueryClient struct {
+	mu        sync.Mutex
+	responses []map[string]int
+	errors    []error
+	calls     int
+}
+
+func (c *stubFinishedEventQueryClient) QueryFinishedEventCounts(
+	_ context.Context,
+	_ string,
+	_ string,
+) (map[string]int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	index := c.calls
+	c.calls++
+	if index < len(c.errors) && c.errors[index] != nil {
+		return nil, c.errors[index]
+	}
+	if index < len(c.responses) {
+		return c.responses[index], nil
+	}
+	return map[string]int{}, nil
+}
+
+func TestAppInsightsVerifierPollsUntilExpectedEventsArrive(t *testing.T) {
+	client := &stubFinishedEventQueryClient{
+		responses: []map[string]int{
+			{"job-1": 1},
+			{"job-1": 2, "job-2": 1},
+		},
+	}
+	verifier := appInsightsVerifier{
+		queryClient:  client,
+		pollInterval: time.Millisecond,
+		timeout:      100 * time.Millisecond,
+	}
+
+	err := verifier.Verify(
+		context.Background(),
+		"workspace-id",
+		"run-id",
+		time.Now().Add(-time.Minute),
+		map[string]int{"job-1": 2, "job-2": 1},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 2, client.calls)
+}
+
+func TestAppInsightsVerifierRetriesTransientQueryErrors(t *testing.T) {
+	client := &stubFinishedEventQueryClient{
+		errors: []error{
+			retryableQueryError{err: errors.New("throttled")},
+			nil,
+		},
+		responses: []map[string]int{
+			nil,
+			{"job-1": 1},
+		},
+	}
+	verifier := appInsightsVerifier{
+		queryClient:  client,
+		pollInterval: time.Millisecond,
+		timeout:      100 * time.Millisecond,
+	}
+
+	err := verifier.Verify(
+		context.Background(),
+		"workspace-id",
+		"run-id",
+		time.Now().Add(-time.Minute),
+		map[string]int{"job-1": 1},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 2, client.calls)
+}
+
+func TestAppInsightsVerifierReportsMissingEventsOnTimeout(t *testing.T) {
+	client := &stubFinishedEventQueryClient{}
+	verifier := appInsightsVerifier{
+		queryClient:  client,
+		pollInterval: time.Millisecond,
+		timeout:      3 * time.Millisecond,
+	}
+
+	err := verifier.Verify(
+		context.Background(),
+		"workspace-id",
+		"run-id",
+		time.Now().Add(-time.Minute),
+		map[string]int{"job-2": 1, "job-1": 2},
+	)
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "job-1 (2), job-2 (1)"), err)
+	assert.Contains(t, err.Error(), `run "run-id"`)
+	assert.Contains(t, err.Error(), "AppEvents")
+}
+
+func TestAppInsightsVerifierStopsOnPermanentQueryError(t *testing.T) {
+	client := &stubFinishedEventQueryClient{
+		errors: []error{errors.New("forbidden")},
+	}
+	verifier := appInsightsVerifier{
+		queryClient:  client,
+		pollInterval: time.Millisecond,
+		timeout:      100 * time.Millisecond,
+	}
+
+	err := verifier.Verify(
+		context.Background(),
+		"workspace-id",
+		"run-id",
+		time.Now().Add(-time.Minute),
+		map[string]int{"job-1": 1},
+	)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "forbidden")
+	assert.Equal(t, 1, client.calls)
+}

--- a/e2etest/newe2e_app_insights_validation_test.go
+++ b/e2etest/newe2e_app_insights_validation_test.go
@@ -1,6 +1,7 @@
 package e2etest
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -12,6 +13,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/Azure/azure-storage-azcopy/v10/cmd"
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 func TestValidateAppInsightsValidationConfig(t *testing.T) {
@@ -82,6 +86,97 @@ func TestAzCopyVerbProducesJobFinishedTelemetry(t *testing.T) {
 	} {
 		assert.False(t, azCopyVerbProducesJobFinishedTelemetry(verb), verb)
 	}
+}
+
+func TestAzCopyCommandProducesJobFinishedTelemetryExcludesDryRuns(t *testing.T) {
+	assert.True(t, azCopyCommandProducesJobFinishedTelemetry(AzCopyVerbCopy, nil))
+	assert.True(t, azCopyCommandProducesJobFinishedTelemetry(
+		AzCopyVerbSync,
+		map[string]string{"dry-run": "false"}))
+	assert.False(t, azCopyCommandProducesJobFinishedTelemetry(
+		AzCopyVerbCopy,
+		map[string]string{"dry-run": "true"}))
+	assert.False(t, azCopyCommandProducesJobFinishedTelemetry(
+		AzCopyVerbSync,
+		map[string]string{"dry-run": "TRUE"}))
+	assert.False(t, azCopyCommandProducesJobFinishedTelemetry(
+		AzCopyVerbRemove,
+		map[string]string{"dry-run": "false"}))
+}
+
+func TestAzCopyJobIDCaptureForwardsAndCapturesJSONOutput(t *testing.T) {
+	var target bytes.Buffer
+	capture := newAzCopyJobIDCapture(&testAzCopyStdout{Buffer: &target})
+	jobID := common.NewJobID().String()
+	initMessage, err := json.Marshal(cmd.InitMsgJsonTemplate{JobID: jobID})
+	require.NoError(t, err)
+	output, err := json.Marshal(cmd.JsonOutputTemplate{
+		MessageType:    cmd.EOutputMessageType.Init().String(),
+		MessageContent: string(initMessage),
+	})
+	require.NoError(t, err)
+	output = append(output, '\n')
+
+	n, err := capture.Write(output)
+	require.NoError(t, err)
+	assert.Equal(t, len(output), n)
+	assert.Equal(t, output, target.Bytes())
+	assert.Equal(t, jobID, capture.JobID())
+}
+
+func TestAzCopyJobIDCaptureHandlesSplitTextOutput(t *testing.T) {
+	var target bytes.Buffer
+	capture := newAzCopyJobIDCapture(&testAzCopyStdout{Buffer: &target})
+	jobID := common.NewJobID().String()
+	output := []byte("\nJob " + jobID + " has started\nLog file is located at: log.txt\n")
+
+	for _, chunk := range [][]byte{output[:9], output[9:31], output[31:]} {
+		n, err := capture.Write(chunk)
+		require.NoError(t, err)
+		assert.Equal(t, len(chunk), n)
+	}
+
+	assert.Equal(t, output, target.Bytes())
+	assert.Equal(t, jobID, capture.JobID())
+}
+
+func TestAzCopyJobIDCaptureFlushesFinalLineAndRejectsInvalidIDs(t *testing.T) {
+	var target bytes.Buffer
+	capture := newAzCopyJobIDCapture(&testAzCopyStdout{Buffer: &target})
+	validJobID := common.NewJobID().String()
+	output := []byte("Job not-a-job-id has started\nJob " + validJobID + " has started")
+
+	n, err := capture.Write(output)
+	require.NoError(t, err)
+	assert.Equal(t, len(output), n)
+	assert.Equal(t, validJobID, capture.JobID())
+	assert.Equal(t, output, target.Bytes())
+}
+
+func TestAzCopyJobIDCaptureSupportsRawAndDiscardStdout(t *testing.T) {
+	for name, target := range map[string]AzCopyStdout{
+		"raw":     &AzCopyRawStdout{},
+		"discard": &AzCopyDiscardStdout{},
+	} {
+		t.Run(name, func(t *testing.T) {
+			capture := newAzCopyJobIDCapture(target)
+			jobID := common.NewJobID().String()
+			output := []byte("Job " + jobID + " has started\n")
+
+			n, err := capture.Write(output)
+			require.NoError(t, err)
+			assert.Equal(t, len(output), n)
+			assert.Equal(t, jobID, capture.JobID())
+		})
+	}
+}
+
+type testAzCopyStdout struct {
+	*bytes.Buffer
+}
+
+func (s *testAzCopyStdout) RawStdout() []string {
+	return strings.Split(s.String(), "\n")
 }
 
 func TestBuildFinishedEventQuery(t *testing.T) {

--- a/e2etest/newe2e_config.go
+++ b/e2etest/newe2e_config.go
@@ -18,6 +18,12 @@ var GlobalConfig NewE2EConfig
 
 // ========= Config definition ==========
 
+type AppInsightsValidationConfig struct {
+	ConnectionString string `env:"AZCOPY_TELEMETRY_CONNECTION_STRING"`
+	WorkspaceID      string `env:"NEW_E2E_APP_INSIGHTS_WORKSPACE_ID"`
+	RunID            string `env:"AZCOPY_E2E_TELEMETRY_RUN_ID"`
+}
+
 /*
 The env tag allows you to specify options.
 The first argument will always be the environment variable name.
@@ -104,6 +110,8 @@ type NewE2EConfig struct {
 
 		StressTestEnabled bool `env:"NEW_E2E_TELEMETRY_STRESS_TEST_ENABLED,default=false"`
 	}
+
+	AppInsightsValidationConfig AppInsightsValidationConfig
 
 	AzCopyExecutableConfig struct {
 		ExecutablePath      string `env:"NEW_E2E_AZCOPY_PATH,required"`

--- a/e2etest/newe2e_oauth_cache.go
+++ b/e2etest/newe2e_oauth_cache.go
@@ -15,6 +15,7 @@ const (
 	AzureManagementResource = "https://management.core.windows.net/.default"
 	AzureStorageResource    = "https://storage.azure.com/.default"
 	AzureDisksResource      = "https://disk.azure.com/.default"
+	LogAnalyticsResource    = "https://api.loganalytics.io/.default"
 )
 
 var PrimaryOAuthCache *OAuthCache

--- a/e2etest/newe2e_runazcopy_stdout.go
+++ b/e2etest/newe2e_runazcopy_stdout.go
@@ -3,6 +3,7 @@ package e2etest
 import (
 	"encoding/json"
 	"strings"
+	"sync"
 
 	"github.com/Azure/azure-storage-azcopy/v10/cmd"
 	"github.com/Azure/azure-storage-azcopy/v10/common"
@@ -14,6 +15,94 @@ var _ AzCopyStdout = &AzCopyParsedCopySyncRemoveStdout{}
 var _ AzCopyStdout = &AzCopyParsedDryrunStdout{}
 var _ AzCopyStdout = &AzCopyParsedJobsListStdout{}
 var _ AzCopyStdout = &AzCopyParsedJobsShowStdout{}
+
+type azCopyJobIDCapture struct {
+	target  AzCopyStdout
+	mu      sync.Mutex
+	pending string
+	jobID   string
+}
+
+func newAzCopyJobIDCapture(target AzCopyStdout) *azCopyJobIDCapture {
+	return &azCopyJobIDCapture{target: target}
+}
+
+func (c *azCopyJobIDCapture) Write(p []byte) (int, error) {
+	n, err := c.target.Write(p)
+	if n > 0 {
+		c.capture(string(p[:n]), false)
+	}
+	return n, err
+}
+
+func (c *azCopyJobIDCapture) JobID() string {
+	c.capture("", true)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.jobID
+}
+
+func (c *azCopyJobIDCapture) capture(chunk string, flush bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.jobID != "" {
+		return
+	}
+
+	c.pending += chunk
+	for {
+		lineEnd := strings.IndexByte(c.pending, '\n')
+		if lineEnd < 0 {
+			break
+		}
+
+		line := strings.TrimSuffix(c.pending[:lineEnd], "\r")
+		c.pending = c.pending[lineEnd+1:]
+		if c.captureLine(line) {
+			return
+		}
+	}
+
+	if flush && c.pending != "" {
+		line := strings.TrimSuffix(c.pending, "\r")
+		c.pending = ""
+		c.captureLine(line)
+	}
+}
+
+func (c *azCopyJobIDCapture) captureLine(line string) bool {
+	var output cmd.JsonOutputTemplate
+	if json.Unmarshal([]byte(line), &output) == nil &&
+		output.MessageType == cmd.EOutputMessageType.Init().String() {
+		var initMessage cmd.InitMsgJsonTemplate
+		if json.Unmarshal([]byte(output.MessageContent), &initMessage) == nil &&
+			c.setJobID(initMessage.JobID) {
+			return true
+		}
+	}
+
+	const (
+		textPrefix = "Job "
+		textSuffix = " has started"
+	)
+	line = strings.TrimSpace(line)
+	if strings.HasPrefix(line, textPrefix) && strings.HasSuffix(line, textSuffix) {
+		return c.setJobID(strings.TrimSuffix(strings.TrimPrefix(line, textPrefix), textSuffix))
+	}
+	return false
+}
+
+func (c *azCopyJobIDCapture) setJobID(candidate string) bool {
+	jobID, err := common.ParseJobID(candidate)
+	if err != nil {
+		return false
+	}
+
+	c.jobID = jobID.String()
+	return true
+}
 
 // ManySubscriberChannel is intended to reproduce the effects of .NET's events.
 // This allows us to *partially* answer the question of how we want to handle testing of prompting in the New E2E framework.

--- a/e2etest/newe2e_task_runazcopy.go
+++ b/e2etest/newe2e_task_runazcopy.go
@@ -397,9 +397,6 @@ func RunAzCopy(a ScenarioAsserter, commandSpec AzCopyCommand) (AzCopyStdout, *Az
 		}
 
 		flagMap = MapFromTags(reflect.ValueOf(commandSpec.Flags), "flag", a, ctx)
-		if AppInsightsTelemetryValidationEnabled() {
-			flagMap["telemetry-sampling-rate"] = "1"
-		}
 		for k, v := range flagMap {
 			out = append(out, fmt.Sprintf("--%s=%s", k, v))
 		}

--- a/e2etest/newe2e_task_runazcopy.go
+++ b/e2etest/newe2e_task_runazcopy.go
@@ -507,12 +507,13 @@ func RunAzCopy(a ScenarioAsserter, commandSpec AzCopyCommand) (AzCopyStdout, *Az
 	}
 
 	stderr := &bytes.Buffer{}
+	jobIDCapture := newAzCopyJobIDCapture(out)
 	command := exec.Cmd{
 		Path: GlobalConfig.AzCopyExecutableConfig.ExecutablePath,
 		Args: args,
 		Env:  env,
 
-		Stdout: out, // todo
+		Stdout: jobIDCapture,
 		Stderr: stderr,
 	}
 	in, err := command.StdinPipe()
@@ -545,10 +546,15 @@ func RunAzCopy(a ScenarioAsserter, commandSpec AzCopyCommand) (AzCopyStdout, *Az
 		Stderr: stderr.String(),
 	})
 
-	if parsed, ok := out.(*AzCopyParsedCopySyncRemoveStdout); ok &&
-		azCopyVerbProducesJobFinishedTelemetry(commandSpec.Verb) &&
-		parsed.InitMsg.JobID != "" {
-		RegisterExpectedAppInsightsJob(parsed.InitMsg.JobID)
+	if azCopyCommandProducesJobFinishedTelemetry(commandSpec.Verb, flagMap) {
+		jobID := jobIDCapture.JobID()
+		if AppInsightsTelemetryValidationEnabled() && jobID == "" {
+			a.NoError("capture AzCopy job ID for Application Insights validation",
+				fmt.Errorf("AzCopy %s output did not contain a valid job ID", commandSpec.Verb))
+		}
+		if jobID != "" {
+			RegisterExpectedAppInsightsJob(jobID)
+		}
 	}
 
 	return out, &AzCopyJobPlan{}
@@ -561,4 +567,9 @@ func azCopyVerbProducesJobFinishedTelemetry(verb AzCopyVerb) bool {
 	default:
 		return false
 	}
+}
+
+func azCopyCommandProducesJobFinishedTelemetry(verb AzCopyVerb, flags map[string]string) bool {
+	return azCopyVerbProducesJobFinishedTelemetry(verb) &&
+		!strings.EqualFold(flags["dry-run"], "true")
 }

--- a/e2etest/newe2e_task_runazcopy.go
+++ b/e2etest/newe2e_task_runazcopy.go
@@ -179,12 +179,14 @@ func (env *AzCopyEnvironment) EnsureInheritEnvironment() {
 }
 
 var RunAzCopyDefaultInheritEnvironment = map[string]bool{
-	"path":             true,
-	"home":             true,
-	"userprofile":      true,
-	"homepath":         true,
-	"homedrive":        true,
-	"azure_config_dir": true,
+	"path":                               true,
+	"home":                               true,
+	"userprofile":                        true,
+	"homepath":                           true,
+	"homedrive":                          true,
+	"azure_config_dir":                   true,
+	"azcopy_telemetry_connection_string": true,
+	"azcopy_e2e_telemetry_run_id":        true,
 }
 
 func (env *AzCopyEnvironment) DefaultInheritEnvironment(a ScenarioAsserter, ctx context.Context) map[string]bool {
@@ -395,6 +397,9 @@ func RunAzCopy(a ScenarioAsserter, commandSpec AzCopyCommand) (AzCopyStdout, *Az
 		}
 
 		flagMap = MapFromTags(reflect.ValueOf(commandSpec.Flags), "flag", a, ctx)
+		if AppInsightsTelemetryValidationEnabled() {
+			flagMap["telemetry-sampling-rate"] = "1"
+		}
 		for k, v := range flagMap {
 			out = append(out, fmt.Sprintf("--%s=%s", k, v))
 		}
@@ -539,6 +544,10 @@ func RunAzCopy(a ScenarioAsserter, commandSpec AzCopyCommand) (AzCopyStdout, *Az
 		Stdout: out.String(),
 		Stderr: stderr.String(),
 	})
+
+	if parsed, ok := out.(*AzCopyParsedCopySyncRemoveStdout); ok && parsed.InitMsg.JobID != "" {
+		RegisterExpectedAppInsightsJob(parsed.InitMsg.JobID)
+	}
 
 	return out, &AzCopyJobPlan{}
 }

--- a/e2etest/newe2e_task_runazcopy.go
+++ b/e2etest/newe2e_task_runazcopy.go
@@ -545,9 +545,20 @@ func RunAzCopy(a ScenarioAsserter, commandSpec AzCopyCommand) (AzCopyStdout, *Az
 		Stderr: stderr.String(),
 	})
 
-	if parsed, ok := out.(*AzCopyParsedCopySyncRemoveStdout); ok && parsed.InitMsg.JobID != "" {
+	if parsed, ok := out.(*AzCopyParsedCopySyncRemoveStdout); ok &&
+		azCopyVerbProducesJobFinishedTelemetry(commandSpec.Verb) &&
+		parsed.InitMsg.JobID != "" {
 		RegisterExpectedAppInsightsJob(parsed.InitMsg.JobID)
 	}
 
 	return out, &AzCopyJobPlan{}
+}
+
+func azCopyVerbProducesJobFinishedTelemetry(verb AzCopyVerb) bool {
+	switch verb {
+	case AzCopyVerbCopy, AzCopyVerbSync, AzCopyVerbJobsResume:
+		return true
+	default:
+		return false
+	}
 }

--- a/e2etest/newe2e_task_runazcopy.go
+++ b/e2etest/newe2e_task_runazcopy.go
@@ -546,16 +546,16 @@ func RunAzCopy(a ScenarioAsserter, commandSpec AzCopyCommand) (AzCopyStdout, *Az
 		Stderr: stderr.String(),
 	})
 
-	if azCopyCommandProducesJobFinishedTelemetry(commandSpec.Verb, flagMap) {
-		jobID := jobIDCapture.JobID()
-		if AppInsightsTelemetryValidationEnabled() && jobID == "" {
-			a.NoError("capture AzCopy job ID for Application Insights validation",
-				fmt.Errorf("AzCopy %s output did not contain a valid job ID", commandSpec.Verb))
-		}
-		if jobID != "" {
-			RegisterExpectedAppInsightsJob(jobID)
-		}
+	validationDecision := decideAppInsightsJobValidation(
+		commandSpec.Verb,
+		flagMap,
+		commandSpec.ShouldFail,
+		jobIDCapture.JobID())
+	if AppInsightsTelemetryValidationEnabled() && validationDecision.missingJobID {
+		a.NoError("capture AzCopy job ID for Application Insights validation",
+			fmt.Errorf("AzCopy %s output did not contain a valid job ID", commandSpec.Verb))
 	}
+	RegisterExpectedAppInsightsJob(validationDecision.jobID)
 
 	return out, &AzCopyJobPlan{}
 }
@@ -572,4 +572,24 @@ func azCopyVerbProducesJobFinishedTelemetry(verb AzCopyVerb) bool {
 func azCopyCommandProducesJobFinishedTelemetry(verb AzCopyVerb, flags map[string]string) bool {
 	return azCopyVerbProducesJobFinishedTelemetry(verb) &&
 		!strings.EqualFold(flags["dry-run"], "true")
+}
+
+type appInsightsJobValidationDecision struct {
+	missingJobID bool
+	jobID        string
+}
+
+func decideAppInsightsJobValidation(
+	verb AzCopyVerb,
+	flags map[string]string,
+	shouldFail bool,
+	jobID string,
+) appInsightsJobValidationDecision {
+	if !azCopyCommandProducesJobFinishedTelemetry(verb, flags) {
+		return appInsightsJobValidationDecision{}
+	}
+	if jobID != "" {
+		return appInsightsJobValidationDecision{jobID: jobID}
+	}
+	return appInsightsJobValidationDecision{missingJobID: !shouldFail}
 }

--- a/e2etest/newe2e_task_runazcopy_parameters.go
+++ b/e2etest/newe2e_task_runazcopy_parameters.go
@@ -216,6 +216,8 @@ type GlobalFlags struct {
 	// TODO: Ongoing performance profiling work
 	MemoryProfile *string `flag:"memory-profile,defaultfunc:DefaultMemoryProfile"`
 	//CpuProfile *string `flag:"cpu-profile"`
+
+	TelemetrySamplingRate *float64 `flag:"telemetry-sampling-rate"`
 }
 
 func (GlobalFlags) DefaultAwaitContinue(a ScenarioAsserter, ctx context.Context) string {

--- a/e2etest/newe2e_task_runazcopy_parameters.go
+++ b/e2etest/newe2e_task_runazcopy_parameters.go
@@ -216,8 +216,6 @@ type GlobalFlags struct {
 	// TODO: Ongoing performance profiling work
 	MemoryProfile *string `flag:"memory-profile,defaultfunc:DefaultMemoryProfile"`
 	//CpuProfile *string `flag:"cpu-profile"`
-
-	TelemetrySamplingRate *float64 `flag:"telemetry-sampling-rate"`
 }
 
 func (GlobalFlags) DefaultAwaitContinue(a ScenarioAsserter, ctx context.Context) string {

--- a/e2etest/zt_aanewe2e_testmain_test.go
+++ b/e2etest/zt_aanewe2e_testmain_test.go
@@ -20,6 +20,7 @@ var FrameworkHooks = []TestFrameworkHook{
 	{HookName: "Config", SetupHook: LoadConfigHook},
 	{HookName: "Workload Identity Setup", SetupHook: WorkloadIdentitySetup},
 	{HookName: "OAuth Cache", SetupHook: SetupOAuthCache},
+	{HookName: "Application Insights Validation", SetupHook: SetupAppInsightsTelemetryValidation, TeardownHook: VerifyAppInsightsTelemetry},
 	{HookName: "ARM Client", SetupHook: SetupArmClient, TeardownHook: TeardownArmClient},
 	{HookName: "Default accts", SetupHook: AccountRegistryInitHook, TeardownHook: AccountRegistryCleanupHook},
 	{HookName: "Synthetic Test Suite Registration", SetupHook: RegisterSyntheticStressTestHook},

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,10 @@ require (
 	github.com/keybase/go-keychain v0.0.1
 	github.com/minio/minio-go/v7 v7.2.1
 	github.com/spf13/pflag v1.0.10
+	go.opentelemetry.io/otel v1.44.0
+	go.opentelemetry.io/otel/metric v1.44.0
+	go.opentelemetry.io/otel/sdk v1.44.0
+	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	golang.org/x/net v0.57.0
 )
 
@@ -92,10 +96,6 @@ require (
 	go.opentelemetry.io/contrib/detectors/gcp v1.43.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.68.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 // indirect
-	go.opentelemetry.io/otel v1.44.0 // indirect
-	go.opentelemetry.io/otel/metric v1.44.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/text v0.40.0 // indirect

--- a/jobsAdmin/init.go
+++ b/jobsAdmin/init.go
@@ -319,6 +319,12 @@ func GetJobSummary(jobID common.JobID) common.ListJobSummaryResponse {
 		js.AverageE2EMilliseconds = pipeStats.AverageE2EMilliseconds()
 		js.NetworkErrorPercentage = pipeStats.NetworkErrorPercentage()
 		js.ServerBusyPercentage = pipeStats.TotalServerBusyPercentage()
+		js.StorageHTTPAttemptCount = pipeStats.HTTPAttemptCount()
+		js.NetworkErrorAttemptCount = pipeStats.NetworkErrorAttemptCount()
+		js.ServerBusy503Count = pipeStats.GetTotalRetries()
+		js.ServerBusyThroughputCount = pipeStats.ServerBusyThroughputCount()
+		js.ServerBusyIOPSCount = pipeStats.ServerBusyIOPSCount()
+		js.ServerBusyOtherCount = pipeStats.ServerBusyOtherCount()
 	}
 
 	// If the status is cancelled, then no need to check for completerJobOrdered
@@ -487,6 +493,12 @@ func resurrectJobSummary(jm ste.IJobMgr) common.ListJobSummaryResponse {
 		js.AverageE2EMilliseconds = pipeStats.AverageE2EMilliseconds()
 		js.NetworkErrorPercentage = pipeStats.NetworkErrorPercentage()
 		js.ServerBusyPercentage = pipeStats.TotalServerBusyPercentage()
+		js.StorageHTTPAttemptCount = pipeStats.HTTPAttemptCount()
+		js.NetworkErrorAttemptCount = pipeStats.NetworkErrorAttemptCount()
+		js.ServerBusy503Count = pipeStats.GetTotalRetries()
+		js.ServerBusyThroughputCount = pipeStats.ServerBusyThroughputCount()
+		js.ServerBusyIOPSCount = pipeStats.ServerBusyIOPSCount()
+		js.ServerBusyOtherCount = pipeStats.ServerBusyOtherCount()
 	}
 
 	// If the status is cancelled, then no need to check for completerJobOrdered

--- a/ste/xferStatsPolicy.go
+++ b/ste/xferStatsPolicy.go
@@ -84,6 +84,16 @@ func (s *PipelineNetworkStats) NetworkErrorPercentage() float32 {
 	}
 }
 
+func (s *PipelineNetworkStats) HTTPAttemptCount() int64 {
+	s.nocopy.Check()
+	return atomic.LoadInt64(&s.atomicOperationCount)
+}
+
+func (s *PipelineNetworkStats) NetworkErrorAttemptCount() int64 {
+	s.nocopy.Check()
+	return atomic.LoadInt64(&s.atomicNetworkErrorCount)
+}
+
 func (s *PipelineNetworkStats) TotalServerBusyPercentage() float32 {
 	s.nocopy.Check()
 	ops := float32(atomic.LoadInt64(&s.atomicOperationCount))
@@ -101,6 +111,21 @@ func (s *PipelineNetworkStats) GetTotalRetries() int64 {
 	return atomic.LoadInt64(&s.atomic503CountThroughput) +
 		atomic.LoadInt64(&s.atomic503CountIOPS) +
 		atomic.LoadInt64(&s.atomic503CountUnknown)
+}
+
+func (s *PipelineNetworkStats) ServerBusyThroughputCount() int64 {
+	s.nocopy.Check()
+	return atomic.LoadInt64(&s.atomic503CountThroughput)
+}
+
+func (s *PipelineNetworkStats) ServerBusyIOPSCount() int64 {
+	s.nocopy.Check()
+	return atomic.LoadInt64(&s.atomic503CountIOPS)
+}
+
+func (s *PipelineNetworkStats) ServerBusyOtherCount() int64 {
+	s.nocopy.Check()
+	return atomic.LoadInt64(&s.atomic503CountUnknown)
 }
 
 func (s *PipelineNetworkStats) IOPSServerBusyPercentage() float32 {

--- a/telemetry/events.go
+++ b/telemetry/events.go
@@ -42,8 +42,6 @@ import (
 type ResourceAttributes struct {
 	AzCopyVersion      string // "10.32.2"
 	SchemaVersion      string
-	SamplingRate       float64
-	SamplerVersion     string
 	E2ETestRunID       string // optional correlation ID used only by AzCopy E2E validation
 	OSType             string // runtime.GOOS
 	OSVersion          string // uname / RtlGetVersion
@@ -62,8 +60,6 @@ func (ra ResourceAttributes) props() map[string]string {
 	props := map[string]string{
 		"AzCopyVersion":      ra.AzCopyVersion,
 		"SchemaVersion":      ra.SchemaVersion,
-		"SamplingRate":       strconv.FormatFloat(ra.SamplingRate, 'f', -1, 64),
-		"SamplerVersion":     ra.SamplerVersion,
 		"OSType":             ra.OSType,
 		"OSVersion":          ra.OSVersion,
 		"HostArch":           ra.HostArch,
@@ -447,8 +443,6 @@ const (
 var propertyValueLimits = map[string]int{
 	"AzCopyVersion":             64,
 	"SchemaVersion":             32,
-	"SamplingRate":              32,
-	"SamplerVersion":            64,
 	"E2ETestRunID":              maxIdentifierValueLen,
 	"OSType":                    32,
 	"OSVersion":                 maxHostValueLen,

--- a/telemetry/events.go
+++ b/telemetry/events.go
@@ -129,10 +129,8 @@ type JobDimensions struct {
 	DestType                  string
 	SourceProtocol            string // "smb" | "nfs" | "local" | "https" | "s3" | "gcs"
 	SourceMountType           string // "nas-smb" | "nas-nfs" | "local-disk" | "cloud-azure" | ...
-	SourceStorageAccount      string // Azure storage account name; empty for non-Azure or unrecognized endpoints
 	SourceScope               string // service | container | share | bucket | object-or-prefix | local-* | stream | benchmark
 	DestProtocol              string
-	DestStorageAccount        string // Azure storage account name; empty for non-Azure or unrecognized endpoints
 	DestScope                 string
 	DestEndpointKind          string // "public" | "private-endpoint"
 	SourceCloudType           string // Azure environment: "public" | "gov" | "china" | "germany"; empty for non-Azure
@@ -150,22 +148,20 @@ type JobDimensions struct {
 
 func (jd JobDimensions) props() map[string]string {
 	props := map[string]string{
-		"Command":              jd.Command,
-		"FromTo":               jd.FromTo,
-		"SourceType":           jd.SourceType,
-		"DestType":             jd.DestType,
-		"SourceProtocol":       jd.SourceProtocol,
-		"SourceMountType":      jd.SourceMountType,
-		"SourceStorageAccount": jd.SourceStorageAccount,
-		"SourceScope":          jd.SourceScope,
-		"DestProtocol":         jd.DestProtocol,
-		"DestStorageAccount":   jd.DestStorageAccount,
-		"DestScope":            jd.DestScope,
-		"DestEndpointKind":     jd.DestEndpointKind,
-		"SourceCloudType":      jd.SourceCloudType,
-		"DestCloudType":        jd.DestCloudType,
-		"SourceAuthMechanism":  jd.SourceAuthMechanism,
-		"DestAuthMechanism":    jd.DestAuthMechanism,
+		"Command":             jd.Command,
+		"FromTo":              jd.FromTo,
+		"SourceType":          jd.SourceType,
+		"DestType":            jd.DestType,
+		"SourceProtocol":      jd.SourceProtocol,
+		"SourceMountType":     jd.SourceMountType,
+		"SourceScope":         jd.SourceScope,
+		"DestProtocol":        jd.DestProtocol,
+		"DestScope":           jd.DestScope,
+		"DestEndpointKind":    jd.DestEndpointKind,
+		"SourceCloudType":     jd.SourceCloudType,
+		"DestCloudType":       jd.DestCloudType,
+		"SourceAuthMechanism": jd.SourceAuthMechanism,
+		"DestAuthMechanism":   jd.DestAuthMechanism,
 	}
 	if jd.SummaryCounterScope != "" {
 		props["SummaryCounterScope"] = jd.SummaryCounterScope
@@ -472,10 +468,8 @@ var propertyValueLimits = map[string]int{
 	"DestType":                  64,
 	"SourceProtocol":            32,
 	"SourceMountType":           64,
-	"SourceStorageAccount":      maxHostValueLen,
 	"SourceScope":               64,
 	"DestProtocol":              32,
-	"DestStorageAccount":        maxHostValueLen,
 	"DestScope":                 64,
 	"DestEndpointKind":          64,
 	"SourceCloudType":           32,

--- a/telemetry/events.go
+++ b/telemetry/events.go
@@ -1,0 +1,559 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package telemetry defines the AzCopy telemetry event model and the reporter
+// used to send those events to Azure Monitor (Application Insights).
+//
+// Two events mirror what AzCopy emits per run:
+//
+//	Event 1 (azcopy.job.started)  - emitted at job start.
+//	Event 2 (azcopy.job.finished) - emitted at job completion, with measurements.
+package telemetry
+
+import (
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+// ---------------------------------------------------------------------------
+// Resource attributes - machine/system facts, constant for the process.
+// Attached to BOTH metric events.
+// ---------------------------------------------------------------------------
+
+type ResourceAttributes struct {
+	AzCopyVersion      string // "10.32.2"
+	SchemaVersion      string
+	SamplingRate       float64
+	SamplerVersion     string
+	E2ETestRunID       string // optional correlation ID used only by AzCopy E2E validation
+	OSType             string // runtime.GOOS
+	OSVersion          string // uname / RtlGetVersion
+	HostArch           string // runtime.GOARCH
+	HostNumCPU         int    // runtime.NumCPU()
+	HostCPUModel       string // /proc/cpuinfo, WMI, sysctl
+	HostMemoryTotalGB  int    // total physical memory
+	HostNICSpeedMbps   int    // best-effort; -1 when unavailable
+	HostNICSpeedBucket string // unknown | <1gbps | 1-<10gbps | 10-<40gbps | >=40gbps
+	AzureVMDetected    bool   // true when Azure Instance Metadata Service responds
+	InstallationID     string // anonymous, stable per-install identifier (no PII)
+	InvocationContext  string // "interactive" | "ci" | "sdk" | "unknown"
+}
+
+func (ra ResourceAttributes) props() map[string]string {
+	props := map[string]string{
+		"AzCopyVersion":      ra.AzCopyVersion,
+		"SchemaVersion":      ra.SchemaVersion,
+		"SamplingRate":       strconv.FormatFloat(ra.SamplingRate, 'f', -1, 64),
+		"SamplerVersion":     ra.SamplerVersion,
+		"OSType":             ra.OSType,
+		"OSVersion":          ra.OSVersion,
+		"HostArch":           ra.HostArch,
+		"HostNumCPU":         strconv.Itoa(ra.HostNumCPU),
+		"HostCPUModel":       ra.HostCPUModel,
+		"HostMemoryTotalGB":  strconv.Itoa(ra.HostMemoryTotalGB),
+		"HostNICSpeedMbps":   strconv.Itoa(ra.HostNICSpeedMbps),
+		"HostNICSpeedBucket": ra.HostNICSpeedBucket,
+		"AzureVMDetected":    strconv.FormatBool(ra.AzureVMDetected),
+		"InstallationID":     ra.InstallationID,
+		"InvocationContext":  ra.InvocationContext,
+	}
+	if ra.E2ETestRunID != "" {
+		props["E2ETestRunID"] = ra.E2ETestRunID
+	}
+	return props
+}
+
+// ---------------------------------------------------------------------------
+// Job dimension attributes - job-specific facts attached to each data point.
+// Present on BOTH events.
+// ---------------------------------------------------------------------------
+
+type OptionAttributes struct {
+	FlagsSet   []string
+	EnvVarsSet []string
+	Values     map[string]string
+}
+
+func (o OptionAttributes) Clone() OptionAttributes {
+	clone := OptionAttributes{
+		FlagsSet:   append([]string(nil), o.FlagsSet...),
+		EnvVarsSet: append([]string(nil), o.EnvVarsSet...),
+	}
+	if len(o.Values) > 0 {
+		clone.Values = make(map[string]string, len(o.Values))
+		for key, value := range o.Values {
+			clone.Values[key] = value
+		}
+	}
+	return clone
+}
+
+func (o OptionAttributes) addTo(props map[string]string) {
+	if len(o.FlagsSet) > 0 {
+		props["OptFlagsSet"] = truncateValue(strings.Join(o.FlagsSet, ","))
+	}
+	if len(o.EnvVarsSet) > 0 {
+		props["OptEnvVarsSet"] = truncateValue(strings.Join(o.EnvVarsSet, ","))
+	}
+	for key, value := range o.Values {
+		if value != "" {
+			props[key] = truncateValue(value)
+		}
+	}
+}
+
+type JobDimensions struct {
+	Command                   string // "copy" | "sync" | "remove"
+	SummaryCounterScope       string // job-cumulative for resume summaries; empty otherwise
+	FromTo                    string // "LocalBlob", "BlobLocal", "S3Blob", ...
+	SourceType                string // "Local" | "Blob" | "File" | "S3" | ...
+	DestType                  string
+	SourceProtocol            string // "smb" | "nfs" | "local" | "https" | "s3" | "gcs"
+	SourceMountType           string // "nas-smb" | "nas-nfs" | "local-disk" | "cloud-azure" | ...
+	SourceStorageAccount      string // Azure storage account name; empty for non-Azure or unrecognized endpoints
+	SourceScope               string // service | container | share | bucket | object-or-prefix | local-* | stream | benchmark
+	DestProtocol              string
+	DestStorageAccount        string // Azure storage account name; empty for non-Azure or unrecognized endpoints
+	DestScope                 string
+	DestEndpointKind          string // "public" | "private-endpoint"
+	SourceCloudType           string // Azure environment: "public" | "gov" | "china" | "germany"; empty for non-Azure
+	DestCloudType             string // Azure environment: "public" | "gov" | "china" | "germany"; empty for non-Azure
+	SourceAuthMechanism       string // "OAuthToken" | "Anonymous" | "SharedKey" | ...
+	DestAuthMechanism         string // "OAuthToken" | "Anonymous" | "SharedKey" | ...
+	BenchmarkMode             string // upload | download
+	BenchmarkFileCount        int64
+	BenchmarkFileSizeBytes    int64
+	BenchmarkFolderCount      int64
+	BenchmarkCleanupRequested bool
+	BenchmarkIsCleanup        bool
+	Options                   OptionAttributes
+}
+
+func (jd JobDimensions) props() map[string]string {
+	props := map[string]string{
+		"Command":              jd.Command,
+		"FromTo":               jd.FromTo,
+		"SourceType":           jd.SourceType,
+		"DestType":             jd.DestType,
+		"SourceProtocol":       jd.SourceProtocol,
+		"SourceMountType":      jd.SourceMountType,
+		"SourceStorageAccount": jd.SourceStorageAccount,
+		"SourceScope":          jd.SourceScope,
+		"DestProtocol":         jd.DestProtocol,
+		"DestStorageAccount":   jd.DestStorageAccount,
+		"DestScope":            jd.DestScope,
+		"DestEndpointKind":     jd.DestEndpointKind,
+		"SourceCloudType":      jd.SourceCloudType,
+		"DestCloudType":        jd.DestCloudType,
+		"SourceAuthMechanism":  jd.SourceAuthMechanism,
+		"DestAuthMechanism":    jd.DestAuthMechanism,
+	}
+	if jd.SummaryCounterScope != "" {
+		props["SummaryCounterScope"] = jd.SummaryCounterScope
+	}
+	if jd.Command == "bench" {
+		props["BenchmarkMode"] = jd.BenchmarkMode
+		props["BenchmarkFileCount"] = strconv.FormatInt(jd.BenchmarkFileCount, 10)
+		props["BenchmarkFileSizeBytes"] = strconv.FormatInt(jd.BenchmarkFileSizeBytes, 10)
+		props["BenchmarkFolderCount"] = strconv.FormatInt(jd.BenchmarkFolderCount, 10)
+		props["BenchmarkCleanupRequested"] = strconv.FormatBool(jd.BenchmarkCleanupRequested)
+		props["BenchmarkIsCleanup"] = strconv.FormatBool(jd.BenchmarkIsCleanup)
+	}
+	jd.Options.addTo(props)
+	return props
+}
+
+// ---------------------------------------------------------------------------
+// Event 1: job.started
+// ---------------------------------------------------------------------------
+
+type JobStartedEvent struct {
+	Resource   ResourceAttributes
+	Dimensions JobDimensions
+	// JobID correlates the original attempt and all resume attempts. A paired
+	// job.started and job.finished event also share an InvocationID.
+	JobID        string
+	InvocationID string
+	Timestamp    time.Time
+	StartedCount int64 // monotonic counter increment, always 1
+}
+
+// ---------------------------------------------------------------------------
+// Event 2: job.finished (+ measurements)
+// ---------------------------------------------------------------------------
+
+type JobFinishedEvent struct {
+	Resource       ResourceAttributes
+	Dimensions     JobDimensions
+	JobID          string
+	InvocationID   string
+	StartTimestamp time.Time
+	EndTimestamp   time.Time
+
+	FinishedCount    int64  // monotonic counter increment, always 1
+	JobStatus        string // "Completed" | "CompletedWithErrors" | "Failed" | "Cancelled" | ...
+	TerminalStage    string // initialization | enumeration | transfer | completion | completed
+	JobErrorCategory string // authentication | authorization | throttling | timeout | network | local-io | conflict | not-found | service | azcopy | initialization | enumeration | transfer | completion | unknown
+	JobErrorCode     string // bounded stable code; never raw error text
+
+	// FailureErrorCodes is a compact, bounded histogram of the error codes seen
+	// across failed transfers, e.g. "403:5,500:2" (ordered by descending count).
+	// Empty when there were no failures. Contains no PII (only numeric codes).
+	FailureErrorCodes      string
+	FailureErrorOtherCount int64
+	PerformanceConstraint  string
+	PerformanceAdviceCodes []string
+
+	// Measurements (from ListJobSummaryResponse + ElapsedTime)
+	BytesEnumerated                 int64 // Source sizes in scheduled job-plan entries after filters and copy/sync comparison; not all bytes scanned
+	BytesExpected                   int64 // Current successful + still-expected payload bytes
+	BytesTransferred                int64 // Logical successful payload bytes; no retry duplication
+	BytesOverWire                   int64 // Physical payload traffic; includes retries and failed-transfer traffic
+	ObjectsScheduled                int64 // File-like payload transfers: regular files/objects, symlinks, and converted hardlinks
+	RegularFilesScheduled           int64 // Regular file/object transfers only
+	SymlinksScheduled               int64 // Preserved symlink transfers
+	HardlinksConvertedScheduled     int64 // Hardlinks scheduled as converted file transfers
+	FolderPropertiesScheduled       int64 // Folder existence/property transfers, not contained files
+	ObjectsCompleted                int64 // Completed payload objects, excluding folder-property transfers
+	ObjectsFailed                   int64 // Failed payload objects, excluding folder-property transfers
+	ObjectsSkipped                  int64 // Skipped payload objects, excluding folder-property transfers
+	FolderPropertiesCompleted       int64
+	FolderPropertiesFailed          int64
+	FolderPropertiesSkipped         int64
+	SourceObjectsScanned            int64
+	SourceBytesScanned              int64
+	SourceAverageObjectSizeBytes    float64
+	SourceObjectSizeP50BytesApprox  int64
+	SourceObjectSizeP90BytesApprox  int64
+	SourceObjectSizeP95BytesApprox  int64
+	SourceObjectsUnder1MiB          int64
+	SourceObjectsUnder1MiBRatioPct  float64
+	SourceMaxDirectoryDepth         int64
+	ContainersScanned               int64
+	ContainersTouched               int64
+	BucketsScanned                  int64
+	BucketsTouched                  int64
+	TransfersCompleted              int64   // TransfersCompleted
+	TransfersFailed                 int64   // TransfersFailed
+	TransfersSkipped                int64   // TransfersSkipped
+	TransfersTotal                  int64   // TotalTransfers
+	JobDurationSeconds              float64 // Entire job attempt, including enumeration/finalization
+	EnumerationPhaseDurationSeconds float64 // Tracker start through final job part dispatch; overlaps transfer
+	TransferPhaseDurationSeconds    float64 // First part ordered through terminal wait; may overlap enumeration
+	JobThroughputMbps               float64 // BytesTransferred * 8 / 1e6 / JobDurationSeconds
+	TransferPhaseThroughputMbps     float64 // BytesTransferred * 8 / 1e6 / TransferPhaseDurationSeconds
+	AverageStorageHTTPAttemptE2EMs  int64   // Mean Storage HTTP attempt duration; retries are separate attempts
+	AvgIOPS                         int64
+	StorageHTTPAttemptCount         int64
+	NetworkErrorAttemptCount        int64
+	ServerBusy503Count              int64
+	ServerBusyThroughputCount       int64
+	ServerBusyIOPSCount             int64
+	ServerBusyOtherCount            int64
+	ServerBusyPct                   float64
+	NetworkErrorPct                 float64
+	PercentComplete                 float64 // PercentComplete (0-100); useful especially for cancelled jobs
+}
+
+// namedMetric is a single numeric measurement to be sent to a backend.
+type namedMetric struct {
+	Name  string
+	Value float64
+	Count int
+}
+
+// MetricEvent is implemented by every telemetry event the telemetry package can
+// process and send. A single Reporter can therefore handle either event type.
+type MetricEvent interface {
+	// EventName returns the metric/event name (e.g. "azcopy.job.started").
+	EventName() string
+	// attributes returns the flattened resource + dimension properties.
+	attributes() map[string]string
+	// measurements returns the numeric data points to send.
+	measurements() []namedMetric
+	// timestamp returns the event time to stamp on the telemetry.
+	timestamp() time.Time
+}
+
+func (JobStartedEvent) EventName() string  { return "azcopy.job.started" }
+func (JobFinishedEvent) EventName() string { return "azcopy.job.finished" }
+
+func (e JobStartedEvent) timestamp() time.Time  { return e.Timestamp }
+func (e JobFinishedEvent) timestamp() time.Time { return e.EndTimestamp }
+
+func (e JobStartedEvent) attributes() map[string]string {
+	attrs := mergeProps(e.Resource.props(), e.Dimensions.props())
+	attrs["JobID"] = e.JobID
+	if e.InvocationID != "" {
+		attrs["InvocationID"] = e.InvocationID
+	}
+	return boundProperties(attrs)
+}
+
+func (e JobFinishedEvent) attributes() map[string]string {
+	attrs := mergeProps(e.Resource.props(), e.Dimensions.props())
+	attrs["JobID"] = e.JobID
+	if e.InvocationID != "" {
+		attrs["InvocationID"] = e.InvocationID
+	}
+	attrs["JobStatus"] = e.JobStatus
+	attrs["TerminalStage"] = e.TerminalStage
+	if e.JobErrorCategory != "" {
+		attrs["JobErrorCategory"] = e.JobErrorCategory
+	}
+	if e.JobErrorCode != "" {
+		attrs["JobErrorCode"] = e.JobErrorCode
+	}
+	if e.FailureErrorCodes != "" {
+		attrs["FailureErrorCodes"] = e.FailureErrorCodes
+	}
+	if e.PerformanceConstraint != "" {
+		attrs["PerformanceConstraint"] = e.PerformanceConstraint
+	}
+	if len(e.PerformanceAdviceCodes) > 0 {
+		attrs["PerformanceAdviceCodes"] = truncateValue(strings.Join(e.PerformanceAdviceCodes, ","))
+	}
+	return boundProperties(attrs)
+}
+
+func (e JobStartedEvent) measurements() []namedMetric {
+	return []namedMetric{
+		{Name: "azcopy.job.started", Value: float64(e.StartedCount), Count: 1},
+	}
+}
+
+func (e JobFinishedEvent) measurements() []namedMetric {
+	return []namedMetric{
+		{Name: "azcopy.job.finished", Value: float64(e.FinishedCount), Count: 1},
+		{Name: "azcopy.failure_error_other_count", Value: float64(e.FailureErrorOtherCount), Count: 1},
+		{Name: "azcopy.bytes_enumerated", Value: float64(e.BytesEnumerated), Count: 1},
+		{Name: "azcopy.bytes_expected", Value: float64(e.BytesExpected), Count: 1},
+		{Name: "azcopy.bytes_transferred", Value: float64(e.BytesTransferred), Count: 1},
+		{Name: "azcopy.bytes_over_wire", Value: float64(e.BytesOverWire), Count: 1},
+		{Name: "azcopy.objects_scheduled", Value: float64(e.ObjectsScheduled), Count: 1},
+		{Name: "azcopy.regular_files_scheduled", Value: float64(e.RegularFilesScheduled), Count: 1},
+		{Name: "azcopy.symlinks_scheduled", Value: float64(e.SymlinksScheduled), Count: 1},
+		{Name: "azcopy.hardlinks_converted_scheduled", Value: float64(e.HardlinksConvertedScheduled), Count: 1},
+		{Name: "azcopy.folder_properties_scheduled", Value: float64(e.FolderPropertiesScheduled), Count: 1},
+		{Name: "azcopy.objects_completed", Value: float64(e.ObjectsCompleted), Count: 1},
+		{Name: "azcopy.objects_failed", Value: float64(e.ObjectsFailed), Count: 1},
+		{Name: "azcopy.objects_skipped", Value: float64(e.ObjectsSkipped), Count: 1},
+		{Name: "azcopy.folder_properties_completed", Value: float64(e.FolderPropertiesCompleted), Count: 1},
+		{Name: "azcopy.folder_properties_failed", Value: float64(e.FolderPropertiesFailed), Count: 1},
+		{Name: "azcopy.folder_properties_skipped", Value: float64(e.FolderPropertiesSkipped), Count: 1},
+		{Name: "azcopy.source_objects_scanned", Value: float64(e.SourceObjectsScanned), Count: 1},
+		{Name: "azcopy.source_bytes_scanned", Value: float64(e.SourceBytesScanned), Count: 1},
+		{Name: "azcopy.source_average_object_size_bytes", Value: e.SourceAverageObjectSizeBytes, Count: 1},
+		{Name: "azcopy.source_object_size_p50_bytes_approx", Value: float64(e.SourceObjectSizeP50BytesApprox), Count: 1},
+		{Name: "azcopy.source_object_size_p90_bytes_approx", Value: float64(e.SourceObjectSizeP90BytesApprox), Count: 1},
+		{Name: "azcopy.source_object_size_p95_bytes_approx", Value: float64(e.SourceObjectSizeP95BytesApprox), Count: 1},
+		{Name: "azcopy.source_objects_under_1_mib", Value: float64(e.SourceObjectsUnder1MiB), Count: 1},
+		{Name: "azcopy.source_objects_under_1_mib_ratio_pct", Value: e.SourceObjectsUnder1MiBRatioPct, Count: 1},
+		{Name: "azcopy.source_max_directory_depth", Value: float64(e.SourceMaxDirectoryDepth), Count: 1},
+		{Name: "azcopy.containers_scanned", Value: float64(e.ContainersScanned), Count: 1},
+		{Name: "azcopy.containers_touched", Value: float64(e.ContainersTouched), Count: 1},
+		{Name: "azcopy.buckets_scanned", Value: float64(e.BucketsScanned), Count: 1},
+		{Name: "azcopy.buckets_touched", Value: float64(e.BucketsTouched), Count: 1},
+		{Name: "azcopy.transfers_completed", Value: float64(e.TransfersCompleted), Count: 1},
+		{Name: "azcopy.transfers_failed", Value: float64(e.TransfersFailed), Count: 1},
+		{Name: "azcopy.transfers_skipped", Value: float64(e.TransfersSkipped), Count: 1},
+		{Name: "azcopy.transfers_total", Value: float64(e.TransfersTotal), Count: 1},
+		{Name: "azcopy.job_duration_seconds", Value: e.JobDurationSeconds, Count: 1},
+		{Name: "azcopy.enumeration_phase_duration_seconds", Value: e.EnumerationPhaseDurationSeconds, Count: 1},
+		{Name: "azcopy.transfer_phase_duration_seconds", Value: e.TransferPhaseDurationSeconds, Count: 1},
+		{Name: "azcopy.job_throughput_mbps", Value: e.JobThroughputMbps, Count: 1},
+		{Name: "azcopy.transfer_phase_throughput_mbps", Value: e.TransferPhaseThroughputMbps, Count: 1},
+		{Name: "azcopy.average_storage_http_attempt_e2e_ms", Value: float64(e.AverageStorageHTTPAttemptE2EMs), Count: 1},
+		{Name: "azcopy.avg_iops", Value: float64(e.AvgIOPS), Count: 1},
+		{Name: "azcopy.storage_http_attempt_count", Value: float64(e.StorageHTTPAttemptCount), Count: 1},
+		{Name: "azcopy.network_error_attempt_count", Value: float64(e.NetworkErrorAttemptCount), Count: 1},
+		{Name: "azcopy.server_busy_503_count", Value: float64(e.ServerBusy503Count), Count: 1},
+		{Name: "azcopy.server_busy_throughput_count", Value: float64(e.ServerBusyThroughputCount), Count: 1},
+		{Name: "azcopy.server_busy_iops_count", Value: float64(e.ServerBusyIOPSCount), Count: 1},
+		{Name: "azcopy.server_busy_other_count", Value: float64(e.ServerBusyOtherCount), Count: 1},
+		{Name: "azcopy.server_busy_pct", Value: e.ServerBusyPct, Count: 1},
+		{Name: "azcopy.network_error_pct", Value: e.NetworkErrorPct, Count: 1},
+		{Name: "azcopy.percent_complete", Value: e.PercentComplete, Count: 1},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Event 3: command.invoked
+//
+// Emitted once for commands that do not emit paired job-attempt start/finish
+// events. It is a lightweight usage signal carrying only the resource
+// attributes plus the canonical full command path, so we can answer which
+// subcommands customers use without conflating nested commands or aliases.
+// ---------------------------------------------------------------------------
+
+type CommandInvokedEvent struct {
+	Resource ResourceAttributes
+	Command  string // "login" | "jobs.list" | "remove" | ...
+	Options  OptionAttributes
+	// JobID is present when the invocation has an AzCopy JobID.
+	JobID        string
+	InvocationID string
+	Timestamp    time.Time
+	InvokedCount int64 // monotonic counter increment, always 1
+}
+
+func (CommandInvokedEvent) EventName() string { return "azcopy.command.invoked" }
+
+func (e CommandInvokedEvent) timestamp() time.Time { return e.Timestamp }
+
+func (e CommandInvokedEvent) attributes() map[string]string {
+	attrs := e.Resource.props()
+	attrs["Command"] = e.Command
+	e.Options.addTo(attrs)
+	if e.JobID != "" {
+		attrs["JobID"] = e.JobID
+	}
+	if e.InvocationID != "" {
+		attrs["InvocationID"] = e.InvocationID
+	}
+	return boundProperties(attrs)
+}
+
+func (e CommandInvokedEvent) measurements() []namedMetric {
+	return []namedMetric{
+		{Name: "azcopy.command.invoked", Value: float64(e.InvokedCount), Count: 1},
+	}
+}
+
+const (
+	maxPropValueLen         = 1024
+	maxIdentifierValueLen   = 128
+	maxHostValueLen         = 256
+	maxOptionValueLen       = 512
+	maxCompactListValueLen  = 512
+	truncatedPropertyMarker = "...(truncated)"
+)
+
+var propertyValueLimits = map[string]int{
+	"AzCopyVersion":             64,
+	"SchemaVersion":             32,
+	"SamplingRate":              32,
+	"SamplerVersion":            64,
+	"E2ETestRunID":              maxIdentifierValueLen,
+	"OSType":                    32,
+	"OSVersion":                 maxHostValueLen,
+	"HostArch":                  32,
+	"HostNumCPU":                32,
+	"HostCPUModel":              maxHostValueLen,
+	"HostMemoryTotalGB":         32,
+	"HostNICSpeedMbps":          32,
+	"HostNICSpeedBucket":        32,
+	"AzureVMDetected":           5,
+	"InstallationID":            maxIdentifierValueLen,
+	"InvocationContext":         32,
+	"Command":                   64,
+	"SummaryCounterScope":       32,
+	"FromTo":                    64,
+	"SourceType":                64,
+	"DestType":                  64,
+	"SourceProtocol":            32,
+	"SourceMountType":           64,
+	"SourceStorageAccount":      maxHostValueLen,
+	"SourceScope":               64,
+	"DestProtocol":              32,
+	"DestStorageAccount":        maxHostValueLen,
+	"DestScope":                 64,
+	"DestEndpointKind":          64,
+	"SourceCloudType":           32,
+	"DestCloudType":             32,
+	"SourceAuthMechanism":       64,
+	"DestAuthMechanism":         64,
+	"BenchmarkMode":             32,
+	"BenchmarkFileCount":        32,
+	"BenchmarkFileSizeBytes":    32,
+	"BenchmarkFolderCount":      32,
+	"BenchmarkCleanupRequested": 5,
+	"BenchmarkIsCleanup":        5,
+	"JobID":                     maxIdentifierValueLen,
+	"InvocationID":              maxIdentifierValueLen,
+	"JobStatus":                 maxIdentifierValueLen,
+	"TerminalStage":             maxIdentifierValueLen,
+	"JobErrorCategory":          maxIdentifierValueLen,
+	"JobErrorCode":              maxIdentifierValueLen,
+	"FailureErrorCodes":         maxCompactListValueLen,
+	"PerformanceConstraint":     maxIdentifierValueLen,
+	"PerformanceAdviceCodes":    maxCompactListValueLen,
+	"OptFlagsSet":               maxPropValueLen,
+	"OptEnvVarsSet":             maxOptionValueLen,
+	"OptExcludeBlobTypes":       maxPropValueLen,
+}
+
+// truncateValue caps a property value at maxPropValueLen, appending a marker
+// when truncation occurs.
+func truncateValue(v string) string {
+	return truncateValueTo(v, maxPropValueLen)
+}
+
+func truncateValueTo(value string, maxBytes int) string {
+	value = strings.ToValidUTF8(value, "\uFFFD")
+	if maxBytes <= 0 {
+		return ""
+	}
+	if len(value) <= maxBytes {
+		return value
+	}
+
+	marker := truncatedPropertyMarker
+	end := maxBytes - len(marker)
+	if end <= 0 {
+		marker = ""
+		end = maxBytes
+	}
+	for end > 0 && !utf8.RuneStart(value[end]) {
+		end--
+	}
+	return value[:end] + marker
+}
+
+func propertyValueLimit(name string) int {
+	if limit, ok := propertyValueLimits[name]; ok {
+		return limit
+	}
+	if strings.HasPrefix(name, "Opt") {
+		return maxOptionValueLen
+	}
+	return maxPropValueLen
+}
+
+func boundProperties(properties map[string]string) map[string]string {
+	for name, value := range properties {
+		properties[name] = truncateValueTo(value, propertyValueLimit(name))
+	}
+	return properties
+}
+
+// mergeProps merges the given property maps into a single map. Later maps win
+// on key collisions.
+func mergeProps(maps ...map[string]string) map[string]string {
+	out := make(map[string]string)
+	for _, m := range maps {
+		for k, v := range m {
+			out[k] = v
+		}
+	}
+	return out
+}

--- a/telemetry/reporter.go
+++ b/telemetry/reporter.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -368,9 +369,81 @@ func postEnvelopes(ctx context.Context, client httpDoer, endpoint string, envelo
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusPartialContent {
+		if err := validatePartialIngestionResponse(resp.Body); err != nil {
+			return resp.StatusCode, err
+		}
+	}
 	if resp.StatusCode >= 300 {
 		respBody, _ := io.ReadAll(resp.Body)
 		return resp.StatusCode, fmt.Errorf("app insights returned %d: %s", resp.StatusCode, string(respBody))
 	}
 	return resp.StatusCode, nil
+}
+
+type partialIngestionResponse struct {
+	ItemsReceived int                     `json:"itemsReceived"`
+	ItemsAccepted int                     `json:"itemsAccepted"`
+	Errors        []partialIngestionIssue `json:"errors"`
+}
+
+type partialIngestionIssue struct {
+	Index      int    `json:"index"`
+	StatusCode int    `json:"statusCode"`
+	Message    string `json:"message"`
+}
+
+func validatePartialIngestionResponse(body io.Reader) error {
+	var result partialIngestionResponse
+	decoder := json.NewDecoder(io.LimitReader(body, 64*1024))
+	if err := decoder.Decode(&result); err != nil {
+		return fmt.Errorf("app insights returned 206 with an invalid response: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return errors.New("app insights returned 206 with an invalid response: trailing content")
+	}
+	if result.ItemsReceived <= 0 || result.ItemsAccepted < 0 || result.ItemsAccepted > result.ItemsReceived {
+		return fmt.Errorf(
+			"app insights returned 206 with invalid item counts (received=%d accepted=%d)",
+			result.ItemsReceived,
+			result.ItemsAccepted)
+	}
+
+	rejected := result.ItemsReceived - result.ItemsAccepted
+	if rejected <= 0 || len(result.Errors) != rejected {
+		return fmt.Errorf(
+			"app insights returned 206 with inconsistent rejection details (received=%d accepted=%d errors=%d)",
+			result.ItemsReceived,
+			result.ItemsAccepted,
+			len(result.Errors))
+	}
+	rejectedIndexes := make(map[int]struct{}, len(result.Errors))
+	for _, issue := range result.Errors {
+		if issue.Index < 0 || issue.Index >= result.ItemsReceived {
+			return fmt.Errorf(
+				"app insights returned 206 with an invalid rejected item index %d (received=%d)",
+				issue.Index,
+				result.ItemsReceived)
+		}
+		if _, exists := rejectedIndexes[issue.Index]; exists {
+			return fmt.Errorf("app insights returned 206 with duplicate rejected item index %d", issue.Index)
+		}
+		rejectedIndexes[issue.Index] = struct{}{}
+		if issue.StatusCode < http.StatusBadRequest || issue.StatusCode > 599 {
+			return fmt.Errorf(
+				"app insights returned 206 with invalid rejection status %d at item index %d",
+				issue.StatusCode,
+				issue.Index)
+		}
+	}
+
+	first := result.Errors[0]
+	return fmt.Errorf(
+		"app insights partially accepted telemetry (received=%d accepted=%d rejected=%d; first rejection index=%d status=%d: %s)",
+		result.ItemsReceived,
+		result.ItemsAccepted,
+		rejected,
+		first.Index,
+		first.StatusCode,
+		strings.TrimSpace(first.Message))
 }

--- a/telemetry/reporter.go
+++ b/telemetry/reporter.go
@@ -29,6 +29,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -99,7 +100,7 @@ func parseConnectionString(cs string) map[string]string {
 	for _, part := range strings.Split(cs, ";") {
 		kv := strings.SplitN(part, "=", 2)
 		if len(kv) == 2 {
-			m[strings.TrimSpace(kv[0])] = strings.TrimSpace(kv[1])
+			m[strings.ToLower(strings.TrimSpace(kv[0]))] = strings.TrimSpace(kv[1])
 		}
 	}
 	return m
@@ -109,10 +110,39 @@ func parseConnectionString(cs string) map[string]string {
 // ingestion endpoint (no trailing slash) and instrumentation key.
 func (r *Reporter) endpointAndKey() (endpoint, ikey string, err error) {
 	parts := parseConnectionString(r.cfg.ConnectionString)
-	endpoint = strings.TrimRight(parts["IngestionEndpoint"], "/")
-	ikey = parts["InstrumentationKey"]
-	if endpoint == "" || ikey == "" {
-		return "", "", fmt.Errorf("connection string must contain IngestionEndpoint and InstrumentationKey")
+	ikey = parts["instrumentationkey"]
+	if ikey == "" {
+		return "", "", fmt.Errorf("connection string must contain InstrumentationKey")
+	}
+	if authorization := parts["authorization"]; authorization != "" && !strings.EqualFold(authorization, "ikey") {
+		return "", "", fmt.Errorf("unsupported Application Insights authorization %q", authorization)
+	}
+
+	endpoint = parts["ingestionendpoint"]
+	if endpoint == "" {
+		suffix := parts["endpointsuffix"]
+		if suffix == "" {
+			return "", "", fmt.Errorf("connection string must contain IngestionEndpoint or EndpointSuffix")
+		}
+		if strings.ContainsAny(suffix, "/:@?#") {
+			return "", "", fmt.Errorf("invalid Application Insights EndpointSuffix %q", suffix)
+		}
+		locationPrefix := ""
+		if location := parts["location"]; location != "" {
+			if strings.ContainsAny(location, "/.:@?#") {
+				return "", "", fmt.Errorf("invalid Application Insights Location %q", location)
+			}
+			locationPrefix = location + "."
+		}
+		endpoint = "https://" + locationPrefix + "dc." + suffix
+	}
+
+	endpoint = strings.TrimRight(endpoint, "/")
+	parsedEndpoint, parseErr := url.Parse(endpoint)
+	if parseErr != nil || parsedEndpoint.Host == "" ||
+		(parsedEndpoint.Scheme != "http" && parsedEndpoint.Scheme != "https") ||
+		parsedEndpoint.User != nil || parsedEndpoint.RawQuery != "" || parsedEndpoint.Fragment != "" {
+		return "", "", fmt.Errorf("invalid Application Insights ingestion endpoint %q", endpoint)
 	}
 	return endpoint, ikey, nil
 }

--- a/telemetry/reporter.go
+++ b/telemetry/reporter.go
@@ -1,0 +1,376 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+)
+
+// httpDoer is the subset of *http.Client used to send telemetry. It is an
+// interface so tests can inject a stub transport instead of making real calls.
+type httpDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// Backend selects which telemetry backend to use.
+type Backend string
+
+const (
+	BackendOTel        Backend = "otel"        // OpenTelemetry SDK with App Insights exporter
+	BackendAppInsights Backend = "appinsights" // Direct App Insights Track API
+)
+
+// Config holds the configuration for telemetry reporting.
+type Config struct {
+	// Backend selects otel or appinsights.
+	Backend Backend
+
+	// ConnectionString is the Application Insights connection string.
+	// Required when Backend == BackendOTel or BackendAppInsights.
+	ConnectionString string
+
+	// HTTPClient is the client used to POST telemetry. Optional; when nil the
+	// reporter falls back to http.DefaultClient. Injecting a client makes the
+	// reporter fully unit-testable.
+	HTTPClient httpDoer
+}
+
+// Reporter sends telemetry events to Azure Monitor.
+type Reporter struct {
+	cfg Config
+}
+
+// NewReporter creates a Reporter from the given config.
+func NewReporter(cfg Config) *Reporter {
+	return &Reporter{cfg: cfg}
+}
+
+// httpClient returns the configured HTTP client, defaulting to
+// http.DefaultClient when none was injected.
+func (r *Reporter) httpClient() httpDoer {
+	if r.cfg.HTTPClient != nil {
+		return r.cfg.HTTPClient
+	}
+	return http.DefaultClient
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+// parseConnectionString extracts key-value pairs from an Application Insights
+// connection string (e.g. "InstrumentationKey=abc;IngestionEndpoint=https://...").
+func parseConnectionString(cs string) map[string]string {
+	m := make(map[string]string)
+	for _, part := range strings.Split(cs, ";") {
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) == 2 {
+			m[strings.TrimSpace(kv[0])] = strings.TrimSpace(kv[1])
+		}
+	}
+	return m
+}
+
+// endpointAndKey parses the configured connection string and returns the
+// ingestion endpoint (no trailing slash) and instrumentation key.
+func (r *Reporter) endpointAndKey() (endpoint, ikey string, err error) {
+	parts := parseConnectionString(r.cfg.ConnectionString)
+	endpoint = strings.TrimRight(parts["IngestionEndpoint"], "/")
+	ikey = parts["InstrumentationKey"]
+	if endpoint == "" || ikey == "" {
+		return "", "", fmt.Errorf("connection string must contain IngestionEndpoint and InstrumentationKey")
+	}
+	return endpoint, ikey, nil
+}
+
+// ---------------------------------------------------------------------------
+// OTel backend – real OpenTelemetry SDK with a custom App Insights exporter
+// ---------------------------------------------------------------------------
+
+// sendEventOTel records a MetricEvent's measurements through the OpenTelemetry
+// SDK pipeline (meter -> instruments -> manual reader -> App Insights exporter)
+// instead of hand-building envelopes. This is the "real" OTel path: the same
+// instrumentation could target any OTel-compatible backend (OTLP collector,
+// Prometheus, another vendor) simply by swapping the exporter, without touching
+// the calling code.
+func (r *Reporter) sendEventOTel(ctx context.Context, evt MetricEvent) error {
+	endpoint, ikey, err := r.endpointAndKey()
+	if err != nil {
+		return err
+	}
+
+	exporter := &appInsightsExporter{
+		endpoint:  endpoint,
+		ikey:      ikey,
+		client:    r.httpClient(),
+		eventName: evt.EventName(),
+		timestamp: evt.timestamp(),
+	}
+
+	res, err := resource.New(ctx,
+		resource.WithAttributes(
+			semconv.ServiceNameKey.String("azcopy"),
+		),
+	)
+	if err != nil {
+		return fmt.Errorf("create resource: %w", err)
+	}
+
+	reader := metric.NewManualReader()
+	provider := metric.NewMeterProvider(
+		metric.WithResource(res),
+		metric.WithReader(reader),
+	)
+	defer func() {
+		if err := provider.Shutdown(ctx); err != nil {
+			log.Printf("telemetry: otel shutdown error: %v", err)
+		}
+	}()
+
+	meter := provider.Meter("azcopy")
+
+	// The event's flattened resource + dimension properties become OTel
+	// attributes carried on every measurement.
+	attrs := propsToAttributes(evt.attributes())
+
+	// Each numeric measurement becomes its own counter instrument, recorded
+	// with the shared attribute set. The manual reader then collects them for
+	// a single export pass.
+	for _, m := range evt.measurements() {
+		counter, err := meter.Float64Counter(m.Name)
+		if err != nil {
+			return fmt.Errorf("create instrument %s: %w", m.Name, err)
+		}
+		counter.Add(ctx, m.Value, otelmetric.WithAttributes(attrs...))
+	}
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(ctx, &rm); err != nil {
+		return fmt.Errorf("collect metrics: %w", err)
+	}
+	if err := exporter.Export(ctx, &rm); err != nil {
+		return fmt.Errorf("export metrics: %w", err)
+	}
+
+	log.Printf("telemetry: sent packed %s event to App Insights via OTel SDK", evt.EventName())
+	return nil
+}
+
+// propsToAttributes converts a flat string property map into OTel attributes.
+func propsToAttributes(props map[string]string) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, len(props))
+	for k, v := range props {
+		attrs = append(attrs, attribute.String(k, v))
+	}
+	return attrs
+}
+
+// appInsightsExporter implements a lightweight OTel metric exporter
+// that sends data to the Application Insights /v2.1/track endpoint.
+type appInsightsExporter struct {
+	endpoint  string
+	ikey      string
+	client    httpDoer
+	eventName string
+	timestamp time.Time
+}
+
+func (e *appInsightsExporter) Export(ctx context.Context, rm *metricdata.ResourceMetrics) error {
+	// Collect every data point before sending them in one HTTP batch.
+	var points []metricPoint
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			points = append(points, metricToPoints(m)...)
+		}
+	}
+
+	envelopes := e.pointsToEnvelopes(points)
+	if len(envelopes) == 0 {
+		return nil
+	}
+
+	client := e.client
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	resp, err := postEnvelopes(ctx, client, e.endpoint, envelopes)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("telemetry: otel export to App Insights (HTTP %d, %d envelopes)", resp, len(envelopes))
+	return nil
+}
+
+// metricPoint is a single data point extracted from OTel metric data, carrying
+// the attribute set it was recorded with.
+type metricPoint struct {
+	name  string
+	value float64
+	props map[string]string
+}
+
+func metricToPoints(m metricdata.Metrics) []metricPoint {
+	var points []metricPoint
+	add := func(value float64, count int, attrs attribute.Set) {
+		points = append(points, metricPoint{
+			name:  m.Name,
+			value: value,
+			props: attrsToProps(attrs),
+		})
+	}
+
+	switch data := m.Data.(type) {
+	case metricdata.Sum[int64]:
+		for _, dp := range data.DataPoints {
+			add(float64(dp.Value), 1, dp.Attributes)
+		}
+	case metricdata.Sum[float64]:
+		for _, dp := range data.DataPoints {
+			add(dp.Value, 1, dp.Attributes)
+		}
+	case metricdata.Gauge[int64]:
+		for _, dp := range data.DataPoints {
+			add(float64(dp.Value), 1, dp.Attributes)
+		}
+	case metricdata.Gauge[float64]:
+		for _, dp := range data.DataPoints {
+			add(dp.Value, 1, dp.Attributes)
+		}
+	case metricdata.Histogram[int64]:
+		for _, dp := range data.DataPoints {
+			add(float64(dp.Sum), int(dp.Count), dp.Attributes)
+		}
+	case metricdata.Histogram[float64]:
+		for _, dp := range data.DataPoints {
+			add(dp.Sum, int(dp.Count), dp.Attributes)
+		}
+	}
+
+	return points
+}
+
+// pointsToEnvelopes packs all data points from one MetricEvent into one custom
+// event row. All points recorded by sendEventOTel carry the same properties.
+func (e *appInsightsExporter) pointsToEnvelopes(points []metricPoint) []appInsightsEnvelope {
+	if len(points) == 0 {
+		return nil
+	}
+
+	measurements := make(map[string]float64, len(points))
+	for _, point := range points {
+		measurements[point.name] = point.value
+	}
+
+	return []appInsightsEnvelope{{
+		Name: "Microsoft.ApplicationInsights.Event",
+		Time: e.timestamp.UTC().Format(time.RFC3339),
+		IKey: e.ikey,
+		Data: appInsightsData{
+			BaseType: "EventData",
+			BaseData: appInsightsEventData{
+				Version:      2,
+				Name:         e.eventName,
+				Properties:   points[0].props,
+				Measurements: measurements,
+			},
+		},
+	}}
+}
+
+func attrsToProps(attrs attribute.Set) map[string]string {
+	props := make(map[string]string)
+	iter := attrs.Iter()
+	for iter.Next() {
+		kv := iter.Attribute()
+		props[string(kv.Key)] = kv.Value.Emit()
+	}
+	return props
+}
+
+// ---------------------------------------------------------------------------
+// Shared App Insights /v2.1/track envelope types (used by both backends)
+// ---------------------------------------------------------------------------
+
+// appInsightsEnvelope is the telemetry envelope for the /v2.1/track API.
+type appInsightsEnvelope struct {
+	Name string          `json:"name"`
+	Time string          `json:"time"`
+	IKey string          `json:"iKey"`
+	Data appInsightsData `json:"data"`
+}
+
+type appInsightsData struct {
+	BaseType string               `json:"baseType"`
+	BaseData appInsightsEventData `json:"baseData"`
+}
+
+type appInsightsEventData struct {
+	Version      int                `json:"ver"`
+	Name         string             `json:"name"`
+	Properties   map[string]string  `json:"properties,omitempty"`
+	Measurements map[string]float64 `json:"measurements,omitempty"`
+}
+
+// postEnvelopes sends a batch of telemetry envelopes to the App Insights
+// /v2.1/track ingestion endpoint using the given client. It returns the HTTP
+// status code on success.
+func postEnvelopes(ctx context.Context, client httpDoer, endpoint string, envelopes []appInsightsEnvelope) (int, error) {
+	body, err := json.Marshal(envelopes)
+	if err != nil {
+		return 0, fmt.Errorf("marshal envelopes: %w", err)
+	}
+
+	url := endpoint + "/v2.1/track"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return 0, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("send metrics: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return resp.StatusCode, fmt.Errorf("app insights returned %d: %s", resp.StatusCode, string(respBody))
+	}
+	return resp.StatusCode, nil
+}

--- a/telemetry/reporter_test.go
+++ b/telemetry/reporter_test.go
@@ -1,0 +1,666 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testConnString = "InstrumentationKey=11111111-2222-3333-4444-555555555555;IngestionEndpoint=https://eastus.example.com/"
+
+// stubClient is an httpDoer that records the last request it received and
+// returns a canned response (or error), so we can assert on telemetry traffic
+// without making real network calls.
+type stubClient struct {
+	lastReq  *http.Request
+	lastBody []byte
+	status   int
+	respBody string
+	err      error
+	calls    int
+}
+
+func (c *stubClient) Do(req *http.Request) (*http.Response, error) {
+	c.calls++
+	c.lastReq = req
+	if req.Body != nil {
+		c.lastBody, _ = io.ReadAll(req.Body)
+	}
+	if c.err != nil {
+		return nil, c.err
+	}
+	status := c.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(bytes.NewReader([]byte(c.respBody))),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func sampleStarted() JobStartedEvent {
+	ts := time.Date(2026, 6, 23, 10, 0, 0, 0, time.UTC)
+	return JobStartedEvent{
+		Resource: ResourceAttributes{
+			AzCopyVersion:    "10.32.2",
+			SchemaVersion:    "1",
+			SamplingRate:     0.01,
+			SamplerVersion:   "job-id-sha256-v1",
+			OSType:           "linux",
+			HostArch:         "amd64",
+			HostNumCPU:       8,
+			HostNICSpeedMbps: -1,
+			AzureVMDetected:  true,
+			InstallationID:   "abc123",
+		},
+		Dimensions: JobDimensions{
+			Command:         "copy",
+			FromTo:          "LocalBlob",
+			SourceType:      "Local",
+			DestType:        "Blob",
+			SourceCloudType: "",
+			DestCloudType:   "public",
+			Options: OptionAttributes{
+				FlagsSet: []string{"recursive", "put-md5"},
+				Values: map[string]string{
+					"OptRecursive":   "true",
+					"OptBlockSizeMB": "8",
+				},
+			},
+		},
+		JobID:        "job-1234",
+		InvocationID: "invocation-1234",
+		Timestamp:    ts,
+		StartedCount: 1,
+	}
+}
+
+func sampleFinished() JobFinishedEvent {
+	start := time.Date(2026, 6, 23, 10, 0, 0, 0, time.UTC)
+	return JobFinishedEvent{
+		Resource:                        sampleStarted().Resource,
+		Dimensions:                      sampleStarted().Dimensions,
+		JobID:                           "job-1234",
+		InvocationID:                    "invocation-1234",
+		StartTimestamp:                  start,
+		EndTimestamp:                    start.Add(time.Minute),
+		FinishedCount:                   1,
+		JobStatus:                       "CompletedWithErrors",
+		TerminalStage:                   "completed",
+		JobErrorCategory:                "transfer",
+		JobErrorCode:                    "transfer-failures",
+		FailureErrorOtherCount:          2,
+		PerformanceConstraint:           "Service",
+		PerformanceAdviceCodes:          []string{"NetworkErrors", "AccountIOPS"},
+		BytesEnumerated:                 2048,
+		BytesExpected:                   1536,
+		BytesTransferred:                1024,
+		BytesOverWire:                   1100,
+		ObjectsScheduled:                9,
+		RegularFilesScheduled:           6,
+		SymlinksScheduled:               2,
+		HardlinksConvertedScheduled:     1,
+		FolderPropertiesScheduled:       4,
+		ObjectsCompleted:                7,
+		ObjectsFailed:                   1,
+		ObjectsSkipped:                  1,
+		FolderPropertiesCompleted:       3,
+		FolderPropertiesFailed:          0,
+		FolderPropertiesSkipped:         1,
+		SourceObjectsScanned:            20,
+		SourceBytesScanned:              40960,
+		SourceAverageObjectSizeBytes:    2048,
+		SourceObjectSizeP50BytesApprox:  1024,
+		SourceObjectSizeP90BytesApprox:  16 * 1024 * 1024,
+		SourceObjectSizeP95BytesApprox:  256 * 1024 * 1024,
+		SourceObjectsUnder1MiB:          12,
+		SourceObjectsUnder1MiBRatioPct:  60,
+		SourceMaxDirectoryDepth:         5,
+		ContainersScanned:               3,
+		ContainersTouched:               2,
+		TransfersCompleted:              10,
+		TransfersFailed:                 1,
+		TransfersSkipped:                2,
+		TransfersTotal:                  13,
+		JobDurationSeconds:              60,
+		EnumerationPhaseDurationSeconds: 40,
+		TransferPhaseDurationSeconds:    50,
+		JobThroughputMbps:               0.0001365,
+		TransferPhaseThroughputMbps:     0.00016384,
+		AverageStorageHTTPAttemptE2EMs:  42,
+		AvgIOPS:                         100,
+		StorageHTTPAttemptCount:         1000,
+		NetworkErrorAttemptCount:        2,
+		ServerBusy503Count:              15,
+		ServerBusyThroughputCount:       10,
+		ServerBusyIOPSCount:             3,
+		ServerBusyOtherCount:            2,
+		ServerBusyPct:                   1.5,
+		NetworkErrorPct:                 0.2,
+		PercentComplete:                 100,
+	}
+}
+
+func TestParseConnectionString(t *testing.T) {
+	m := parseConnectionString(testConnString)
+	assert.Equal(t, "11111111-2222-3333-4444-555555555555", m["InstrumentationKey"])
+	assert.Equal(t, "https://eastus.example.com/", m["IngestionEndpoint"])
+
+	// Tolerates whitespace and ignores malformed segments.
+	m = parseConnectionString(" A = 1 ; bogus ; B=2")
+	assert.Equal(t, "1", m["A"])
+	assert.Equal(t, "2", m["B"])
+	_, ok := m["bogus"]
+	assert.False(t, ok)
+}
+
+func TestEndpointAndKey(t *testing.T) {
+	r := NewReporter(Config{ConnectionString: testConnString})
+	endpoint, ikey, err := r.endpointAndKey()
+	require.NoError(t, err)
+	assert.Equal(t, "https://eastus.example.com", endpoint) // trailing slash trimmed
+	assert.Equal(t, "11111111-2222-3333-4444-555555555555", ikey)
+
+	_, _, err = NewReporter(Config{ConnectionString: "garbage"}).endpointAndKey()
+	assert.Error(t, err)
+}
+
+func TestEventNamesAndTimestamps(t *testing.T) {
+	s := sampleStarted()
+	f := sampleFinished()
+	assert.Equal(t, "azcopy.job.started", s.EventName())
+	assert.Equal(t, "azcopy.job.finished", f.EventName())
+	assert.Equal(t, s.Timestamp, s.timestamp())
+	assert.Equal(t, f.EndTimestamp, f.timestamp())
+}
+
+func TestStartedMeasurements(t *testing.T) {
+	m := sampleStarted().measurements()
+	require.Len(t, m, 1)
+	assert.Equal(t, "azcopy.job.started", m[0].Name)
+	assert.Equal(t, float64(1), m[0].Value)
+}
+
+func TestFinishedMeasurements(t *testing.T) {
+	m := sampleFinished().measurements()
+	byName := map[string]float64{}
+	for _, nm := range m {
+		byName[nm.Name] = nm.Value
+	}
+	assert.Equal(t, float64(1024), byName["azcopy.bytes_transferred"])
+	assert.Equal(t, float64(2), byName["azcopy.failure_error_other_count"])
+	assert.Equal(t, float64(2048), byName["azcopy.bytes_enumerated"])
+	assert.Equal(t, float64(1536), byName["azcopy.bytes_expected"])
+	assert.Equal(t, float64(1100), byName["azcopy.bytes_over_wire"])
+	assert.Equal(t, float64(9), byName["azcopy.objects_scheduled"])
+	assert.Equal(t, float64(6), byName["azcopy.regular_files_scheduled"])
+	assert.Equal(t, float64(2), byName["azcopy.symlinks_scheduled"])
+	assert.Equal(t, float64(1), byName["azcopy.hardlinks_converted_scheduled"])
+	assert.Equal(t, float64(4), byName["azcopy.folder_properties_scheduled"])
+	assert.Equal(t, float64(7), byName["azcopy.objects_completed"])
+	assert.Equal(t, float64(1), byName["azcopy.objects_failed"])
+	assert.Equal(t, float64(1), byName["azcopy.objects_skipped"])
+	assert.Equal(t, float64(3), byName["azcopy.folder_properties_completed"])
+	assert.Equal(t, float64(0), byName["azcopy.folder_properties_failed"])
+	assert.Equal(t, float64(1), byName["azcopy.folder_properties_skipped"])
+	assert.Equal(t, float64(20), byName["azcopy.source_objects_scanned"])
+	assert.Equal(t, float64(40960), byName["azcopy.source_bytes_scanned"])
+	assert.Equal(t, float64(2048), byName["azcopy.source_average_object_size_bytes"])
+	assert.Equal(t, float64(1024), byName["azcopy.source_object_size_p50_bytes_approx"])
+	assert.Equal(t, float64(16*1024*1024), byName["azcopy.source_object_size_p90_bytes_approx"])
+	assert.Equal(t, float64(256*1024*1024), byName["azcopy.source_object_size_p95_bytes_approx"])
+	assert.Equal(t, float64(12), byName["azcopy.source_objects_under_1_mib"])
+	assert.Equal(t, float64(60), byName["azcopy.source_objects_under_1_mib_ratio_pct"])
+	assert.Equal(t, float64(5), byName["azcopy.source_max_directory_depth"])
+	assert.Equal(t, float64(3), byName["azcopy.containers_scanned"])
+	assert.Equal(t, float64(2), byName["azcopy.containers_touched"])
+	assert.Equal(t, float64(10), byName["azcopy.transfers_completed"])
+	assert.Equal(t, float64(1), byName["azcopy.transfers_failed"])
+	assert.Equal(t, float64(2), byName["azcopy.transfers_skipped"])
+	assert.Equal(t, float64(13), byName["azcopy.transfers_total"])
+	assert.Equal(t, float64(60), byName["azcopy.job_duration_seconds"])
+	assert.Equal(t, float64(40), byName["azcopy.enumeration_phase_duration_seconds"])
+	assert.Equal(t, float64(50), byName["azcopy.transfer_phase_duration_seconds"])
+	assert.Equal(t, 0.0001365, byName["azcopy.job_throughput_mbps"])
+	assert.Equal(t, 0.00016384, byName["azcopy.transfer_phase_throughput_mbps"])
+	assert.Equal(t, float64(42), byName["azcopy.average_storage_http_attempt_e2e_ms"])
+	assert.Equal(t, float64(100), byName["azcopy.avg_iops"])
+	assert.Equal(t, float64(1000), byName["azcopy.storage_http_attempt_count"])
+	assert.Equal(t, float64(2), byName["azcopy.network_error_attempt_count"])
+	assert.Equal(t, float64(15), byName["azcopy.server_busy_503_count"])
+	assert.Equal(t, float64(10), byName["azcopy.server_busy_throughput_count"])
+	assert.Equal(t, float64(3), byName["azcopy.server_busy_iops_count"])
+	assert.Equal(t, float64(2), byName["azcopy.server_busy_other_count"])
+	assert.InDelta(t, 1.5, byName["azcopy.server_busy_pct"], 1e-9)
+	assert.InDelta(t, 0.2, byName["azcopy.network_error_pct"], 1e-9)
+	assert.Equal(t, float64(100), byName["azcopy.percent_complete"])
+	assert.Len(t, m, 50)
+}
+
+func TestCommandInvokedEvent(t *testing.T) {
+	ts := time.Date(2026, 6, 23, 10, 0, 0, 0, time.UTC)
+	e := CommandInvokedEvent{
+		Resource: sampleStarted().Resource,
+		Command:  "login",
+		Options: OptionAttributes{
+			FlagsSet: []string{"method", "tenant"},
+			Values:   map[string]string{"OptLoginType": "device"},
+		},
+		JobID:        "job-9999",
+		InvocationID: "invocation-9999",
+		Timestamp:    ts,
+		InvokedCount: 1,
+	}
+	assert.Equal(t, "azcopy.command.invoked", e.EventName())
+	assert.Equal(t, ts, e.timestamp())
+
+	m := e.measurements()
+	require.Len(t, m, 1)
+	assert.Equal(t, "azcopy.command.invoked", m[0].Name)
+	assert.Equal(t, float64(1), m[0].Value)
+
+	attrs := e.attributes()
+	assert.Equal(t, "login", attrs["Command"])
+	assert.Equal(t, "method,tenant", attrs["OptFlagsSet"])
+	assert.Equal(t, "device", attrs["OptLoginType"])
+	assert.Equal(t, "job-9999", attrs["JobID"])
+	assert.Equal(t, "invocation-9999", attrs["InvocationID"])
+	// Resource attributes are included.
+	assert.Equal(t, "10.32.2", attrs["AzCopyVersion"])
+	_, hasServiceName := attrs["ServiceName"]
+	assert.False(t, hasServiceName)
+	_, hasServiceVersion := attrs["ServiceVersion"]
+	assert.False(t, hasServiceVersion)
+	// No job dimensions on a command.invoked event.
+	_, hasFromTo := attrs["FromTo"]
+	assert.False(t, hasFromTo)
+
+	// Empty JobID is omitted.
+	e.JobID = ""
+	_, hasJobID := e.attributes()["JobID"]
+	assert.False(t, hasJobID)
+}
+
+func TestAttributesIncludeResourceAndDimensions(t *testing.T) {
+	attrs := sampleFinished().attributes()
+	assert.Equal(t, "10.32.2", attrs["AzCopyVersion"])
+	_, hasServiceName := attrs["ServiceName"]
+	assert.False(t, hasServiceName)
+	_, hasServiceVersion := attrs["ServiceVersion"]
+	assert.False(t, hasServiceVersion)
+	assert.Equal(t, "1", attrs["SchemaVersion"])
+	assert.Equal(t, "0.01", attrs["SamplingRate"])
+	_, hasSamplingUnit := attrs["SamplingUnit"]
+	assert.False(t, hasSamplingUnit)
+	assert.Equal(t, "job-id-sha256-v1", attrs["SamplerVersion"])
+	assert.Equal(t, "true", attrs["AzureVMDetected"])
+	_, hasHostVirtualization := attrs["HostVirtualization"]
+	assert.False(t, hasHostVirtualization)
+	_, hasNetworkRunContext := attrs["NetworkRunContext"]
+	assert.False(t, hasNetworkRunContext)
+	assert.Equal(t, "copy", attrs["Command"])
+	_, hasAttemptType := attrs["AttemptType"]
+	assert.False(t, hasAttemptType)
+	_, hasMeasurementScope := attrs["MeasurementScope"]
+	assert.False(t, hasMeasurementScope)
+	assert.Equal(t, "true", attrs["OptRecursive"])
+	assert.Equal(t, "8", attrs["OptBlockSizeMB"])
+	assert.Equal(t, "recursive,put-md5", attrs["OptFlagsSet"])
+	// JobStatus is only present on the finished event.
+	assert.Equal(t, "CompletedWithErrors", attrs["JobStatus"])
+	_, hasTerminalReason := attrs["TerminalReason"]
+	assert.False(t, hasTerminalReason)
+	assert.Equal(t, "completed", attrs["TerminalStage"])
+	assert.Equal(t, "transfer", attrs["JobErrorCategory"])
+	assert.Equal(t, "transfer-failures", attrs["JobErrorCode"])
+	assert.Equal(t, "Service", attrs["PerformanceConstraint"])
+	_, hasPrimaryAdvice := attrs["PrimaryPerformanceAdviceCode"]
+	assert.False(t, hasPrimaryAdvice)
+	assert.Equal(t, "NetworkErrors,AccountIOPS", attrs["PerformanceAdviceCodes"])
+	_, hasStatus := sampleStarted().attributes()["JobStatus"]
+	assert.False(t, hasStatus)
+	_, hasE2ETestRunID := attrs["E2ETestRunID"]
+	assert.False(t, hasE2ETestRunID)
+}
+
+func TestE2ETestRunIDIsIncludedAndBoundedWhenConfigured(t *testing.T) {
+	event := sampleFinished()
+	event.Resource.E2ETestRunID = strings.Repeat("r", maxIdentifierValueLen+100)
+
+	attrs := event.attributes()
+	assert.Len(t, attrs["E2ETestRunID"], maxIdentifierValueLen)
+	assert.True(t, strings.HasSuffix(attrs["E2ETestRunID"], truncatedPropertyMarker))
+
+	command := CommandInvokedEvent{
+		Resource:     event.Resource,
+		Command:      "jobs.list",
+		Timestamp:    time.Now(),
+		InvokedCount: 1,
+	}
+	assert.Equal(t, attrs["E2ETestRunID"], command.attributes()["E2ETestRunID"])
+}
+
+func TestBenchmarkDimensionsProperties(t *testing.T) {
+	properties := JobDimensions{
+		Command:                   "bench",
+		BenchmarkMode:             "upload",
+		BenchmarkFileCount:        100,
+		BenchmarkFileSizeBytes:    256 * 1024 * 1024,
+		BenchmarkFolderCount:      10,
+		BenchmarkCleanupRequested: true,
+		BenchmarkIsCleanup:        false,
+	}.props()
+	assert.Equal(t, "upload", properties["BenchmarkMode"])
+	assert.Equal(t, "100", properties["BenchmarkFileCount"])
+	assert.Equal(t, "268435456", properties["BenchmarkFileSizeBytes"])
+	assert.Equal(t, "10", properties["BenchmarkFolderCount"])
+	assert.Equal(t, "true", properties["BenchmarkCleanupRequested"])
+	assert.Equal(t, "false", properties["BenchmarkIsCleanup"])
+}
+
+func TestResumeDimensionsProperties(t *testing.T) {
+	properties := JobDimensions{
+		Command:             "jobs.resume",
+		SummaryCounterScope: "job-cumulative",
+	}.props()
+	assert.Equal(t, "jobs.resume", properties["Command"])
+	assert.Equal(t, "job-cumulative", properties["SummaryCounterScope"])
+}
+
+func TestJobIDCorrelatesEvents(t *testing.T) {
+	// The started and finished events for an attempt share JobID and InvocationID.
+	started := sampleStarted().attributes()
+	finished := sampleFinished().attributes()
+	assert.Equal(t, "job-1234", started["JobID"])
+	assert.Equal(t, "job-1234", finished["JobID"])
+	assert.Equal(t, started["JobID"], finished["JobID"])
+	assert.Equal(t, "invocation-1234", started["InvocationID"])
+	assert.Equal(t, started["InvocationID"], finished["InvocationID"])
+}
+
+func TestOptFlagsSetTruncation(t *testing.T) {
+	// A run with many flags must not produce an OptFlagsSet value larger than
+	// the cap, so the telemetry payload stays bounded.
+	flags := make([]string, 0, 500)
+	for i := 0; i < 500; i++ {
+		flags = append(flags, "--some-long-flag-name")
+	}
+	attrs := JobDimensions{Options: OptionAttributes{FlagsSet: flags}}.props()
+	val := attrs["OptFlagsSet"]
+	assert.LessOrEqual(t, len(val), maxPropValueLen)
+	assert.True(t, strings.HasSuffix(val, "...(truncated)"))
+
+	// A short flag set is left untouched.
+	short := JobDimensions{Options: OptionAttributes{FlagsSet: []string{"recursive", "put-md5"}}}.props()
+	assert.Equal(t, "recursive,put-md5", short["OptFlagsSet"])
+	assert.NotContains(t, short["OptFlagsSet"], "truncated")
+}
+
+func TestBoundPropertiesAppliesDefaultAndSpecificLimits(t *testing.T) {
+	oversized := strings.Repeat("x", maxPropValueLen+100)
+	properties := map[string]string{
+		"FutureProperty": oversized,
+		"OptFutureValue": oversized,
+	}
+	for name := range propertyValueLimits {
+		properties[name] = oversized
+	}
+
+	boundProperties(properties)
+	for name, value := range properties {
+		assert.LessOrEqual(t, len(value), propertyValueLimit(name), name)
+		if propertyValueLimit(name) > len(truncatedPropertyMarker) {
+			assert.True(t, strings.HasSuffix(value, truncatedPropertyMarker), name)
+		}
+	}
+	assert.Len(t, properties["OptFutureValue"], maxOptionValueLen)
+	assert.Len(t, properties["FutureProperty"], maxPropValueLen)
+}
+
+func TestTruncateValueToPreservesUTF8(t *testing.T) {
+	value := strings.Repeat("界", maxPropValueLen)
+	truncated := truncateValueTo(value, maxPropValueLen)
+
+	assert.LessOrEqual(t, len(truncated), maxPropValueLen)
+	assert.True(t, utf8.ValidString(truncated))
+	assert.True(t, strings.HasSuffix(truncated, truncatedPropertyMarker))
+}
+
+func TestEventPropertiesAreBoundedBeforeExport(t *testing.T) {
+	oversized := strings.Repeat("x", maxPropValueLen+100)
+	event := sampleFinished()
+	event.Resource.OSVersion = oversized
+	event.Resource.HostCPUModel = oversized
+	event.Dimensions.SourceStorageAccount = oversized
+	event.Dimensions.Options = OptionAttributes{
+		FlagsSet: []string{oversized, oversized},
+		Values:   map[string]string{"OptFutureValue": oversized},
+	}
+	event.JobID = oversized
+	event.InvocationID = oversized
+	event.JobStatus = oversized
+	event.FailureErrorCodes = oversized
+
+	envelope := eventToEnvelopes("ikey-1", event)[0]
+	for name, value := range envelope.Data.BaseData.Properties {
+		assert.LessOrEqual(t, len(value), propertyValueLimit(name), name)
+	}
+	assert.Len(t, envelope.Data.BaseData.Properties["OSVersion"], maxHostValueLen)
+	assert.Len(t, envelope.Data.BaseData.Properties["JobID"], maxIdentifierValueLen)
+	assert.Len(t, envelope.Data.BaseData.Properties["OptFutureValue"], maxOptionValueLen)
+
+	command := CommandInvokedEvent{
+		Resource:     event.Resource,
+		Command:      oversized,
+		Options:      event.Dimensions.Options,
+		JobID:        oversized,
+		InvocationID: oversized,
+		Timestamp:    time.Now(),
+		InvokedCount: 1,
+	}
+	for name, value := range command.attributes() {
+		assert.LessOrEqual(t, len(value), propertyValueLimit(name), name)
+	}
+}
+
+func TestUnsetOptionsAreOmitted(t *testing.T) {
+	attrs := JobDimensions{Command: "copy"}.props()
+	for _, key := range []string{"OptFlagsSet", "OptEnvVarsSet", "OptRecursive", "OptBlockSizeMB", "OptConcurrency"} {
+		_, exists := attrs[key]
+		assert.False(t, exists, key)
+	}
+}
+
+func TestMergeProps(t *testing.T) {
+	out := mergeProps(
+		map[string]string{"a": "1", "b": "1"},
+		map[string]string{"b": "2", "c": "3"},
+	)
+	assert.Equal(t, map[string]string{"a": "1", "b": "2", "c": "3"}, out)
+}
+
+func TestEventToEnvelopes(t *testing.T) {
+	envelopes := eventToEnvelopes("ikey-1", sampleFinished())
+	require.Len(t, envelopes, 1)
+	envelope := envelopes[0]
+	assert.Equal(t, "Microsoft.ApplicationInsights.Event", envelope.Name)
+	assert.Equal(t, "ikey-1", envelope.IKey)
+	assert.Equal(t, "EventData", envelope.Data.BaseType)
+	assert.Equal(t, 2, envelope.Data.BaseData.Version)
+	assert.Equal(t, "azcopy.job.finished", envelope.Data.BaseData.Name)
+	assert.Len(t, envelope.Data.BaseData.Measurements, 50)
+	assert.Equal(t, float64(1), envelope.Data.BaseData.Measurements["azcopy.job.finished"])
+	assert.Equal(t, float64(1024), envelope.Data.BaseData.Measurements["azcopy.bytes_transferred"])
+	assert.Equal(t, float64(100), envelope.Data.BaseData.Measurements["azcopy.percent_complete"])
+	assert.Equal(t, "copy", envelope.Data.BaseData.Properties["Command"])
+	assert.Equal(t, "", envelope.Data.BaseData.Properties["SourceCloudType"])
+	assert.Equal(t, "public", envelope.Data.BaseData.Properties["DestCloudType"])
+	_, hasSourceEndpointIdentity := envelope.Data.BaseData.Properties["SourceEndpointIdentity"]
+	assert.False(t, hasSourceEndpointIdentity)
+	_, hasDestEndpointIdentity := envelope.Data.BaseData.Properties["DestEndpointIdentity"]
+	assert.False(t, hasDestEndpointIdentity)
+	_, hasCloudType := envelope.Data.BaseData.Properties["CloudType"]
+	assert.False(t, hasCloudType)
+}
+
+func TestReportEventAppInsights(t *testing.T) {
+	client := &stubClient{status: http.StatusOK}
+	r := NewReporter(Config{
+		Backend:          BackendAppInsights,
+		ConnectionString: testConnString,
+		HTTPClient:       client,
+	})
+
+	err := r.ReportEvent(context.Background(), sampleFinished())
+	require.NoError(t, err)
+	require.Equal(t, 1, client.calls)
+
+	// Validate the request targets the track endpoint with JSON content.
+	assert.Equal(t, http.MethodPost, client.lastReq.Method)
+	assert.Equal(t, "https://eastus.example.com/v2.1/track", client.lastReq.URL.String())
+	assert.Equal(t, "application/json", client.lastReq.Header.Get("Content-Type"))
+
+	var envs []appInsightsEnvelope
+	require.NoError(t, json.Unmarshal(client.lastBody, &envs))
+	require.Len(t, envs, 1)
+	assert.Equal(t, "Microsoft.ApplicationInsights.Event", envs[0].Name)
+	assert.Equal(t, "EventData", envs[0].Data.BaseType)
+	assert.Equal(t, "azcopy.job.finished", envs[0].Data.BaseData.Name)
+	assert.Len(t, envs[0].Data.BaseData.Measurements, 50)
+	assert.Equal(t, float64(100), envs[0].Data.BaseData.Measurements["azcopy.percent_complete"])
+}
+
+func TestReportEventAppInsightsServerError(t *testing.T) {
+	client := &stubClient{status: http.StatusInternalServerError, respBody: "boom"}
+	r := NewReporter(Config{
+		Backend:          BackendAppInsights,
+		ConnectionString: testConnString,
+		HTTPClient:       client,
+	})
+	err := r.ReportEvent(context.Background(), sampleStarted())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestReportEventTransportError(t *testing.T) {
+	client := &stubClient{err: errors.New("network down")}
+	r := NewReporter(Config{
+		Backend:          BackendAppInsights,
+		ConnectionString: testConnString,
+		HTTPClient:       client,
+	})
+	err := r.ReportEvent(context.Background(), sampleStarted())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "network down")
+}
+
+func TestReportEventOTel(t *testing.T) {
+	client := &stubClient{status: http.StatusOK}
+	r := NewReporter(Config{
+		Backend:          BackendOTel,
+		ConnectionString: testConnString,
+		HTTPClient:       client,
+	})
+
+	err := r.ReportEvent(context.Background(), sampleFinished())
+	require.NoError(t, err)
+	require.Equal(t, 1, client.calls)
+	assert.Equal(t, "https://eastus.example.com/v2.1/track", client.lastReq.URL.String())
+
+	var envs []appInsightsEnvelope
+	require.NoError(t, json.Unmarshal(client.lastBody, &envs))
+	require.Len(t, envs, 1)
+	assert.Equal(t, "Microsoft.ApplicationInsights.Event", envs[0].Name)
+	assert.Equal(t, "EventData", envs[0].Data.BaseType)
+	assert.Equal(t, "azcopy.job.finished", envs[0].Data.BaseData.Name)
+	assert.Len(t, envs[0].Data.BaseData.Measurements, 50)
+	assert.Equal(t, float64(100), envs[0].Data.BaseData.Measurements["azcopy.percent_complete"])
+	assert.Equal(t, "copy", envs[0].Data.BaseData.Properties["Command"])
+}
+
+func TestReportEventBackendsBoundProperties(t *testing.T) {
+	for _, backend := range []Backend{BackendAppInsights, BackendOTel} {
+		t.Run(string(backend), func(t *testing.T) {
+			oversized := strings.Repeat("x", maxPropValueLen+100)
+			event := sampleFinished()
+			event.Resource.OSVersion = oversized
+			event.Dimensions.Options.Values = map[string]string{"OptFutureValue": oversized}
+			event.JobID = oversized
+
+			client := &stubClient{status: http.StatusOK}
+			reporter := NewReporter(Config{
+				Backend:          backend,
+				ConnectionString: testConnString,
+				HTTPClient:       client,
+			})
+			require.NoError(t, reporter.ReportEvent(context.Background(), event))
+
+			var envelopes []appInsightsEnvelope
+			require.NoError(t, json.Unmarshal(client.lastBody, &envelopes))
+			require.Len(t, envelopes, 1)
+			for name, value := range envelopes[0].Data.BaseData.Properties {
+				assert.LessOrEqual(t, len(value), propertyValueLimit(name), name)
+			}
+			assert.Len(t, envelopes[0].Data.BaseData.Properties["OSVersion"], maxHostValueLen)
+			assert.Len(t, envelopes[0].Data.BaseData.Properties["JobID"], maxIdentifierValueLen)
+			assert.Len(t, envelopes[0].Data.BaseData.Properties["OptFutureValue"], maxOptionValueLen)
+		})
+	}
+}
+
+func TestReportEvents_StopsOnFirstError(t *testing.T) {
+	client := &stubClient{status: http.StatusInternalServerError}
+	r := NewReporter(Config{
+		Backend:          BackendAppInsights,
+		ConnectionString: testConnString,
+		HTTPClient:       client,
+	})
+	err := r.ReportEvents(context.Background(), sampleStarted(), sampleFinished())
+	require.Error(t, err)
+	assert.Equal(t, 1, client.calls) // stopped after the first failed send
+}
+
+func TestReportEventUnknownBackend(t *testing.T) {
+	r := NewReporter(Config{Backend: "nope", ConnectionString: testConnString})
+	err := r.ReportEvent(context.Background(), sampleStarted())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown telemetry backend")
+}
+
+func TestReportEventMissingConnectionString(t *testing.T) {
+	r := NewReporter(Config{Backend: BackendAppInsights, ConnectionString: ""})
+	err := r.ReportEvent(context.Background(), sampleStarted())
+	require.Error(t, err)
+}

--- a/telemetry/reporter_test.go
+++ b/telemetry/reporter_test.go
@@ -463,7 +463,6 @@ func TestEventPropertiesAreBoundedBeforeExport(t *testing.T) {
 	event := sampleFinished()
 	event.Resource.OSVersion = oversized
 	event.Resource.HostCPUModel = oversized
-	event.Dimensions.SourceStorageAccount = oversized
 	event.Dimensions.Options = OptionAttributes{
 		FlagsSet: []string{oversized, oversized},
 		Values:   map[string]string{"OptFutureValue": oversized},
@@ -531,6 +530,10 @@ func TestEventToEnvelopes(t *testing.T) {
 	assert.False(t, hasSourceEndpointIdentity)
 	_, hasDestEndpointIdentity := envelope.Data.BaseData.Properties["DestEndpointIdentity"]
 	assert.False(t, hasDestEndpointIdentity)
+	_, hasSourceStorageAccount := envelope.Data.BaseData.Properties["SourceStorageAccount"]
+	assert.False(t, hasSourceStorageAccount)
+	_, hasDestStorageAccount := envelope.Data.BaseData.Properties["DestStorageAccount"]
+	assert.False(t, hasDestStorageAccount)
 	_, hasCloudType := envelope.Data.BaseData.Properties["CloudType"]
 	assert.False(t, hasCloudType)
 }
@@ -572,6 +575,56 @@ func TestReportEventAppInsightsServerError(t *testing.T) {
 	err := r.ReportEvent(context.Background(), sampleStarted())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "500")
+}
+
+func TestReportEventAppInsightsRejectsPartialAcceptance(t *testing.T) {
+	client := &stubClient{
+		status:   http.StatusPartialContent,
+		respBody: `{"itemsReceived":2,"itemsAccepted":1,"errors":[{"index":1,"statusCode":400,"message":"invalid field"}]}`,
+	}
+	r := NewReporter(Config{
+		Backend:          BackendAppInsights,
+		ConnectionString: testConnString,
+		HTTPClient:       client,
+	})
+
+	err := r.ReportEvent(context.Background(), sampleStarted())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "partially accepted telemetry")
+	assert.ErrorContains(t, err, "index=1 status=400")
+}
+
+func TestReportEventAppInsightsRejectsInvalidPartialResponses(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "empty", body: "", want: "invalid response"},
+		{name: "malformed", body: "{", want: "invalid response"},
+		{name: "invalid counts", body: `{"itemsReceived":1,"itemsAccepted":2}`, want: "invalid item counts"},
+		{name: "missing errors", body: `{"itemsReceived":2,"itemsAccepted":1}`, want: "inconsistent rejection details"},
+		{name: "invalid index", body: `{"itemsReceived":2,"itemsAccepted":1,"errors":[{"index":2}]}`, want: "invalid rejected item index"},
+		{name: "no rejection", body: `{"itemsReceived":1,"itemsAccepted":1}`, want: "inconsistent rejection details"},
+		{name: "trailing content", body: `{"itemsReceived":2,"itemsAccepted":1,"errors":[{"index":1,"statusCode":400}]} trailing`, want: "trailing content"},
+		{name: "duplicate index", body: `{"itemsReceived":3,"itemsAccepted":1,"errors":[{"index":1,"statusCode":400},{"index":1,"statusCode":400}]}`, want: "duplicate rejected item index"},
+		{name: "invalid status", body: `{"itemsReceived":2,"itemsAccepted":1,"errors":[{"index":1,"statusCode":0}]}`, want: "invalid rejection status"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &stubClient{status: http.StatusPartialContent, respBody: test.body}
+			r := NewReporter(Config{
+				Backend:          BackendAppInsights,
+				ConnectionString: testConnString,
+				HTTPClient:       client,
+			})
+
+			err := r.ReportEvent(context.Background(), sampleStarted())
+			require.Error(t, err)
+			assert.ErrorContains(t, err, test.want)
+		})
+	}
 }
 
 func TestReportEventTransportError(t *testing.T) {

--- a/telemetry/reporter_test.go
+++ b/telemetry/reporter_test.go
@@ -76,8 +76,6 @@ func sampleStarted() JobStartedEvent {
 		Resource: ResourceAttributes{
 			AzCopyVersion:    "10.32.2",
 			SchemaVersion:    "1",
-			SamplingRate:     0.01,
-			SamplerVersion:   "job-id-sha256-v1",
 			OSType:           "linux",
 			HostArch:         "amd64",
 			HostNumCPU:       8,
@@ -175,26 +173,100 @@ func sampleFinished() JobFinishedEvent {
 
 func TestParseConnectionString(t *testing.T) {
 	m := parseConnectionString(testConnString)
-	assert.Equal(t, "11111111-2222-3333-4444-555555555555", m["InstrumentationKey"])
-	assert.Equal(t, "https://eastus.example.com/", m["IngestionEndpoint"])
+	assert.Equal(t, "11111111-2222-3333-4444-555555555555", m["instrumentationkey"])
+	assert.Equal(t, "https://eastus.example.com/", m["ingestionendpoint"])
 
-	// Tolerates whitespace and ignores malformed segments.
-	m = parseConnectionString(" A = 1 ; bogus ; B=2")
-	assert.Equal(t, "1", m["A"])
-	assert.Equal(t, "2", m["B"])
+	// Keys are case-insensitive; whitespace and malformed segments are tolerated.
+	m = parseConnectionString(" A = 1 ; bogus ; b=2")
+	assert.Equal(t, "1", m["a"])
+	assert.Equal(t, "2", m["b"])
 	_, ok := m["bogus"]
 	assert.False(t, ok)
 }
 
 func TestEndpointAndKey(t *testing.T) {
-	r := NewReporter(Config{ConnectionString: testConnString})
-	endpoint, ikey, err := r.endpointAndKey()
-	require.NoError(t, err)
-	assert.Equal(t, "https://eastus.example.com", endpoint) // trailing slash trimmed
-	assert.Equal(t, "11111111-2222-3333-4444-555555555555", ikey)
+	const ikey = "11111111-2222-3333-4444-555555555555"
+	tests := []struct {
+		name           string
+		connection     string
+		wantEndpoint   string
+		wantErrContain string
+	}{
+		{
+			name:         "explicit endpoint",
+			connection:   testConnString,
+			wantEndpoint: "https://eastus.example.com",
+		},
+		{
+			name:         "explicit endpoint takes precedence",
+			connection:   "InstrumentationKey=" + ikey + ";IngestionEndpoint=https://proxy.example.test/custom/;EndpointSuffix=ai.contoso.com;Location=westus2;Authorization=IKEY",
+			wantEndpoint: "https://proxy.example.test/custom",
+		},
+		{
+			name:         "case insensitive keys",
+			connection:   " instrumentationkey=" + ikey + "; ingestionendpoint = https://example.test/ ",
+			wantEndpoint: "https://example.test",
+		},
+		{
+			name:         "endpoint suffix",
+			connection:   "InstrumentationKey=" + ikey + ";EndpointSuffix=applicationinsights.azure.cn",
+			wantEndpoint: "https://dc.applicationinsights.azure.cn",
+		},
+		{
+			name:         "endpoint suffix with location",
+			connection:   "InstrumentationKey=" + ikey + ";EndpointSuffix=ai.contoso.com;Location=westus2",
+			wantEndpoint: "https://westus2.dc.ai.contoso.com",
+		},
+		{
+			name:           "missing instrumentation key",
+			connection:     "IngestionEndpoint=https://example.test",
+			wantErrContain: "InstrumentationKey",
+		},
+		{
+			name:           "missing endpoint configuration",
+			connection:     "InstrumentationKey=" + ikey,
+			wantErrContain: "IngestionEndpoint or EndpointSuffix",
+		},
+		{
+			name:           "unsupported authorization",
+			connection:     "InstrumentationKey=" + ikey + ";IngestionEndpoint=https://example.test;Authorization=AAD",
+			wantErrContain: "unsupported",
+		},
+		{
+			name:           "malformed endpoint",
+			connection:     "InstrumentationKey=" + ikey + ";IngestionEndpoint=example.test",
+			wantErrContain: "invalid",
+		},
+		{
+			name:           "endpoint with query",
+			connection:     "InstrumentationKey=" + ikey + ";IngestionEndpoint=https://example.test?route=ingestion",
+			wantErrContain: "invalid",
+		},
+		{
+			name:           "malformed endpoint suffix",
+			connection:     "InstrumentationKey=" + ikey + ";EndpointSuffix=https://example.test",
+			wantErrContain: "EndpointSuffix",
+		},
+		{
+			name:           "malformed location",
+			connection:     "InstrumentationKey=" + ikey + ";EndpointSuffix=ai.contoso.com;Location=west/us",
+			wantErrContain: "Location",
+		},
+	}
 
-	_, _, err = NewReporter(Config{ConnectionString: "garbage"}).endpointAndKey()
-	assert.Error(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			endpoint, gotKey, err := NewReporter(Config{ConnectionString: tt.connection}).endpointAndKey()
+			if tt.wantErrContain != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrContain)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantEndpoint, endpoint)
+			assert.Equal(t, ikey, gotKey)
+		})
+	}
 }
 
 func TestEventNamesAndTimestamps(t *testing.T) {
@@ -321,10 +393,6 @@ func TestAttributesIncludeResourceAndDimensions(t *testing.T) {
 	_, hasServiceVersion := attrs["ServiceVersion"]
 	assert.False(t, hasServiceVersion)
 	assert.Equal(t, "1", attrs["SchemaVersion"])
-	assert.Equal(t, "0.01", attrs["SamplingRate"])
-	_, hasSamplingUnit := attrs["SamplingUnit"]
-	assert.False(t, hasSamplingUnit)
-	assert.Equal(t, "job-id-sha256-v1", attrs["SamplerVersion"])
 	assert.Equal(t, "true", attrs["AzureVMDetected"])
 	_, hasHostVirtualization := attrs["HostVirtualization"]
 	assert.False(t, hasHostVirtualization)

--- a/telemetry/send_events.go
+++ b/telemetry/send_events.go
@@ -1,0 +1,106 @@
+// Copyright © Microsoft <wastore@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+)
+
+// ReportEvents processes and sends one or more generated telemetry events
+// (JobStartedEvent / JobFinishedEvent) using the configured backend. It stops
+// and returns on the first error.
+func (r *Reporter) ReportEvents(ctx context.Context, events ...MetricEvent) error {
+	for _, evt := range events {
+		if err := r.ReportEvent(ctx, evt); err != nil {
+			return fmt.Errorf("report %s: %w", evt.EventName(), err)
+		}
+	}
+	return nil
+}
+
+// ReportEvent processes a single telemetry event into data points and sends
+// them using the configured backend.
+func (r *Reporter) ReportEvent(ctx context.Context, evt MetricEvent) error {
+	switch r.cfg.Backend {
+	case BackendOTel:
+		return r.sendEventOTel(ctx, evt)
+	case BackendAppInsights:
+		return r.sendEventAppInsights(ctx, evt)
+	default:
+		return fmt.Errorf("unknown telemetry backend: %q", r.cfg.Backend)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// App Insights path - one packed custom event per lifecycle event.
+// ---------------------------------------------------------------------------
+
+func (r *Reporter) sendEventAppInsights(ctx context.Context, evt MetricEvent) error {
+	endpoint, ikey, err := r.endpointAndKey()
+	if err != nil {
+		return err
+	}
+
+	envelopes := eventToEnvelopes(ikey, evt)
+	if len(envelopes) == 0 {
+		return nil
+	}
+
+	if _, err := postEnvelopes(ctx, r.httpClient(), endpoint, envelopes); err != nil {
+		return err
+	}
+
+	log.Printf("telemetry: sent packed %s event to App Insights", evt.EventName())
+	return nil
+}
+
+// eventToEnvelopes converts an event into one App Insights custom event. Numeric
+// measurements share the row's dimensions instead of repeating them in one
+// metric envelope per measurement.
+func eventToEnvelopes(ikey string, evt MetricEvent) []appInsightsEnvelope {
+	measurements := evt.measurements()
+	if len(measurements) == 0 {
+		return nil
+	}
+
+	packedMeasurements := make(map[string]float64, len(measurements))
+	for _, m := range measurements {
+		packedMeasurements[m.Name] = m.Value
+	}
+
+	return []appInsightsEnvelope{{
+		Name: "Microsoft.ApplicationInsights.Event",
+		Time: evt.timestamp().UTC().Format(time.RFC3339),
+		IKey: ikey,
+		Data: appInsightsData{
+			BaseType: "EventData",
+			BaseData: appInsightsEventData{
+				Version:      2,
+				Name:         evt.EventName(),
+				Properties:   evt.attributes(),
+				Measurements: packedMeasurements,
+			},
+		},
+	}}
+}

--- a/traverser/zc_enumerator.go
+++ b/traverser/zc_enumerator.go
@@ -706,6 +706,8 @@ type SyncEnumerator struct {
 	// there is flexibility in which side we scan first, it could be either the source or the destination
 	primaryTraverser   ResourceTraverser
 	secondaryTraverser ResourceTraverser
+	primaryObserver    ObjectProcessor
+	secondaryObserver  ObjectProcessor
 
 	// the results from the primary traverser would be stored here
 	objectIndexer *ObjectIndexer
@@ -724,13 +726,33 @@ type SyncEnumerator struct {
 
 func NewSyncEnumerator(primaryTraverser, secondaryTraverser ResourceTraverser, indexer *ObjectIndexer,
 	filters []ObjectFilter, comparator ObjectProcessor, finalize func() error) *SyncEnumerator {
+	return NewSyncEnumeratorWithObservers(primaryTraverser, secondaryTraverser, indexer, filters, comparator, finalize, nil, nil)
+}
+
+func NewSyncEnumeratorWithObservers(primaryTraverser, secondaryTraverser ResourceTraverser, indexer *ObjectIndexer,
+	filters []ObjectFilter, comparator ObjectProcessor, finalize func() error,
+	primaryObserver, secondaryObserver ObjectProcessor) *SyncEnumerator {
 	return &SyncEnumerator{
 		primaryTraverser:   primaryTraverser,
 		secondaryTraverser: secondaryTraverser,
+		primaryObserver:    primaryObserver,
+		secondaryObserver:  secondaryObserver,
 		objectIndexer:      indexer,
 		filters:            filters,
 		objectComparator:   comparator,
 		finalize:           finalize,
+	}
+}
+
+func observeThen(observer, processor ObjectProcessor) ObjectProcessor {
+	if observer == nil {
+		return processor
+	}
+	return func(object StoredObject) error {
+		if err := observer(object); err != nil {
+			return err
+		}
+		return processor(object)
 	}
 }
 
@@ -748,7 +770,7 @@ func (e *SyncEnumerator) Enumerate() (err error) {
 	}
 
 	// enumerate the primary resource and build lookup map
-	err = e.primaryTraverser.Traverse(NoPreProccessor, e.objectIndexer.Store, e.filters)
+	err = e.primaryTraverser.Traverse(NoPreProccessor, observeThen(e.primaryObserver, e.objectIndexer.Store), e.filters)
 	handleAcceptableErrors()
 	if err != nil {
 		return err
@@ -758,7 +780,7 @@ func (e *SyncEnumerator) Enumerate() (err error) {
 	// they will be passed to the object comparator
 	// which can process given objects based on what's already indexed
 	// note: transferring can start while scanning is ongoing
-	err = e.secondaryTraverser.Traverse(NoPreProccessor, e.objectComparator, e.filters)
+	err = e.secondaryTraverser.Traverse(NoPreProccessor, observeThen(e.secondaryObserver, e.objectComparator), e.filters)
 	handleAcceptableErrors()
 	if err != nil {
 		return


### PR DESCRIPTION
## Description

- **Feature / Bug Fix**: Adds privacy-conscious client-side telemetry for AzCopy command and job lifecycles. The change emits typed command, host, resource, transfer, performance, and terminal outcome dimensions to Application Insights; embeds telemetry configuration in release builds; and adds deterministic E2E ingestion validation. Telemetry can be disabled with `--disable-telemetry` or `AZCOPY_DISABLE_TELEMETRY=true`.
- Telemetry delivery is asynchronous and bounded: individual sends time out after one second and process shutdown drains pending telemetry for at most two seconds. `job.started` is ordered before its corresponding `job.finished` event.
- Percentage-based sampling is intentionally not used. Eligible events are emitted whenever telemetry is enabled.
- Application Insights connection-string parsing supports case-insensitive keys, explicit ingestion endpoints, endpoint suffix/location derivation, and strict authorization/URL validation.
- Free-text benchmark descriptions and raw storage-account identifiers are not emitted.
- **Related Links**: N/A

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Documentation update required
- [x] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?

- `go test ./telemetry ./azcopy`
- Targeted `./cmd` telemetry tests
- Targeted `./e2etest` telemetry policy and ingestion-validation tests, including successful commands, expected failures with and without Job IDs, dry runs, and non-terminal commands
- Telemetry regression coverage for enable/disable behavior, started-before-finished ordering, non-blocking dispatch, bounded shutdown flushing, and Application Insights connection-string parsing
- Exact GitHub lint command completed with zero issues: `golangci-lint run --config=.config/.golangci.yaml --tests=false --max-issues-per-linter=0 --max-same-issues=0 --timeout 5m0s`
- `git diff --check`
- Repeated sample telemetry ingestion and representative Application Insights KQL query validation

Thank you for your contribution to AzCopy!