### PR TITLE
During sync, when failure is to access source, report source access error instead of error stating "trying to sync between different resource types"

### DIFF
--- a/cmd/moverDependencies.go
+++ b/cmd/moverDependencies.go
@@ -333,6 +333,7 @@ type RawMoverSyncCmdArgs struct {
 	PreserveInfo            bool
 	ForceIfReadOnly         bool
 	Md5ValidationOption     string
+	PutMd5                  bool
 	CompareHash             string
 	LocalHashStorageMode    string
 	Hardlinks               string
@@ -352,6 +353,7 @@ type SyncCmdArgsInput struct {
 	PreserveSMBInfo         bool
 	ForceIfReadOnly         bool
 	Md5ValidationOption     string
+	PutMd5                  bool
 	CompareHash             string
 	LocalHashStorageMode    string
 	Hardlinks               string
@@ -372,6 +374,7 @@ func CookRawSyncCmdArgs(args RawMoverSyncCmdArgs) (cookedSyncCmdArgs, error) {
 		preserveInfo:            args.PreserveInfo,
 		forceIfReadOnly:         args.ForceIfReadOnly,
 		md5ValidationOption:     args.Md5ValidationOption,
+		putMd5:                  args.PutMd5,
 		compareHash:             args.CompareHash,
 		localHashStorageMode:    args.LocalHashStorageMode,
 		hardlinks:               args.Hardlinks,

--- a/cmd/syncEnumerator.go
+++ b/cmd/syncEnumerator.go
@@ -213,8 +213,14 @@ func (cca *cookedSyncCmdArgs) InitEnumerator(ctx context.Context, enumeratorOpti
 	}
 
 	// verify that the traversers are targeting the same type of resources
-	sourceIsDir, _ := sourceTraverser.IsDirectory(true)
+	sourceIsDir, sourceErr := sourceTraverser.IsDirectory(true)
 	destIsDir, err := destinationTraverser.IsDirectory(true)
+
+	// If the source doesn't exist, return the error directly instead of falling through
+	// to the resource type mismatch check which produces a confusing error message.
+	if sourceErr != nil && !cca.fromTo.From().IsRemote() {
+		return nil, fmt.Errorf("failed to scan source %s due to %w", cca.source.Value, sourceErr)
+	}
 
 	var resourceMismatchError = errors.New("trying to sync between different resource types (either file <-> directory or directory <-> file) which is not allowed." +
 		"sync must happen between source and destination of the same type, e.g. either file <-> file or directory <-> directory." +

--- a/cmd/syncEnumerator.go
+++ b/cmd/syncEnumerator.go
@@ -214,13 +214,13 @@ func (cca *cookedSyncCmdArgs) InitEnumerator(ctx context.Context, enumeratorOpti
 
 	// verify that the traversers are targeting the same type of resources
 	sourceIsDir, sourceErr := sourceTraverser.IsDirectory(true)
-	destIsDir, err := destinationTraverser.IsDirectory(true)
-
 	// If the source doesn't exist, return the error directly instead of falling through
 	// to the resource type mismatch check which produces a confusing error message.
 	if sourceErr != nil && !cca.fromTo.From().IsRemote() {
 		return nil, fmt.Errorf("failed to scan source %s due to %w", cca.source.Value, sourceErr)
 	}
+
+	destIsDir, err := destinationTraverser.IsDirectory(true)
 
 	var resourceMismatchError = errors.New("trying to sync between different resource types (either file <-> directory or directory <-> file) which is not allowed." +
 		"sync must happen between source and destination of the same type, e.g. either file <-> file or directory <-> directory." +


### PR DESCRIPTION
## Description
Targeted improvement to error handling in the syncEnumerator.go file. The change adds an explicit check for source scanning errors before proceeding to resource type validation. This prevents confusing error messages about resource type mismatches when the real issue is that the source path doesn't exist or is inaccessible

- ** Bug Fix**: Instead of reporting misleading error of "trying to sync between different resource types", report source access error.

- **Related Links**:
- ADO 39182300
- [Team thread](<link>)
- [Documents](<link>)
- [Email Subject]

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
Tested with storage mover. 
Error after fix:
Sync Job(e602292a-73bd-43f2-b59c-8294f0021928, 5074f856-6287-4223-9356-fe71c12ffe49) failed in initCopyEnumerator with error: failed to scan source /m/aq9H/WrongSubPath-Source due to stat /m/aq9H/WrongSubPath-Source: no such file or directory

Error before fix:

Sync Job(e602292a-73bd-43f2-b59c-8294f0021928, 953a7611-8539-4c9f-9702-d53fb102ebfd) failed in initCopyEnumerator with error: trying to sync between different resource types (either file <-> directory or directory <-> file) which is not allowed.sync must happen between source and destination of the same type, e.g. either file <-> file or directory <-> directory.To make sure target is handled as a directory, add a trailing '/' to the target.


Thank you for your contribution to AzCopy!
