### PR TITLE
Resolve MOVER_SYNC_MJ_TRAV per job for streaming merge-join

### DIFF
--- a/cmd/syncMergeJoinTwoWayConsumer.go
+++ b/cmd/syncMergeJoinTwoWayConsumer.go
@@ -409,17 +409,21 @@ func (e *mergeJoinTraversalError) Unwrap() error  { return e.err }
 // set (and GC pressure) bounded.
 const mergeJoinDefaultParallelTraversers int32 = 32
 
-// mergeJoinParallelTraversers is the directory-crawl parallelism for streaming merge-join jobs.
-// Override with MOVER_SYNC_MJ_TRAV as a positive integer. The indexMap sync path is unaffected and
-// keeps its own parallelism (orchestratorOptions.parallelTraversers).
-var mergeJoinParallelTraversers = func() int32 {
+// resolveMergeJoinParallelTraversers returns the directory-crawl parallelism for streaming
+// merge-join jobs. Override with MOVER_SYNC_MJ_TRAV as a positive integer. The indexMap sync path
+// is unaffected and keeps its own parallelism (orchestratorOptions.parallelTraversers).
+//
+// Resolved per call (per job) rather than at package init so a per-job env override applied after
+// process start (e.g. the mover's featureConfig runtime tuning, which os.Setenv's MOVER_SYNC_MJ_TRAV
+// when a job is picked up) is honored instead of being frozen to the startup value.
+func resolveMergeJoinParallelTraversers() int32 {
 	if v := strings.TrimSpace(enum.EEnvironmentVariable.MoverSyncMergeJoinTraversers().Get()); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			return int32(n)
 		}
 	}
 	return mergeJoinDefaultParallelTraversers
-}()
+}
 
 // useStreamingMergeJoin reports whether the streaming merge-join should be used for
 // this transfer. Enablement is decided entirely in the mover and passed to azcopy as the single

--- a/cmd/syncOrchestrator.go
+++ b/cmd/syncOrchestrator.go
@@ -637,9 +637,10 @@ func syncOrchestratorHandler(cca *cookedSyncCmdArgs, enumerator *syncEnumerator,
 		// orchestratorOptions.parallelTraversers unchanged — because the merge-join also lists
 		// source and destination concurrently within each directory.
 		if orchestratorOptions != nil {
-			orchestratorOptions.parallelTraversers = mergeJoinParallelTraversers
+			mjTrav := resolveMergeJoinParallelTraversers()
+			orchestratorOptions.parallelTraversers = mjTrav
 			syncOrchestratorLog(common.LogInfo, fmt.Sprintf(
-				"Streaming merge-join directory-crawl parallelism set to %d (%s)", mergeJoinParallelTraversers, enum.EEnvironmentVariable.MoverSyncMergeJoinTraversers().Name), true)
+				"Streaming merge-join directory-crawl parallelism set to %d (%s)", mjTrav, enum.EEnvironmentVariable.MoverSyncMergeJoinTraversers().Name), true)
 		}
 	} else if cca.useStreamingMergeJoin {
 		syncOrchestratorLog(common.LogInfo, fmt.Sprintf(


### PR DESCRIPTION
## Problem
`mover_sync_mj_trav` (featureConfig) → `MOVER_SYNC_MJ_TRAV` never took effect for the streaming merge-join: the directory-crawl parallelism always ran at the default **32**, even when the override was set (e.g. `40`).

## Root cause
`mergeJoinParallelTraversers` was a **package-level `var` initialized by a `func(){...}()`**, so Go evaluated it **once at process startup** — before any job runs. The mover applies featureConfig runtime tuning by `os.Setenv`-ing `MOVER_SYNC_MJ_TRAV` **per job** (when a job is picked up), which is *after* package init. Since azcopy runs in-process in the mover worker, that per-job `Setenv` was always too late, so the value stayed frozen at the startup value (usually unset → 32).

Observed in production logs: worker logged `Applied high-perf runtime tuning override ... mover_sync_mj_trav=40`, but azcopy then logged `Streaming merge-join directory-crawl parallelism set to 32 (MOVER_SYNC_MJ_TRAV)`.

This is the same class of bug the other three knobs avoid (`AZCOPY_CONCURRENCY_VALUE`, `MOVER_SHUFFLE_PARTS`, `AZCOPY_CONCURRENT_SCAN`), which are read lazily/per-job and therefore honored the override.

## Fix
- Replace the frozen package-level `var mergeJoinParallelTraversers` with a per-call function `resolveMergeJoinParallelTraversers()` that reads `MOVER_SYNC_MJ_TRAV` at call time.
- Call it in the **per-job** sync-orchestrator block (`syncOrchestrator.go`) where `orchestratorOptions.parallelTraversers` is set, so the env is read at job time.

No caching (`sync.Once` deliberately avoided): the value is per-subscription and re-applied per job, and the worker serves jobs for different subscriptions over its lifetime, so each job must read the current env.

Default (32) and the indexMap sync path are unchanged.

## Validation
- `go vet`/gopls: no errors in the two changed files. (Repo-wide `go build` currently fails only in the unrelated `common/enum/enum_def` package due to a local Go 1.25.4 vs newer-reflect mismatch — pre-existing, untouched here.)
- Behavior: the resolver runs inside the per-job orchestrator block, which executes after the worker's per-job `os.Setenv`, so `MOVER_SYNC_MJ_TRAV` is now read as the current value (e.g. 40) instead of the startup-frozen 32.
