### PR TITLE
Handle transient AFD gateway responses without Storage error-code headers and add corresponding tests

### DIFF
--- a/ste/xferRetryHelper.go
+++ b/ste/xferRetryHelper.go
@@ -54,6 +54,14 @@ func GetShouldRetry(log *LogOptions) RetryFunc {
 			if storageErrorCodes, ok := RetryStatusCodes[resp.StatusCode]; ok {
 				// compare to status codes
 				errorCodes := getErrorCodes(resp)
+				// Intermediaries such as Azure Front Door can generate transient 502 or 504
+				// HTML responses without Azure Storage error-code headers. In that case,
+				// apply the wildcard policy configured for the HTTP status itself. Do not
+				// return false when the wildcard is disabled because the copy-source status
+				// header below may still identify a retryable condition.
+				if len(errorCodes) == 0 && storageErrorCodes[StorageErrorCodesWildcard] {
+					return true
+				}
 				for _, errorCode := range errorCodes {
 					if policy, ok := storageErrorCodes[errorCode]; ok {
 						if policy && log != nil && log.ShouldLog(common.ELogLevel.Debug()) {

--- a/ste/xferRetryHelper_test.go
+++ b/ste/xferRetryHelper_test.go
@@ -1,14 +1,21 @@
 package ste
 
 import (
+	"context"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"runtime"
+	"sync/atomic"
 	"syscall"
 	"testing"
+	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetShouldRetry(t *testing.T) {
@@ -40,6 +47,12 @@ func TestGetShouldRetry(t *testing.T) {
 					"x-ms-error-code": {code},
 				},
 			},
+			ShouldRetry: retry,
+		}
+	}
+	RespWithoutErrorCodeTest := func(status int, retry bool) *ResponseRetryPair {
+		return &ResponseRetryPair{
+			Resp:        &http.Response{StatusCode: status, Header: make(http.Header)},
 			ShouldRetry: retry,
 		}
 	}
@@ -90,6 +103,28 @@ func TestGetShouldRetry(t *testing.T) {
 			},
 		},
 		{
+			Rules: ParseRules("502; 504"),
+			Tests: []*ResponseRetryPair{
+				RespWithoutErrorCodeTest(http.StatusBadGateway, true),
+				RespWithoutErrorCodeTest(http.StatusGatewayTimeout, true),
+				RespWithoutErrorCodeTest(http.StatusNotImplemented, false),
+			},
+		},
+		{
+			Rules: ParseRules("502: OriginTimeout; 504"),
+			Tests: []*ResponseRetryPair{
+				{
+					Resp: &http.Response{
+						StatusCode: http.StatusBadGateway,
+						Header: http.Header{
+							"x-ms-copy-source-status-code": {"504"},
+						},
+					},
+					ShouldRetry: true,
+				},
+			},
+		},
+		{
 			TestCond: func() bool {
 				return runtime.GOOS == "windows" || runtime.GOOS == "darwin" || runtime.GOOS == "linux"
 			},
@@ -137,6 +172,59 @@ func TestGetShouldRetry(t *testing.T) {
 			assert.Equalf(t, v.ShouldRetry, res, "expected result mismatch on entry %d test %d \n %v", entryNum, testNum,
 				matrix[entryNum].Tests[testNum])
 		}
+	}
+}
+
+func TestGetShouldRetryRetriesAFDGatewayResponse(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		errorCode  string
+	}{
+		{name: "connection aborted", statusCode: http.StatusBadGateway, errorCode: "OriginConnectionAborted"},
+		{name: "origin timeout", statusCode: http.StatusGatewayTimeout, errorCode: "OriginTimeout"},
+	}
+
+	previousRetryStatusCodes := RetryStatusCodes
+	retryStatusCodes, err := ParseRetryCodes("502; 504")
+	require.NoError(t, err)
+	RetryStatusCodes = retryStatusCodes
+	t.Cleanup(func() { RetryStatusCodes = previousRetryStatusCodes })
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var attempts int32
+			server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+				if atomic.AddInt32(&attempts, 1) == 1 {
+					response.Header().Set("Content-Type", "text/html")
+					response.Header().Set("X-Azure-Ref", "afd-test-reference")
+					response.WriteHeader(test.statusCode)
+					_, _ = response.Write([]byte("<html><body>" + test.errorCode + "</body></html>"))
+					return
+				}
+
+				response.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			pipeline := azruntime.NewPipeline("", "", azruntime.PipelineOptions{}, &policy.ClientOptions{
+				Retry: policy.RetryOptions{
+					MaxRetries:    1,
+					RetryDelay:    time.Millisecond,
+					MaxRetryDelay: time.Millisecond,
+					ShouldRetry:   GetShouldRetry(nil),
+				},
+				Transport: http.DefaultClient,
+			})
+			request, err := azruntime.NewRequest(context.Background(), http.MethodPut, server.URL)
+			require.NoError(t, err)
+
+			response, err := pipeline.Do(request)
+			require.NoError(t, err)
+			defer response.Body.Close()
+			assert.Equal(t, http.StatusOK, response.StatusCode)
+			assert.Equal(t, int32(2), atomic.LoadInt32(&attempts))
+		})
 	}
 }
 


### PR DESCRIPTION
## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**: Addresses a retry-handling gap for transient responses generated by intermediaries such as Azure Front Door. AFD can return `502 Bad Gateway` or `504 Gateway Timeout` HTML responses without an Azure Storage `x-ms-error-code` header. These responses are now evaluated using the wildcard policy configured for their HTTP status code. The change preserves evaluation of `x-ms-copy-source-status-code` when the wildcard policy is disabled.

- **Related Links**:
- Issues
- Team thread
- Documents
- [Email Subject]

## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update required
- [ ] Code quality improvement
- [ ] Other (describe):

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

Added unit coverage for:

- Headerless `502 Bad Gateway` responses being retried.
- Headerless `504 Gateway Timeout` responses being retried.
- An unconfigured `501 Not Implemented` response not being retried.
- Continued evaluation of a retryable copy-source status when the response status wildcard is disabled.

Added an HTTP pipeline integration test that simulates AFD-style responses:

- `502 OriginConnectionAborted`
- `504 OriginTimeout`
- HTML response bodies with an AFD reference header
- No Azure Storage error-code header
- A successful response on the second request

The integration test verifies that the azcore pipeline sends exactly two requests and returns the successful response.

Focused validation:

```text
go test ./ste -run '^TestGetShouldRetry(RetriesAFDGatewayResponse)?$' -count=1
```

Formatting and whitespace validation also passed:

```text
gofmt -d ste/xferRetryHelper.go ste/xferRetryHelper_test.go
git diff --check -- ste/xferRetryHelper.go ste/xferRetryHelper_test.go
```

A Windows AMD64 private-testing binary was also built successfully using the repository’s pipeline-equivalent build settings.

Thank you for your contribution to AzCopy!