### PR TITLE
Fix StorageMover logs missing transfer errors

### DIFF
--- a/common/lifecyleMgr.go
+++ b/common/lifecyleMgr.go
@@ -54,6 +54,7 @@ type LifecycleMgr interface {
 	Init(OutputBuilder)                                          // let the user know the job has started and initial information like log location
 	Progress(OutputBuilder)                                      // print on the same line over and over again, not allowed to float up
 	Exit(OutputBuilder, ExitCode)                                // indicates successful execution exit after printing, allow user to specify exit code
+	SanitizeLogMessage(string) string                            // return log message with sensitive information removed
 	Info(string)                                                 // simple print, allowed to float up
 	Warn(string)                                                 // simple print, allowed to float up
 	Dryrun(OutputBuilder)                                        // print files for dry run mode
@@ -270,6 +271,10 @@ func (lcm *lifecycleMgr) Progress(o OutputBuilder) {
 		msgContent: messageContent,
 		msgType:    EOutputMessageType.Progress(),
 	}
+}
+
+func (lcm *lifecycleMgr) SanitizeLogMessage(msg string) string {
+	return lcm.logSanitizer.SanitizeLogMessage(msg)
 }
 
 func (lcm *lifecycleMgr) Info(msg string) {

--- a/ste/JobPartPlan.go
+++ b/ste/JobPartPlan.go
@@ -450,6 +450,9 @@ func (jppt *JobPartPlanTransfer) ErrorMessage() string {
 // overWrite flags if set to true overWrites the errorMessage.
 // If overWrite flag is set to false, then errorMessage won't be overwritten.
 func (jppt *JobPartPlanTransfer) SetErrorMessage(errorMessage string, overwrite bool) {
+	// redact any sensitive information from the error message before saving it to the job part plan transfer; RedactSecretQueryParamForLogging and SanitizeLogMessage don't cover the exact same set of cases, so we use both to be safe.
+	errorMessage = common.GetLifecycleMgr().SanitizeLogMessage(common.URLStringExtension(errorMessage).RedactSecretQueryParamForLogging())
+
 	savedErrorMessageLength := atomic.LoadInt32(&jppt.errorMessageLength)
 	currentErrorMessageLength := int32(len(errorMessage))
 

--- a/ste/mgr-JobPartTransferMgr.go
+++ b/ste/mgr-JobPartTransferMgr.go
@@ -49,6 +49,7 @@ type IJobPartTransferMgr interface {
 	TransferStatusIgnoringCancellation() common.TransferStatus
 	SetStatus(status common.TransferStatus)
 	SetErrorCode(errorCode int32)
+	SetErrorMessage(errorMessage string)
 	SetNumberOfChunks(numChunks uint32)
 	SetActionAfterLastChunk(f func())
 	ReportTransferDone() uint32

--- a/ste/testJobPartTransferManager_test.go
+++ b/ste/testJobPartTransferManager_test.go
@@ -201,6 +201,8 @@ func (t *testJobPartTransferManager) SetErrorCode(errorCode int32) {
 	panic("implement me")
 }
 
+func (t *testJobPartTransferManager) SetErrorMessage(errorMessage string) {}
+
 func (t *testJobPartTransferManager) SetNumberOfChunks(numChunks uint32) {
 	panic("implement me")
 }

--- a/ste/xfer-anyToRemote-file.go
+++ b/ste/xfer-anyToRemote-file.go
@@ -186,7 +186,9 @@ func anyToRemote(jptm IJobPartTransferMgr, pacer pacer, senderFactory senderFact
 			srcRQ := srcURL.Query()
 
 			if len(srcRQ["sharesnapshot"]) == 0 && len(srcRQ["snapshot"]) == 0 && len(srcRQ["versionid"]) == 0 {
-				jptm.LogSendError(info.Source, info.Destination, "Transfer source and destination are the same, which would cause data loss. Aborting transfer.", 0)
+				err_msg := "Transfer source and destination are the same, which would cause data loss. Aborting transfer."
+				jptm.LogSendError(info.Source, info.Destination, err_msg, 0)
+				jptm.SetErrorMessage(err_msg)
 				jptm.SetStatus(common.ETransferStatus.Failed())
 				jptm.ReportTransferDone()
 				return
@@ -231,6 +233,7 @@ func anyToRemote_file(jptm IJobPartTransferMgr, info *TransferInfo, pacer pacer,
 	srcInfoProvider, err := sipf(jptm)
 	if err != nil {
 		jptm.LogSendError(info.Source, info.Destination, err.Error(), 0)
+		jptm.SetErrorMessage(err.Error())
 		jptm.SetStatus(common.ETransferStatus.Failed())
 		jptm.ReportTransferDone()
 		return
@@ -252,6 +255,7 @@ func anyToRemote_file(jptm IJobPartTransferMgr, info *TransferInfo, pacer pacer,
 	s, err := senderFactory(jptm, info.Destination, pacer, srcInfoProvider)
 	if err != nil {
 		jptm.LogSendError(info.Source, info.Destination, err.Error(), 0)
+		jptm.SetErrorMessage(err.Error())
 		jptm.SetStatus(common.ETransferStatus.Failed())
 		jptm.ReportTransferDone()
 		return
@@ -273,7 +277,9 @@ func anyToRemote_file(jptm IJobPartTransferMgr, info *TransferInfo, pacer pacer,
 	if jptm.GetOverwriteOption() != common.EOverwriteOption.True() {
 		exists, dstLmt, existenceErr := s.RemoteFileExists()
 		if existenceErr != nil {
-			jptm.LogSendError(info.Source, info.Destination, "Could not check destination file existence. "+existenceErr.Error(), 0)
+			err_msg := "Could not check destination file existence. " + existenceErr.Error()
+			jptm.LogSendError(info.Source, info.Destination, err_msg, 0)
+			jptm.SetErrorMessage(err_msg)
 			jptm.SetStatus(common.ETransferStatus.Failed()) // is a real failure, not just a SkippedFileAlreadyExists, in this case
 			jptm.ReportTransferDone()
 			return
@@ -317,7 +323,9 @@ func anyToRemote_file(jptm IJobPartTransferMgr, info *TransferInfo, pacer pacer,
 			if strings.Contains(err.Error(), "Access is denied") && runtime.GOOS == "windows" {
 				suffix = " See --" + common.BackupModeFlagName + " flag if you need to read all files regardless of their permissions"
 			}
-			jptm.LogSendError(info.Source, info.Destination, "Couldn't open source. "+err.Error()+suffix, 0)
+			err_msg := "Couldn't open source. " + err.Error() + suffix
+			jptm.LogSendError(info.Source, info.Destination, err_msg, 0)
+			jptm.SetErrorMessage(err_msg)
 			jptm.SetStatus(common.ETransferStatus.Failed())
 			jptm.ReportTransferDone()
 			return
@@ -333,13 +341,18 @@ func anyToRemote_file(jptm IJobPartTransferMgr, info *TransferInfo, pacer pacer,
 		(srcInfoProvider.IsLocal() || isS2SCopier && info.S2SSourceChangeValidation) {
 		lmt, err := srcInfoProvider.GetFreshFileLastModifiedTime()
 		if err != nil {
-			jptm.LogSendError(info.Source, info.Destination, "Couldn't get source's last modified time-"+err.Error(), 0)
+			err_msg := "Couldn't get source's last modified time-" + err.Error()
+			jptm.LogSendError(info.Source, info.Destination, err_msg, 0)
+			jptm.SetErrorMessage(err_msg)
 			jptm.SetStatus(common.ETransferStatus.Failed())
 			jptm.ReportTransferDone()
 			return
 		}
+
 		if !lmt.Equal(jptm.LastModifiedTime()) {
-			jptm.LogSendError(info.Source, info.Destination, "File modified since transfer scheduled", 0)
+			err_msg := fmt.Sprintf("File modified since transfer scheduled. Enumeration %v, current %v", jptm.LastModifiedTime(), lmt)
+			jptm.LogSendError(info.Source, info.Destination, err_msg, 0)
+			jptm.SetErrorMessage(err_msg)
 			jptm.SetStatus(common.ETransferStatus.Failed())
 			jptm.ReportTransferDone()
 			return
@@ -354,6 +367,7 @@ func anyToRemote_file(jptm IJobPartTransferMgr, info *TransferInfo, pacer pacer,
 	err = jptm.WaitUntilLockDestination(jptm.Context())
 	if err != nil {
 		jptm.LogSendError(info.Source, info.Destination, err.Error(), 0)
+		jptm.SetErrorMessage(err.Error())
 		jptm.SetStatus(common.ETransferStatus.Failed())
 		jptm.ReportTransferDone()
 		return

--- a/ste/xfer-anyToRemote-fileProperties.go
+++ b/ste/xfer-anyToRemote-fileProperties.go
@@ -44,6 +44,7 @@ func anyToRemote_fileProperties(jptm IJobPartTransferMgr, info *TransferInfo, pa
 	srcInfoProvider, err := sipf(jptm)
 	if err != nil {
 		jptm.LogSendError(info.Source, info.Destination, err.Error(), 0)
+		jptm.SetErrorMessage(err.Error())
 		jptm.SetStatus(common.ETransferStatus.Failed())
 		jptm.ReportTransferDone()
 		return
@@ -58,13 +59,16 @@ func anyToRemote_fileProperties(jptm IJobPartTransferMgr, info *TransferInfo, pa
 	baseSender, err := senderFactory(jptm, info.Destination, pacer, srcInfoProvider)
 	if err != nil {
 		jptm.LogSendError(info.Source, info.Destination, err.Error(), 0)
+		jptm.SetErrorMessage(err.Error())
 		jptm.SetStatus(common.ETransferStatus.Failed())
 		jptm.ReportTransferDone()
 		return
 	}
 	s, ok := baseSender.(propertiesSender)
 	if !ok {
-		jptm.LogSendError(info.Source, info.Destination, "sender implementation does not support copying properties alone", 0)
+		err_msg := "sender implementation does not support copying properties alone"
+		jptm.LogSendError(info.Source, info.Destination, err_msg, 0)
+		jptm.SetErrorMessage(err_msg)
 		jptm.SetStatus(common.ETransferStatus.Failed())
 		jptm.ReportTransferDone()
 		return
@@ -74,6 +78,7 @@ func anyToRemote_fileProperties(jptm IJobPartTransferMgr, info *TransferInfo, pa
 	err = jptm.WaitUntilLockDestination(jptm.Context())
 	if err != nil {
 		jptm.LogSendError(info.Source, info.Destination, err.Error(), 0)
+		jptm.SetErrorMessage(err.Error())
 		jptm.SetStatus(common.ETransferStatus.Failed())
 		jptm.ReportTransferDone()
 		return

--- a/ste/xfer-anyToRemote-folder.go
+++ b/ste/xfer-anyToRemote-folder.go
@@ -39,6 +39,7 @@ func anyToRemote_folder(jptm IJobPartTransferMgr, info *TransferInfo, pacer pace
 	srcInfoProvider, err := sipf(jptm)
 	if err != nil {
 		jptm.LogSendError(info.Source, info.Destination, err.Error(), 0)
+		jptm.SetErrorMessage(err.Error())
 		jptm.SetStatus(common.ETransferStatus.Failed())
 		jptm.ReportTransferDone()
 		return
@@ -50,13 +51,16 @@ func anyToRemote_folder(jptm IJobPartTransferMgr, info *TransferInfo, pacer pace
 	baseSender, err := senderFactory(jptm, info.Destination, pacer, srcInfoProvider)
 	if err != nil {
 		jptm.LogSendError(info.Source, info.Destination, err.Error(), 0)
+		jptm.SetErrorMessage(err.Error())
 		jptm.SetStatus(common.ETransferStatus.Failed())
 		jptm.ReportTransferDone()
 		return
 	}
 	s, ok := baseSender.(folderSender)
 	if !ok {
-		jptm.LogSendError(info.Source, info.Destination, "sender implementation does not support folders", 0)
+		err_msg := "sender implementation does not support folders"
+		jptm.LogSendError(info.Source, info.Destination, err_msg, 0)
+		jptm.SetErrorMessage(err_msg)
 		jptm.SetStatus(common.ETransferStatus.Failed())
 		jptm.ReportTransferDone()
 		return

--- a/ste/xfer-anyToRemote-symlink.go
+++ b/ste/xfer-anyToRemote-symlink.go
@@ -17,6 +17,7 @@ func anyToRemote_symlink(jptm IJobPartTransferMgr, info *TransferInfo, pacer pac
 	srcInfoProvider, err := sipf(jptm)
 	if err != nil {
 		jptm.LogSendError(info.Source, info.Destination, err.Error(), 0)
+		jptm.SetErrorMessage(err.Error())
 		jptm.SetStatus(common.ETransferStatus.Failed())
 		jptm.ReportTransferDone()
 		return
@@ -26,7 +27,9 @@ func anyToRemote_symlink(jptm IJobPartTransferMgr, info *TransferInfo, pacer pac
 	}
 	symSIP, ok := srcInfoProvider.(ISymlinkBearingSourceInfoProvider)
 	if !ok {
-		jptm.LogSendError(info.Source, info.Destination, "source info provider implementation does not support symlinks", 0)
+		err_msg := "source info provider implementation does not support symlinks"
+		jptm.LogSendError(info.Source, info.Destination, err_msg, 0)
+		jptm.SetErrorMessage(err_msg)
 		jptm.SetStatus(common.ETransferStatus.Failed())
 		jptm.ReportTransferDone()
 		return
@@ -43,6 +46,7 @@ func anyToRemote_symlink(jptm IJobPartTransferMgr, info *TransferInfo, pacer pac
 	baseSender, err := senderFactory(jptm, info.Destination, pacer, srcInfoProvider)
 	if err != nil {
 		jptm.LogSendError(info.Source, info.Destination, err.Error(), 0)
+		jptm.SetErrorMessage(err.Error())
 		jptm.SetStatus(common.ETransferStatus.Failed())
 		jptm.ReportTransferDone()
 		return
@@ -50,7 +54,9 @@ func anyToRemote_symlink(jptm IJobPartTransferMgr, info *TransferInfo, pacer pac
 
 	s, ok := baseSender.(symlinkSender) // todo: symlinkSender
 	if !ok {
-		jptm.LogSendError(info.Source, info.Destination, "sender implementation does not support symlinks", 0)
+		err_msg := "sender implementation does not support symlinks"
+		jptm.LogSendError(info.Source, info.Destination, err_msg, 0)
+		jptm.SetErrorMessage(err_msg)
 		jptm.SetStatus(common.ETransferStatus.Failed())
 		jptm.ReportTransferDone()
 		return

--- a/ste/xfer-deleteBlob.go
+++ b/ste/xfer-deleteBlob.go
@@ -40,6 +40,7 @@ func doDeleteBlob(jptm IJobPartTransferMgr) {
 	transferDone := func(status common.TransferStatus, err error) {
 		if status == common.ETransferStatus.Failed() {
 			jptm.LogError(info.Source, "DELETE ERROR ", err)
+			jptm.SetErrorMessage(fmt.Sprintf("DELETE FAILED: %v, %v", info.Source, err.Error()))
 		} else if status == common.ETransferStatus.SkippedBlobHasSnapshots() {
 			explainedSkippedRemoveOnce.Do(func() {
 				common.GetLifecycleMgr().Info("Blobs with snapshots are skipped. Please specify the --delete-snapshots flag for alternative behaviors.")

--- a/ste/xfer-deleteBlobFS.go
+++ b/ste/xfer-deleteBlobFS.go
@@ -74,6 +74,7 @@ func doDeleteHNSResource(jptm IJobPartTransferMgr) {
 
 		if status == common.ETransferStatus.Failed() {
 			jptm.LogError(info.Source, "DELETE ERROR ", err)
+			jptm.SetErrorMessage(fmt.Sprintf("DELETE FAILED: %v, %v", info.Source, err.Error()))
 		} else {
 			jptm.Log(common.LogInfo, fmt.Sprintf("DELETE SUCCESSFUL: %s", strings.Split(info.Source, "?")[0]))
 		}

--- a/ste/xfer-deleteFile.go
+++ b/ste/xfer-deleteFile.go
@@ -85,14 +85,14 @@ func doDeleteFile(jptm IJobPartTransferMgr) {
 			//	 We'll favor correctness over memory-efficiency for now, and leave the code as it is.
 			//   If we find that memory usage is an issue in cases with lots of failures, we can revisit in the future.
 		}
-		if jptm.ShouldLog(common.LogInfo) {
-			if status == common.ETransferStatus.Failed() {
+		if status == common.ETransferStatus.Failed() {
+			if jptm.ShouldLog(common.LogInfo) {
 				jptm.LogError(info.Source, "DELETE ERROR ", err)
-				jptm.SetErrorMessage(fmt.Sprintf("DELETE FAILED: %v, %v", info.Source, err.Error()))
-			} else {
-				if jptm.ShouldLog(common.LogInfo) {
-					jptm.Log(common.LogInfo, fmt.Sprintf("DELETE SUCCESSFUL: %s", strings.Split(info.Destination, "?")[0]))
-				}
+			}
+			jptm.SetErrorMessage(fmt.Sprintf("DELETE FAILED: source %v, error %v", info.Source, err.Error()))
+		} else {
+			if jptm.ShouldLog(common.LogInfo) {
+				jptm.Log(common.LogInfo, fmt.Sprintf("DELETE SUCCESSFUL: %s", strings.Split(info.Destination, "?")[0]))
 			}
 		}
 		jptm.SetStatus(status)

--- a/ste/xfer-deleteFile.go
+++ b/ste/xfer-deleteFile.go
@@ -88,6 +88,7 @@ func doDeleteFile(jptm IJobPartTransferMgr) {
 		if jptm.ShouldLog(common.LogInfo) {
 			if status == common.ETransferStatus.Failed() {
 				jptm.LogError(info.Source, "DELETE ERROR ", err)
+				jptm.SetErrorMessage(fmt.Sprintf("DELETE FAILED: %v, %v", info.Source, err.Error()))
 			} else {
 				if jptm.ShouldLog(common.LogInfo) {
 					jptm.Log(common.LogInfo, fmt.Sprintf("DELETE SUCCESSFUL: %s", strings.Split(info.Destination, "?")[0]))

--- a/ste/xfer-remoteToLocal-file.go
+++ b/ste/xfer-remoteToLocal-file.go
@@ -57,6 +57,7 @@ func remoteToLocal_file(jptm IJobPartTransferMgr, pacer pacer, df downloaderFact
 	// We are using a separate instance per transfer, in case some implementations need to hold per-transfer state
 	dl, err := df(jptm)
 	if err != nil {
+		jptm.SetErrorMessage(err.Error())
 		jptm.SetStatus(common.ETransferStatus.Failed())
 		jptm.ReportTransferDone()
 		return
@@ -109,6 +110,7 @@ func remoteToLocal_file(jptm IJobPartTransferMgr, pacer pacer, df downloaderFact
 		// This will save hours in the event a user has say, a several hundred gigabyte file.
 		if len(info.SrcHTTPHeaders.ContentMD5) == 0 {
 			jptm.LogDownloadError(info.Source, info.Destination, errExpectedMd5Missing.Error(), 0)
+			jptm.SetErrorMessage(errExpectedMd5Missing.Error())
 			jptm.SetStatus(common.ETransferStatus.Failed())
 			jptm.ReportTransferDone()
 			return
@@ -255,7 +257,9 @@ func remoteToLocal_file(jptm IJobPartTransferMgr, pacer pacer, df downloaderFact
 	/*
 		dstFileInfo, err := dstFile.Stat()
 		if err != nil || (dstFileInfo.Size() != blobSize) {
-			jptm.LogDownloadError(info.Source, info.Destination, "File Creation Error "+err.Error(), 0)
+			err_msg := "File Creation Error " + err.Error()
+			jptm.LogDownloadError(info.Source, info.Destination, err_msg, 0)
+			jptm.SetErrorMessage(err_msg)
 			jptm.SetStatus(common.ETransferStatus.Failed())
 			// Since the transfer failed, the file created above should be deleted
 			// If there was an error while opening / creating the file, delete will fail.

--- a/ste/xfer-remoteToLocal-folder.go
+++ b/ste/xfer-remoteToLocal-folder.go
@@ -40,7 +40,9 @@ func remoteToLocal_folder(jptm IJobPartTransferMgr, pacer pacer, df downloaderFa
 
 	d, err := df(jptm)
 	if err != nil {
-		jptm.LogDownloadError(info.Source, info.Destination, "failed to create downloader", 0)
+		err_msg := "failed to create downloader: " + err.Error()
+		jptm.LogDownloadError(info.Source, info.Destination, err_msg, 0)
+		jptm.SetErrorMessage(err_msg)
 		jptm.SetStatus(common.ETransferStatus.Failed())
 		jptm.ReportTransferDone()
 		return
@@ -48,7 +50,9 @@ func remoteToLocal_folder(jptm IJobPartTransferMgr, pacer pacer, df downloaderFa
 
 	dl, ok := d.(folderDownloader)
 	if !ok {
-		jptm.LogDownloadError(info.Source, info.Destination, "downloader implementation does not support folders", 0)
+		err_msg := "downloader implementation does not support folders"
+		jptm.LogDownloadError(info.Source, info.Destination, err_msg, 0)
+		jptm.SetErrorMessage(err_msg)
 		jptm.SetStatus(common.ETransferStatus.Failed())
 		jptm.ReportTransferDone()
 		return

--- a/ste/xfer-remoteToLocal-symlink.go
+++ b/ste/xfer-remoteToLocal-symlink.go
@@ -1,8 +1,9 @@
 package ste
 
 import (
-	"github.com/Azure/azure-storage-azcopy/v10/common"
 	"os"
+
+	"github.com/Azure/azure-storage-azcopy/v10/common"
 )
 
 func remoteToLocal_symlink(jptm IJobPartTransferMgr, pacer pacer, df downloaderFactory) {
@@ -62,6 +63,7 @@ func remoteToLocal_symlink(jptm IJobPartTransferMgr, pacer pacer, df downloaderF
 	d, err := df(jptm)
 	if err != nil {
 		jptm.LogDownloadError(info.Source, info.Destination, err.Error(), 0)
+		jptm.SetErrorMessage(err.Error())
 		jptm.SetStatus(common.ETransferStatus.Failed())
 		jptm.ReportTransferDone()
 		return
@@ -69,7 +71,9 @@ func remoteToLocal_symlink(jptm IJobPartTransferMgr, pacer pacer, df downloaderF
 
 	dl, ok := d.(symlinkDownloader)
 	if !ok {
-		jptm.LogDownloadError(info.Source, info.Destination, "downloader implementation does not support symlinks", 0)
+		err_msg := "downloader implementation does not support symlinks"
+		jptm.LogDownloadError(info.Source, info.Destination, err_msg, 0)
+		jptm.SetErrorMessage(err_msg)
 		jptm.SetStatus(common.ETransferStatus.Failed())
 		jptm.ReportTransferDone()
 		return

--- a/ste/xfer-setProperties.go
+++ b/ste/xfer-setProperties.go
@@ -47,6 +47,7 @@ func setPropertiesBlob(jptm IJobPartTransferMgr) {
 	transferDone := func(status common.TransferStatus, err error) {
 		if status == common.ETransferStatus.Failed() {
 			jptm.LogError(info.Source, "SET-PROPERTIES FAILED with error: ", err)
+			jptm.SetErrorMessage(fmt.Sprintf("SET-PROPERTIES FAILED: %v, %v", info.Source, err.Error()))
 		} else {
 			jptm.Log(common.LogInfo, fmt.Sprintf("SET-PROPERTIES SUCCESSFUL: %s", strings.Split(info.Destination, "?")[0]))
 		}
@@ -116,6 +117,7 @@ func setPropertiesBlobFS(jptm IJobPartTransferMgr) {
 	transferDone := func(status common.TransferStatus, err error) {
 		if status == common.ETransferStatus.Failed() {
 			jptm.LogError(info.Source, "SET-PROPERTIES ERROR ", err)
+			jptm.SetErrorMessage(fmt.Sprintf("SET-PROPERTIES FAILED: %v, %v", info.Source, err.Error()))
 		} else {
 			jptm.Log(common.LogInfo, fmt.Sprintf("SET-PROPERTIES SUCCESSFUL: %s", strings.Split(info.Destination, "?")[0]))
 		}
@@ -179,6 +181,7 @@ func setPropertiesFile(jptm IJobPartTransferMgr) {
 	transferDone := func(status common.TransferStatus, err error) {
 		if status == common.ETransferStatus.Failed() {
 			jptm.LogError(info.Source, "SET-PROPERTIES ERROR ", err)
+			jptm.SetErrorMessage(fmt.Sprintf("SET-PROPERTIES FAILED: %v, %v", info.Source, err.Error()))
 		} else {
 			jptm.Log(common.LogInfo, fmt.Sprintf("SET-PROPERTIES SUCCESSFUL: %s", strings.Split(info.Destination, "?")[0]))
 		}


### PR DESCRIPTION
## Description
Note: PR for merging the same change into mover/c2c-stage: https://github.com/Azure/azure-storage-azcopy/pull/3536

This PR adds a number of calls to JobPartPlanTransfer.SetErrorMessage() to make sure that the following call to ReportTransferDone() correctly collects the ErrorMessage from the JobPartPlanTransfer object. That object is eventually passed via the jobStatusManager's xferDone channel to the TransfersFailed field in the ListJobSummaryResponse object that StorageMover collects. The change to add these SetErrorMessage() calls ensures that the error messages are correctly bubbled up to StorageMover. 
SetErrorMessage() also needed to be added to the IJobPartTransferMgr interface that JobPartPlanTransfer embeds.
After fixing the StorageMover-specific issue in all the xfer-anyToRemote files, I decided to be thorough and make the same changes in the rest of the xfer files where this happens.
Note that sometimes a function is called before ReportTransferDone() that already does set the error message, so a SetErrorMessage() call was not added in those instances

I also added sanitization to the SetErrorMessage() function to ensure it removes any credentials that might be in the error message, which Copilot called to attention in the other PR.

- **Related Links**:
- [[On-prem Agent] Azcopy permission denied error is not bubbled to xdatamove, and this results into Copy failed due to an unknown error, AZSM2080](https://msazure.visualstudio.com/One/_workitems/edit/39000424)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
I ran a job before and after this fix, and before the fix you'd see these logs in the StorageMover logs, where the error is an empty string:
"[ATTENTION] Transfer of 'ACLs/07_ConflictDataset_pltikj/conflict_usdkdx.txt' failed with error: "
Afterwards, you see this: 
"[ATTENTION] Transfer of 'ACLs/07_ConflictDataset_pltikj/conflict_usdkdx.txt' failed with error: Couldn't open source. open /m/d074/ACLs/07_ConflictDataset_pltikj/conflict_usdkdx.txt: permission denied"


Thank you for your contribution to AzCopy!
